### PR TITLE
Ensure that a PushProvider is available on a device before using it.

### DIFF
--- a/changelog.d/2248.misc
+++ b/changelog.d/2248.misc
@@ -1,0 +1,1 @@
+Fallback to UnifiedPush (if available) if the PlayServices are not installed on the device.

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/PushService.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/PushService.kt
@@ -24,6 +24,10 @@ interface PushService {
     // TODO Move away
     fun notificationStyleChanged()
 
+    /**
+     * Return the list of push providers, available at compile time, and
+     * available at runtime, sorted by index.
+     */
     fun getAvailablePushProviders(): List<PushProvider>
 
     /**

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/DefaultPushService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/DefaultPushService.kt
@@ -38,7 +38,9 @@ class DefaultPushService @Inject constructor(
     }
 
     override fun getAvailablePushProviders(): List<PushProvider> {
-        return pushProviders.sortedBy { it.index }
+        return pushProviders
+            .filter { it.isAvailable() }
+            .sortedBy { it.index }
     }
 
     /**

--- a/libraries/pushproviders/api/src/main/kotlin/io/element/android/libraries/pushproviders/api/PushProvider.kt
+++ b/libraries/pushproviders/api/src/main/kotlin/io/element/android/libraries/pushproviders/api/PushProvider.kt
@@ -32,6 +32,11 @@ interface PushProvider {
      */
     val name: String
 
+    /**
+     * Return true if the push provider is available on this device.
+     */
+    fun isAvailable(): Boolean
+
     fun getDistributors(): List<Distributor>
 
     /**

--- a/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/FirebasePushProvider.kt
+++ b/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/FirebasePushProvider.kt
@@ -16,9 +16,13 @@
 
 package io.element.android.libraries.pushproviders.firebase
 
+import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.api.PushProvider
@@ -30,12 +34,26 @@ private val loggerTag = LoggerTag("FirebasePushProvider", LoggerTag.PushLoggerTa
 
 @ContributesMultibinding(AppScope::class)
 class FirebasePushProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val firebaseStore: FirebaseStore,
     private val firebaseTroubleshooter: FirebaseTroubleshooter,
     private val pusherSubscriber: PusherSubscriber,
 ) : PushProvider {
     override val index = FirebaseConfig.INDEX
     override val name = FirebaseConfig.NAME
+
+    override fun isAvailable(): Boolean {
+        // The PlayServices has to be available
+        val apiAvailability = GoogleApiAvailability.getInstance()
+        val resultCode = apiAvailability.isGooglePlayServicesAvailable(context)
+        return if (resultCode == ConnectionResult.SUCCESS) {
+            Timber.tag(loggerTag.value).d("Google Play Services is available")
+            true
+        } else {
+            Timber.tag(loggerTag.value).w("Google Play Services is not available")
+            false
+        }
+    }
 
     override fun getDistributors(): List<Distributor> {
         return listOf(Distributor("Firebase", "Firebase"))

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.pushproviders.unifiedpush
 import android.content.Context
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.element.android.libraries.androidutils.system.getApplicationLabel
+import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.MatrixClient
@@ -26,7 +27,10 @@ import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.api.PushProvider
 import io.element.android.libraries.pushstore.api.clientsecret.PushClientSecret
 import org.unifiedpush.android.connector.UnifiedPush
+import timber.log.Timber
 import javax.inject.Inject
+
+private val loggerTag = LoggerTag("UnifiedPushProvider", LoggerTag.PushLoggerTag)
 
 @ContributesMultibinding(AppScope::class)
 class UnifiedPushProvider @Inject constructor(
@@ -37,6 +41,17 @@ class UnifiedPushProvider @Inject constructor(
 ) : PushProvider {
     override val index = UnifiedPushConfig.INDEX
     override val name = UnifiedPushConfig.NAME
+
+    override fun isAvailable(): Boolean {
+        val isAvailable = getDistributors().isNotEmpty()
+        return if (isAvailable) {
+            Timber.tag(loggerTag.value).d("UnifiedPush is available")
+            true
+        } else {
+            Timber.tag(loggerTag.value).w("UnifiedPush is not available")
+            false
+        }
+    }
 
     override fun getDistributors(): List<Distributor> {
         val distributors = UnifiedPush.getDistributors(context)


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure that a PushProvider is available on a device before using it.
It help to fallback to UnifiedPush (if available) if the PlayServices are not installed on the device.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Let the device fallback to UnifiedPush if the PlayServices is not available on the device, even if installed from the PlayStore.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
