### PR TITLE
Handle `MembershipChange.NONE` rendering in the timeline #2102

### DIFF
--- a/changelog.d/2102.misc
+++ b/changelog.d/2102.misc
@@ -1,0 +1,1 @@
+Handle `MembershipChange.NONE` rendering in the timeline.

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
@@ -104,7 +104,20 @@ class RoomMembershipContentFormatter @Inject constructor(
             } else {
                 sp.getString(R.string.state_event_room_knock_denied, senderDisplayName, userId.value)
             }
-            else -> {
+            MembershipChange.NONE -> if (senderIsYou) {
+                sp.getString(R.string.state_event_room_none_by_you)
+            } else {
+                sp.getString(R.string.state_event_room_none, senderDisplayName)
+            }
+            MembershipChange.ERROR -> {
+                Timber.v("Filtering timeline item for room membership: $membershipContent")
+                null
+            }
+            MembershipChange.NOT_IMPLEMENTED -> {
+                Timber.v("Filtering timeline item for room membership: $membershipContent")
+                null
+            }
+            null -> {
                 Timber.v("Filtering timeline item for room membership: $membershipContent")
                 null
             }

--- a/libraries/eventformatter/impl/src/main/res/values/localazy.xml
+++ b/libraries/eventformatter/impl/src/main/res/values/localazy.xml
@@ -39,6 +39,8 @@
   <string name="state_event_room_name_changed_by_you">"You changed the room name to: %1$s"</string>
   <string name="state_event_room_name_removed">"%1$s removed the room name"</string>
   <string name="state_event_room_name_removed_by_you">"You removed the room name"</string>
+  <string name="state_event_room_none">"%1$s made no changes"</string>
+  <string name="state_event_room_none_by_you">"You made no changes"</string>
   <string name="state_event_room_reject">"%1$s rejected the invitation"</string>
   <string name="state_event_room_reject_by_you">"You rejected the invitation"</string>
   <string name="state_event_room_remove">"%1$s removed %2$s"</string>

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
@@ -471,8 +471,24 @@ class DefaultRoomLastMessageFormatterTest {
 
     @Test
     @Config(qualifiers = "en")
+    fun `Membership change - None`() {
+        val otherName = "Someone"
+        val youContent = RoomMembershipContent(A_USER_ID, MembershipChange.NONE)
+        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), MembershipChange.NONE)
+
+        val youNoneRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
+        val youNoneRoom = formatter.format(youNoneRoomEvent, false)
+        assertThat(youNoneRoom).isEqualTo("You made no changes")
+
+        val someoneNoneRoomEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = someoneContent)
+        val someoneNoneRoom = formatter.format(someoneNoneRoomEvent, false)
+        assertThat(someoneNoneRoom).isEqualTo("$otherName made no changes")
+    }
+
+    @Test
+    @Config(qualifiers = "en")
     fun `Membership change - others`() {
-        val otherChanges = arrayOf(MembershipChange.NONE, MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED)
+        val otherChanges = arrayOf(MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED)
 
         val results = otherChanges.map { change ->
             val content = RoomMembershipContent(A_USER_ID, change)

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
@@ -488,7 +488,7 @@ class DefaultRoomLastMessageFormatterTest {
     @Test
     @Config(qualifiers = "en")
     fun `Membership change - others`() {
-        val otherChanges = arrayOf(MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED)
+        val otherChanges = arrayOf(MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED, null)
 
         val results = otherChanges.map { change ->
             val content = RoomMembershipContent(A_USER_ID, change)


### PR DESCRIPTION
And avoid `else` in the when statement.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Handle `MembershipChange.NONE` rendering in the timeline

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2102 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

<img width="210" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/4b714f6a-3db3-46e9-a14a-58e41713b1d0">


## Tests

<!-- Explain how you tested your development -->

- Edit a room member state Event from Element Web; for instance add an extra Json field in the content, to generate a `no changes` state event.
- Observe hos it's rendered in the timeline. Previsously: see #2102. Now: see screenshot above (the event have been edited twice)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
