### PR TITLE
Disable forwarding for stickers (until it can be properly fixed)

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
@@ -152,6 +152,8 @@ class ActionListPresenter @Inject constructor(
                                 add(TimelineItemAction.Reply)
                             }
                         }
+                        // Stickers can't be forwarded (yet) so we don't show the option
+                        // See https://github.com/element-hq/element-x-android/issues/2161
                         if (!timelineItem.isSticker) {
                             add(TimelineItemAction.Forward)
                         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
@@ -152,7 +152,9 @@ class ActionListPresenter @Inject constructor(
                                 add(TimelineItemAction.Reply)
                             }
                         }
-                        add(TimelineItemAction.Forward)
+                        if (!timelineItem.isSticker) {
+                            add(TimelineItemAction.Forward)
+                        }
                     }
                     if (timelineItem.isMine && timelineItem.isTextMessage) {
                         add(TimelineItemAction.Edit)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
@@ -18,6 +18,7 @@ package io.element.android.features.messages.impl.timeline.model
 
 import androidx.compose.runtime.Immutable
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContent
+import io.element.android.features.messages.impl.timeline.model.event.TimelineItemStickerContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContent
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemVirtualModel
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
@@ -80,6 +81,8 @@ sealed interface TimelineItem {
         val failedToSend: Boolean = localSendState is LocalEventSendState.SendingFailed
 
         val isTextMessage: Boolean = content is TimelineItemTextBasedContent
+
+        val isSticker: Boolean = content is TimelineItemStickerContent
 
         val isRemote = eventId != null
     }


### PR DESCRIPTION
Related to #2161 

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Sticker forwarding doesn't work and it needs more work to fix it
Since this is probably not very urgent I'm just disabling forwarding for sticker events

## Motivation and context

We don't want broken functionality to be available

## Screenshots / GIFs
![image](https://github.com/element-hq/element-x-android/assets/683652/499bdb99-f461-4ca3-b58b-7afd2dbf318d)

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Long press a sticker
- Forward should not be there

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):
Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
