### PR TITLE
Edited text message bubbles should resize when edited

### DIFF
--- a/changelog.d/2260.bugfix
+++ b/changelog.d/2260.bugfix
@@ -1,0 +1,1 @@
+Edited text message bubbles should resize when edited

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Constraints
@@ -61,18 +60,22 @@ fun ContentAvoidingLayout(
 ) {
     val scope = remember { ContentAvoidingLayoutScopeInstance() }
 
-    SubcomposeLayout(
+    Layout(
         modifier = modifier,
-    ) { constraints ->
+        content = {
+            scope.content()
+            overlay()
+        }
+    ) { measurables, constraints ->
 
         // Measure the `overlay` view first, in case we need to shrink the `content`
-        val overlayPlaceable = subcompose(0, overlay).first().measure(Constraints(minWidth = 0, maxWidth = constraints.maxWidth))
+        val overlayPlaceable = measurables.last().measure(Constraints(minWidth = 0, maxWidth = constraints.maxWidth))
         val contentConstraints = if (shrinkContent) {
             Constraints(minWidth = 0, maxWidth = constraints.maxWidth - overlayPlaceable.width)
         } else {
             Constraints(minWidth = 0, maxWidth = constraints.maxWidth)
         }
-        val contentPlaceable = subcompose(1) { scope.content() }.first().measure(contentConstraints)
+        val contentPlaceable = measurables.first().measure(contentConstraints)
 
         var layoutWidth = contentPlaceable.width
         var layoutHeight = contentPlaceable.height

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
@@ -18,6 +18,8 @@ package io.element.android.features.messages.impl.timeline.components.layout
 
 import android.text.Layout
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
@@ -75,7 +77,7 @@ fun ContentAvoidingLayout(
         var layoutWidth = contentPlaceable.width
         var layoutHeight = contentPlaceable.height
 
-        val data = scope.data
+        val data = scope.data.value
 
         // Free space = width of the whole component - width of its non overlapping contents
         val freeSpace = max(contentPlaceable.width - data.nonOverlappingContentWidth, 0)
@@ -135,13 +137,10 @@ interface ContentAvoidingLayoutScope {
 }
 
 private class ContentAvoidingLayoutScopeInstance(
-    val data: ContentAvoidingLayoutData = ContentAvoidingLayoutData(),
+    val data: MutableState<ContentAvoidingLayoutData> = mutableStateOf(ContentAvoidingLayoutData()),
 ) : ContentAvoidingLayoutScope {
     override fun onContentLayoutChanged(data: ContentAvoidingLayoutData) {
-        this.data.contentWidth = data.contentWidth
-        this.data.contentHeight = data.contentHeight
-        this.data.nonOverlappingContentWidth = data.nonOverlappingContentWidth
-        this.data.nonOverlappingContentHeight = data.nonOverlappingContentHeight
+        this.data.value = data
     }
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Makes `ContentAvoidingLayoutScopeInstance` stable and state-aware, so it can be used by `ContentAvoidingLayout` to re-layout when its `data` changes.
- The change above makes it possible to use `Layout` instead of `SubcomposeLayout` for the layout process, which should improve performance.

## Motivation and context

Fixes #2060

## Screenshots / GIFs

https://github.com/element-hq/element-x-android/assets/480955/eddb791a-86f4-4be7-a54f-9e6b7b0d58bd

## Tests

<!-- Explain how you tested your development -->

- In a room, edit a message so it overlaps the timestamp. Once edited, the message bubble should resize and avoid the overlapping.
- Edit it back so it doesn't overlap anymore. The message bubble should resize again.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
