### PR TITLE
Font size on 'All Chats' was changing mid animation

### DIFF
--- a/changelog.d/1572.bugfix
+++ b/changelog.d/1572.bugfix
@@ -1,0 +1,1 @@
+Font size in 'All Chats' header was changing mid-animation.

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
@@ -150,8 +150,8 @@ private fun DefaultRoomListTopBar(
     val statusBarPadding = with(LocalDensity.current) { WindowInsets.statusBars.getTop(this).toDp() }
 
     Box(modifier = modifier) {
-        val smallTextStyle = ElementTheme.typography.aliasScreenTitle
-        val largeTextStyle = ElementTheme.typography.fontHeadingLgBold.copy(
+        val collapsedTitleTextStyle = ElementTheme.typography.aliasScreenTitle
+        val expandedTitleTextStyle = ElementTheme.typography.fontHeadingLgBold.copy(
             // Due to a limitation of MediumTopAppBar, and to avoid the text to be truncated,
             // ensure that the font size will never be bigger than 28.dp.
             fontSize = 28.dp.applyScaleDown().toSp()
@@ -159,7 +159,10 @@ private fun DefaultRoomListTopBar(
         MaterialTheme(
             colorScheme = ElementTheme.materialColors,
             shapes = MaterialTheme.shapes,
-            typography = ElementTheme.materialTypography.copy(headlineSmall = largeTextStyle, titleLarge = smallTextStyle),
+            typography = ElementTheme.materialTypography.copy(
+                headlineSmall = expandedTitleTextStyle,
+                titleLarge = collapsedTitleTextStyle
+            ),
         ) {
             MediumTopAppBar(
                 modifier = Modifier

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
@@ -149,130 +150,131 @@ private fun DefaultRoomListTopBar(
     val statusBarPadding = with(LocalDensity.current) { WindowInsets.statusBars.getTop(this).toDp() }
 
     Box(modifier = modifier) {
-        MediumTopAppBar(
-            modifier = Modifier
-                .onSizeChanged {
-                    appBarHeight = it.height
-                }
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
-                .avatarBloom(
-                    avatarData = avatarData,
-                    background = if (ElementTheme.isLightTheme) {
-                        // Workaround to display a very subtle bloom for avatars with very soft colors
-                        Color(0xFFF9F9F9)
-                    } else {
-                        ElementTheme.materialColors.background
-                    },
-                    blurSize = DpSize(avatarBloomSize, avatarBloomSize),
-                    offset = DpOffset(24.dp, 24.dp + statusBarPadding),
-                    clipToSize = if (appBarHeight > 0) DpSize(
-                        avatarBloomSize,
-                        appBarHeight.toDp()
-                    ) else DpSize.Unspecified,
-                    bottomSoftEdgeColor = ElementTheme.materialColors.background,
-                    bottomSoftEdgeAlpha = 1f - collapsedFraction,
-                    alpha = if (areSearchResultsDisplayed) 0f else 1f,
-                )
-                .statusBarsPadding(),
-            colors = TopAppBarDefaults.mediumTopAppBarColors(
-                containerColor = Color.Transparent,
-                scrolledContainerColor = Color.Transparent,
-            ),
-            title = {
-                val fontStyle = if (scrollBehavior.state.collapsedFraction > 0.5)
-                    ElementTheme.typography.aliasScreenTitle
-                else
-                    ElementTheme.typography.fontHeadingLgBold.copy(
-                        // Due to a limitation of MediumTopAppBar, and to avoid the text to be truncated,
-                        // ensure that the font size will never be bigger than 28.dp.
-                        fontSize = 28.dp.applyScaleDown().toSp()
+        val smallTextStyle = ElementTheme.typography.aliasScreenTitle
+        val largeTextStyle = ElementTheme.typography.fontHeadingLgBold.copy(
+            // Due to a limitation of MediumTopAppBar, and to avoid the text to be truncated,
+            // ensure that the font size will never be bigger than 28.dp.
+            fontSize = 28.dp.applyScaleDown().toSp()
+        )
+        MaterialTheme(
+            colorScheme = ElementTheme.materialColors,
+            shapes = MaterialTheme.shapes,
+            typography = ElementTheme.materialTypography.copy(headlineSmall = largeTextStyle, titleLarge = smallTextStyle),
+        ) {
+            MediumTopAppBar(
+                modifier = Modifier
+                    .onSizeChanged {
+                        appBarHeight = it.height
+                    }
+                    .nestedScroll(scrollBehavior.nestedScrollConnection)
+                    .avatarBloom(
+                        avatarData = avatarData,
+                        background = if (ElementTheme.isLightTheme) {
+                            // Workaround to display a very subtle bloom for avatars with very soft colors
+                            Color(0xFFF9F9F9)
+                        } else {
+                            ElementTheme.materialColors.background
+                        },
+                        blurSize = DpSize(avatarBloomSize, avatarBloomSize),
+                        offset = DpOffset(24.dp, 24.dp + statusBarPadding),
+                        clipToSize = if (appBarHeight > 0) DpSize(
+                            avatarBloomSize,
+                            appBarHeight.toDp()
+                        ) else DpSize.Unspecified,
+                        bottomSoftEdgeColor = ElementTheme.materialColors.background,
+                        bottomSoftEdgeAlpha = 1f - collapsedFraction,
+                        alpha = if (areSearchResultsDisplayed) 0f else 1f,
                     )
-                Text(
-                    style = fontStyle,
-                    text = stringResource(id = R.string.screen_roomlist_main_space_title)
-                )
-            },
-            navigationIcon = {
-                avatarData?.let {
-                    IconButton(
-                        modifier = Modifier.testTag(TestTags.homeScreenSettings),
-                        onClick = onOpenSettings
-                    ) {
-                        Avatar(
-                            avatarData = it,
-                            contentDescription = stringResource(CommonStrings.common_settings),
-                        )
-                        if (showAvatarIndicator) {
-                            RedIndicatorAtom(
-                                modifier = Modifier
-                                    .padding(4.5.dp)
-                                    .align(Alignment.TopEnd)
+                    .statusBarsPadding(),
+                colors = TopAppBarDefaults.mediumTopAppBarColors(
+                    containerColor = Color.Transparent,
+                    scrolledContainerColor = Color.Transparent,
+                ),
+                title = {
+                    Text(text = stringResource(id = R.string.screen_roomlist_main_space_title))
+                },
+                navigationIcon = {
+                    avatarData?.let {
+                        IconButton(
+                            modifier = Modifier.testTag(TestTags.homeScreenSettings),
+                            onClick = onOpenSettings
+                        ) {
+                            Avatar(
+                                avatarData = it,
+                                contentDescription = stringResource(CommonStrings.common_settings),
                             )
+                            if (showAvatarIndicator) {
+                                RedIndicatorAtom(
+                                    modifier = Modifier
+                                        .padding(4.5.dp)
+                                        .align(Alignment.TopEnd)
+                                )
+                            }
                         }
                     }
-                }
-            },
-            actions = {
-                IconButton(
-                    onClick = onSearchClicked,
-                ) {
-                    Icon(
-                        imageVector = CompoundIcons.Search,
-                        contentDescription = stringResource(CommonStrings.action_search),
-                    )
-                }
-                if (RoomListConfig.hasDropdownMenu) {
-                    var showMenu by remember { mutableStateOf(false) }
+                },
+                actions = {
                     IconButton(
-                        onClick = { showMenu = !showMenu }
+                        onClick = onSearchClicked,
                     ) {
                         Icon(
-                            imageVector = CompoundIcons.OverflowVertical,
-                            contentDescription = null,
+                            imageVector = CompoundIcons.Search,
+                            contentDescription = stringResource(CommonStrings.action_search),
                         )
                     }
-                    DropdownMenu(
-                        expanded = showMenu,
-                        onDismissRequest = { showMenu = false }
-                    ) {
-                        if (RoomListConfig.showInviteMenuItem) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    showMenu = false
-                                    onMenuActionClicked(RoomListMenuAction.InviteFriends)
-                                },
-                                text = { Text(stringResource(id = CommonStrings.action_invite)) },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = CompoundIcons.ShareAndroid,
-                                        tint = ElementTheme.materialColors.secondary,
-                                        contentDescription = null,
-                                    )
-                                }
+                    if (RoomListConfig.hasDropdownMenu) {
+                        var showMenu by remember { mutableStateOf(false) }
+                        IconButton(
+                            onClick = { showMenu = !showMenu }
+                        ) {
+                            Icon(
+                                imageVector = CompoundIcons.OverflowVertical,
+                                contentDescription = null,
                             )
                         }
-                        if (RoomListConfig.showReportProblemMenuItem) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    showMenu = false
-                                    onMenuActionClicked(RoomListMenuAction.ReportBug)
-                                },
-                                text = { Text(stringResource(id = CommonStrings.common_report_a_problem)) },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = CompoundIcons.ChatProblem,
-                                        tint = ElementTheme.materialColors.secondary,
-                                        contentDescription = null,
-                                    )
-                                }
-                            )
+                        DropdownMenu(
+                            expanded = showMenu,
+                            onDismissRequest = { showMenu = false }
+                        ) {
+                            if (RoomListConfig.showInviteMenuItem) {
+                                DropdownMenuItem(
+                                    onClick = {
+                                        showMenu = false
+                                        onMenuActionClicked(RoomListMenuAction.InviteFriends)
+                                    },
+                                    text = { Text(stringResource(id = CommonStrings.action_invite)) },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = CompoundIcons.ShareAndroid,
+                                            tint = ElementTheme.materialColors.secondary,
+                                            contentDescription = null,
+                                        )
+                                    }
+                                )
+                            }
+                            if (RoomListConfig.showReportProblemMenuItem) {
+                                DropdownMenuItem(
+                                    onClick = {
+                                        showMenu = false
+                                        onMenuActionClicked(RoomListMenuAction.ReportBug)
+                                    },
+                                    text = { Text(stringResource(id = CommonStrings.common_report_a_problem)) },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = CompoundIcons.ChatProblem,
+                                            tint = ElementTheme.materialColors.secondary,
+                                            contentDescription = null,
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
-                }
-            },
-            scrollBehavior = scrollBehavior,
-            windowInsets = WindowInsets(0.dp),
-        )
+                },
+                scrollBehavior = scrollBehavior,
+                windowInsets = WindowInsets(0.dp),
+            )
+        }
 
         HorizontalDivider(
             modifier =


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Wraps `MediumTopAppBar` in a `MaterialTheme` with the custom text styles needed for small / large title set to the right values.
- Removes the workaround relying on `collapsedFraction`.

## Motivation and context

Fixes #1572.

## Screenshots / GIFs

https://github.com/element-hq/element-x-android/assets/480955/c60edf6d-1919-4473-90f5-2513a2b93d24

## Tests

- In the room list, slowly scroll up/down so the title collapses and grows again.

If there are no font size changes, it's working fine.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
