### PR TITLE
Rust SDK: prefer using interfaces when they exist

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -35,9 +35,10 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.BackupStateListener
 import org.matrix.rustcomponents.sdk.BackupSteadyStateListener
-import org.matrix.rustcomponents.sdk.Client
+import org.matrix.rustcomponents.sdk.ClientInterface
+import org.matrix.rustcomponents.sdk.Disposable.Companion.destroy
 import org.matrix.rustcomponents.sdk.EnableRecoveryProgressListener
-import org.matrix.rustcomponents.sdk.Encryption
+import org.matrix.rustcomponents.sdk.EncryptionInterface
 import org.matrix.rustcomponents.sdk.RecoveryStateListener
 import org.matrix.rustcomponents.sdk.BackupState as RustBackupState
 import org.matrix.rustcomponents.sdk.BackupUploadState as RustBackupUploadState
@@ -46,13 +47,13 @@ import org.matrix.rustcomponents.sdk.RecoveryState as RustRecoveryState
 import org.matrix.rustcomponents.sdk.SteadyStateException as RustSteadyStateException
 
 internal class RustEncryptionService(
-    client: Client,
+    client: ClientInterface,
     syncService: RustSyncService,
     sessionCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
 ) : EncryptionService {
 
-    private val service: Encryption = client.encryption()
+    private val service: EncryptionInterface = client.encryption()
 
     private val backupStateMapper = BackupStateMapper()
     private val recoveryStateMapper = RecoveryStateMapper()
@@ -104,7 +105,7 @@ internal class RustEncryptionService(
 
     fun destroy() {
         // No way to remove the listeners...
-        service.destroy()
+        destroy(service)
     }
 
     override suspend fun enableBackups(): Result<Unit> = withContext(dispatchers.io) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/MediaSource.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/MediaSource.kt
@@ -17,9 +17,9 @@
 package io.element.android.libraries.matrix.impl.media
 
 import io.element.android.libraries.matrix.api.media.MediaSource
-import org.matrix.rustcomponents.sdk.use
-import org.matrix.rustcomponents.sdk.MediaSource as RustMediaSource
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.MediaSourceInterface
 
-fun RustMediaSource.map(): MediaSource = use {
+fun MediaSourceInterface.map(): MediaSource = useAny {
     MediaSource(it.url(), it.toJson())
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
@@ -24,12 +24,12 @@ import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.notification.NotificationService
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.withContext
-import org.matrix.rustcomponents.sdk.NotificationClient
+import org.matrix.rustcomponents.sdk.NotificationClientInterface
 import org.matrix.rustcomponents.sdk.use
 
 class RustNotificationService(
     sessionId: SessionId,
-    private val notificationClient: NotificationClient,
+    private val notificationClient: NotificationClientInterface,
     private val dispatchers: CoroutineDispatchers,
     clock: SystemClock,
 ) : NotificationService {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -20,19 +20,20 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.impl.room.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventMessageMapper
+import io.element.android.libraries.matrix.impl.util.useAny
 import org.matrix.rustcomponents.sdk.MessageLikeEventContent
 import org.matrix.rustcomponents.sdk.StateEventContent
-import org.matrix.rustcomponents.sdk.TimelineEvent
+import org.matrix.rustcomponents.sdk.TimelineEventInterface
 import org.matrix.rustcomponents.sdk.TimelineEventType
 import org.matrix.rustcomponents.sdk.use
 import javax.inject.Inject
 
 class TimelineEventToNotificationContentMapper @Inject constructor() {
 
-    fun map(timelineEvent: TimelineEvent): NotificationContent {
-        return timelineEvent.use {
+    fun map(timelineEvent: TimelineEventInterface): NotificationContent {
+        return timelineEvent.useAny {
             timelineEvent.eventType().use { eventType ->
-                eventType.toContent(senderId = UserId(timelineEvent.senderId()))
+                eventType.toContent(senderId = UserId(it.senderId()))
             }
         }
     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notificationsettings/RustNotificationSettingsService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notificationsettings/RustNotificationSettingsService.kt
@@ -26,13 +26,13 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.withContext
-import org.matrix.rustcomponents.sdk.NotificationSettings
 import org.matrix.rustcomponents.sdk.NotificationSettingsDelegate
 import org.matrix.rustcomponents.sdk.NotificationSettingsException
+import org.matrix.rustcomponents.sdk.NotificationSettingsInterface
 import timber.log.Timber
 
 class RustNotificationSettingsService(
-    private val notificationSettings: NotificationSettings,
+    private val notificationSettings: NotificationSettingsInterface,
     private val dispatchers: CoroutineDispatchers,
 ) : NotificationSettingsService {
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/pushers/RustPushersService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/pushers/RustPushersService.kt
@@ -20,14 +20,14 @@ import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.pusher.SetHttpPusherData
 import kotlinx.coroutines.withContext
-import org.matrix.rustcomponents.sdk.Client
+import org.matrix.rustcomponents.sdk.ClientInterface
 import org.matrix.rustcomponents.sdk.HttpPusherData
 import org.matrix.rustcomponents.sdk.PushFormat
 import org.matrix.rustcomponents.sdk.PusherIdentifiers
 import org.matrix.rustcomponents.sdk.PusherKind
 
 class RustPushersService(
-    private val client: Client,
+    private val client: ClientInterface,
     private val dispatchers: CoroutineDispatchers
 ) : PushersService {
     override suspend fun setHttpPusher(setHttpPusherData: SetHttpPusherData): Result<Unit> {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
@@ -20,6 +20,9 @@ import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.EventTimelineItemInterface
+import org.matrix.rustcomponents.sdk.RoomMemberInterface
 import org.matrix.rustcomponents.sdk.use
 import org.matrix.rustcomponents.sdk.Membership as RustMembership
 import org.matrix.rustcomponents.sdk.RoomInfo as RustRoomInfo
@@ -42,8 +45,8 @@ class MatrixRoomInfoMapper(
             canonicalAlias = it.canonicalAlias,
             alternativeAliases = it.alternativeAliases,
             currentUserMembership = it.membership.map(),
-            latestEvent = it.latestEvent?.use (timelineItemMapper::map),
-            inviter = it.inviter?.use(RoomMemberMapper::map),
+            latestEvent = (it.latestEvent as? EventTimelineItemInterface)?.useAny(timelineItemMapper::map),
+            inviter = (it.inviter as? RoomMemberInterface)?.useAny(RoomMemberMapper::map),
             activeMembersCount = it.activeMembersCount.toLong(),
             invitedMembersCount = it.invitedMembersCount.toLong(),
             joinedMembersCount = it.joinedMembersCount.toLong(),
@@ -56,13 +59,13 @@ class MatrixRoomInfoMapper(
     }
 }
 
-fun RustMembership.map(): CurrentUserMembership = when(this) {
+fun RustMembership.map(): CurrentUserMembership = when (this) {
     RustMembership.INVITED -> CurrentUserMembership.INVITED
     RustMembership.JOINED -> CurrentUserMembership.JOINED
     RustMembership.LEFT -> CurrentUserMembership.LEFT
 }
 
-fun RustRoomNotificationMode.map(): RoomNotificationMode = when(this) {
+fun RustRoomNotificationMode.map(): RoomNotificationMode = when (this) {
     RustRoomNotificationMode.ALL_MESSAGES -> RoomNotificationMode.ALL_MESSAGES
     RustRoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY -> RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY
     RustRoomNotificationMode.MUTE -> RoomNotificationMode.MUTE

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomMemberMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomMemberMapper.kt
@@ -19,12 +19,13 @@ package io.element.android.libraries.matrix.impl.room
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.RoomMemberInterface
 import org.matrix.rustcomponents.sdk.MembershipState as RustMembershipState
-import org.matrix.rustcomponents.sdk.RoomMember as RustRoomMember
 
 object RoomMemberMapper {
 
-    fun map(roomMember: RustRoomMember): RoomMember = roomMember.use {
+    fun map(roomMember: RoomMemberInterface): RoomMember = roomMember.useAny {
         RoomMember(
             UserId(it.userId()),
             it.displayName(),

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
@@ -19,16 +19,18 @@ package io.element.android.libraries.matrix.impl.room
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.timeline.item.event.EventType
+import io.element.android.libraries.matrix.impl.util.useAny
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.RequiredState
-import org.matrix.rustcomponents.sdk.RoomListService
+import org.matrix.rustcomponents.sdk.RoomListItemInterface
+import org.matrix.rustcomponents.sdk.RoomListServiceInterface
 import org.matrix.rustcomponents.sdk.RoomSubscription
 import timber.log.Timber
 
 class RoomSyncSubscriber(
-    private val roomListService: RoomListService,
+    private val roomListService: RoomListServiceInterface,
     private val dispatchers: CoroutineDispatchers,
 ) {
 
@@ -51,7 +53,7 @@ class RoomSyncSubscriber(
                 val currentSubscription = subscriptionCounts.getOrElse(roomId) { 0 }
                 if (currentSubscription == 0) {
                     Timber.d("Subscribing to room $roomId}")
-                    roomListService.room(roomId.value).use { roomListItem ->
+                    (roomListService.room(roomId.value) as RoomListItemInterface).useAny { roomListItem ->
                         roomListItem.subscribe(settings)
                     }
                 }
@@ -70,7 +72,7 @@ class RoomSyncSubscriber(
                     0 -> return@withContext
                     1 -> {
                         Timber.d("Unsubscribe from room $roomId")
-                        roomListService.room(roomId.value).use { roomListItem ->
+                        (roomListService.room(roomId.value) as RoomListItemInterface).useAny { roomListItem ->
                             roomListItem.unsubscribe()
                         }
                     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/message/RoomMessageFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/message/RoomMessageFactory.kt
@@ -18,10 +18,10 @@ package io.element.android.libraries.matrix.impl.room.message
 
 import io.element.android.libraries.matrix.api.room.message.RoomMessage
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
-import org.matrix.rustcomponents.sdk.EventTimelineItem as RustEventTimelineItem
+import org.matrix.rustcomponents.sdk.EventTimelineItemInterface
 
 class RoomMessageFactory {
-    fun create(eventTimelineItem: RustEventTimelineItem?): RoomMessage? {
+    fun create(eventTimelineItem: EventTimelineItemInterface?): RoomMessage? {
         eventTimelineItem ?: return null
         val mappedTimelineItem = EventTimelineItemMapper().map(eventTimelineItem)
         return RoomMessage(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
@@ -27,7 +27,7 @@ import org.matrix.rustcomponents.sdk.RoomListEntriesListener
 import org.matrix.rustcomponents.sdk.RoomListEntriesUpdate
 import org.matrix.rustcomponents.sdk.RoomListEntry
 import org.matrix.rustcomponents.sdk.RoomListInterface
-import org.matrix.rustcomponents.sdk.RoomListItem
+import org.matrix.rustcomponents.sdk.RoomListItemInterface
 import org.matrix.rustcomponents.sdk.RoomListLoadingState
 import org.matrix.rustcomponents.sdk.RoomListLoadingStateListener
 import org.matrix.rustcomponents.sdk.RoomListServiceInterface
@@ -104,7 +104,7 @@ fun RoomListServiceInterface.syncIndicator(): Flow<RoomListServiceSyncIndicator>
         }
     }.buffer(Channel.UNLIMITED)
 
-fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItem? {
+fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItemInterface? {
     return try {
         room(roomId)
     } catch (exception: Exception) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
@@ -21,13 +21,15 @@ import io.element.android.libraries.matrix.api.roomlist.RoomSummaryDetails
 import io.element.android.libraries.matrix.impl.notificationsettings.RoomNotificationSettingsMapper
 import io.element.android.libraries.matrix.impl.room.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.room.message.RoomMessageFactory
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.EventTimelineItemInterface
 import org.matrix.rustcomponents.sdk.RoomInfo
-import org.matrix.rustcomponents.sdk.use
+import org.matrix.rustcomponents.sdk.RoomMemberInterface
 
 class RoomSummaryDetailsFactory(private val roomMessageFactory: RoomMessageFactory = RoomMessageFactory()) {
 
     fun create(roomInfo: RoomInfo): RoomSummaryDetails {
-        val latestRoomMessage = roomInfo.latestEvent?.use {
+        val latestRoomMessage = (roomInfo.latestEvent as? EventTimelineItemInterface)?.useAny {
             roomMessageFactory.create(it)
         }
         return RoomSummaryDetails(
@@ -39,7 +41,7 @@ class RoomSummaryDetailsFactory(private val roomMessageFactory: RoomMessageFacto
             unreadNotificationCount = roomInfo.notificationCount.toInt(),
             lastMessage = latestRoomMessage,
             lastMessageTimestamp = latestRoomMessage?.originServerTs,
-            inviter = roomInfo.inviter?.let(RoomMemberMapper::map),
+            inviter = (roomInfo.inviter as? RoomMemberInterface)?.let(RoomMemberMapper::map),
             notificationMode = roomInfo.userDefinedNotificationMode?.let(RoomNotificationSettingsMapper::mapMode),
             hasOngoingCall = roomInfo.hasRoomCall,
         )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.matrix.impl.roomlist
 
 import io.element.android.libraries.core.coroutine.parallelMap
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
+import io.element.android.libraries.matrix.impl.util.useAny
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -134,7 +135,7 @@ class RoomSummaryListProcessor(
     }
 
     private suspend fun buildAndCacheRoomSummaryForIdentifier(identifier: String): RoomSummary {
-        val builtRoomSummary = roomListService.roomOrNull(identifier)?.use { roomListItem ->
+        val builtRoomSummary = roomListService.roomOrNull(identifier)?.useAny { roomListItem ->
             roomListItem.roomInfo().use { roomInfo ->
                 RoomSummary.Filled(
                     details = roomSummaryDetailsFactory.create(roomInfo)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
@@ -37,13 +37,13 @@ import org.matrix.rustcomponents.sdk.RoomListException
 import org.matrix.rustcomponents.sdk.RoomListInput
 import org.matrix.rustcomponents.sdk.RoomListLoadingState
 import org.matrix.rustcomponents.sdk.RoomListRange
+import org.matrix.rustcomponents.sdk.RoomListServiceInterface
 import org.matrix.rustcomponents.sdk.RoomListServiceState
 import org.matrix.rustcomponents.sdk.RoomListServiceSyncIndicator
 import timber.log.Timber
-import org.matrix.rustcomponents.sdk.RoomListService as InnerRustRoomListService
 
 class RustRoomListService(
-    private val innerRoomListService: InnerRustRoomListService,
+    private val innerRoomListService: RoomListServiceInterface,
     private val sessionCoroutineScope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher,
     roomSummaryDetailsFactory: RoomSummaryDetailsFactory = RoomSummaryDetailsFactory(),

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessor.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.matrix.rustcomponents.sdk.TimelineChange
 import org.matrix.rustcomponents.sdk.TimelineDiff
-import org.matrix.rustcomponents.sdk.TimelineItem
+import org.matrix.rustcomponents.sdk.TimelineItemInterface
 import timber.log.Timber
 
 internal class MatrixTimelineDiffProcessor(
@@ -32,7 +32,7 @@ internal class MatrixTimelineDiffProcessor(
 
     private val mutex = Mutex()
 
-    suspend fun postItems(items: List<TimelineItem>) {
+    suspend fun postItems(items: List<TimelineItemInterface>) {
         updateTimelineItems {
             Timber.v("Update timeline items from postItems (with ${items.size} items) on ${Thread.currentThread()}")
             val mappedItems = items.map { it.asMatrixTimelineItem() }
@@ -104,7 +104,7 @@ internal class MatrixTimelineDiffProcessor(
         }
     }
 
-    private fun TimelineItem.asMatrixTimelineItem(): MatrixTimelineItem {
+    private fun TimelineItemInterface.asMatrixTimelineItem(): MatrixTimelineItem {
         return timelineItemFactory.map(this)
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
@@ -20,9 +20,11 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
 import io.element.android.libraries.matrix.impl.timeline.item.virtual.VirtualTimelineItemMapper
+import io.element.android.libraries.matrix.impl.util.useAny
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.matrix.rustcomponents.sdk.TimelineItem
+import org.matrix.rustcomponents.sdk.TimelineItemInterface
 
 class MatrixTimelineItemMapper(
     private val fetchDetailsForEvent: suspend (EventId) -> Result<Unit>,
@@ -31,7 +33,7 @@ class MatrixTimelineItemMapper(
     private val eventTimelineItemMapper: EventTimelineItemMapper = EventTimelineItemMapper(),
 ) {
 
-    fun map(timelineItem: TimelineItem): MatrixTimelineItem = timelineItem.use {
+    fun map(timelineItem: TimelineItemInterface): MatrixTimelineItem = timelineItem.useAny {
         val uniqueId = timelineItem.uniqueId().toLong()
         val asEvent = it.asEvent()
         if (asEvent != null) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
@@ -23,7 +23,6 @@ import io.element.android.libraries.matrix.impl.timeline.item.virtual.VirtualTim
 import io.element.android.libraries.matrix.impl.util.useAny
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.matrix.rustcomponents.sdk.TimelineItem
 import org.matrix.rustcomponents.sdk.TimelineItemInterface
 
 class MatrixTimelineItemMapper(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
@@ -31,11 +31,11 @@ import org.matrix.rustcomponents.sdk.BackPaginationStatus
 import org.matrix.rustcomponents.sdk.BackPaginationStatusListener
 import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.TimelineDiff
-import org.matrix.rustcomponents.sdk.TimelineItem
+import org.matrix.rustcomponents.sdk.TimelineItemInterface
 import org.matrix.rustcomponents.sdk.TimelineListener
 import timber.log.Timber
 
-internal fun RoomInterface.timelineDiffFlow(onInitialList: suspend (List<TimelineItem>) -> Unit): Flow<List<TimelineDiff>> =
+internal fun RoomInterface.timelineDiffFlow(onInitialList: suspend (List<TimelineItemInterface>) -> Unit): Flow<List<TimelineDiff>> =
     callbackFlow {
         val listener = object : TimelineListener {
             override fun onUpdate(diff: List<TimelineDiff>) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
@@ -29,13 +29,13 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import org.matrix.rustcomponents.sdk.BackPaginationStatus
 import org.matrix.rustcomponents.sdk.BackPaginationStatusListener
-import org.matrix.rustcomponents.sdk.Room
+import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.TimelineDiff
 import org.matrix.rustcomponents.sdk.TimelineItem
 import org.matrix.rustcomponents.sdk.TimelineListener
 import timber.log.Timber
 
-internal fun Room.timelineDiffFlow(onInitialList: suspend (List<TimelineItem>) -> Unit): Flow<List<TimelineDiff>> =
+internal fun RoomInterface.timelineDiffFlow(onInitialList: suspend (List<TimelineItem>) -> Unit): Flow<List<TimelineDiff>> =
     callbackFlow {
         val listener = object : TimelineListener {
             override fun onUpdate(diff: List<TimelineDiff>) {
@@ -59,7 +59,7 @@ internal fun Room.timelineDiffFlow(onInitialList: suspend (List<TimelineItem>) -
         Timber.d(it, "timelineDiffFlow() failed")
     }.buffer(Channel.UNLIMITED)
 
-internal fun Room.backPaginationStatusFlow(): Flow<BackPaginationStatus> =
+internal fun RoomInterface.backPaginationStatusFlow(): Flow<BackPaginationStatus> =
     mxCallbackFlow {
         val listener = object : BackPaginationStatusListener {
             override fun onUpdate(status: BackPaginationStatus) {
@@ -71,7 +71,7 @@ internal fun Room.backPaginationStatusFlow(): Flow<BackPaginationStatus> =
         }
     }.buffer(Channel.UNLIMITED)
 
-internal suspend fun Room.runWithTimelineListenerRegistered(action: suspend () -> Unit) {
+internal suspend fun RoomInterface.runWithTimelineListenerRegistered(action: suspend () -> Unit) {
     val result = addTimelineListener(NoOpTimelineListener)
     try {
         action()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.BackPaginationStatus
 import org.matrix.rustcomponents.sdk.EventItemOrigin
 import org.matrix.rustcomponents.sdk.PaginationOptions
-import org.matrix.rustcomponents.sdk.Room
+import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.TimelineDiff
 import org.matrix.rustcomponents.sdk.TimelineItem
 import timber.log.Timber
@@ -59,7 +59,7 @@ class RustMatrixTimeline(
     roomCoroutineScope: CoroutineScope,
     isKeyBackupEnabled: Boolean,
     private val matrixRoom: MatrixRoom,
-    private val innerRoom: Room,
+    private val innerRoom: RoomInterface,
     private val dispatcher: CoroutineDispatcher,
     private val lastLoginTimestamp: Date?,
     private val onNewSyncedEvent: () -> Unit,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -48,7 +48,7 @@ import org.matrix.rustcomponents.sdk.EventItemOrigin
 import org.matrix.rustcomponents.sdk.PaginationOptions
 import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.TimelineDiff
-import org.matrix.rustcomponents.sdk.TimelineItem
+import org.matrix.rustcomponents.sdk.TimelineItemInterface
 import timber.log.Timber
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
@@ -138,7 +138,7 @@ class RustMatrixTimeline(
         encryptedHistoryPostProcessor.process(items)
     }
 
-    private suspend fun postItems(items: List<TimelineItem>) = coroutineScope {
+    private suspend fun postItems(items: List<TimelineItemInterface>) = coroutineScope {
         // Split the initial items in multiple list as there is no pagination in the cached data, so we can post timelineItems asap.
         items.chunked(INITIAL_MAX_SIZE).reversed().forEach {
             ensureActive()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineDiffExt.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineDiffExt.kt
@@ -19,7 +19,7 @@ package io.element.android.libraries.matrix.impl.timeline
 import org.matrix.rustcomponents.sdk.EventItemOrigin
 import org.matrix.rustcomponents.sdk.TimelineChange
 import org.matrix.rustcomponents.sdk.TimelineDiff
-import org.matrix.rustcomponents.sdk.TimelineItem
+import org.matrix.rustcomponents.sdk.TimelineItemInterface
 
 /**
  * Tries to get an event origin from the TimelineDiff.
@@ -49,6 +49,6 @@ internal fun TimelineDiff.eventOrigin(): EventItemOrigin? {
     }
 }
 
-private fun TimelineItem.eventOrigin(): EventItemOrigin? {
+private fun TimelineItemInterface.eventOrigin(): EventItemOrigin? {
     return asEvent()?.origin()
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventMessageMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventMessageMapper.kt
@@ -34,7 +34,8 @@ import io.element.android.libraries.matrix.api.timeline.item.event.UnknownMessag
 import io.element.android.libraries.matrix.api.timeline.item.event.VideoMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.VoiceMessageType
 import io.element.android.libraries.matrix.impl.media.map
-import org.matrix.rustcomponents.sdk.Message
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.MessageInterface
 import org.matrix.rustcomponents.sdk.MessageType
 import org.matrix.rustcomponents.sdk.ProfileDetails
 import org.matrix.rustcomponents.sdk.RepliedToEventDetails
@@ -47,7 +48,7 @@ class EventMessageMapper {
 
     private val timelineEventContentMapper by lazy { TimelineEventContentMapper() }
 
-    fun map(message: Message): MessageContent = message.use {
+    fun map(message: MessageInterface): MessageContent = message.useAny {
         val type = it.msgtype().use(this::mapMessageType)
         val inReplyToEvent: InReplyTo? = it.inReplyTo()?.use { details ->
             val inReplyToId = EventId(details.eventId)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventTimelineItemMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/EventTimelineItemMapper.kt
@@ -20,22 +20,23 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.TransactionId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.timeline.item.TimelineItemDebugInfo
-import io.element.android.libraries.matrix.api.timeline.item.event.TimelineItemEventOrigin
 import io.element.android.libraries.matrix.api.timeline.item.event.EventReaction
 import io.element.android.libraries.matrix.api.timeline.item.event.EventTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileTimelineDetails
 import io.element.android.libraries.matrix.api.timeline.item.event.ReactionSender
+import io.element.android.libraries.matrix.api.timeline.item.event.TimelineItemEventOrigin
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.EventTimelineItemInterface
 import org.matrix.rustcomponents.sdk.Reaction
 import org.matrix.rustcomponents.sdk.EventItemOrigin as RustEventItemOrigin
 import org.matrix.rustcomponents.sdk.EventSendState as RustEventSendState
-import org.matrix.rustcomponents.sdk.EventTimelineItem as RustEventTimelineItem
 import org.matrix.rustcomponents.sdk.EventTimelineItemDebugInfo as RustEventTimelineItemDebugInfo
 import org.matrix.rustcomponents.sdk.ProfileDetails as RustProfileDetails
 
 class EventTimelineItemMapper(private val contentMapper: TimelineEventContentMapper = TimelineEventContentMapper()) {
 
-    fun map(eventTimelineItem: RustEventTimelineItem): EventTimelineItem = eventTimelineItem.use {
+    fun map(eventTimelineItem: EventTimelineItemInterface): EventTimelineItem = eventTimelineItem.useAny {
         EventTimelineItem(
             eventId = it.eventId()?.let(::EventId),
             transactionId = it.transactionId()?.let(::TransactionId),

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
@@ -32,7 +32,8 @@ import io.element.android.libraries.matrix.api.timeline.item.event.UnableToDecry
 import io.element.android.libraries.matrix.api.timeline.item.event.UnknownContent
 import io.element.android.libraries.matrix.impl.media.map
 import io.element.android.libraries.matrix.impl.poll.map
-import org.matrix.rustcomponents.sdk.TimelineItemContent
+import io.element.android.libraries.matrix.impl.util.useAny
+import org.matrix.rustcomponents.sdk.TimelineItemContentInterface
 import org.matrix.rustcomponents.sdk.TimelineItemContentKind
 import org.matrix.rustcomponents.sdk.use
 import org.matrix.rustcomponents.sdk.EncryptedMessage as RustEncryptedMessage
@@ -41,15 +42,15 @@ import org.matrix.rustcomponents.sdk.OtherState as RustOtherState
 
 class TimelineEventContentMapper(private val eventMessageMapper: EventMessageMapper = EventMessageMapper()) {
 
-    fun map(content: TimelineItemContent): EventContent {
-        return content.use {
+    fun map(content: TimelineItemContentInterface): EventContent {
+        return content.useAny {
             content.kind().use { kind ->
                 map(content, kind)
             }
         }
     }
 
-    private fun map(content: TimelineItemContent, kind: TimelineItemContentKind) = when (kind) {
+    private fun map(content: TimelineItemContentInterface, kind: TimelineItemContentKind) = when (kind) {
         is TimelineItemContentKind.FailedToParseMessageLike -> {
             FailedToParseMessageLikeContent(
                 eventType = kind.eventType,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/util/UseAny.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/util/UseAny.kt
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.matrix.impl.auth
+package io.element.android.libraries.matrix.impl.util
 
-import io.element.android.libraries.matrix.api.auth.MatrixHomeServerDetails
-import io.element.android.libraries.matrix.impl.util.useAny
-import org.matrix.rustcomponents.sdk.HomeserverLoginDetailsInterface
+import org.matrix.rustcomponents.sdk.Disposable
+import org.matrix.rustcomponents.sdk.use
 
-fun HomeserverLoginDetailsInterface.map(): MatrixHomeServerDetails = useAny {
-    MatrixHomeServerDetails(
-        url = url(),
-        supportsPasswordLogin = supportsPasswordLogin(),
-        supportsOidcLogin = supportsOidcLogin(),
-    )
+// `use` extension function but for any object
+inline fun <T, R> T.useAny(block: (T) -> R): R {
+    return if (this is Disposable) {
+        use(block)
+    } else {
+        block(this)
+    }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatu
 import io.element.android.libraries.matrix.api.verification.VerificationEmoji
 import io.element.android.libraries.matrix.api.verification.VerificationFlowState
 import io.element.android.libraries.matrix.impl.sync.RustSyncService
+import io.element.android.libraries.matrix.impl.util.useAny
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -33,6 +34,7 @@ import org.matrix.rustcomponents.sdk.SessionVerificationController
 import org.matrix.rustcomponents.sdk.SessionVerificationControllerDelegate
 import org.matrix.rustcomponents.sdk.SessionVerificationControllerInterface
 import org.matrix.rustcomponents.sdk.SessionVerificationEmoji
+import org.matrix.rustcomponents.sdk.SessionVerificationEmojiInterface
 
 class RustSessionVerificationService(
     private val syncService: RustSyncService,
@@ -104,9 +106,10 @@ class RustSessionVerificationService(
         updateVerificationStatus(isVerified = true)
     }
 
+    // TODO Should be SessionVerificationEmojiInterface
     override fun didReceiveVerificationData(data: List<SessionVerificationEmoji>) {
         val emojis = data.map { emoji ->
-            emoji.use { VerificationEmoji(it.symbol(), it.description()) }
+            (emoji as SessionVerificationEmojiInterface).useAny { VerificationEmoji(it.symbol(), it.description()) }
         }
         _verificationFlowState.value = VerificationFlowState.ReceivedVerificationData(emojis)
     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/MatrixWidgetSettings.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/MatrixWidgetSettings.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.matrix.impl.widget
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
 import org.matrix.rustcomponents.sdk.ClientProperties
 import org.matrix.rustcomponents.sdk.Room
+import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.WidgetSettings
 import org.matrix.rustcomponents.sdk.generateWebviewUrl
 
@@ -35,13 +36,13 @@ fun MatrixWidgetSettings.Companion.fromRustWidgetSettings(widgetSettings: Widget
 )
 
 suspend fun MatrixWidgetSettings.generateWidgetWebViewUrl(
-    room: Room,
+    room: RoomInterface,
     clientId: String,
     languageTag: String? = null,
     theme: String? = null
 ) = generateWebviewUrl(
     widgetSettings = this.toRustWidgetSettings(),
-    room = room,
+    room = (room as Room) /* TODO SDK Change */,
     props = ClientProperties(
         clientId = clientId,
         languageTag = languageTag,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/MatrixWidgetSettings.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/MatrixWidgetSettings.kt
@@ -42,7 +42,7 @@ suspend fun MatrixWidgetSettings.generateWidgetWebViewUrl(
     theme: String? = null
 ) = generateWebviewUrl(
     widgetSettings = this.toRustWidgetSettings(),
-    room = (room as Room) /* TODO SDK Change */,
+    room = room as Room, /* TODO SDK Change */
     props = ClientProperties(
         clientId = clientId,
         languageTag = languageTag,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.matrix.rustcomponents.sdk.Room
+import org.matrix.rustcomponents.sdk.RoomInterface
 import org.matrix.rustcomponents.sdk.WidgetCapabilitiesProvider
 import org.matrix.rustcomponents.sdk.makeWidgetDriver
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,9 +33,9 @@ import kotlin.coroutines.coroutineContext
 
 class RustWidgetDriver(
     widgetSettings: MatrixWidgetSettings,
-    private val room: Room,
+    private val room: RoomInterface,
     private val widgetCapabilitiesProvider: WidgetCapabilitiesProvider,
-): MatrixWidgetDriver {
+) : MatrixWidgetDriver {
 
     // It's important to have extra capacity here to make sure we don't drop any messages
     override val incomingMessages = MutableSharedFlow<String>(extraBufferCapacity = 10)
@@ -55,7 +56,10 @@ class RustWidgetDriver(
         val coroutineScope = CoroutineScope(coroutineContext)
         coroutineScope.launch {
             // This call will suspend the coroutine while the driver is running, so it needs to be launched separately
-            driverAndHandle.driver.run(room, widgetCapabilitiesProvider)
+            driverAndHandle.driver.run(
+                room as Room, /* TODO Need SDK API change */
+                widgetCapabilitiesProvider,
+            )
         }
         receiveMessageJob = coroutineScope.launch(Dispatchers.IO) {
             try {


### PR DESCRIPTION
Draft, WIP.

The idea is to use the interfaces declared in the FFI layer as much as possible.

Sometimes the object has to be cast to be able to use FFI API. Also the FFI layer does not return systematically interface but sometimes the implementation type.

Adding `useAny` since the interface does not extend `Disposable`. Ideally it could be the case, but not a blocker, since we have the handy `Disposable.destroy(...)` to help (could be renamed to `use` but I prefer to have a different name for clarity).

I think I have use all the possible interface and at all places, but I may have missed some.

This work will help to unit test our implementation, but allowing to inject our own test implementation of the interfaces.