### PR TITLE
Fix mention selector getting stuck when quickly deleting the prompt

### DIFF
--- a/changelog.d/2192.bugfix
+++ b/changelog.d/2192.bugfix
@@ -1,0 +1,1 @@
+Mention selector gets stuck when quickly deleting the prompt.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -192,7 +192,7 @@ class MessageComposerPresenter @Inject constructor(
             // This will trigger a search immediately when `@` is typed
             val mentionStartTrigger = suggestionSearchTrigger.filter { it?.text.isNullOrEmpty() }
             // This will start a search when the user changes the text after the `@` with a debounce to prevent too much wasted work
-            val mentionCompletionTrigger = suggestionSearchTrigger.filter { !it?.text.isNullOrEmpty() }.debounce(0.3.seconds)
+            val mentionCompletionTrigger = suggestionSearchTrigger.debounce(0.3.seconds).filter { !it?.text.isNullOrEmpty() }
             merge(mentionStartTrigger, mentionCompletionTrigger)
                 .combine(room.membersStateFlow) { suggestion, roomMembersState ->
                     memberSuggestions.clear()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Changes the order of the `debounce` and `filter` values so the filter always take place after the debounce, ensuring we get the 'empty prompt' event in time instead of an outdated one with some text.

## Motivation and context

Fixes #2192.

## Tests

<!-- Explain how you tested your development -->

- Go to a room and type `@` with some some text so the selector is displayed.
- Quickly remove the text by keeping the backspace key pressed.

If the mention selector is properly dismissed, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
