### PR TITLE
Trim whitespace at the end of messages

### DIFF
--- a/changelog.d/2099.bugfix
+++ b/changelog.d/2099.bugfix
@@ -1,0 +1,1 @@
+Trim whitespace at the end of messages to ensure we render the right content.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -74,7 +74,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             is EmoteMessageType -> {
                 val emoteBody = "* $senderDisplayName ${messageType.body}"
                 TimelineItemEmoteContent(
-                    body = emoteBody,
+                    body = emoteBody.trimEnd(),
                     htmlDocument = messageType.formatted?.toHtmlDocument(prefix = "* $senderDisplayName"),
                     formattedBody = parseHtml(messageType.formatted, prefix = "* $senderDisplayName") ?: emoteBody.withLinks(),
                     isEdited = content.isEdited,
@@ -83,7 +83,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             is ImageMessageType -> {
                 val aspectRatio = aspectRatioOf(messageType.info?.width, messageType.info?.height)
                 TimelineItemImageContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     mediaSource = messageType.source,
                     thumbnailSource = messageType.info?.thumbnailSource,
                     mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -98,7 +98,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             is StickerMessageType -> {
                 val aspectRatio = aspectRatioOf(messageType.info?.width, messageType.info?.height)
                 TimelineItemStickerContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     mediaSource = messageType.source,
                     thumbnailSource = messageType.info?.thumbnailSource,
                     mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -114,7 +114,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
                 val location = Location.fromGeoUri(messageType.geoUri)
                 if (location == null) {
                     TimelineItemTextContent(
-                        body = messageType.body,
+                        body = messageType.body.trimEnd(),
                         htmlDocument = null,
                         plainText = messageType.body,
                         formattedBody = null,
@@ -131,7 +131,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             is VideoMessageType -> {
                 val aspectRatio = aspectRatioOf(messageType.info?.width, messageType.info?.height)
                 TimelineItemVideoContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     thumbnailSource = messageType.info?.thumbnailSource,
                     videoSource = messageType.source,
                     mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -146,7 +146,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             }
             is AudioMessageType -> {
                 TimelineItemAudioContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     mediaSource = messageType.source,
                     duration = messageType.info?.duration ?: Duration.ZERO,
                     mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -159,7 +159,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
                     true -> {
                         TimelineItemVoiceContent(
                             eventId = eventId,
-                            body = messageType.body,
+                            body = messageType.body.trimEnd(),
                             mediaSource = messageType.source,
                             duration = messageType.info?.duration ?: Duration.ZERO,
                             mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -168,7 +168,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
                     }
                     false -> {
                         TimelineItemAudioContent(
-                            body = messageType.body,
+                            body = messageType.body.trimEnd(),
                             mediaSource = messageType.source,
                             duration = messageType.info?.duration ?: Duration.ZERO,
                             mimeType = messageType.info?.mimetype ?: MimeTypes.OctetStream,
@@ -181,7 +181,7 @@ class TimelineItemContentMessageFactory @Inject constructor(
             is FileMessageType -> {
                 val fileExtension = fileExtensionExtractor.extractFromName(messageType.body)
                 TimelineItemFileContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     thumbnailSource = messageType.info?.thumbnailSource,
                     fileSource = messageType.source,
                     mimeType = messageType.info?.mimetype ?: MimeTypes.fromFileExtension(fileExtension),
@@ -190,21 +190,21 @@ class TimelineItemContentMessageFactory @Inject constructor(
                 )
             }
             is NoticeMessageType -> TimelineItemNoticeContent(
-                body = messageType.body,
+                body = messageType.body.trimEnd(),
                 htmlDocument = messageType.formatted?.toHtmlDocument(),
                 formattedBody = parseHtml(messageType.formatted) ?: messageType.body.withLinks(),
                 isEdited = content.isEdited,
             )
             is TextMessageType -> {
                 TimelineItemTextContent(
-                    body = messageType.body,
+                    body = messageType.body.trimEnd(),
                     htmlDocument = messageType.formatted?.toHtmlDocument(),
                     formattedBody = parseHtml(messageType.formatted) ?: messageType.body.withLinks(),
                     isEdited = content.isEdited,
                 )
             }
             is OtherMessageType -> TimelineItemTextContent(
-                body = messageType.body,
+                body = messageType.body.trimEnd(),
                 htmlDocument = null,
                 formattedBody = messageType.body.withLinks(),
                 isEdited = content.isEdited,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -17,7 +17,6 @@
 package io.element.android.features.messages.impl.timeline.factories.event
 
 import android.text.Spannable
-import android.text.SpannedString
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import androidx.core.text.buildSpannedString

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -32,7 +32,11 @@ import org.jsoup.nodes.Document
  * @param prefix if not null, the prefix will be inserted at the beginning of the message.
  */
 fun FormattedBody.toHtmlDocument(prefix: String? = null): Document? {
-    return takeIf { it.format == MessageFormat.HTML }?.body?.let { formattedBody ->
+    return takeIf { it.format == MessageFormat.HTML }?.body
+        // Trim whitespace at the end to avoid having wrong rendering of the message.
+        // We don't trim the start in case it's used as indentation.
+        ?.trimEnd()
+        ?.let { formattedBody ->
         val dom = if (prefix != null) {
             Jsoup.parse("$prefix $formattedBody")
         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Trim whitespace *at the end* of both formatted and plain text messages. We don't trim leading whitespace in case it's used for formatting or some nice ASCII art.

```
             (__)    
     `\------(oo)
       ||    (__)
       ||w--||     \|/
   \|/
```

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/2099.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Send a message with one or several trailing whitespaces or new lines.

In the timeline those extra whitespace chars should be gone.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
