### PR TITLE
Remove some state events at the start of DMs

### DIFF
--- a/changelog.d/2217.misc
+++ b/changelog.d/2217.misc
@@ -1,0 +1,1 @@
+Remove room creation, self-join of room creator and 'this is the beginning of X' timeline items for DMs.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -145,7 +145,7 @@ fun TimelineView(
                     }
                 }
             }
-            if (state.paginationState.beginningOfRoomReached) {
+            if (state.paginationState.beginningOfRoomReached && !state.timelineRoomInfo.isDirect) {
                 item(contentType = "BeginningOfRoomReached") {
                     TimelineItemRoomBeginningView(roomName = roomName)
                 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -592,6 +592,7 @@ class RustMatrixRoom(
             matrixRoom = this,
             roomCoroutineScope = roomCoroutineScope,
             dispatcher = roomDispatcher,
+            currentUserId = sessionId,
             lastLoginTimestamp = sessionData.loginTimestamp,
             onNewSyncedEvent = onNewSyncedEvent,
             innerTimeline = timeline,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -592,7 +592,6 @@ class RustMatrixRoom(
             matrixRoom = this,
             roomCoroutineScope = roomCoroutineScope,
             dispatcher = roomDispatcher,
-            currentUserId = sessionId,
             lastLoginTimestamp = sessionData.loginTimestamp,
             onNewSyncedEvent = onNewSyncedEvent,
             innerTimeline = timeline,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustMatrixTimeline.kt
@@ -17,7 +17,6 @@
 package io.element.android.libraries.matrix.impl.timeline
 
 import io.element.android.libraries.matrix.api.core.EventId
-import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
@@ -65,7 +64,6 @@ class RustMatrixTimeline(
     private val matrixRoom: MatrixRoom,
     private val innerTimeline: Timeline,
     private val dispatcher: CoroutineDispatcher,
-    private val currentUserId: UserId,
     lastLoginTimestamp: Date?,
     private val onNewSyncedEvent: () -> Unit,
 ) : MatrixTimeline {
@@ -115,7 +113,6 @@ class RustMatrixTimeline(
         .mapLatest { items ->
             dmBeginningTimelineProcessor.process(
                 items = items,
-                currentUserId = currentUserId,
                 isDm = matrixRoom.isDirect && matrixRoom.isOneToOne,
                 isAtStartOfTimeline = paginationState.value.beginningOfRoomReached
             )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessor.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.timeline.postprocessor
+
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
+import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
+import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
+import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
+
+/**
+ * This timeline post-processor removes the room creation event and the self-join event from the timeline for DMs.
+ */
+class DmBeginningTimelineProcessor {
+    fun process(
+        items: List<MatrixTimelineItem>,
+        currentUserId: UserId,
+        isDm: Boolean,
+        isAtStartOfTimeline: Boolean
+    ): List<MatrixTimelineItem> {
+        if (!isDm || !isAtStartOfTimeline) return items
+        // This is usually index 1
+        val roomCreationEventIndex = items.indexOfFirst {
+            val stateEventContent = (it as? MatrixTimelineItem.Event)?.event?.content as? StateContent
+            stateEventContent?.content is OtherState.RoomCreate
+        }
+        // This is usually index 2
+        val selfUserJoinedEventIndex = items.indexOfFirst {
+            val event = (it as? MatrixTimelineItem.Event)?.event
+            val stateEventContent = event?.content as? RoomMembershipContent
+            stateEventContent?.change == MembershipChange.JOINED && event.sender == currentUserId
+        }
+        val newItems = items.toMutableList()
+        if (selfUserJoinedEventIndex in 0..newItems.size) {
+            newItems.removeAt(selfUserJoinedEventIndex)
+        }
+        if (roomCreationEventIndex in 0..newItems.size) {
+            newItems.removeAt(roomCreationEventIndex)
+        }
+        return newItems
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessor.kt
@@ -50,8 +50,12 @@ class DmBeginningTimelineProcessor {
 
         // Remove items at the indices we found
         val newItems = items.toMutableList()
-        newItems.removeAt(selfUserJoinedEventIndex)
-        newItems.removeAt(roomCreationEventIndex)
+        if (selfUserJoinedEventIndex in newItems.indices) {
+            newItems.removeAt(selfUserJoinedEventIndex)
+        }
+        if (roomCreationEventIndex in newItems.indices) {
+            newItems.removeAt(roomCreationEventIndex)
+        }
         return newItems
     }
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/DmBeginningTimelineProcessorTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.timeline.postprocessor
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
+import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
+import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
+import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.timeline.aMessageContent
+import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import org.junit.Test
+
+class DmBeginningTimelineProcessorTest {
+    @Test
+    fun `processor removes room creation event and self-join event from DM timeline`() {
+        val timelineItems = listOf(
+            MatrixTimelineItem.Event("m.room.create", anEventTimelineItem(content = StateContent("", OtherState.RoomCreate))),
+            MatrixTimelineItem.Event("m.room.member", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, MembershipChange.JOINED))),
+        )
+        val processor = DmBeginningTimelineProcessor()
+        val processedItems = processor.process(timelineItems, isDm = true, isAtStartOfTimeline = true)
+        assertThat(processedItems).isEmpty()
+    }
+
+    @Test
+    fun `processor removes room creation event and self-join event from DM timeline even if they're not the first items`() {
+        val timelineItems = listOf(
+            MatrixTimelineItem.Event("m.room.member_other", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, MembershipChange.JOINED))),
+            MatrixTimelineItem.Event("m.room.create", anEventTimelineItem(content = StateContent("", OtherState.RoomCreate))),
+            MatrixTimelineItem.Event("m.room.message", anEventTimelineItem(content = aMessageContent("hi"))),
+            MatrixTimelineItem.Event("m.room.member", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, MembershipChange.JOINED))),
+        )
+        val expected = listOf(
+            MatrixTimelineItem.Event("m.room.member_other", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, MembershipChange.JOINED))),
+            MatrixTimelineItem.Event("m.room.message", anEventTimelineItem(content = aMessageContent("hi"))),
+        )
+        val processor = DmBeginningTimelineProcessor()
+        val processedItems = processor.process(timelineItems, isDm = true, isAtStartOfTimeline = true)
+        assertThat(processedItems).isEqualTo(expected)
+    }
+
+    @Test
+    fun `processor won't remove items if it's not a DM`() {
+        val timelineItems = listOf(
+            MatrixTimelineItem.Event("m.room.create", anEventTimelineItem(content = StateContent("", OtherState.RoomCreate))),
+            MatrixTimelineItem.Event("m.room.member", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, MembershipChange.JOINED))),
+        )
+        val processor = DmBeginningTimelineProcessor()
+        val processedItems = processor.process(timelineItems, isDm = false, isAtStartOfTimeline = true)
+        assertThat(processedItems).isEqualTo(timelineItems)
+    }
+
+    @Test
+    fun `processor won't remove items if it's not at the start of the timeline`() {
+        val timelineItems = listOf(
+            MatrixTimelineItem.Event("m.room.create", anEventTimelineItem(content = StateContent("", OtherState.RoomCreate))),
+            MatrixTimelineItem.Event("m.room.member", anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, MembershipChange.JOINED))),
+        )
+        val processor = DmBeginningTimelineProcessor()
+        val processedItems = processor.process(timelineItems,isDm = true, isAtStartOfTimeline = false)
+        assertThat(processedItems).isEqualTo(timelineItems)
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : remove items from DMs to improve UX

## Content

In DMs, we're removing from the timeline view:

- The 'This is the beginning of X' message.
- The room creation event.
- The member join event for the creator of the room.

## Motivation and context

Closes #2217.

## Screenshots / GIFs

![image](https://github.com/element-hq/element-x-android/assets/480955/1af80ff5-7df4-414a-bc7f-0b33e570b032)

## Tests

- Create a DM or open a recently created one. Make sure you don't see the first 3 items in the timeline.
- Create a room or open one that was recently created. These items should be there, as it's not a DM.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
