### PR TITLE
Add build script for the RTE library

### DIFF
--- a/features/messages/impl/build.gradle.kts
+++ b/features/messages/impl/build.gradle.kts
@@ -74,7 +74,6 @@ dependencies {
     implementation(libs.vanniktech.blurhash)
     implementation(libs.telephoto.zoomableimage)
     implementation(libs.matrix.emojibase.bindings)
-    api(libs.matrix.richtexteditor.compose)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)

--- a/libraries/textcomposer/impl/build.gradle.kts
+++ b/libraries/textcomposer/impl/build.gradle.kts
@@ -34,8 +34,13 @@ dependencies {
     implementation(projects.libraries.testtags)
     implementation(projects.libraries.uiUtils)
 
-    api(libs.matrix.richtexteditor)
-    api(libs.matrix.richtexteditor.compose)
+    if (file("${rootDir.path}/libraries/textcomposer/lib/library-compose.aar").exists()) {
+        println("\nNote: Using local binaries of the Rich Text Editor.\n")
+        debugApi(projects.libraries.textcomposer.lib)
+    } else {
+        debugApi(libs.matrix.richtexteditor)
+        debugApi(libs.matrix.richtexteditor.compose)
+    }
 
     ksp(libs.showkase.processor)
 

--- a/libraries/textcomposer/impl/build.gradle.kts
+++ b/libraries/textcomposer/impl/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation(projects.libraries.testtags)
     implementation(projects.libraries.uiUtils)
 
+    releaseApi(libs.matrix.richtexteditor)
+    releaseApi(libs.matrix.richtexteditor.compose)
     if (file("${rootDir.path}/libraries/textcomposer/lib/library-compose.aar").exists()) {
         println("\nNote: Using local binaries of the Rich Text Editor.\n")
         debugApi(projects.libraries.textcomposer.lib)

--- a/libraries/textcomposer/lib/.gitignore
+++ b/libraries/textcomposer/lib/.gitignore
@@ -1,0 +1,2 @@
+# Built application files
+*.aar

--- a/libraries/textcomposer/lib/build.gradle.kts
+++ b/libraries/textcomposer/lib/build.gradle.kts
@@ -1,0 +1,3 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file("library.aar"))
+artifacts.add("default", file("library-compose.aar"))

--- a/tools/rte/build_rte.sh
+++ b/tools/rte/build_rte.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Ask to build from local source or to clone the repository
+read -p "Do you want to build the RTE from local source (yes/no) default to yes? " buildLocal
+buildLocal=${buildLocal:-yes}
+
+date=$(gdate +%Y%m%d%H%M%S)
+elementPwd=`pwd`
+
+# Ask for the RTE local source path
+# if folder rte/ exists, use it as default
+if [ ${buildLocal} == "yes" ]; then
+    read -p "Please enter the path to the Rust SDK local source, default to ../matrix-rich-text-editor: " rtePath
+    rtePath=${rtePath:-../matrix-rich-text-editor/}
+    if [ ! -d "${rtePath}" ]; then
+        printf "\nFolder ${rtePath} does not exist. Please clone the matrix-rich-text-editor repository in the folder ../matrix-rich-text-editor.\n\n"
+        exit 0
+    fi
+else
+    read -p "Please enter the RTE repository url, default to https://github.com/matrix-org/matrix-rich-text-editor.git " rteUrl
+    rteUrl=${rteUrl:-https://github.com/matrix-org/matrix-rich-text-editor.git}
+    read -p "Please enter the Rust SDK branch, default to main " rteBranch
+    rteBranch=${rteBranch:-main}
+    cd ..
+    git clone ${rteUrl} matrix-rich-text-editor-$date
+    cd matrix-rich-text-editor-$date
+    git checkout ${rteBranch}
+    rtePath=$(pwd)
+    cd ${elementPwd}
+fi
+
+
+cd ${rtePath}
+git status
+
+read -p "Will build with this version of the RTE ^. Is it correct (yes/no) default to yes? " rteCorrect
+rteCorrect=${rteCorrect:-yes}
+
+if [ ${rteCorrect} != "yes" ]; then
+    exit 0
+fi
+
+# Ask if the user wants to build the app after
+read -p "Do you want to build the app after (yes/no) default to yes? " buildApp
+buildApp=${buildApp:-yes}
+
+cd ${elementPwd}
+
+cd $rtePath
+
+printf "\nBuilding the RTE for aarch64...\n\n"
+make android-bindings-aarch64
+cd platforms/android
+./gradlew :library-compose:assembleRelease
+cp ./library/build/outputs/aar/library-release.aar $elementPwd/libraries/textcomposer/lib/library.aar
+cp ./library-compose/build/outputs/aar/library-compose-release.aar $elementPwd/libraries/textcomposer/lib/library-compose.aar
+
+cd ${elementPwd}
+mkdir -p ./libraries/textcomposer/lib/versions
+cp ./libraries/textcomposer/lib/library.aar ./libraries/textcomposer/lib/versions/library-${date}.aar
+cp ./libraries/textcomposer/lib/library-compose.aar ./libraries/textcomposer/lib/versions/library-compose-${date}.aar
+
+
+if [ ${buildApp} == "yes" ]; then
+    printf "\nBuilding the application...\n\n"
+    ./gradlew assembleDebug
+fi
+
+if [ ${buildLocal} == "no" ]; then
+    printf "\nCleaning up...\n\n"
+    rm -rf ../matrix-rich-text-editor-$date
+fi
+
+printf "\nDone!\n"

--- a/tools/rte/build_rte.sh
+++ b/tools/rte/build_rte.sh
@@ -54,7 +54,7 @@ cd $rtePath
 printf "\nBuilding the RTE for aarch64...\n\n"
 make android-bindings-aarch64
 cd platforms/android
-./gradlew :library-compose:assembleRelease
+./gradlew clean :library:assembleRelease :library-compose:assembleRelease
 cp ./library/build/outputs/aar/library-release.aar $elementPwd/libraries/textcomposer/lib/library.aar
 cp ./library-compose/build/outputs/aar/library-compose-release.aar $elementPwd/libraries/textcomposer/lib/library-compose.aar
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Adds a `tools/rte/build_rte.sh` script that generates local AARs for the RTE library.
- Adds a `:libraries:textcomposer:lib` module that uses them when they exist, instead of the maven dependency.

## Motivation and context

To be able to easily test RTE changes against the EX app.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
