### PR TITLE
Add first tests on compose click interaction.

### DIFF
--- a/features/logout/impl/build.gradle.kts
+++ b/features/logout/impl/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     testImplementation(libs.test.robolectric)
     testImplementation(libs.test.junitext)
     testImplementation(libs.androidx.compose.ui.test.junit)
+    testReleaseImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.libraries.featureflag.test)
     testImplementation(projects.tests.testutils)

--- a/features/logout/impl/build.gradle.kts
+++ b/features/logout/impl/build.gradle.kts
@@ -22,6 +22,12 @@ plugins {
 
 android {
     namespace = "io.element.android.features.logout.impl"
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 anvil {
@@ -48,6 +54,9 @@ dependencies {
     testImplementation(libs.molecule.runtime)
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
+    testImplementation(libs.test.robolectric)
+    testImplementation(libs.test.junitext)
+    testImplementation(libs.androidx.compose.ui.test.junit)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.libraries.featureflag.test)
     testImplementation(projects.tests.testutils)

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutStateProvider.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutStateProvider.kt
@@ -48,6 +48,7 @@ fun aLogoutState(
     recoveryState: RecoveryState = RecoveryState.ENABLED,
     backupUploadState: BackupUploadState = BackupUploadState.Unknown,
     logoutAction: AsyncAction<String?> = AsyncAction.Uninitialized,
+    eventSink: (LogoutEvents) -> Unit = {},
 ) = LogoutState(
     isLastSession = isLastSession,
     backupState = backupState,
@@ -55,5 +56,5 @@ fun aLogoutState(
     recoveryState = recoveryState,
     backupUploadState = backupUploadState,
     logoutAction = logoutAction,
-    eventSink = {}
+    eventSink = eventSink,
 )

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.logout.impl
+
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.libraries.architecture.AsyncAction
+import io.element.android.tests.testutils.EnsureCalledOnce
+import io.element.android.tests.testutils.EnsureCalledOnceWithParam
+import io.element.android.tests.testutils.EnsureNeverCalled
+import io.element.android.tests.testutils.EnsureNeverCalledWithParam
+import io.element.android.tests.testutils.EventsRecorder
+import io.element.android.tests.testutils.clickOn
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LogoutViewTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun `clicking on logout sends a LogoutEvents`() {
+        val eventsRecorder = EventsRecorder<LogoutEvents>()
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                onBackClicked = EnsureNeverCalled(),
+                onSuccessLogout = EnsureNeverCalledWithParam(),
+            )
+        }
+        rule.clickOn("Sign out")
+        eventsRecorder.assertSingle(LogoutEvents.Logout(false))
+    }
+
+    @Test
+    fun `clicking on back invoke back callback`() {
+        val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
+        val callback = EnsureCalledOnce()
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                onBackClicked = callback,
+                onSuccessLogout = EnsureNeverCalledWithParam(),
+            )
+        }
+        rule.onNode(hasContentDescription("Back")).performClick()
+        callback.assertSuccess()
+    }
+
+    @Test
+    fun `clicking on confirm after error sends a LogoutEvents`() {
+        val eventsRecorder = EventsRecorder<LogoutEvents>()
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    logoutAction = AsyncAction.Failure(Exception("Failed to logout")),
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                onBackClicked = EnsureNeverCalled(),
+                onSuccessLogout = EnsureNeverCalledWithParam(),
+            )
+        }
+        rule.clickOn("Sign out anyway")
+        eventsRecorder.assertSingle(LogoutEvents.Logout(true))
+    }
+
+    @Test
+    fun `clicking on cancel after error sends a LogoutEvents`() {
+        val eventsRecorder = EventsRecorder<LogoutEvents>()
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    logoutAction = AsyncAction.Failure(Exception("Failed to logout")),
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                onBackClicked = EnsureNeverCalled(),
+                onSuccessLogout = EnsureNeverCalledWithParam(),
+            )
+        }
+        rule.clickOn("Cancel")
+        eventsRecorder.assertSingle(LogoutEvents.CloseDialogs)
+    }
+
+    @Test
+    fun `success logout invoke onSuccessLogout`() {
+        val data = "data"
+        val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
+        val callback = EnsureCalledOnceWithParam<String?>(data)
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    logoutAction = AsyncAction.Success(data),
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                onBackClicked = EnsureNeverCalled(),
+                onSuccessLogout = callback,
+            )
+        }
+        callback.assertSuccess()
+    }
+
+    @Test
+    fun `last session setting button invoke onChangeRecoveryKeyClicked`() {
+        val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
+        val callback = EnsureCalledOnce()
+        rule.setContent {
+            LogoutView(
+                aLogoutState(
+                    isLastSession = true,
+                    eventSink = eventsRecorder
+                ),
+                onChangeRecoveryKeyClicked = callback,
+                onBackClicked = EnsureNeverCalled(),
+                onSuccessLogout = EnsureNeverCalledWithParam(),
+            )
+        }
+        rule.clickOn("Settings")
+        callback.assertSuccess()
+    }
+}

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
@@ -16,17 +16,18 @@
 
 package io.element.android.features.logout.impl
 
