### PR TITLE
Use `SubcomposeLayout` for `ContentAvoidingLayout`

### DIFF
--- a/changelog.d/2155.bugfix
+++ b/changelog.d/2155.bugfix
@@ -1,0 +1,1 @@
+Use `SubomposeLayout` for `ContentAvoidingLayout` to prevent wrong measurements in the layout process, leading to cut-off text messages in the timeline.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Constraints
@@ -58,23 +59,18 @@ fun ContentAvoidingLayout(
 ) {
     val scope = remember { ContentAvoidingLayoutScopeInstance() }
 
-    Layout(
+    SubcomposeLayout(
         modifier = modifier,
-        content = {
-            scope.content()
-            overlay()
-        }
-    ) { measurables, constraints ->
-        assert(measurables.size == 2) { "ContentAvoidingLayout must have exactly 2 children" }
+    ) { constraints ->
 
         // Measure the `overlay` view first, in case we need to shrink the `content`
-        val overlayPlaceable = measurables.last().measure(Constraints(minWidth = 0, maxWidth = constraints.maxWidth))
+        val overlayPlaceable = subcompose(0, overlay).first().measure(Constraints(minWidth = 0, maxWidth = constraints.maxWidth))
         val contentConstraints = if (shrinkContent) {
             Constraints(minWidth = 0, maxWidth = constraints.maxWidth - overlayPlaceable.width)
         } else {
             Constraints(minWidth = 0, maxWidth = constraints.maxWidth)
         }
-        val contentPlaceable = measurables.first().measure(contentConstraints)
+        val contentPlaceable = subcompose(1) { scope.content() }.first().measure(contentConstraints)
 
         var layoutWidth = contentPlaceable.width
         var layoutHeight = contentPlaceable.height


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Uses `SubomposeLayout` instead of just `Layout` for `ContentAvoidingLayout`.

## Motivation and context

Fixes #2155.

## Screenshots / GIFs

No change.

## Tests

Hopefully, this won't cause performance issues.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
