### PR TITLE
Fix release script

### DIFF
--- a/tools/github/download_github_artifacts.py
+++ b/tools/github/download_github_artifacts.py
@@ -74,13 +74,13 @@ if "/artifacts/" not in artifactUrl:
     print("❌ Invalid parameter --artifactUrl %s. Must contain '/artifacts/'" % artifactUrl)
     exit(1)
 artifactItems = artifactUrl.split("/")
-if len(artifactItems) != 9:
+if len(artifactItems) != 10:
     print("❌ Invalid parameter --artifactUrl %s. Please check the format." % (artifactUrl))
     exit(1)
 
 gitHubRepoOwner = artifactItems[3]
 gitHubRepo = artifactItems[4]
-artifactId = artifactItems[8]
+artifactId = artifactItems[9]
 
 if args.verbose:
     print("gitHubRepoOwner: %s, gitHubRepo: %s, artifactId: %s" % (gitHubRepoOwner, gitHubRepo, artifactId))

--- a/tools/github/download_github_artifacts.py
+++ b/tools/github/download_github_artifacts.py
@@ -21,6 +21,8 @@ import json
 import os
 # Run `pip3 install requests` if not installed yet
 import requests
+# Run `pip3 install re` if not installed yet
+import re
 
 # This script downloads artifacts from GitHub.
 # Ref: https://docs.github.com/en/rest/actions/artifacts#get-an-artifact
@@ -64,23 +66,22 @@ if args.verbose:
     print("Argument:")
     print(args)
 
+
 # Split the artifact URL to get information
-# Ex: https://github.com/element-hq/element-android/suites/9293388174/artifacts/435942121
+# Ex: https://github.com/element-hq/element-x-android/actions/runs/7299827320/artifacts/1131077517
 artifactUrl = args.artifactUrl
-if not artifactUrl.startswith('https://github.com/'):
-    print("❌ Invalid parameter --artifactUrl %s. Must start with 'https://github.com/'" % artifactUrl)
-    exit(1)
-if "/artifacts/" not in artifactUrl:
-    print("❌ Invalid parameter --artifactUrl %s. Must contain '/artifacts/'" % artifactUrl)
-    exit(1)
-artifactItems = artifactUrl.split("/")
-if len(artifactItems) != 10:
-    print("❌ Invalid parameter --artifactUrl %s. Please check the format." % (artifactUrl))
+
+url_regex = r"https://github.com/(.+?)/(.+?)/actions/runs/.+?/artifacts/(.+)"
+result = re.search(url_regex, artifactUrl)
+
+if result is None:
+    print(
+        "❌ Invalid parameter --artifactUrl '%s'. Please check the format.\nIt should be something like: %s" %
+        (artifactUrl, 'https://github.com/element-hq/element-x-android/actions/runs/7299827320/artifacts/1131077517')
+    )
     exit(1)
 
-gitHubRepoOwner = artifactItems[3]
-gitHubRepo = artifactItems[4]
-artifactId = artifactItems[9]
+(gitHubRepoOwner, gitHubRepo, artifactId) = result.groups()
 
 if args.verbose:
     print("gitHubRepoOwner: %s, gitHubRepo: %s, artifactId: %s" % (gitHubRepoOwner, gitHubRepo, artifactId))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Changes the way we pick the artifact id of the built AAB from the CI. Example URL:

> https://github.com/element-hq/element-x-android/actions/runs/7299827320/artifacts/1131077517

This now has 10 sections separated by '/'. <del>Another option would be using a regex.</del>

I ended up using a regex, since it's easier to validate the URL format.

## Motivation and context

The release script failed several times because this is outdated, I believe.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
