### PR TITLE
Reactions power level

### DIFF
--- a/changelog.d/2093.bugfix
+++ b/changelog.d/2093.bugfix
@@ -1,0 +1,1 @@
+Disable ability to send reaction if the user does not have the permission to.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -139,6 +139,7 @@ class MessagesPresenter @AssistedInject constructor(
         val syncUpdateFlow = room.syncUpdateFlow.collectAsState()
         val userHasPermissionToSendMessage by room.canSendMessageAsState(type = MessageEventType.ROOM_MESSAGE, updateKey = syncUpdateFlow.value)
         val userHasPermissionToRedact by room.canRedactAsState(updateKey = syncUpdateFlow.value)
+        val userHasPermissionToSendReaction by room.canSendMessageAsState(type = MessageEventType.REACTION_SENT, updateKey = syncUpdateFlow.value)
         val roomName: Async<String> by remember {
             derivedStateOf { roomInfo?.name?.let { Async.Success(it) } ?: Async.Uninitialized }
         }
@@ -219,6 +220,7 @@ class MessagesPresenter @AssistedInject constructor(
             roomAvatar = roomAvatar,
             userHasPermissionToSendMessage = userHasPermissionToSendMessage,
             userHasPermissionToRedact = userHasPermissionToRedact,
+            userHasPermissionToSendReaction = userHasPermissionToSendReaction,
             composerState = composerState,
             voiceMessageComposerState = voiceMessageComposerState,
             timelineState = timelineState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
@@ -37,6 +37,7 @@ data class MessagesState(
     val roomAvatar: Async<AvatarData>,
     val userHasPermissionToSendMessage: Boolean,
     val userHasPermissionToRedact: Boolean,
+    val userHasPermissionToSendReaction: Boolean,
     val composerState: MessageComposerState,
     val voiceMessageComposerState: VoiceMessageComposerState,
     val timelineState: TimelineState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -87,6 +87,7 @@ fun aMessagesState() = MessagesState(
     roomAvatar = Async.Success(AvatarData("!id:domain", "Room name", size = AvatarSize.TimelineRoom)),
     userHasPermissionToSendMessage = true,
     userHasPermissionToRedact = false,
+    userHasPermissionToSendReaction = true,
     composerState = aMessageComposerState().copy(
         richTextEditorState = RichTextEditorState("Hello", initialFocus = true),
         isFullScreen = false,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -159,6 +159,7 @@ fun MessagesView(
                 event = event,
                 canRedact = state.userHasPermissionToRedact,
                 canSendMessage = state.userHasPermissionToSendMessage,
+                canSendReaction = state.userHasPermissionToSendReaction,
             )
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListEvents.kt
@@ -24,5 +24,6 @@ sealed interface ActionListEvents {
         val event: TimelineItem.Event,
         val canRedact: Boolean,
         val canSendMessage: Boolean,
+        val canSendReaction: Boolean,
     ) : ActionListEvents
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
@@ -59,6 +59,7 @@ class ActionListPresenter @Inject constructor(
                     timelineItem = event.event,
                     userCanRedact = event.canRedact,
                     userCanSendMessage = event.canSendMessage,
+                    userCanSendReaction = event.canSendReaction,
                     isDeveloperModeEnabled = isDeveloperModeEnabled,
                     target = target,
                 )
@@ -75,6 +76,7 @@ class ActionListPresenter @Inject constructor(
         timelineItem: TimelineItem.Event,
         userCanRedact: Boolean,
         userCanSendMessage: Boolean,
+        userCanSendReaction: Boolean,
         isDeveloperModeEnabled: Boolean,
         target: MutableState<ActionListState.Target>
     ) = launch {
@@ -169,7 +171,9 @@ class ActionListPresenter @Inject constructor(
                     }
                 }
             }
-        val displayEmojiReactions = timelineItem.isRemote && timelineItem.content.canReact()
+        val displayEmojiReactions = userCanSendReaction &&
+            timelineItem.isRemote
+            && timelineItem.content.canReact()
         if (actions.isNotEmpty() || displayEmojiReactions) {
             target.value = ActionListState.Target.Success(
                 event = timelineItem,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
@@ -172,8 +172,8 @@ class ActionListPresenter @Inject constructor(
                 }
             }
         val displayEmojiReactions = userCanSendReaction &&
-            timelineItem.isRemote
-            && timelineItem.content.canReact()
+            timelineItem.isRemote &&
+            timelineItem.content.canReact()
         if (actions.isNotEmpty() || displayEmojiReactions) {
             target.value = ActionListState.Target.Success(
                 event = timelineItem,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListState.kt
@@ -24,7 +24,6 @@ import kotlinx.collections.immutable.ImmutableList
 @Immutable
 data class ActionListState(
     val target: Target,
-    val displayEmojiReactions: Boolean,
     val eventSink: (ActionListEvents) -> Unit,
 ) {
     sealed interface Target {
@@ -32,6 +31,7 @@ data class ActionListState(
         data class Loading(val event: TimelineItem.Event) : Target
         data class Success(
             val event: TimelineItem.Event,
+            val displayEmojiReactions: Boolean,
             val actions: ImmutableList<TimelineItemAction>,
         ) : Target
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListStateProvider.kt
@@ -42,6 +42,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent().copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -50,6 +51,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemImageContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -58,6 +60,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemVideoContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -66,6 +69,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemFileContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -74,6 +78,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemAudioContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -82,6 +87,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemVoiceContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -90,6 +96,7 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemLocationContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = true,
                         actions = aTimelineItemActionList(),
                     )
                 ),
@@ -98,18 +105,18 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
                         event = aTimelineItemEvent(content = aTimelineItemLocationContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = false,
                         actions = aTimelineItemActionList(),
                     ),
-                    displayEmojiReactions = false,
                 ),
                 anActionListState().copy(
                     target = ActionListState.Target.Success(
                         event = aTimelineItemEvent(content = aTimelineItemPollContent()).copy(
                             reactionsState = reactionsState
                         ),
+                        displayEmojiReactions = false,
                         actions = aTimelineItemPollActionList(),
                     ),
-                    displayEmojiReactions = false,
                 ),
             )
         }
@@ -117,7 +124,6 @@ open class ActionListStateProvider : PreviewParameterProvider<ActionListState> {
 
 fun anActionListState() = ActionListState(
     target = ActionListState.Target.None,
-    displayEmojiReactions = true,
     eventSink = {}
 )
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
@@ -179,7 +179,7 @@ private fun SheetContent(
                         HorizontalDivider()
                     }
                 }
-                if (state.displayEmojiReactions) {
+                if (target.displayEmojiReactions) {
                     item {
                         EmojiReactionsRow(
                             highlightedEmojis = target.event.reactionsState.highlightedKeys,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -98,6 +98,7 @@ class TimelinePresenter @AssistedInject constructor(
         val paginationState by timeline.paginationState.collectAsState()
         val syncUpdateFlow = room.syncUpdateFlow.collectAsState()
         val userHasPermissionToSendMessage by room.canSendMessageAsState(type = MessageEventType.ROOM_MESSAGE, updateKey = syncUpdateFlow.value)
+        val userHasPermissionToSendReaction by room.canSendMessageAsState(type = MessageEventType.REACTION_SENT, updateKey = syncUpdateFlow.value)
 
         val prevMostRecentItemId = rememberSaveable { mutableStateOf<String?>(null) }
         val newItemState = remember { mutableStateOf(NewEventState.None) }
@@ -175,12 +176,18 @@ class TimelinePresenter @AssistedInject constructor(
                 .launchIn(this)
         }
 
+        val timelineRoomInfo by remember {
+            derivedStateOf {
+                TimelineRoomInfo(
+                    isDirect = room.isDirect,
+                    userHasPermissionToSendMessage = userHasPermissionToSendMessage,
+                    userHasPermissionToSendReaction = userHasPermissionToSendReaction,
+                )
+            }
+        }
         return TimelineState(
-            timelineRoomInfo = TimelineRoomInfo(
-                isDirect = room.isDirect
-            ),
+            timelineRoomInfo = timelineRoomInfo,
             highlightedEventId = highlightedEventId.value,
-            userHasPermissionToSendMessage = userHasPermissionToSendMessage,
             paginationState = paginationState,
             timelineItems = timelineItems,
             showReadReceipts = readReceiptsEnabled,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
@@ -30,7 +30,6 @@ data class TimelineState(
     val timelineRoomInfo: TimelineRoomInfo,
     val showReadReceipts: Boolean,
     val highlightedEventId: EventId?,
-    val userHasPermissionToSendMessage: Boolean,
     val paginationState: MatrixTimeline.PaginationState,
     val newEventState: NewEventState,
     val sessionState: SessionState,
@@ -40,4 +39,6 @@ data class TimelineState(
 @Immutable
 data class TimelineRoomInfo(
     val isDirect: Boolean,
+    val userHasPermissionToSendMessage: Boolean,
+    val userHasPermissionToSendReaction: Boolean,
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
@@ -55,7 +55,6 @@ fun aTimelineState(timelineItems: ImmutableList<TimelineItem> = persistentListOf
         beginningOfRoomReached = false,
     ),
     highlightedEventId = null,
-    userHasPermissionToSendMessage = true,
     newEventState = NewEventState.None,
     sessionState = aSessionState(
         isSessionVerified = true,
@@ -218,4 +217,6 @@ internal fun aTimelineRoomInfo(
     isDirect: Boolean = false,
 ) = TimelineRoomInfo(
     isDirect = isDirect,
+    userHasPermissionToSendMessage = true,
+    userHasPermissionToSendReaction = true,
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -123,7 +123,6 @@ fun TimelineView(
                     isLastOutgoingMessage = (timelineItem as? TimelineItem.Event)?.isMine == true
                         && state.timelineItems.first().identifier() == timelineItem.identifier(),
                     highlightedItem = state.highlightedEventId?.value,
-                    userHasPermissionToSendMessage = state.userHasPermissionToSendMessage,
                     onClick = onMessageClicked,
                     onLongClick = onMessageLongClicked,
                     onUserDataClick = onUserDataClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/ATimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/ATimelineItemEventRow.kt
@@ -35,7 +35,6 @@ internal fun ATimelineItemEventRow(
     showReadReceipts = showReadReceipts,
     isLastOutgoingMessage = isLastOutgoingMessage,
     isHighlighted = isHighlighted,
-    canReply = true,
     onClick = {},
     onLongClick = {},
     onUserDataClick = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -81,6 +81,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemImageContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
+import io.element.android.features.messages.impl.timeline.model.event.canBeRepliedTo
 import io.element.android.features.messages.impl.timeline.model.metadata
 import io.element.android.libraries.androidutils.system.openUrlInExternalApp
 import io.element.android.libraries.designsystem.colors.AvatarColorsProvider
@@ -112,7 +113,6 @@ fun TimelineItemEventRow(
     showReadReceipts: Boolean,
     isLastOutgoingMessage: Boolean,
     isHighlighted: Boolean,
-    canReply: Boolean,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     onUserDataClick: (UserId) -> Unit,
@@ -151,6 +151,7 @@ fun TimelineItemEventRow(
         } else {
             Spacer(modifier = Modifier.height(2.dp))
         }
+        val canReply = timelineRoomInfo.userHasPermissionToSendMessage && event.content.canBeRepliedTo()
         if (canReply) {
             val state: SwipeableActionsState = rememberSwipeableActionsState()
             val offset = state.offset.floatValue
@@ -335,6 +336,7 @@ private fun TimelineItemEventRowContent(
         if (event.reactionsState.reactions.isNotEmpty()) {
             TimelineItemReactionsView(
                 reactionsState = event.reactionsState,
+                userCanSendReaction = timelineRoomInfo.userHasPermissionToSendReaction,
                 isOutgoing = event.isMine,
                 onReactionClicked = onReactionClicked,
                 onReactionLongClicked = onReactionLongClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemGroupedEventsRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemGroupedEventsRow.kt
@@ -131,7 +131,6 @@ private fun TimelineItemGroupedEventsRowContent(
                         isLastOutgoingMessage = isLastOutgoingMessage,
                         highlightedItem = highlightedItem,
                         sessionState = sessionState,
-                        userHasPermissionToSendMessage = false,
                         onClick = onClick,
                         onLongClick = onLongClick,
                         inReplyToClick = inReplyToClick,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemReactionsView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemReactionsView.kt
@@ -31,8 +31,8 @@ import io.element.android.features.messages.impl.R
 import io.element.android.features.messages.impl.timeline.aTimelineItemReactions
 import io.element.android.features.messages.impl.timeline.model.AggregatedReaction
 import io.element.android.features.messages.impl.timeline.model.TimelineItemReactions
-import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.utils.CommonDrawables
 import kotlinx.collections.immutable.ImmutableList
 
@@ -40,6 +40,7 @@ import kotlinx.collections.immutable.ImmutableList
 fun TimelineItemReactionsView(
     reactionsState: TimelineItemReactions,
     isOutgoing: Boolean,
+    userCanSendReaction: Boolean,
     onReactionClicked: (emoji: String) -> Unit,
     onReactionLongClicked: (emoji: String) -> Unit,
     onMoreReactionsClicked: () -> Unit,
@@ -49,6 +50,7 @@ fun TimelineItemReactionsView(
     TimelineItemReactionsView(
         modifier = modifier,
         reactions = reactionsState.reactions,
+        userCanSendReaction = userCanSendReaction,
         expanded = expanded,
         isOutgoing = isOutgoing,
         onReactionClick = onReactionClicked,
@@ -61,6 +63,7 @@ fun TimelineItemReactionsView(
 @Composable
 private fun TimelineItemReactionsView(
     reactions: ImmutableList<AggregatedReaction>,
+    userCanSendReaction: Boolean,
     isOutgoing: Boolean,
     expanded: Boolean,
     onReactionClick: (emoji: String) -> Unit,
@@ -93,19 +96,26 @@ private fun TimelineItemReactionsView(
                     onLongClick = {}
                 )
             },
-            addMoreButton = {
-                MessagesReactionButton(
-                    content = MessagesReactionsButtonContent.Icon(CommonDrawables.ic_add_reaction),
-                    onClick = onMoreReactionsClick,
-                    onLongClick = {}
-                )
-            },
+            addMoreButton = if (userCanSendReaction) {
+                {
+                    MessagesReactionButton(
+                        content = MessagesReactionsButtonContent.Icon(CommonDrawables.ic_add_reaction),
+                        onClick = onMoreReactionsClick,
+                        onLongClick = {}
+                    )
+                }
+            } else null,
             reactions = {
                 reactions.forEach { reaction ->
                     CompositionLocalProvider(LocalLayoutDirection provides currentLayout) {
                         MessagesReactionButton(
                             content = MessagesReactionsButtonContent.Reaction(reaction = reaction),
-                            onClick = { onReactionClick(reaction.key) },
+                            onClick = {
+                                // Always allow user to redact their own reactions
+                                if (reaction.isHighlighted || userCanSendReaction) {
+                                    onReactionClick(reaction.key)
+                                }
+                            },
                             onLongClick = { onReactionLongClick(reaction.key) }
                         )
                     }
@@ -157,6 +167,7 @@ private fun ContentToPreview(
         reactionsState = TimelineItemReactions(
             reactions
         ),
+        userCanSendReaction = true,
         isOutgoing = isOutgoing,
         onReactionClicked = {},
         onReactionLongClicked = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemRow.kt
@@ -18,11 +18,10 @@ package io.element.android.features.messages.impl.timeline.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import io.element.android.features.messages.impl.timeline.TimelineRoomInfo
 import io.element.android.features.messages.impl.timeline.TimelineEvents
+import io.element.android.features.messages.impl.timeline.TimelineRoomInfo
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemStateContent
-import io.element.android.features.messages.impl.timeline.model.event.canBeRepliedTo
 import io.element.android.features.messages.impl.timeline.session.SessionState
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
@@ -34,7 +33,6 @@ internal fun TimelineItemRow(
     showReadReceipts: Boolean,
     isLastOutgoingMessage: Boolean,
     highlightedItem: String?,
-    userHasPermissionToSendMessage: Boolean,
     sessionState: SessionState,
     onUserDataClick: (UserId) -> Unit,
     onClick: (TimelineItem.Event) -> Unit,
@@ -77,7 +75,6 @@ internal fun TimelineItemRow(
                     showReadReceipts = showReadReceipts,
                     isLastOutgoingMessage = isLastOutgoingMessage,
                     isHighlighted = highlightedItem == timelineItem.identifier(),
-                    canReply = userHasPermissionToSendMessage && timelineItem.content.canBeRepliedTo(),
                     onClick = { onClick(timelineItem) },
                     onLongClick = { onLongClick(timelineItem) },
                     onUserDataClick = onUserDataClick,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
@@ -47,6 +47,7 @@ fun TimelineItemEventContent.canBeRepliedTo(): Boolean =
 
 /**
  * Return true if user can react (i.e. send a reaction) on the event content.
+ * This does not take into account the power level of the user.
  */
 fun TimelineItemEventContent.canReact(): Boolean =
     when (this) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
@@ -68,8 +68,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = false,
+                    actions = persistentListOf(
                         TimelineItemAction.ViewSource,
                     )
                 )
@@ -93,8 +94,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = false,
+                    actions = persistentListOf(
                         TimelineItemAction.ViewSource,
                     )
                 )
@@ -121,8 +123,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.Copy,
@@ -153,8 +156,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Forward,
                         TimelineItemAction.Copy,
                         TimelineItemAction.ViewSource,
@@ -182,8 +186,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.Copy,
@@ -215,8 +220,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.Edit,
@@ -248,8 +254,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.ViewSource,
@@ -279,8 +286,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    stateEvent,
-                    persistentListOf(
+                    event = stateEvent,
+                    displayEmojiReactions = false,
+                    actions = persistentListOf(
                         TimelineItemAction.Copy,
                         TimelineItemAction.ViewSource,
                     )
@@ -308,8 +316,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    stateEvent,
-                    persistentListOf(
+                    event = stateEvent,
+                    displayEmojiReactions = false,
+                    actions = persistentListOf(
                         TimelineItemAction.Copy,
                     )
                 )
@@ -336,8 +345,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.Edit,
@@ -373,7 +383,6 @@ class ActionListPresenterTest {
             initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(redactedEvent, canRedact = false, canSendMessage = true))
             awaitItem().run {
                 assertThat(target).isEqualTo(ActionListState.Target.None)
-                assertThat(displayEmojiReactions).isFalse()
             }
         }
     }
@@ -395,15 +404,15 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = false,
+                    actions = persistentListOf(
                         TimelineItemAction.Edit,
                         TimelineItemAction.Copy,
                         TimelineItemAction.Redact,
                     )
                 )
             )
-            assertThat(successState.displayEmojiReactions).isFalse()
         }
     }
 
@@ -423,8 +432,9 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Edit,
                         TimelineItemAction.EndPoll,
@@ -432,9 +442,9 @@ class ActionListPresenterTest {
                     )
                 )
             )
-            assertThat(successState.displayEmojiReactions).isTrue()
         }
     }
+
     @Test
     fun `present - compute for non-editable poll message`() = runTest {
         val presenter = createActionListPresenter(isDeveloperModeEnabled = false)
@@ -451,15 +461,15 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.EndPoll,
                         TimelineItemAction.Redact,
                     )
                 )
             )
-            assertThat(successState.displayEmojiReactions).isTrue()
         }
     }
 
@@ -479,14 +489,14 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Redact,
                     )
                 )
             )
-            assertThat(successState.displayEmojiReactions).isTrue()
         }
     }
 
@@ -505,15 +515,15 @@ class ActionListPresenterTest {
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
-                    messageEvent,
-                    persistentListOf(
+                    event = messageEvent,
+                    displayEmojiReactions = true,
+                    actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
                         TimelineItemAction.Redact,
                     )
                 )
             )
-            assertThat(successState.displayEmojiReactions).isTrue()
         }
     }
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
@@ -62,7 +62,7 @@ class ActionListPresenterTest {
         }.test {
             val initialState = awaitItem()
             val messageEvent = aMessageEvent(isMine = true, content = TimelineItemRedactedContent)
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -88,7 +88,7 @@ class ActionListPresenterTest {
         }.test {
             val initialState = awaitItem()
             val messageEvent = aMessageEvent(isMine = false, content = TimelineItemRedactedContent)
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -117,7 +117,7 @@ class ActionListPresenterTest {
                 isMine = false,
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -150,7 +150,7 @@ class ActionListPresenterTest {
                 isMine = false,
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = false))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = false, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -182,12 +182,44 @@ class ActionListPresenterTest {
                 isMine = false,
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = true, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = true, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
                     event = messageEvent,
                     displayEmojiReactions = true,
+                    actions = persistentListOf(
+                        TimelineItemAction.Reply,
+                        TimelineItemAction.Forward,
+                        TimelineItemAction.Copy,
+                        TimelineItemAction.ViewSource,
+                        TimelineItemAction.ReportContent,
+                        TimelineItemAction.Redact,
+                    )
+                )
+            )
+            initialState.eventSink.invoke(ActionListEvents.Clear)
+            assertThat(awaitItem().target).isEqualTo(ActionListState.Target.None)
+        }
+    }
+
+    @Test
+    fun `present - compute for others message and cannot send reaction`() = runTest {
+        val presenter = createActionListPresenter(isDeveloperModeEnabled = true)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val messageEvent = aMessageEvent(
+                isMine = false,
+                content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
+            )
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = true, canSendMessage = true, canSendReaction = false))
+            val successState = awaitItem()
+            assertThat(successState.target).isEqualTo(
+                ActionListState.Target.Success(
+                    event = messageEvent,
+                    displayEmojiReactions = false,
                     actions = persistentListOf(
                         TimelineItemAction.Reply,
                         TimelineItemAction.Forward,
@@ -214,7 +246,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -248,7 +280,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = aTimelineItemImageContent(),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -280,7 +312,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = aTimelineItemStateEventContent(),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(stateEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(stateEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -310,7 +342,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = aTimelineItemStateEventContent(),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(stateEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(stateEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -339,7 +371,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null)
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             // val loadingState = awaitItem()
             // assertThat(loadingState.target).isEqualTo(ActionListState.Target.Loading(messageEvent))
             val successState = awaitItem()
@@ -377,10 +409,10 @@ class ActionListPresenterTest {
                 content = TimelineItemRedactedContent,
             )
 
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             assertThat(awaitItem().target).isInstanceOf(ActionListState.Target.Success::class.java)
 
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(redactedEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(redactedEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             awaitItem().run {
                 assertThat(target).isEqualTo(ActionListState.Target.None)
             }
@@ -400,7 +432,7 @@ class ActionListPresenterTest {
                 content = TimelineItemTextContent(body = A_MESSAGE, htmlDocument = null, isEdited = false, formattedBody = null),
             )
 
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
@@ -428,7 +460,7 @@ class ActionListPresenterTest {
                 isEditable = true,
                 content = aTimelineItemPollContent(answerItems = aPollAnswerItemList(hasVotes = false)),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
@@ -457,7 +489,7 @@ class ActionListPresenterTest {
                 isEditable = false,
                 content = aTimelineItemPollContent(answerItems = aPollAnswerItemList(hasVotes = true)),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
@@ -485,7 +517,7 @@ class ActionListPresenterTest {
                 isEditable = false,
                 content = aTimelineItemPollContent(isEnded = true),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(
@@ -511,7 +543,7 @@ class ActionListPresenterTest {
                 isMine = true,
                 content = aTimelineItemVoiceContent(),
             )
-            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true))
+            initialState.eventSink.invoke(ActionListEvents.ComputeForMessage(messageEvent, canRedact = false, canSendMessage = true, canSendReaction = true))
             val successState = awaitItem()
             assertThat(successState.target).isEqualTo(
                 ActionListState.Target.Success(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Consider the user power level to enable or disable the ability to send reaction.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2093 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No change, hence I could add preview for the case of power level is too low.

## Tests

<!-- Explain how you tested your development -->

- Change the power level require to send a reaction and observe the effect

![ReactPermission](https://github.com/element-hq/element-x-android/assets/3940906/df732249-0428-4445-ace4-0697ccdc22e4)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