-import androidx.compose.ui.test.hasContentDescription
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.performClick
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.libraries.architecture.AsyncAction
+import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.tests.testutils.EnsureCalledOnce
 import io.element.android.tests.testutils.EnsureCalledOnceWithParam
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
+import io.element.android.tests.testutils.pressBack
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,7 +35,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class LogoutViewTest {
 
-    @get:Rule val rule = createComposeRule()
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun `clicking on logout sends a LogoutEvents`() {
@@ -49,7 +50,7 @@ class LogoutViewTest {
                 onSuccessLogout = EnsureNeverCalledWithParam(),
             )
         }
-        rule.clickOn("Sign out")
+        rule.clickOn(CommonStrings.action_signout)
         eventsRecorder.assertSingle(LogoutEvents.Logout(false))
     }
 
@@ -67,7 +68,7 @@ class LogoutViewTest {
                 onSuccessLogout = EnsureNeverCalledWithParam(),
             )
         }
-        rule.onNode(hasContentDescription("Back")).performClick()
+        rule.pressBack()
         callback.assertSuccess()
     }
 
@@ -85,7 +86,7 @@ class LogoutViewTest {
                 onSuccessLogout = EnsureNeverCalledWithParam(),
             )
         }
-        rule.clickOn("Sign out anyway")
+        rule.clickOn(CommonStrings.action_signout_anyway)
         eventsRecorder.assertSingle(LogoutEvents.Logout(true))
     }
 
@@ -103,7 +104,7 @@ class LogoutViewTest {
                 onSuccessLogout = EnsureNeverCalledWithParam(),
             )
         }
-        rule.clickOn("Cancel")
+        rule.clickOn(CommonStrings.action_cancel)
         eventsRecorder.assertSingle(LogoutEvents.CloseDialogs)
     }
 
@@ -141,7 +142,7 @@ class LogoutViewTest {
                 onSuccessLogout = EnsureNeverCalledWithParam(),
             )
         }
-        rule.clickOn("Settings")
+        rule.clickOn(CommonStrings.common_settings)
         callback.assertSuccess()
     }
 }

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
@@ -21,12 +21,12 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.ui.strings.CommonStrings
-import io.element.android.tests.testutils.EnsureCalledOnce
-import io.element.android.tests.testutils.EnsureCalledOnceWithParam
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
+import io.element.android.tests.testutils.ensureCalledOnce
+import io.element.android.tests.testutils.ensureCalledOnceWithParam
 import io.element.android.tests.testutils.pressBack
 import org.junit.Rule
 import org.junit.Test
