### PR TITLE
Attempt to exclude Preview function from code coverage computation.

### DIFF
--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/coverage/ExcludeFromJacocoGeneratedReport.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/coverage/ExcludeFromJacocoGeneratedReport.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.architecture.coverage
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.ANNOTATION_CLASS,
+)
+annotation class ExcludeFromJacocoGeneratedReport

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/preview/PreviewWithLargeHeight.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/preview/PreviewWithLargeHeight.kt
@@ -17,10 +17,12 @@
 package io.element.android.libraries.designsystem.preview
 
 import androidx.compose.ui.tooling.preview.Preview
+import io.element.android.libraries.architecture.coverage.ExcludeFromJacocoGeneratedReport
 
 /**
  * Our Paparazzi tests will check components with non-null `heightDp` and use a custom rendering for them,
  * adding extra vertical space so long scrolling components can be displayed. This is a helper for that functionality.
  */
 @Preview(heightDp = 1000)
+@ExcludeFromJacocoGeneratedReport
 annotation class PreviewWithLargeHeight

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/preview/PreviewsDayNight.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/preview/PreviewsDayNight.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.designsystem.preview
 
 import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Preview
+import io.element.android.libraries.architecture.coverage.ExcludeFromJacocoGeneratedReport
 
 /**
  * Marker for a night mode preview.
@@ -51,4 +52,5 @@ const val DAY_MODE_NAME = "Day"
     uiMode = Configuration.UI_MODE_NIGHT_YES,
     fontScale = 1f,
 )
+@ExcludeFromJacocoGeneratedReport
 annotation class PreviewsDayNight


### PR DESCRIPTION
Preview are using empty lambda that are never covered during the Preview test.
Draft, checking what the CI is reporting.