### PR TITLE
[Technical] Open stickers using the thumbnail url if the main url is empty

### DIFF
--- a/changelog.d/1949.bugfix
+++ b/changelog.d/1949.bugfix
@@ -1,0 +1,1 @@
+Make sure the media viewer tries the main url first (if not empty) then the thumbnail url and then not open if both are missing instead of failing with an error dialog

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
@@ -255,17 +255,25 @@ class MessagesFlowNode @AssistedInject constructor(
                 overlay.show(navTarget)
             }
             is TimelineItemStickerContent -> {
-                val navTarget = NavTarget.MediaViewer(
-                    mediaInfo = MediaInfo(
-                        name = event.content.body,
-                        mimeType = event.content.mimeType,
-                        formattedFileSize = event.content.formattedFileSize,
-                        fileExtension = event.content.fileExtension
-                    ),
-                    mediaSource = event.content.mediaSource,
-                    thumbnailSource = event.content.thumbnailSource,
-                )
-                overlay.show(navTarget)
+                /* Sticker may have an empty url and no thumbnail
+                   if encrypted on certain bridges */
+                if (event.content.preferredMediaSource != null) {
+                    val navTarget = NavTarget.MediaViewer(
+                        mediaInfo = MediaInfo(
+                            name = event.content.body,
+                            mimeType = event.content.mimeType,
+                            formattedFileSize = event.content.formattedFileSize,
+                            fileExtension = event.content.fileExtension
+                        ),
+                        mediaSource = event.content.preferredMediaSource,
+                        thumbnailSource = event.content.thumbnailSource,
+                    )
+                    overlay.show(navTarget)
+                }
+                else
+                {
+                    Unit
+                }
             }
             is TimelineItemVideoContent -> {
                 val navTarget = NavTarget.MediaViewer(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
@@ -270,10 +270,6 @@ class MessagesFlowNode @AssistedInject constructor(
                     )
                     overlay.show(navTarget)
                 }
-                else
-                {
-                    Unit
-                }
             }
             is TimelineItemVideoContent -> {
                 val navTarget = NavTarget.MediaViewer(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemStickerContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemStickerContent.kt
@@ -16,7 +16,6 @@
 
 package io.element.android.features.messages.impl.timeline.model.event
 
-import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.matrix.api.media.MediaSource
 
 data class TimelineItemStickerContent(
@@ -33,9 +32,7 @@ data class TimelineItemStickerContent(
 ) : TimelineItemEventContent {
     override val type: String = "TimelineItemStickerContent"
 
-    val preferredMediaSource = if (mimeType == MimeTypes.Gif) {
-        mediaSource
-    } else {
-        thumbnailSource ?: mediaSource
-    }
+    /* Stickers are supposed to be small images so
+       we allow using the mediaSource (unless the url is empty) */
+    val preferredMediaSource = if (mediaSource.url.isEmpty()) thumbnailSource else mediaSource
 }


### PR DESCRIPTION
This is a workaround for https://github.com/matrix-org/matrix-spec/issues/1667

Several bridges (see https://github.com/mautrix/whatsapp/pull/680) correctly send stickers as encrypted images but the spec doesn't cover that and the Rust SDK fails to parse them unless the url field is there (it can be an empty string)

This change makes sure the media viewer opens the sticker using the thumbnail url (if present) and it does not open if not (instead of trying to load an empty url and end with an error message)

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Use the thumbnail url if the event's main url is empty

## Motivation and context

Adding the real url might confuse other clients.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Bridge a sticker from whatsapp/telegram/signal with the patch that adds the url field
OR
Copy the event and send it to a room manually adding the url field
- See the sticker, click it, it opens

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
