### PR TITLE
Fix crash when sending image with latest posthog

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,3 +35,8 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# Needed for Posthog
+-keepclassmembers class android.view.JavaViewSpy {
+    static int windowAttachCount(android.view.View);
+}

--- a/changelog.d/+crash-sending-image-with-latest-posthog.bugfix
+++ b/changelog.d/+crash-sending-image-with-latest-posthog.bugfix
@@ -1,0 +1,1 @@
+Fix crash sending image with latest Posthog because of an usage of an internal Android method.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds proguard rule to keep an Android internal method even if it's unused.

## Motivation and context

Latest proguard version `3.1.0` crashes the app when sending a picture in release mode.

Thanks @surakin for the tentative fix.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