@@ -57,7 +57,7 @@ class LogoutViewTest {
     @Test
     fun `clicking on back invoke back callback`() {
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        EnsureCalledOnce().run { callback ->
+        ensureCalledOnce { callback ->
             rule.setContent {
                 LogoutView(
                     aLogoutState(
@@ -112,7 +112,7 @@ class LogoutViewTest {
     fun `success logout invoke onSuccessLogout`() {
         val data = "data"
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        EnsureCalledOnceWithParam<String?>(data).run { callback ->
+        ensureCalledOnceWithParam<String?>(data) { callback ->
             rule.setContent {
                 LogoutView(
                     aLogoutState(
@@ -130,7 +130,7 @@ class LogoutViewTest {
     @Test
     fun `last session setting button invoke onChangeRecoveryKeyClicked`() {
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        EnsureCalledOnce().run { callback ->
+        ensureCalledOnce { callback ->
             rule.setContent {
                 LogoutView(
                     aLogoutState(

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutViewTest.kt
@@ -57,19 +57,19 @@ class LogoutViewTest {
     @Test
     fun `clicking on back invoke back callback`() {
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        val callback = EnsureCalledOnce()
-        rule.setContent {
-            LogoutView(
-                aLogoutState(
-                    eventSink = eventsRecorder
-                ),
-                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
-                onBackClicked = callback,
-                onSuccessLogout = EnsureNeverCalledWithParam(),
-            )
+        EnsureCalledOnce().run { callback ->
+            rule.setContent {
+                LogoutView(
+                    aLogoutState(
+                        eventSink = eventsRecorder
+                    ),
+                    onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                    onBackClicked = callback,
+                    onSuccessLogout = EnsureNeverCalledWithParam(),
+                )
+            }
+            rule.pressBack()
         }
-        rule.pressBack()
-        callback.assertSuccess()
     }
 
     @Test
@@ -112,37 +112,37 @@ class LogoutViewTest {
     fun `success logout invoke onSuccessLogout`() {
         val data = "data"
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        val callback = EnsureCalledOnceWithParam<String?>(data)
-        rule.setContent {
-            LogoutView(
-                aLogoutState(
-                    logoutAction = AsyncAction.Success(data),
-                    eventSink = eventsRecorder
-                ),
-                onChangeRecoveryKeyClicked = EnsureNeverCalled(),
-                onBackClicked = EnsureNeverCalled(),
-                onSuccessLogout = callback,
-            )
+        EnsureCalledOnceWithParam<String?>(data).run { callback ->
+            rule.setContent {
+                LogoutView(
+                    aLogoutState(
+                        logoutAction = AsyncAction.Success(data),
+                        eventSink = eventsRecorder
+                    ),
+                    onChangeRecoveryKeyClicked = EnsureNeverCalled(),
+                    onBackClicked = EnsureNeverCalled(),
+                    onSuccessLogout = callback,
+                )
+            }
         }
-        callback.assertSuccess()
     }
 
     @Test
     fun `last session setting button invoke onChangeRecoveryKeyClicked`() {
         val eventsRecorder = EventsRecorder<LogoutEvents>(expectEvents = false)
-        val callback = EnsureCalledOnce()
-        rule.setContent {
-            LogoutView(
-                aLogoutState(
-                    isLastSession = true,
-                    eventSink = eventsRecorder
-                ),
-                onChangeRecoveryKeyClicked = callback,
-                onBackClicked = EnsureNeverCalled(),
-                onSuccessLogout = EnsureNeverCalledWithParam(),
-            )
+        EnsureCalledOnce().run { callback ->
+            rule.setContent {
+                LogoutView(
+                    aLogoutState(
+                        isLastSession = true,
+                        eventSink = eventsRecorder
+                    ),
+                    onChangeRecoveryKeyClicked = callback,
+                    onBackClicked = EnsureNeverCalled(),
+                    onSuccessLogout = EnsureNeverCalledWithParam(),
+                )
+            }
+            rule.clickOn(CommonStrings.common_settings)
         }
-        rule.clickOn(CommonStrings.common_settings)
-        callback.assertSuccess()
     }
 }

--- a/tests/testutils/build.gradle.kts
+++ b/tests/testutils/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.test.truth)
     implementation(libs.coroutines.test)
     implementation(projects.libraries.core)
+    implementation(projects.libraries.uiStrings)
     implementation(libs.test.turbine)
     implementation(libs.molecule.runtime)
     implementation(libs.androidx.compose.ui.test.junit)

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.tests.testutils
+
+class EnsureCalledOnce : () -> Unit {
+    private var counter = 0
+    override fun invoke() {
+        counter++
+    }
+
+    fun assertSuccess() {
+        if (counter != 1) {
+            throw AssertionError("Expected to be called once, but was called $counter times")
+        }
+    }
+}
+
+class EnsureCalledOnceWithParam<T>(
+    private val expectedParam: T
+) : (T) -> Unit {
+    private var counter = 0
+    override fun invoke(p1: T) {
+        if (p1 != expectedParam) {
+            throw AssertionError("Expected to be called with $expectedParam, but was called with $p1")
+        }
+        counter++
+    }
+
+    fun assertSuccess() {
+        if (counter != 1) {
+            throw AssertionError("Expected to be called once, but was called $counter times")
+        }
+    }
+}

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
@@ -27,6 +27,11 @@ class EnsureCalledOnce : () -> Unit {
             throw AssertionError("Expected to be called once, but was called $counter times")
         }
     }
+
+    fun run(block: (callback: EnsureCalledOnce) -> Unit) {
+        block(this)
+        assertSuccess()
+    }
 }
 
 class EnsureCalledOnceWithParam<T>(
@@ -44,5 +49,10 @@ class EnsureCalledOnceWithParam<T>(
         if (counter != 1) {
             throw AssertionError("Expected to be called once, but was called $counter times")
         }
+    }
+
+    fun run(block: (callback: EnsureCalledOnceWithParam<T>) -> Unit) {
+        block(this)
+        assertSuccess()
     }
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureCalledOnce.kt
@@ -27,11 +27,12 @@ class EnsureCalledOnce : () -> Unit {
             throw AssertionError("Expected to be called once, but was called $counter times")
         }
     }
+}
 
-    fun run(block: (callback: EnsureCalledOnce) -> Unit) {
-        block(this)
-        assertSuccess()
-    }
+fun ensureCalledOnce(block: (callback: EnsureCalledOnce) -> Unit) {
+    val callback = EnsureCalledOnce()
+    block(callback)
+    callback.assertSuccess()
 }
 
 class EnsureCalledOnceWithParam<T>(
@@ -50,9 +51,10 @@ class EnsureCalledOnceWithParam<T>(
             throw AssertionError("Expected to be called once, but was called $counter times")
         }
     }
+}
 
-    fun run(block: (callback: EnsureCalledOnceWithParam<T>) -> Unit) {
-        block(this)
-        assertSuccess()
-    }
+fun <T> ensureCalledOnceWithParam(param: T, block: (callback: EnsureCalledOnceWithParam<T>) -> Unit) {
+    val callback = EnsureCalledOnceWithParam(param)
+    block(callback)
+    callback.assertSuccess()
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureNeverCalled.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureNeverCalled.kt
@@ -24,6 +24,6 @@ class EnsureNeverCalled : () -> Unit {
 
 class EnsureNeverCalledWithParam<T> : (T) -> Unit {
     override fun invoke(p1: T) {
-        throw AssertionError("Should not be called")
+        throw AssertionError("Should not be called and is called with $p1")
     }
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureNeverCalled.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EnsureNeverCalled.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id("io.element.android-compose-library")
-    alias(libs.plugins.ksp)
-}
 
-android {
-    namespace = "io.element.android.tests.testutils"
+package io.element.android.tests.testutils
 
-    buildFeatures {
-        buildConfig = true
+class EnsureNeverCalled : () -> Unit {
+    override fun invoke() {
+        throw AssertionError("Should not be called")
     }
 }
 
-dependencies {
-    implementation(libs.test.junit)
-    implementation(libs.test.truth)
-    implementation(libs.coroutines.test)
-    implementation(projects.libraries.core)
-    implementation(libs.test.turbine)
-    implementation(libs.molecule.runtime)
-    implementation(libs.androidx.compose.ui.test.junit)
+class EnsureNeverCalledWithParam<T> : (T) -> Unit {
+    override fun invoke(p1: T) {
+        throw AssertionError("Should not be called")
+    }
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.tests.testutils
+
+import com.google.common.truth.Truth.assertThat
+
+class EventsRecorder<T>(
+    private val expectEvents: Boolean = true
+) : (T) -> Unit {
+    private val events = mutableListOf<T>()
+
+    override fun invoke(event: T) {
+        if (expectEvents) {
+            events.add(event)
+        } else {
+            throw AssertionError("Unexpected event: $event")
+        }
+    }
+
+    fun assertSingle(event: T) {
+        assertList(listOf(event))
+    }
+
+    fun assertList(expectedEvents: List<T>) {
+        assertThat(events).isEqualTo(expectedEvents)
+    }
+}

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/SemanticsNodeInteractionsProviderExtensions.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/SemanticsNodeInteractionsProviderExtensions.kt
@@ -16,12 +16,23 @@
 
 package io.element.android.tests.testutils
 
-import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.activity.ComponentActivity
+import androidx.annotation.StringRes
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.performClick
+import io.element.android.libraries.ui.strings.CommonStrings
+import org.junit.rules.TestRule
 
-fun SemanticsNodeInteractionsProvider.clickOn(text: String) {
+fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.clickOn(@StringRes res: Int) {
+    val text = activity.getString(res)
     onNode(hasText(text) and hasClickAction())
         .performClick()
+}
+
+fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.pressBack() {
+    val text = activity.getString(CommonStrings.action_back)
+    onNode(hasContentDescription(text)).performClick()
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/SemanticsNodeInteractionsProviderExtensions.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/SemanticsNodeInteractionsProviderExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id("io.element.android-compose-library")
-    alias(libs.plugins.ksp)
-}
 
-android {
-    namespace = "io.element.android.tests.testutils"
+package io.element.android.tests.testutils
 
-    buildFeatures {
-        buildConfig = true
-    }
-}
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.performClick
 
-dependencies {
-    implementation(libs.test.junit)
-    implementation(libs.test.truth)
-    implementation(libs.coroutines.test)
-    implementation(projects.libraries.core)
-    implementation(libs.test.turbine)
-    implementation(libs.molecule.runtime)
-    implementation(libs.androidx.compose.ui.test.junit)
+fun SemanticsNodeInteractionsProvider.clickOn(text: String) {
+    onNode(hasText(text) and hasClickAction())
+        .performClick()
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : more test

## Content

<!-- Describe shortly what has been changed -->
Add compose test to check eventSink and callback behavior. Should increase code coverage.
This PR introduce some utility classes, but there is lots of work to do to add tests on the project. This first PR add test on LogoutView as a POC.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
#813

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- No change on the app to test

## Tested devices

- NA

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
