### PR TITLE
Restore Github PAT in record screenshots, disable Maestro for forks

### DIFF
--- a/.github/workflows/fork-pr-notice.yml
+++ b/.github/workflows/fork-pr-notice.yml
@@ -1,0 +1,30 @@
+name: Community PR notice
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    name: Welcome comment
+    steps:
+      - name: Add auto-generated commit warning
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Thank you for your contribution! Here are a few things to check in the PR to ensure it's reviewed as quickly as possible:
+            
+                - Your branch should be based on `origin/develop`, at least when it was created.
+                - There is a changelog entry in the `changelog.d` folder with [the Towncrier format](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments).
+                - The test pass locally running `./gradlew test`.
+                - The code quality check suite pass locally running `./gradlew runQualityChecks`.
+                - If you modified anything related to the UI, including previews, you'll have to run the `Record screenshots` GH action in your forked repo: that will generate compatible new screenshots. However, given Github Actions limitations, **it will prevent the CI from running temporarily**, until you upload a new commit after that one. To do so, just pull the latest changes and push [an empty commit](https://coderwall.com/p/vkdekq/git-commit-allow-empty).`
+            })

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -24,27 +24,31 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Remove Run-Maestro label
-        if: ${{ github.event.label.name == 'Run-Maestro' }}
+        if: ${{ !github.event.pull_request.fork && github.event.label.name == 'Run-Maestro' }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: Run-Maestro
       - uses: actions/checkout@v4
+        if: ${{ !github.event.pull_request.fork }}
         with:
           # Ensure we are building the branch and not the branch after being merged on develop
           # https://github.com/actions/checkout/issues/881
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v4
         name: Use JDK 17
+        if: ${{ !github.event.pull_request.fork }}
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
       - name: Assemble debug APK
         run: ./gradlew :app:assembleDebug $CI_GRADLE_ARG_PROPERTIES
+        if: ${{ !github.event.pull_request.fork }}
         env:
           ELEMENT_ANDROID_MAPTILER_API_KEY: ${{ secrets.MAPTILER_KEY }}
           ELEMENT_ANDROID_MAPTILER_LIGHT_MAP_ID: ${{ secrets.MAPTILER_LIGHT_MAP_ID }}
           ELEMENT_ANDROID_MAPTILER_DARK_MAP_ID: ${{ secrets.MAPTILER_DARK_MAP_ID }}
       - uses: mobile-dev-inc/action-maestro-cloud@v1.8.0
+        if: ${{ !github.event.pull_request.fork }}
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           # Doc says (https://github.com/mobile-dev-inc/action-maestro-cloud#android):

--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -43,7 +43,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Record screenshots
+        id: record
         run: ./.github/workflows/scripts/recordScreenshots.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : fix CI (again)

## Content

- Restores the GH PAT so we can use the record screenshot action properly and not have the CI blocked for ourselves.
- Skips Maestro check for PRs from forks, since it won't be able to run anyway.
- Adds a new workflow that should run on PRs from forks and add a comment explaining different checks and how to handle the record screenshots task.

## Motivation and context

Fix `Record screenshots` blocking the CI until a new commit is uploaded in our repo.
