### PR TITLE
Handle tapping on user mentions

### DIFF
--- a/changelog.d/1448.feature
+++ b/changelog.d/1448.feature
@@ -1,0 +1,1 @@
+Tapping on a user mention pill opens their profile.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -44,6 +44,7 @@ import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.ProgressCallback
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.permalink.PermalinkBuilder
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.Mention
@@ -335,7 +336,7 @@ class MessageComposerPresenter @Inject constructor(
                     add(Mention.AtRoom)
                 }
                 for (userId in state.userIds) {
-                    add(Mention.User(userId))
+                    add(Mention.User(UserId(userId)))
                 }
             }
         }.orEmpty()

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenterTest.kt
@@ -862,7 +862,7 @@ class MessageComposerPresenterTest {
 
             advanceUntilIdle()
 
-            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID.value)))
+            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID)))
 
             // Check intentional mentions on reply sent
             initialState.eventSink(MessageComposerEvents.SetMode(aReplyMode()))
@@ -877,7 +877,7 @@ class MessageComposerPresenterTest {
             initialState.eventSink(MessageComposerEvents.SendMessage(A_MESSAGE.toMessage()))
             advanceUntilIdle()
 
-            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID_2.value)))
+            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID_2)))
 
             // Check intentional mentions on edit message
             skipItems(1)
@@ -893,7 +893,7 @@ class MessageComposerPresenterTest {
             initialState.eventSink(MessageComposerEvents.SendMessage(A_MESSAGE.toMessage()))
             advanceUntilIdle()
 
-            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID_3.value)))
+            assertThat(room.sendMessageMentions).isEqualTo(listOf(Mention.User(A_USER_ID_3)))
 
             skipItems(1)
         }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/permalink/PermalinkData.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/permalink/PermalinkData.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.matrix.api.permalink
 
 import android.net.Uri
 import androidx.compose.runtime.Immutable
+import io.element.android.libraries.matrix.api.core.RoomId
 import kotlinx.collections.immutable.ImmutableList
 
 /**
@@ -32,7 +33,15 @@ sealed interface PermalinkData {
         val isRoomAlias: Boolean,
         val eventId: String?,
         val viaParameters: ImmutableList<String>
-    ) : PermalinkData
+    ) : PermalinkData {
+        fun getRoomId(): RoomId? {
+            return roomIdOrAlias.takeIf { !isRoomAlias }?.let(::RoomId)
+        }
+
+        fun getRoomAlias(): String? {
+            return roomIdOrAlias.takeIf { isRoomAlias }
+        }
+    }
 
     /*
      * &room_name=Team2

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/Mention.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/Mention.kt
@@ -16,7 +16,11 @@
 
 package io.element.android.libraries.matrix.api.room
 
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.UserId
+
 sealed interface Mention {
-    data class User(val userId: String): Mention
+    data class User(val userId: UserId): Mention
     data object AtRoom: Mention
+    data class Room(val roomId: RoomId?, val roomAlias: String?): Mention
 }

--- a/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/permalink/PermalinkDataTest.kt
+++ b/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/permalink/PermalinkDataTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.api.permalink
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Test
+
+class PermalinkDataTest {
+
+    @Test
+    fun `getRoomId() returns value when isRoomAlias is false`() {
+        val permalinkData = PermalinkData.RoomLink(
+                roomIdOrAlias = "!abcdef123456:matrix.org",
+                isRoomAlias = false,
+                eventId = null,
+                viaParameters = persistentListOf(),
+        )
+        assertThat(permalinkData.getRoomId()).isNotNull()
+        assertThat(permalinkData.getRoomAlias()).isNull()
+    }
+
+    @Test
+    fun `getRoomAlias() returns value when isRoomAlias is true`() {
+        val permalinkData = PermalinkData.RoomLink(
+            roomIdOrAlias = "#room:matrix.org",
+            isRoomAlias = true,
+            eventId = null,
+            viaParameters = persistentListOf(),
+        )
+        assertThat(permalinkData.getRoomId()).isNull()
+        assertThat(permalinkData.getRoomAlias()).isNotNull()
+    }
+
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/Mention.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/Mention.kt
@@ -21,6 +21,6 @@ import org.matrix.rustcomponents.sdk.Mentions
 
 fun List<Mention>.map(): Mentions {
     val hasAtRoom = any { it is Mention.AtRoom }
-    val userIds = filterIsInstance<Mention.User>().map { it.userId }
+    val userIds = filterIsInstance<Mention.User>().map { it.userId.value }
     return Mentions(userIds, hasAtRoom)
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Added code to handle tapping on mentions for `onLinkClicked` callback.
- Added specific `onMentionClicked(Mention)` callback.
- Added `Mention.Room` and a couple of helper functions to get the room id and alias from `Permalink.RoomLink`.
- Make a user mention open the user's profile. Room and `@room` mentions do nothing for now.

## Motivation and context

Closes #1448 .

## Screenshots / GIFs

There should be no UI changes.

## Tests

<!-- Explain how you tested your development -->

- Open a room.
- Tap on a user mention pill, see that it opens its profile.
- Tap on an `@room` or room/event mention pill, it should do nothing.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
