### PR TITLE
Hide keyboard when tapping on a message in the timeline

### DIFF
--- a/changelog.d/2182.bugfix
+++ b/changelog.d/2182.bugfix
@@ -1,0 +1,1 @@
+Hide keyboard when tapping on a message in the timeline.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
@@ -139,8 +139,8 @@ class MessagesFlowNode @AssistedInject constructor(
                         callback?.onRoomDetailsClicked()
                     }
 
-                    override fun onEventClicked(event: TimelineItem.Event) {
-                        processEventClicked(event)
+                    override fun onEventClicked(event: TimelineItem.Event): Boolean {
+                        return processEventClicked(event)
                     }
 
                     override fun onPreviewAttachments(attachments: ImmutableList<Attachment>) {
@@ -239,8 +239,8 @@ class MessagesFlowNode @AssistedInject constructor(
         }
     }
 
-    private fun processEventClicked(event: TimelineItem.Event) {
-        when (event.content) {
+    private fun processEventClicked(event: TimelineItem.Event): Boolean {
+        return when (event.content) {
             is TimelineItemImageContent -> {
                 val navTarget = NavTarget.MediaViewer(
                     mediaInfo = MediaInfo(
@@ -253,6 +253,7 @@ class MessagesFlowNode @AssistedInject constructor(
                     thumbnailSource = event.content.thumbnailSource,
                 )
                 overlay.show(navTarget)
+                true
             }
             is TimelineItemStickerContent -> {
                 /* Sticker may have an empty url and no thumbnail
@@ -269,6 +270,9 @@ class MessagesFlowNode @AssistedInject constructor(
                         thumbnailSource = event.content.thumbnailSource,
                     )
                     overlay.show(navTarget)
+                    true
+                } else {
+                    false
                 }
             }
             is TimelineItemVideoContent -> {
@@ -283,6 +287,7 @@ class MessagesFlowNode @AssistedInject constructor(
                     thumbnailSource = event.content.thumbnailSource,
                 )
                 overlay.show(navTarget)
+                true
             }
             is TimelineItemFileContent -> {
                 val navTarget = NavTarget.MediaViewer(
@@ -296,6 +301,7 @@ class MessagesFlowNode @AssistedInject constructor(
                     thumbnailSource = event.content.thumbnailSource,
                 )
                 overlay.show(navTarget)
+                true
             }
             is TimelineItemAudioContent -> {
                 val navTarget = NavTarget.MediaViewer(
@@ -309,6 +315,7 @@ class MessagesFlowNode @AssistedInject constructor(
                     thumbnailSource = null,
                 )
                 overlay.show(navTarget)
+                true
             }
             is TimelineItemLocationContent -> {
                 val navTarget = NavTarget.LocationViewer(
@@ -316,8 +323,9 @@ class MessagesFlowNode @AssistedInject constructor(
                     description = event.content.description,
                 )
                 overlay.show(navTarget)
+                true
             }
-            else -> Unit
+            else -> false
         }
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
@@ -31,6 +31,7 @@ import io.element.android.features.messages.impl.attachments.Attachment
 import io.element.android.features.messages.impl.timeline.di.LocalTimelineItemPresenterFactories
 import io.element.android.features.messages.impl.timeline.di.TimelineItemPresenterFactories
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.mediaplayer.api.MediaPlayer
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.matrix.api.core.EventId
@@ -48,7 +49,7 @@ class MessagesNode @AssistedInject constructor(
     @Assisted plugins: List<Plugin>,
     private val room: MatrixRoom,
     private val analyticsService: AnalyticsService,
-    private val presenterFactory: MessagesPresenter.Factory,
+    presenterFactory: MessagesPresenter.Factory,
     private val timelineItemPresenterFactories: TimelineItemPresenterFactories,
     private val mediaPlayer: MediaPlayer,
 ) : Node(buildContext, plugins = plugins), MessagesNavigator {
@@ -58,7 +59,7 @@ class MessagesNode @AssistedInject constructor(
 
     interface Callback : Plugin {
         fun onRoomDetailsClicked()
-        fun onEventClicked(event: TimelineItem.Event)
+        fun onEventClicked(event: TimelineItem.Event): Boolean
         fun onPreviewAttachments(attachments: ImmutableList<Attachment>)
         fun onUserDataClicked(userId: UserId)
         fun onShowEventDebugInfoClicked(eventId: EventId?, debugInfo: TimelineItemDebugInfo)
@@ -85,8 +86,8 @@ class MessagesNode @AssistedInject constructor(
         callback?.onRoomDetailsClicked()
     }
 
-    private fun onEventClicked(event: TimelineItem.Event) {
-        callback?.onEventClicked(event)
+    private fun onEventClicked(event: TimelineItem.Event): Boolean {
+        return callback?.onEventClicked(event).orFalse()
     }
 
     private fun onPreviewAttachments(attachments: ImmutableList<Attachment>) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -117,7 +117,7 @@ fun MessagesView(
     state: MessagesState,
     onBackPressed: () -> Unit,
     onRoomDetailsClicked: () -> Unit,
-    onEventClicked: (event: TimelineItem.Event) -> Unit,
+    onEventClicked: (event: TimelineItem.Event) -> Boolean,
     onUserDataClicked: (UserId) -> Unit,
     onPreviewAttachments: (ImmutableList<Attachment>) -> Unit,
     onSendLocationClicked: () -> Unit,
@@ -148,8 +148,10 @@ fun MessagesView(
 
     fun onMessageClicked(event: TimelineItem.Event) {
         Timber.v("OnMessageClicked= ${event.id}")
-        localView.hideKeyboard()
-        onEventClicked(event)
+        val hideKeyboard = onEventClicked(event)
+        if (hideKeyboard) {
+            localView.hideKeyboard()
+        }
     }
 
     fun onMessageLongClicked(event: TimelineItem.Event) {
@@ -570,7 +572,7 @@ internal fun MessagesViewPreview(@PreviewParameter(MessagesStateProvider::class)
         state = state,
         onBackPressed = {},
         onRoomDetailsClicked = {},
-        onEventClicked = {},
+        onEventClicked = { false },
         onPreviewAttachments = {},
         onUserDataClicked = {},
         onSendLocationClicked = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -148,6 +148,7 @@ fun MessagesView(
 
     fun onMessageClicked(event: TimelineItem.Event) {
         Timber.v("OnMessageClicked= ${event.id}")
+        localView.hideKeyboard()
         onEventClicked(event)
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Hides the keyboard when tapping on any event of the timeline.

## Motivation and context

Fixes #2182 .

## Tests

<!-- Explain how you tested your development -->

- Open a room, tap on the message composer so the keyboard is displayed.
- Then tap on a picture/video.

If the keyboard is hidden, it's working as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
