### PR TITLE
Fix crashes for extremely long messages with no line breaks

### DIFF
--- a/changelog.d/2105.bugfix
+++ b/changelog.d/2105.bugfix
@@ -1,0 +1,1 @@
+Fix crashes in room list when the last message for a room was an extremely long one (several thousands of characters) with no line breaks.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/MessageSummaryFormatterImpl.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/MessageSummaryFormatterImpl.kt
@@ -42,6 +42,12 @@ import javax.inject.Inject
 class MessageSummaryFormatterImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : MessageSummaryFormatter {
+
+    companion object {
+        // Max characters to display in the summary message. This works around https://github.com/element-hq/element-x-android/issues/2105
+        private const val MAX_SAFE_LENGTH = 500
+    }
+
     override fun format(event: TimelineItem.Event): String {
         return when (event.content) {
             is TimelineItemTextBasedContent -> event.content.plainText
@@ -58,6 +64,6 @@ class MessageSummaryFormatterImpl @Inject constructor(
             is TimelineItemVideoContent -> context.getString(CommonStrings.common_video)
             is TimelineItemFileContent -> context.getString(CommonStrings.common_file)
             is TimelineItemAudioContent -> context.getString(CommonStrings.common_audio)
-        }
+        }.take(MAX_SAFE_LENGTH)
     }
 }

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -63,47 +63,52 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
     private val stateContentFormatter: StateContentFormatter,
 ) : RoomLastMessageFormatter {
 
+    companion object {
+        // Max characters to display in the last message. This works around https://github.com/element-hq/element-x-android/issues/2105
+        private const val MAX_SAFE_LENGTH = 500
+    }
+
     override fun format(event: EventTimelineItem, isDmRoom: Boolean): CharSequence? {
         val isOutgoing = event.isOwn
         val senderDisplayName = (event.senderProfile as? ProfileTimelineDetails.Ready)?.displayName ?: event.sender.value
         return when (val content = event.content) {
-            is MessageContent -> processMessageContents(content, senderDisplayName, isDmRoom)
-            RedactedContent -> {
-                val message = sp.getString(CommonStrings.common_message_removed)
-                if (!isDmRoom) {
-                    prefix(message, senderDisplayName)
-                } else {
-                    message
+                is MessageContent -> processMessageContents(content, senderDisplayName, isDmRoom)
+                RedactedContent -> {
+                    val message = sp.getString(CommonStrings.common_message_removed)
+                    if (!isDmRoom) {
+                        prefix(message, senderDisplayName)
+                    } else {
+                        message
+                    }
                 }
-            }
-            is StickerContent -> {
-                content.body
-            }
-            is UnableToDecryptContent -> {
-                val message = sp.getString(CommonStrings.common_waiting_for_decryption_key)
-                if (!isDmRoom) {
-                    prefix(message, senderDisplayName)
-                } else {
-                    message
+                is StickerContent -> {
+                    content.body
                 }
-            }
-            is RoomMembershipContent -> {
-                roomMembershipContentFormatter.format(content, senderDisplayName, isOutgoing)
-            }
-            is ProfileChangeContent -> {
-                profileChangeContentFormatter.format(content, senderDisplayName, isOutgoing)
-            }
-            is StateContent -> {
-                stateContentFormatter.format(content, senderDisplayName, isOutgoing, RenderingMode.RoomList)
-            }
-            is PollContent -> {
-                val message = sp.getString(CommonStrings.common_poll_summary, content.question)
-                prefixIfNeeded(message, senderDisplayName, isDmRoom)
-            }
-            is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {
-                prefixIfNeeded(sp.getString(CommonStrings.common_unsupported_event), senderDisplayName, isDmRoom)
-            }
-        }
+                is UnableToDecryptContent -> {
+                    val message = sp.getString(CommonStrings.common_waiting_for_decryption_key)
+                    if (!isDmRoom) {
+                        prefix(message, senderDisplayName)
+                    } else {
+                        message
+                    }
+                }
+                is RoomMembershipContent -> {
+                    roomMembershipContentFormatter.format(content, senderDisplayName, isOutgoing)
+                }
+                is ProfileChangeContent -> {
+                    profileChangeContentFormatter.format(content, senderDisplayName, isOutgoing)
+                }
+                is StateContent -> {
+                    stateContentFormatter.format(content, senderDisplayName, isOutgoing, RenderingMode.RoomList)
+                }
+                is PollContent -> {
+                    val message = sp.getString(CommonStrings.common_poll_summary, content.question)
+                    prefixIfNeeded(message, senderDisplayName, isDmRoom)
+                }
+                is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {
+                    prefixIfNeeded(sp.getString(CommonStrings.common_unsupported_event), senderDisplayName, isDmRoom)
+                }
+            }?.take(MAX_SAFE_LENGTH)
     }
 
     private fun processMessageContents(messageContent: MessageContent, senderDisplayName: String, isDmRoom: Boolean): CharSequence? {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Adds a max safe length for room list's last message and message summaries.

## Motivation and context

Fixes #2105 .

This can affect the rendering of the timeline too, but I'm not sure about how to handle this. Should we hard truncate them at N length? Should we look for the first `\n` char and if it's > N truncate it them? Should we add some suffix to the end of the message to make sure users understand it's been truncated?

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

- In `DefaultRoomLastMessageFormatter.kt`, replace one of the results with some `buildString { ... }` that ends up having several thousand characters without any line breaks.
- Run the app with those changes.

If it doesn't crash, the substring is doing its job and the issue is fixed. To be sure you can remove the trailing `.take(MAX_SAFE_LENGTH)` expression.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
