### PR TITLE
Only build `app` module for Maestro tests.

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
       - name: Assemble debug APK
-        run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:assembleDebug $CI_GRADLE_ARG_PROPERTIES
         env:
           ELEMENT_ANDROID_MAPTILER_API_KEY: ${{ secrets.MAPTILER_KEY }}
           ELEMENT_ANDROID_MAPTILER_LIGHT_MAP_ID: ${{ secrets.MAPTILER_LIGHT_MAP_ID }}


### PR DESCRIPTION
This should save some time since the sample module would no longer be built before running the tests.

Technically, this could still be improved by trying to download the built artefacts from the last `build.yml` run in the same PR and building the apk otherwise, but that seems like an overkill.
