### PR TITLE
Do not let Renovate assign a reviewer anymore

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "config:base"
   ],
   "labels": ["dependencies"],
-  "reviewers": ["team:element-x-android-reviewers"],
   "ignoreDeps": ["string:app_name"],
   "packageRules": [
     {


### PR DESCRIPTION
Now that we have a CODEOWNERS file, there is no need for Renovate to assign a reviewer to assign a reviewer. It will be done automatically by GitHub.

(I think - see below) It leads to double assignment to the team, which is not handled fine by GitHub, for instance in [this PR](https://github.com/vector-im/element-x-android/pull/421):

<img width="321" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/0e8c0b3c-9d6e-4134-a40b-536ed051e515">

This is also maybe due to this weird timeline:

<img width="848" alt="image" src="https://github.com/vector-im/element-x-android/assets/3940906/26238eaa-3d35-4de2-bbe4-e6dc808bcb89">

Anyway we can merge this PR and see what's happening on new PRs from Renovate in the coming days.
