### PR TITLE
Fix French translation for "gallery"

### DIFF
--- a/changelog.d/2250.misc
+++ b/changelog.d/2250.misc
@@ -1,0 +1,1 @@
+Fix French translation's spelling of gallery.

--- a/features/messages/impl/src/main/res/values-fr/translations.xml
+++ b/features/messages/impl/src/main/res/values-fr/translations.xml
@@ -23,7 +23,7 @@
   <string name="screen_room_attachment_source_camera_photo">"Prendre une photo"</string>
   <string name="screen_room_attachment_source_camera_video">"Enregistrer une vidéo"</string>
   <string name="screen_room_attachment_source_files">"Pièce jointe"</string>
-  <string name="screen_room_attachment_source_gallery">"Gallerie Photo et Vidéo"</string>
+  <string name="screen_room_attachment_source_gallery">"Galerie Photo et Vidéo"</string>
   <string name="screen_room_attachment_source_location">"Position"</string>
   <string name="screen_room_attachment_source_poll">"Sondage"</string>
   <string name="screen_room_attachment_text_formatting">"Formatage du texte"</string>


### PR DESCRIPTION
Small typo in the French translations that I've noticed yesterday evening.