### PR TITLE
Fix record screenshots workflow and script for forks

### DIFF
--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -26,7 +26,7 @@ jobs:
         uses: nschloe/action-cached-lfs-checkout@v1.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       - name: ⏬ Checkout with LFS (Branch)
         if: github.event_name == 'workflow_dispatch'
         uses: nschloe/action-cached-lfs-checkout@v1.2.2
@@ -45,6 +45,5 @@ jobs:
       - name: Record screenshots
         run: ./.github/workflows/scripts/recordScreenshots.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-

--- a/.github/workflows/scripts/recordScreenshots.sh
+++ b/.github/workflows/scripts/recordScreenshots.sh
@@ -68,11 +68,27 @@ echo "Record screenshots"
 ./gradlew recordPaparazziDebug --stacktrace -PpreDexEnable=false --max-workers 4 --warn
 
 echo "Committing changes"
-git config user.name "ElementBot"
-git config user.email "benoitm+elementbot@element.io"
+git config http.sslVerify false
+
+if [[ -z ${INPUT_AUTHOR_NAME} ]]; then
+  git config user.name "ElementBot"
+else
+  git config --local user.name "${INPUT_AUTHOR_NAME}"
+fi
+
+if [[ -z ${INPUT_AUTHOR_EMAIL} ]]; then
+  git config user.email "benoitm+elementbot@element.io"
+else
+  git config --local user.name "${INPUT_AUTHOR_EMAIL}"
+fi
 git add -A
 git commit -m "Update screenshots"
 
+GITHUB_REPO="https://$GITHUB_ACTOR:$TOKEN@github.com/$REPO.git"
 echo "Pushing changes"
-git push "https://$TOKEN@github.com/$REPO.git" $BRANCH
+if [[ -z ${GITHUB_ACTOR} ]]; then
+  echo "No GITHUB_ACTOR env var"
+  GITHUB_REPO="https://$TOKEN@github.com/$REPO.git"
+fi
+git push $GITHUB_REPO "$BRANCH"
 echo "Done!"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : fix CI step for forks.

## Content

Changes the script and workflow files for the record screenshot step so it's compatible with forks too.

## Motivation and context

The 'Record screenshots' job wasn't working for forks, and having consistent screenshots generated by the CI is a must for us. We could try to merge the PRs from forks to a branch on our repo other than `develop` and then run the screenshot recording ourselves, but it's probably not something sustainable in the long term.

## Tests

- [x] Run record screenshot job from the label in our repo: https://github.com/element-hq/element-x-android/actions/runs/7383299546?pr=2141.
- [x] Run record screenshot job from the GH actions screen: https://github.com/element-hq/element-x-android/actions/runs/7383393152
- [x] Run record screenshot job from the GH actions screen in a fork: https://github.com/jmartinesp/element-x-android/actions/runs/7383233614/job/20084103172

Sadly, it's not possible to run the GH action using the label on PRs that come from forks, since the `GITHUB_TOKEN` used is read only and won't allow you to upload anything to the original branch. Users who upload PRs will have to run the action manually in their repo.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
