### PR TITLE
Add warning about updating `com.autonomousapps.dependency-analysis`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -213,6 +213,7 @@ detekt = "io.gitlab.arturbosch.detekt:1.23.4"
 ktlint = "org.jlleitschuh.gradle.ktlint:12.0.3"
 dependencygraph = "com.savvasdalkitsis.module-dependency-graph:0.12"
 dependencycheck = "org.owasp.dependencycheck:9.0.7"
+# DO NOT UPGRADE FOR NOW! This causes the build to fail with local AAR versions of the Rust SDK
 dependencyanalysis = "com.autonomousapps.dependency-analysis:1.27.0"
 paparazzi = "app.cash.paparazzi:1.3.1"
 kover = "org.jetbrains.kotlinx.kover:0.6.1"


### PR DESCRIPTION
Versions > 1.27.0 won't allow use local AAR builds of the Rust SDK, until this is fixed a warning should be added so we don't update this dependency accidentally.