### PR TITLE
Feature/bma/open room avatar

### DIFF
--- a/changelog.d/1918.misc
+++ b/changelog.d/1918.misc
@@ -1,0 +1,1 @@
+Add ability to see the room avatar in the media viewer.

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsFlowNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsFlowNode.kt
@@ -34,7 +34,7 @@ import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditNode
 import io.element.android.features.roomdetails.impl.invite.RoomInviteMembersNode
 import io.element.android.features.roomdetails.impl.members.RoomMemberListNode
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsNode
-import io.element.android.features.roomdetails.impl.members.details.avatar.RoomMemberAvatarPreviewNode
+import io.element.android.features.roomdetails.impl.members.details.avatar.AvatarPreviewNode
 import io.element.android.features.roomdetails.impl.notificationsettings.RoomNotificationSettingsNode
 import io.element.android.libraries.architecture.BackstackNode
 import io.element.android.libraries.architecture.animation.rememberDefaultTransitionHandler
@@ -87,7 +87,7 @@ class RoomDetailsFlowNode @AssistedInject constructor(
         data class RoomMemberDetails(val roomMemberId: UserId) : NavTarget
 
         @Parcelize
-        data class MemberAvatarPreview(val userName: String, val avatarUrl: String) : NavTarget
+        data class AvatarPreview(val userName: String, val avatarUrl: String) : NavTarget
     }
 
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
@@ -111,7 +111,7 @@ class RoomDetailsFlowNode @AssistedInject constructor(
                     }
 
                     override fun openAvatarPreview(username: String, url: String) {
-                        backstack.push(NavTarget.MemberAvatarPreview(username, url))
+                        backstack.push(NavTarget.AvatarPreview(username, url))
                     }
                 }
                 createNode<RoomDetailsNode>(buildContext, listOf(roomDetailsCallback))
@@ -151,7 +151,7 @@ class RoomDetailsFlowNode @AssistedInject constructor(
             is NavTarget.RoomMemberDetails -> {
                 val callback = object : RoomMemberDetailsNode.Callback {
                     override fun openAvatarPreview(username: String, avatarUrl: String) {
-                        backstack.push(NavTarget.MemberAvatarPreview(username, avatarUrl))
+                        backstack.push(NavTarget.AvatarPreview(username, avatarUrl))
                     }
 
                     override fun onStartDM(roomId: RoomId) {
@@ -161,7 +161,7 @@ class RoomDetailsFlowNode @AssistedInject constructor(
                 val plugins = listOf(RoomMemberDetailsNode.RoomMemberDetailsInput(navTarget.roomMemberId), callback)
                 createNode<RoomMemberDetailsNode>(buildContext, plugins)
             }
-            is NavTarget.MemberAvatarPreview -> {
+            is NavTarget.AvatarPreview -> {
                 // We need to fake the MimeType here for the viewer to work.
                 val mimeType = MimeTypes.Images
                 val input = MediaViewerNode.Inputs(
@@ -176,7 +176,7 @@ class RoomDetailsFlowNode @AssistedInject constructor(
                     canDownload = false,
                     canShare = false,
                 )
-                createNode<RoomMemberAvatarPreviewNode>(buildContext, listOf(input))
+                createNode<AvatarPreviewNode>(buildContext, listOf(input))
             }
         }
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.features.roomdetails.impl
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -120,7 +121,12 @@ fun RoomDetailsView(
                         avatarUrl = state.roomAvatarUrl,
                         roomId = state.roomId,
                         roomName = state.roomName,
-                        roomAlias = state.roomAlias
+                        roomAlias = state.roomAlias,
+                        openAvatarPreview = {
+                            if (state.roomAvatarUrl != null) {
+                                openAvatarPreview(state.roomName, state.roomAvatarUrl)
+                            }
+                        },
                     )
                     MainActionsSection(
                         state = state,
@@ -265,6 +271,7 @@ private fun RoomHeaderSection(
     roomId: String,
     roomName: String,
     roomAlias: String?,
+    openAvatarPreview: (url: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -275,7 +282,9 @@ private fun RoomHeaderSection(
     ) {
         Avatar(
             avatarData = AvatarData(roomId, roomName, avatarUrl, AvatarSize.RoomHeader),
-            modifier = Modifier.size(70.dp)
+            modifier = Modifier
+                .size(70.dp)
+                .clickable(enabled = avatarUrl != null) { openAvatarPreview(avatarUrl!!) }
         )
         Spacer(modifier = Modifier.height(24.dp))
         Text(

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -122,10 +122,8 @@ fun RoomDetailsView(
                         roomId = state.roomId,
                         roomName = state.roomName,
                         roomAlias = state.roomAlias,
-                        openAvatarPreview = {
-                            if (state.roomAvatarUrl != null) {
-                                openAvatarPreview(state.roomName, state.roomAvatarUrl)
-                            }
+                        openAvatarPreview = { avatarUrl ->
+                            openAvatarPreview(state.roomName, avatarUrl)
                         },
                     )
                     MainActionsSection(
@@ -140,10 +138,8 @@ fun RoomDetailsView(
                         avatarUrl = state.roomAvatarUrl ?: member.avatarUrl,
                         userId = member.userId.value,
                         userName = state.roomName,
-                        openAvatarPreview = {
-                            if (member.avatarUrl != null) {
-                                openAvatarPreview(member.displayName ?: member.userId.value, member.avatarUrl!!)
-                            }
+                        openAvatarPreview = { avatarUrl ->
+                            openAvatarPreview(member.displayName ?: member.userId.value, avatarUrl)
                         },
                     )
                     RoomMemberMainActionsSection(onShareUser = ::onShareMember)

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -78,6 +78,7 @@ import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.designsystem.utils.CommonDrawables
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
+import io.element.android.libraries.matrix.api.room.getBestName
 import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
@@ -139,7 +140,7 @@ fun RoomDetailsView(
                         userId = member.userId.value,
                         userName = state.roomName,
                         openAvatarPreview = { avatarUrl ->
-                            openAvatarPreview(member.displayName ?: member.userId.value, avatarUrl)
+                            openAvatarPreview(member.getBestName(), avatarUrl)
                         },
                     )
                     RoomMemberMainActionsSection(onShareUser = ::onShareMember)

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/avatar/AvatarPreviewNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/avatar/AvatarPreviewNode.kt
@@ -26,7 +26,7 @@ import io.element.android.libraries.mediaviewer.api.viewer.MediaViewerNode
 import io.element.android.libraries.mediaviewer.api.viewer.MediaViewerPresenter
 
 @ContributesNode(RoomScope::class)
-class RoomMemberAvatarPreviewNode @AssistedInject constructor(
+class AvatarPreviewNode @AssistedInject constructor(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
     presenterFactory: MediaViewerPresenter.Factory,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMember.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMember.kt
@@ -32,3 +32,7 @@ data class RoomMember(
 enum class RoomMembershipState {
     BAN, INVITE, JOIN, KNOCK, LEAVE
 }
+
+fun RoomMember.getBestName(): String {
+    return displayName?.takeIf { it.isNotEmpty() } ?: userId.value
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Open room avatar fullscreen from room detail screen.
The hard work has been done in #1911, so the PR is quite small.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #1911 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room which has a room avatar
- Go to the detail screen (tap on room name)
- Click on the avatar and observe it is now displayed fullscreen and can be zoomed in

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
