### PR TITLE
Return cached room members before fetching new ones, do it in batches

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/room/RoomLoadedFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/RoomLoadedFlowNode.kt
@@ -118,14 +118,7 @@ class RoomLoadedFlowNode @AssistedInject constructor(
     }
 
     private fun fetchRoomMembers() = lifecycleScope.launch {
-        val room = inputs.room
-        room.updateMembers()
-            .onFailure {
-                Timber.e(it, "Fail to fetch members for room ${room.roomId}")
-            }
-            .onSuccess {
-                Timber.v("Success fetching members for room ${room.roomId}")
-            }
+        inputs.room.updateMembers()
     }
 
     private fun createRoomDetailsNode(buildContext: BuildContext, initialTarget: RoomDetailsEntryPoint.InitialTarget): Node {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -26,11 +26,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.lifecycle.Lifecycle
 import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomPresenter
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.MatrixClient
@@ -76,7 +78,12 @@ class RoomDetailsPresenter @Inject constructor(
                 room.updateRoomNotificationSettings()
                 observeNotificationSettings()
             }
-            room.updateMembers()
+        }
+
+        OnLifecycleEvent { _, event ->
+            if (event == Lifecycle.Event.ON_CREATE) {
+                scope.launch { room.updateMembers() }
+            }
         }
 
         val membersState by room.membersStateFlow.collectAsState()

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -80,6 +80,7 @@ class RoomDetailsPresenter @Inject constructor(
             }
         }
 
+        // Update room members only when first presenting the node
         OnLifecycleEvent { _, event ->
             if (event == Lifecycle.Event.ON_CREATE) {
                 scope.launch { room.updateMembers() }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListDataSource.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListDataSource.kt
@@ -19,11 +19,8 @@ package io.element.android.features.roomdetails.impl.members
 import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.room.MatrixRoom
-import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.roomMembers
-import kotlinx.coroutines.flow.dropWhile
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -32,11 +29,7 @@ class RoomMemberListDataSource @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers,
 ) {
     suspend fun search(query: String): List<RoomMember> = withContext(coroutineDispatchers.io) {
-        val roomMembers = room.membersStateFlow
-            .dropWhile { it !is MatrixRoomMembersState.Ready }
-            .first()
-            .roomMembers()
-            .orEmpty()
+        val roomMembers = room.membersStateFlow.value.roomMembers().orEmpty()
         val filteredMembers = if (query.isBlank()) {
             roomMembers
         } else {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListDataSource.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListDataSource.kt
@@ -29,7 +29,8 @@ class RoomMemberListDataSource @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers,
 ) {
     suspend fun search(query: String): List<RoomMember> = withContext(coroutineDispatchers.io) {
-        val roomMembers = room.membersStateFlow.value.roomMembers().orEmpty()
+        val roomMembersState = room.membersStateFlow.value
+        val roomMembers = roomMembersState.roomMembers().orEmpty()
         val filteredMembers = if (query.isBlank()) {
             roomMembers
         } else {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.designsystem.theme.components.SearchBarResul
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.room.powerlevels.canInvite
+import io.element.android.libraries.matrix.api.room.roomMembers
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -55,9 +56,9 @@ class RoomMemberListPresenter @Inject constructor(
             value = room.canInvite().getOrElse { false }
         }
 
-        LaunchedEffect(Unit) {
+        LaunchedEffect(membersState) {
             withContext(coroutineDispatchers.io) {
-                val members = roomMemberListDataSource.search("").groupBy { it.membership }
+                val members = membersState.roomMembers().orEmpty().groupBy { it.membership }
                 roomMembers = AsyncData.Success(
                     RoomMembers(
                         invited = members.getOrDefault(RoomMembershipState.INVITE, emptyList()).toImmutableList(),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
@@ -30,6 +30,7 @@ import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.room.MatrixRoom
+import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.room.powerlevels.canInvite
 import io.element.android.libraries.matrix.api.room.roomMembers
@@ -57,6 +58,9 @@ class RoomMemberListPresenter @Inject constructor(
         }
 
         LaunchedEffect(membersState) {
+            if (membersState is MatrixRoomMembersState.Unknown) {
+                return@LaunchedEffect
+            }
             withContext(coroutineDispatchers.io) {
                 val members = membersState.roomMembers().orEmpty().groupBy { it.membership }
                 roomMembers = AsyncData.Success(

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -57,9 +57,11 @@ import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.libraries.matrix.test.room.aRoomInfo
+import io.element.android.tests.testutils.FakeLifecycleOwner
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.consumeItemsUntilPredicate
 import io.element.android.tests.testutils.testCoroutineDispatchers
+import io.element.android.tests.testutils.withFakeLifecycleOwner
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -72,6 +74,10 @@ import kotlin.time.Duration.Companion.milliseconds
 class RoomDetailsPresenterTests {
     @get:Rule
     val warmUpRule = WarmUpRule()
+
+    private val fakeLifecycleOwner = FakeLifecycleOwner().apply {
+        givenState(Lifecycle.State.RESUMED)
+    }
 
     private fun TestScope.createRoomDetailsPresenter(
         room: MatrixRoom,
@@ -104,7 +110,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom()
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -128,7 +134,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -147,7 +153,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(name = null)
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -171,7 +177,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -189,7 +195,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room, dispatchers = testCoroutineDispatchers())
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -209,7 +215,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -226,7 +232,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -246,7 +252,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -277,7 +283,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -309,7 +315,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -332,7 +338,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -355,7 +361,7 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -375,7 +381,7 @@ class RoomDetailsPresenterTests {
 
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -396,7 +402,7 @@ class RoomDetailsPresenterTests {
 
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -420,7 +426,7 @@ class RoomDetailsPresenterTests {
             dispatchers = testCoroutineDispatchers()
         )
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -443,7 +449,7 @@ class RoomDetailsPresenterTests {
             notificationSettingsService = notificationSettingsService,
         )
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -462,7 +468,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(notificationSettingsService = notificationSettingsService)
         val presenter = createRoomDetailsPresenter(room = room, notificationSettingsService = notificationSettingsService)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -484,7 +490,7 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(notificationSettingsService = notificationSettingsService)
         val presenter = createRoomDetailsPresenter(room = room, notificationSettingsService = notificationSettingsService)
         moleculeFlow(RecompositionMode.Immediate) {
-            withFakeLifecycleOwner {
+            withFakeLifecycleOwner(fakeLifecycleOwner) {
                 presenter.present()
             }
         }.test {
@@ -519,19 +525,3 @@ fun aMatrixRoom(
     isDirect = isDirect,
     notificationSettingsService = notificationSettingsService
 )
-
-@Composable
-private fun <T> withFakeLifecycleOwner(lifecycleOwner: LifecycleOwner? = null, block: @Composable () -> T): T {
-    val actualLifecycleOwner = lifecycleOwner ?: remember {
-        object : LifecycleOwner {
-            override val lifecycle: Lifecycle
-                get() = LifecycleRegistry.createUnsafe(this)
-        }
-    }
-
-    var state: T? by remember { mutableStateOf(null) }
-    CompositionLocalProvider(LocalLifecycleOwner provides actualLifecycleOwner) {
-        state = block()
-    }
-    return state!!
-}

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -16,16 +16,7 @@
 
 package io.element.android.features.roomdetails
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -522,9 +522,10 @@ fun aMatrixRoom(
 
 @Composable
 private fun <T> withFakeLifecycleOwner(lifecycleOwner: LifecycleOwner? = null, block: @Composable () -> T): T {
-    val actualLifecycleOwner = lifecycleOwner ?: remember { object : LifecycleOwner {
-        override val lifecycle: Lifecycle
-            get() = LifecycleRegistry.createUnsafe(this)
+    val actualLifecycleOwner = lifecycleOwner ?: remember {
+        object : LifecycleOwner {
+            override val lifecycle: Lifecycle
+                get() = LifecycleRegistry.createUnsafe(this)
         }
     }
 

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -16,6 +16,16 @@
 
 package io.element.android.features.roomdetails
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
@@ -94,7 +104,9 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom()
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             val initialState = awaitItem()
             assertThat(initialState.roomId).isEqualTo(room.roomId.value)
@@ -116,7 +128,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             skipItems(1)
             val updatedState = awaitItem()
@@ -133,7 +147,9 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(name = null)
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             val initialState = awaitItem()
             assertThat(initialState.roomName).isEqualTo(room.displayName)
@@ -155,7 +171,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             val initialState = awaitItem()
             assertThat(initialState.roomType).isEqualTo(RoomDetailsType.Dm(otherRoomMember))
@@ -171,7 +189,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room, dispatchers = testCoroutineDispatchers())
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Initially false
             assertThat(awaitItem().canInvite).isFalse()
@@ -189,7 +209,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             assertThat(awaitItem().canInvite).isFalse()
 
@@ -204,7 +226,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             assertThat(awaitItem().canInvite).isFalse()
 
@@ -222,7 +246,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Initially false
             assertThat(awaitItem().canEdit).isFalse()
@@ -251,7 +277,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Initially false
             assertThat(awaitItem().canEdit).isFalse()
@@ -281,7 +309,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             skipItems(1)
 
@@ -302,7 +332,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Initially false
             assertThat(awaitItem().canEdit).isFalse()
@@ -323,7 +355,9 @@ class RoomDetailsPresenterTests {
         }
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Initially false, and no further events
             assertThat(awaitItem().canEdit).isFalse()
@@ -341,7 +375,9 @@ class RoomDetailsPresenterTests {
 
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // The initial state is "hidden" and no further state changes happen
             assertThat(awaitItem().roomTopic).isEqualTo(RoomTopicState.Hidden)
@@ -360,7 +396,9 @@ class RoomDetailsPresenterTests {
 
         val presenter = createRoomDetailsPresenter(room)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             // Ignore the initial state
             skipItems(1)
@@ -382,7 +420,9 @@ class RoomDetailsPresenterTests {
             dispatchers = testCoroutineDispatchers()
         )
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             awaitItem().eventSink(RoomDetailsEvent.LeaveRoom)
 
@@ -403,7 +443,9 @@ class RoomDetailsPresenterTests {
             notificationSettingsService = notificationSettingsService,
         )
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             notificationSettingsService.setRoomNotificationMode(room.roomId, RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY)
             val updatedState = consumeItemsUntilPredicate {
@@ -420,7 +462,9 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(notificationSettingsService = notificationSettingsService)
         val presenter = createRoomDetailsPresenter(room = room, notificationSettingsService = notificationSettingsService)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             awaitItem().eventSink(RoomDetailsEvent.MuteNotification)
             val updatedState = consumeItemsUntilPredicate(timeout = 250.milliseconds) {
@@ -440,7 +484,9 @@ class RoomDetailsPresenterTests {
         val room = aMatrixRoom(notificationSettingsService = notificationSettingsService)
         val presenter = createRoomDetailsPresenter(room = room, notificationSettingsService = notificationSettingsService)
         moleculeFlow(RecompositionMode.Immediate) {
-            presenter.present()
+            withFakeLifecycleOwner {
+                presenter.present()
+            }
         }.test {
             awaitItem().eventSink(RoomDetailsEvent.UnmuteNotification)
             val updatedState = consumeItemsUntilPredicate {
@@ -473,3 +519,18 @@ fun aMatrixRoom(
     isDirect = isDirect,
     notificationSettingsService = notificationSettingsService
 )
+
+@Composable
+private fun <T> withFakeLifecycleOwner(lifecycleOwner: LifecycleOwner? = null, block: @Composable () -> T): T {
+    val actualLifecycleOwner = lifecycleOwner ?: remember { object : LifecycleOwner {
+        override val lifecycle: Lifecycle
+            get() = LifecycleRegistry.createUnsafe(this)
+        }
+    }
+
+    var state: T? by remember { mutableStateOf(null) }
+    CompositionLocalProvider(LocalLifecycleOwner provides actualLifecycleOwner) {
+        state = block()
+    }
+    return state!!
+}

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
@@ -47,15 +47,20 @@ class RoomMemberListPresenterTests {
 
     @Test
     fun `search is done automatically on start, but is async`() = runTest {
-        val presenter = createPresenter()
+        val room = FakeMatrixRoom()
+        val presenter = createPresenter(matrixRoom = room)
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
+            skipItems(1)
             val initialState = awaitItem()
             assertThat(initialState.roomMembers).isInstanceOf(AsyncData.Loading::class.java)
             assertThat(initialState.searchQuery).isEmpty()
             assertThat(initialState.searchResults).isInstanceOf(SearchBarResultState.Initial::class.java)
             assertThat(initialState.isSearchActive).isFalse()
+            room.givenRoomMembersState(MatrixRoomMembersState.Ready(aRoomMemberList()))
+            // Skip item while the new members state is processed
+            skipItems(1)
             val loadedState = awaitItem()
             assertThat(loadedState.roomMembers).isInstanceOf(AsyncData.Success::class.java)
             assertThat((loadedState.roomMembers as AsyncData.Success).data.invited).isEqualTo(listOf(aVictor(), aWalter()))

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -75,7 +75,7 @@ interface MatrixRoom : Closeable {
     /**
      * Try to load the room members and update the membersFlow.
      */
-    suspend fun updateMembers(): Result<Unit>
+    suspend fun updateMembers()
 
     suspend fun updateRoomNotificationSettings(): Result<Unit>
 

--- a/libraries/matrix/impl/build.gradle.kts
+++ b/libraries/matrix/impl/build.gradle.kts
@@ -53,4 +53,5 @@ dependencies {
     testImplementation(libs.test.truth)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(libs.coroutines.test)
+    testImplementation(libs.test.turbine)
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -18,7 +18,7 @@ package io.element.android.libraries.matrix.impl.notification
 
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.NotificationContent
-import io.element.android.libraries.matrix.impl.room.RoomMemberMapper
+import io.element.android.libraries.matrix.impl.room.member.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventMessageMapper
 import org.matrix.rustcomponents.sdk.MessageLikeEventContent
 import org.matrix.rustcomponents.sdk.StateEventContent

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
@@ -19,6 +19,7 @@ package io.element.android.libraries.matrix.impl.room
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
+import io.element.android.libraries.matrix.impl.room.member.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
 import kotlinx.collections.immutable.toImmutableList
 import org.matrix.rustcomponents.sdk.use

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -186,7 +186,7 @@ class RustMatrixRoom(
     override val activeMemberCount: Long
         get() = innerRoom.activeMembersCount().toLong()
 
-    override suspend fun updateMembers() = roomMemberListFetcher.getUpdatedRoomMembers()
+    override suspend fun updateMembers() = roomMemberListFetcher.fetchRoomMembers()
 
     override suspend fun userDisplayName(userId: UserId): Result<String?> = withContext(roomDispatcher) {
         runCatching {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -37,9 +37,9 @@ import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.MatrixRoomNotificationSettingsState
 import io.element.android.libraries.matrix.api.room.Mention
 import io.element.android.libraries.matrix.api.room.MessageEventType
+import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.StateEventType
 import io.element.android.libraries.matrix.api.room.location.AssetType
-import io.element.android.libraries.matrix.api.room.roomMembers
 import io.element.android.libraries.matrix.api.room.roomNotificationSettings
 import io.element.android.libraries.matrix.api.timeline.MatrixTimeline
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
@@ -53,7 +53,6 @@ import io.element.android.libraries.matrix.impl.poll.toInner
 import io.element.android.libraries.matrix.impl.room.location.toInner
 import io.element.android.libraries.matrix.impl.timeline.AsyncMatrixTimeline
 import io.element.android.libraries.matrix.impl.timeline.RustMatrixTimeline
-import io.element.android.libraries.matrix.impl.util.destroyAll
 import io.element.android.libraries.matrix.impl.util.mxCallbackFlow
 import io.element.android.libraries.matrix.impl.widget.RustWidgetDriver
 import io.element.android.libraries.matrix.impl.widget.generateWidgetWebViewUrl
@@ -70,12 +69,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.EventTimelineItem
 import org.matrix.rustcomponents.sdk.RoomInfo
 import org.matrix.rustcomponents.sdk.RoomInfoListener
 import org.matrix.rustcomponents.sdk.RoomListItem
-import org.matrix.rustcomponents.sdk.RoomMember
+import org.matrix.rustcomponents.sdk.RoomMembersIterator
 import org.matrix.rustcomponents.sdk.RoomMessageEventContentWithoutRelation
 import org.matrix.rustcomponents.sdk.SendAttachmentJoinHandle
 import org.matrix.rustcomponents.sdk.WidgetCapabilities
@@ -104,6 +105,9 @@ class RustMatrixRoom(
     private val roomSyncSubscriber: RoomSyncSubscriber,
     private val matrixRoomInfoMapper: MatrixRoomInfoMapper,
 ) : MatrixRoom {
+
+    private val roomMemberMutex = Mutex()
+
     override val roomId = RoomId(innerRoom.id())
 
     override val roomInfoFlow: Flow<MatrixRoomInfo> = mxCallbackFlow {
@@ -192,33 +196,45 @@ class RustMatrixRoom(
     override val activeMemberCount: Long
         get() = innerRoom.activeMembersCount().toLong()
 
-    override suspend fun updateMembers(): Result<Unit> = withContext(roomMembersDispatcher) {
-        val currentState = _membersStateFlow.value
-        val currentMembers = currentState.roomMembers()?.toImmutableList()
-        _membersStateFlow.value = MatrixRoomMembersState.Pending(prevRoomMembers = currentMembers)
-        var rustMembers: List<RoomMember>? = null
-        try {
-            rustMembers = innerRoom.members().use { membersIterator ->
-                buildList {
-                    while (true) {
-                        // Loading the whole membersIterator as a stop-gap measure.
-                        // We should probably implement some sort of paging in the future.
-                        ensureActive()
-                        addAll(membersIterator.nextChunk(1000u) ?: break)
+    override suspend fun updateMembers(): Result<Unit> {
+        if (roomMemberMutex.isLocked) {
+            Timber.i("Room members are already being updated for room $roomId")
+            return Result.success(Unit)
+        }
+        return roomMemberMutex.withLock {
+            withContext(roomMembersDispatcher) {
+                // Load cached members as fallback and to get faster results
+                val cachedMembers = try {
+                    if (membersStateFlow.value !is MatrixRoomMembersState.Ready) {
+                        Timber.i("Loading cached members for room $roomId")
+                        parseAndEmitMembers(innerRoom.membersNoSync()).toImmutableList()
+                    } else {
+                        Timber.i("No need to load cached members found for room $roomId")
+                        null
                     }
+                } catch (exception: Exception) {
+                    Timber.e(exception, "Failed to load cached members for room $roomId")
+                    if (exception is CancellationException) {
+                        throw exception
+                    }
+                    null
+                }
+
+                // Start loading new members
+                _membersStateFlow.value = MatrixRoomMembersState.Pending(prevRoomMembers = cachedMembers)
+                try {
+                    Timber.i("Loading updated members for room $roomId")
+                    parseAndEmitMembers(innerRoom.members()).toImmutableList()
+                    Timber.i("Loaded updated members for room $roomId")
+                    Result.success(Unit)
+                } catch (exception: CancellationException) {
+                    _membersStateFlow.value = MatrixRoomMembersState.Error(prevRoomMembers = cachedMembers, failure = exception)
+                    throw exception
+                } catch (exception: Exception) {
+                    _membersStateFlow.value = MatrixRoomMembersState.Error(prevRoomMembers = cachedMembers, failure = exception)
+                    Result.failure(exception)
                 }
             }
-            val mappedMembers = rustMembers.parallelMap(RoomMemberMapper::map)
-            _membersStateFlow.value = MatrixRoomMembersState.Ready(mappedMembers.toImmutableList())
-            Result.success(Unit)
-        } catch (exception: CancellationException) {
-            _membersStateFlow.value = MatrixRoomMembersState.Error(prevRoomMembers = currentMembers, failure = exception)
-            throw exception
-        } catch (exception: Exception) {
-            _membersStateFlow.value = MatrixRoomMembersState.Error(prevRoomMembers = currentMembers, failure = exception)
-            Result.failure(exception)
-        } finally {
-            rustMembers?.destroyAll()
         }
     }
 
@@ -604,4 +620,19 @@ class RustMatrixRoom(
         } else {
             messageEventContentFromMarkdown(body)
         }
+
+    private suspend fun CoroutineScope.parseAndEmitMembers(roomMembersIterator: RoomMembersIterator): List<RoomMember> {
+        return roomMembersIterator.use { iterator ->
+            buildList {
+                while (true) {
+                    // Loading the whole membersIterator as a stop-gap measure.
+                    // We should probably implement some sort of paging in the future.
+                    ensureActive()
+                    addAll(iterator.nextChunk(1000u)?.parallelMap(RoomMemberMapper::map) ?: break)
+                    Timber.i("Emitting first $size members for room $roomId")
+                    _membersStateFlow.value = MatrixRoomMembersState.Ready(toImmutableList())
+                }
+            }
+        }
+    }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -186,7 +186,7 @@ class RustMatrixRoom(
     override val activeMemberCount: Long
         get() = innerRoom.activeMembersCount().toLong()
 
-    override suspend fun updateMembers(): Result<Unit> = roomMemberListFetcher.getUpdatedRoomMembers()
+    override suspend fun updateMembers() = roomMemberListFetcher.getUpdatedRoomMembers()
 
     override suspend fun userDisplayName(userId: UserId): Result<String?> = withContext(roomDispatcher) {
         runCatching {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.room.member
+
+import io.element.android.libraries.core.coroutine.parallelMap
+import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
+import io.element.android.libraries.matrix.api.room.RoomMember
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.matrix.rustcomponents.sdk.RoomInterface
+import org.matrix.rustcomponents.sdk.RoomMembersIterator
+import org.matrix.rustcomponents.sdk.use
+import timber.log.Timber
+import kotlin.coroutines.cancellation.CancellationException
+
+internal class RoomMemberListFetcher(
+    private val room: RoomInterface,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    companion object {
+        private const val PAGE_SIZE = 1000
+    }
+
+    private val roomMemberMutex = Mutex()
+
+    private val _membersFlow = MutableStateFlow<MatrixRoomMembersState>(MatrixRoomMembersState.Unknown)
+    val membersFlow: StateFlow<MatrixRoomMembersState> = _membersFlow
+
+    suspend fun getUpdatedRoomMembers(returnCachedFirst: Boolean = true): Result<Unit> {
+        if (roomMemberMutex.isLocked) {
+            Timber.i("Room members are already being updated for room ${room.id()}")
+            return Result.success(Unit)
+        }
+        return roomMemberMutex.withLock {
+            withContext(dispatcher) {
+                // Load cached members as fallback and to get faster results
+                if (returnCachedFirst) {
+                    val cachedMembers = try {
+                        if (_membersFlow.value !is MatrixRoomMembersState.Ready) {
+                            Timber.i("Loading cached members for room ${room.id()}")
+                            getCachedRoomMembers().toImmutableList()
+                        } else {
+                            Timber.i("No need to load cached members found for room ${room.id()}")
+                            null
+                        }
+                    } catch (exception: Exception) {
+                        Timber.e(exception, "Failed to load cached members for room ${room.id()}")
+                        if (exception is CancellationException) {
+                            throw exception
+                        }
+                        null
+                    }
+                    _membersFlow.value = MatrixRoomMembersState.Pending(prevRoomMembers = cachedMembers)
+                }
+
+                // Start loading new members
+                val iterator = room.members()
+                parseAndEmitMembers(iterator)
+                Result.success(Unit)
+            }
+        }
+    }
+
+    suspend fun getCachedRoomMembers() = withContext(dispatcher) {
+        val iterator = room.membersNoSync()
+        parseAndEmitMembers(iterator)
+    }
+
+    private suspend fun CoroutineScope.parseAndEmitMembers(roomMembersIterator: RoomMembersIterator): List<RoomMember> {
+        return roomMembersIterator.use { iterator ->
+            buildList {
+                while (true) {
+                    // Loading the whole membersIterator as a stop-gap measure.
+                    // We should probably implement some sort of paging in the future.
+                    ensureActive()
+                    addAll(iterator.nextChunk(PAGE_SIZE.toUInt())?.parallelMap(RoomMemberMapper::map) ?: break)
+                    Timber.i("Emitting first $size members for room ${room.id()}")
+                    _membersFlow.value = MatrixRoomMembersState.Ready(toImmutableList())
+                }
+            }
+        }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
@@ -53,8 +53,7 @@ internal class RoomMemberListFetcher(
      * It will emit the cached members first, and then the updated members in batches of [pageSize] items, through [membersFlow].
      * @param withCache Whether to load the cached members first. Defaults to true.
      */
-    @Suppress("InstanceOfCheckForException")
-    suspend fun getUpdatedRoomMembers(withCache: Boolean = true) {
+    suspend fun fetchRoomMembers(withCache: Boolean = true) {
         if (updatedRoomMemberMutex.isLocked) {
             Timber.i("Room members are already being updated for room $roomId")
             return
@@ -64,7 +63,7 @@ internal class RoomMemberListFetcher(
                 // Load cached members as fallback and to get faster results
                 if (withCache) {
                     if (_membersFlow.value !is MatrixRoomMembersState.Ready) {
-                        getCachedRoomMembers()
+                        fetchCachedRoomMembers()
                     } else {
                         Timber.i("No need to load cached members found for room $roomId")
                     }
@@ -89,8 +88,7 @@ internal class RoomMemberListFetcher(
         }
     }
 
-    @Suppress("InstanceOfCheckForException")
-    internal suspend fun getCachedRoomMembers() = withContext(dispatcher) {
+    internal suspend fun fetchCachedRoomMembers() = withContext(dispatcher) {
         Timber.i("Loading cached members for room $roomId")
         try {
             val iterator = room.membersNoSync()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
@@ -34,6 +34,9 @@ import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * This class fetches the room members for a given room in a 'paginated' way, and taking into account previous cached values.
+ */
 internal class RoomMemberListFetcher(
     private val room: RoomInterface,
     private val dispatcher: CoroutineDispatcher,
@@ -45,6 +48,11 @@ internal class RoomMemberListFetcher(
     private val _membersFlow = MutableStateFlow<MatrixRoomMembersState>(MatrixRoomMembersState.Unknown)
     val membersFlow: StateFlow<MatrixRoomMembersState> = _membersFlow
 
+    /**
+     * Fetches the room members for the given room.
+     * It will emit the cached members first, and then the updated members in batches of [pageSize] items, through [membersFlow].
+     * @param withCache Whether to load the cached members first. Defaults to true.
+     */
     @Suppress("InstanceOfCheckForException")
     suspend fun getUpdatedRoomMembers(withCache: Boolean = true) {
         if (updatedRoomMemberMutex.isLocked) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
@@ -107,7 +107,8 @@ internal class RoomMemberListFetcher(
                     // Loading the whole membersIterator as a stop-gap measure.
                     // We should probably implement some sort of paging in the future.
                     coroutineContext.ensureActive()
-                    addAll(iterator.nextChunk(pageSize.toUInt())?.parallelMap(RoomMemberMapper::map) ?: break)
+                    val chunk = iterator.nextChunk(pageSize.toUInt())?.parallelMap(RoomMemberMapper::map) ?: break
+                    addAll(chunk)
                     Timber.i("Emitting first $size members for room $roomId")
                     _membersFlow.value = MatrixRoomMembersState.Ready(toImmutableList())
                 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcher.kt
@@ -75,14 +75,12 @@ internal class RoomMemberListFetcher(
                 try {
                     // Start loading new members
                     parseAndEmitMembers(room.members())
-                    Result.success(Unit)
+                } catch (exception: CancellationException) {
+                    Timber.d("Cancelled loading updated members for room $roomId")
+                    throw exception
                 } catch (exception: Exception) {
                     Timber.e(exception, "Failed to load updated members for room $roomId")
                     _membersFlow.value = MatrixRoomMembersState.Error(exception, prevRoomMembers)
-                    if (exception is CancellationException) {
-                        throw exception
-                    }
-                    Result.failure(exception)
                 }
             }
         }
@@ -93,12 +91,12 @@ internal class RoomMemberListFetcher(
         try {
             val iterator = room.membersNoSync()
             parseAndEmitMembers(iterator)
+        } catch (exception: CancellationException) {
+            Timber.d("Cancelled loading cached members for room $roomId")
+            throw exception
         } catch (exception: Exception) {
             Timber.e(exception, "Failed to load cached members for room $roomId")
             _membersFlow.value = MatrixRoomMembersState.Error(exception, _membersFlow.value.roomMembers()?.toImmutableList())
-            if (exception is CancellationException) {
-                throw exception
-            }
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.matrix.impl.room
+package io.element.android.libraries.matrix.impl.room.member
 
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.RoomMember

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
@@ -19,7 +19,7 @@ package io.element.android.libraries.matrix.impl.roomlist
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.roomlist.RoomSummaryDetails
 import io.element.android.libraries.matrix.impl.notificationsettings.RoomNotificationSettingsMapper
-import io.element.android.libraries.matrix.impl.room.RoomMemberMapper
+import io.element.android.libraries.matrix.impl.room.member.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.room.message.RoomMessageFactory
 import org.matrix.rustcomponents.sdk.RoomInfo
 import org.matrix.rustcomponents.sdk.use

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcherTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcherTest.kt
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.room.member
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
+import io.element.android.libraries.matrix.api.room.roomMembers
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.A_USER_ID_3
+import io.element.android.libraries.matrix.test.A_USER_ID_4
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.matrix.rustcomponents.sdk.MembershipState
+import org.matrix.rustcomponents.sdk.NoPointer
+import org.matrix.rustcomponents.sdk.Room
+import org.matrix.rustcomponents.sdk.RoomMember
+import org.matrix.rustcomponents.sdk.RoomMembersIterator
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoomMemberListFetcherTest {
+    @Test
+    fun `getCachedRoomMembers - emits cached members, if any`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembersNoSync = {
+            FakeRoomMembersIterator(
+                listOf(
+                    FakeRustRoomMember(A_USER_ID),
+                    FakeRustRoomMember(A_USER_ID_2),
+                    FakeRustRoomMember(A_USER_ID_3),
+                )
+            )
+        })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(2).toList() }
+        runCurrent()
+        fetcher.getCachedRoomMembers()
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(2)
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        assertThat(memberStates[1]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        assertThat((memberStates[1] as? MatrixRoomMembersState.Ready)?.roomMembers?.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getCachedRoomMembers - emits empty list, if no members exist`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembersNoSync = {
+            FakeRoomMembersIterator(emptyList())
+        })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(2).toList() }
+        runCurrent()
+        fetcher.getCachedRoomMembers()
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(2)
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        assertThat(memberStates[1].roomMembers()).isEmpty()
+    }
+
+    @Test
+    fun `getCachedRoomMembers - emits Error on error found`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembersNoSync = {
+            error("Some unexpected issue")
+        })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(2).toList() }
+        runCurrent()
+        fetcher.getCachedRoomMembers()
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(2)
+        assertThat(memberStates.last()).isInstanceOf(MatrixRoomMembersState.Error::class.java)
+    }
+
+    @Test
+    fun `getCachedRoomMembers - emits items using page size`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembersNoSync = {
+            FakeRoomMembersIterator(
+                listOf(
+                    FakeRustRoomMember(A_USER_ID),
+                    FakeRustRoomMember(A_USER_ID_2),
+                    FakeRustRoomMember(A_USER_ID_3),
+                )
+            )
+        })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default, pageSize = 2)
+        val asyncMembers = async { fetcher.membersFlow.take(3).toList() }
+        runCurrent()
+        fetcher.getCachedRoomMembers()
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(3)
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        assertThat(memberStates.drop(1).all { it is MatrixRoomMembersState.Ready }).isTrue()
+        assertThat((memberStates[1] as? MatrixRoomMembersState.Ready)?.roomMembers?.size).isEqualTo(2)
+        assertThat((memberStates[2] as? MatrixRoomMembersState.Ready)?.roomMembers?.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getUpdatedRoomMembers - with 'withCache' set to false emits only new members, if any`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembers = {
+            FakeRoomMembersIterator(
+                listOf(
+                    FakeRustRoomMember(A_USER_ID),
+                    FakeRustRoomMember(A_USER_ID_2),
+                    FakeRustRoomMember(A_USER_ID_3),
+                )
+            )
+        })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(3).toList() }
+        runCurrent()
+        fetcher.getUpdatedRoomMembers(withCache = false)
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(3)
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        assertThat(memberStates[1]).isInstanceOf(MatrixRoomMembersState.Pending::class.java)
+        assertThat(memberStates[2]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        assertThat((memberStates[2] as? MatrixRoomMembersState.Ready)?.roomMembers?.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getUpdatedRoomMembers - on error it emits an Error item`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(getMembers = { error("An unexpected error") })
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(3).toList() }
+        runCurrent()
+        fetcher.getUpdatedRoomMembers(withCache = false)
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(3)
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        assertThat(memberStates[1]).isInstanceOf(MatrixRoomMembersState.Pending::class.java)
+        assertThat(memberStates[2]).isInstanceOf(MatrixRoomMembersState.Error::class.java)
+    }
+
+    @Test
+    fun `getUpdatedRoomMembers - with 'withCache' returns cached items first, then new ones`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(
+            getMembersNoSync = {
+                FakeRoomMembersIterator(listOf(FakeRustRoomMember(A_USER_ID_4)))
+            },
+            getMembers = {
+                FakeRoomMembersIterator(
+                    listOf(
+                        FakeRustRoomMember(A_USER_ID),
+                        FakeRustRoomMember(A_USER_ID_2),
+                        FakeRustRoomMember(A_USER_ID_3),
+                    )
+                )
+            }
+        )
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        val asyncMembers = async { fetcher.membersFlow.take(4).toList() }
+        runCurrent()
+        fetcher.getUpdatedRoomMembers(withCache = true)
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(4)
+        // Initial
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Unknown::class.java)
+        // Loaded cached
+        assertThat(memberStates[1]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        assertThat(memberStates[1].roomMembers()).hasSize(1)
+        // Start loading new
+        assertThat(memberStates[2]).isInstanceOf(MatrixRoomMembersState.Pending::class.java)
+        assertThat(memberStates[3]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        assertThat(memberStates[3].roomMembers()).hasSize(3)
+    }
+
+    @Test
+    fun `getUpdatedRoomMembers - with 'withCache' skips cache if there is already a ready state`() = runTest(StandardTestDispatcher()) {
+        val room = FakeRustRoom(
+            getMembersNoSync = {
+                FakeRoomMembersIterator(listOf(FakeRustRoomMember(A_USER_ID_4)))
+            },
+            getMembers = {
+                FakeRoomMembersIterator(
+                    listOf(
+                        FakeRustRoomMember(A_USER_ID),
+                        FakeRustRoomMember(A_USER_ID_2),
+                        FakeRustRoomMember(A_USER_ID_3),
+                    )
+                )
+            }
+        )
+
+        val fetcher = RoomMemberListFetcher(room, Dispatchers.Default)
+        // Set a ready state
+        fetcher.getUpdatedRoomMembers(withCache = false)
+
+        val asyncMembers = async { fetcher.membersFlow.take(3).toList() }
+        runCurrent()
+        // Start loading new members
+        fetcher.getUpdatedRoomMembers(withCache = true)
+        val memberStates = asyncMembers.await()
+
+        assertThat(memberStates).hasSize(3)
+        // Previous ready state
+        assertThat(memberStates[0]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        // New pending state
+        assertThat(memberStates[1]).isInstanceOf(MatrixRoomMembersState.Pending::class.java)
+        // New ready state
+        assertThat(memberStates[2]).isInstanceOf(MatrixRoomMembersState.Ready::class.java)
+        assertThat(memberStates[2].roomMembers()).hasSize(3)
+    }
+}
+
+class FakeRustRoom(
+    private val getMembers: () -> RoomMembersIterator = { FakeRoomMembersIterator() },
+    private val getMembersNoSync: () -> RoomMembersIterator = { FakeRoomMembersIterator() },
+) : Room(NoPointer) {
+    override fun id(): String {
+        return A_ROOM_ID.value
+    }
+
+    override suspend fun members(): RoomMembersIterator {
+        return getMembers()
+    }
+
+    override suspend fun membersNoSync(): RoomMembersIterator {
+        return getMembersNoSync()
+    }
+
+    override fun close() {
+        // No-op
+    }
+}
+
+class FakeRoomMembersIterator(
+    private var members: List<RoomMember>? = null
+) : RoomMembersIterator(NoPointer) {
+    override fun len(): UInt {
+        return members?.size?.toUInt() ?: 0u
+    }
+
+    override fun nextChunk(chunkSize: UInt): List<RoomMember>? {
+        if (members?.isEmpty() == true) {
+            return null
+        }
+        return members?.let {
+            val result = it.take(chunkSize.toInt())
+            members = it.subList(result.size, it.size)
+            result
+        }
+    }
+}
+
+class FakeRustRoomMember(
+    private val userId: UserId,
+    private val displayName: String? = null,
+    private val avatarUrl: String? = null,
+    private val membership: MembershipState = MembershipState.JOIN,
+    private val isNameAmbiguous: Boolean = false,
+    private val powerLevel: Long = 0L,
+) : RoomMember(NoPointer) {
+    override fun userId(): String {
+        return userId.value
+    }
+
+    override fun displayName(): String? {
+        return displayName
+    }
+
+    override fun avatarUrl(): String? {
+        return avatarUrl
+    }
+
+    override fun membership(): MembershipState {
+        return membership
+    }
+
+    override fun isNameAmbiguous(): Boolean {
+        return isNameAmbiguous
+    }
+
+    override fun powerLevel(): Long {
+        return powerLevel
+    }
+
+    override fun normalizedPowerLevel(): Long {
+        return powerLevel
+    }
+
+    override fun isIgnored(): Boolean {
+        return false
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcherTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberListFetcherTest.kt
@@ -27,7 +27,6 @@ import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.libraries.matrix.test.A_USER_ID_3
 import io.element.android.libraries.matrix.test.A_USER_ID_4
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.matrix.rustcomponents.sdk.MembershipState
@@ -36,7 +35,6 @@ import org.matrix.rustcomponents.sdk.Room
 import org.matrix.rustcomponents.sdk.RoomMember
 import org.matrix.rustcomponents.sdk.RoomMembersIterator
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RoomMemberListFetcherTest {
     @Test
     fun `getCachedRoomMembers - emits cached members, if any`() = runTest {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -169,9 +169,7 @@ class FakeMatrixRoom(
     override val roomNotificationSettingsStateFlow: MutableStateFlow<MatrixRoomNotificationSettingsState> =
         MutableStateFlow(MatrixRoomNotificationSettingsState.Unknown)
 
-    override suspend fun updateMembers(): Result<Unit> = simulateLongTask {
-        updateMembersResult
-    }
+    override suspend fun updateMembers() = Unit
 
     override suspend fun updateRoomNotificationSettings(): Result<Unit> = simulateLongTask {
         val notificationSettings = notificationSettingsService.getRoomNotificationSettings(roomId, isEncrypted, isOneToOne).getOrThrow()

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/WithFakeLifecycleOwner.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/WithFakeLifecycleOwner.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.tests.testutils
 
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
@@ -38,6 +39,7 @@ fun <T> withFakeLifecycleOwner(lifecycleOwner: FakeLifecycleOwner = FakeLifecycl
     return state!!
 }
 
+@SuppressLint("VisibleForTests")
 class FakeLifecycleOwner : LifecycleOwner {
     override val lifecycle: Lifecycle = LifecycleRegistry.createUnsafe(this)
 

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/WithFakeLifecycleOwner.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/WithFakeLifecycleOwner.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.tests.testutils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+@Stable
+@Composable
+fun <T> withFakeLifecycleOwner(lifecycleOwner: FakeLifecycleOwner = FakeLifecycleOwner(), block: @Composable () -> T): T {
+    var state: T? by remember { mutableStateOf(null) }
+    CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+        state = block()
+    }
+    return state!!
+}
+
+class FakeLifecycleOwner : LifecycleOwner {
+    override val lifecycle: Lifecycle = LifecycleRegistry.createUnsafe(this)
+
+    fun givenState(state: Lifecycle.State) {
+        (lifecycle as LifecycleRegistry).currentState = state
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Create `RoomMemberListFetcher` to load and emit `RoomMember` items from `RoomMemberIterator` instances in a paginated way. This should improve room member loading times for large rooms a lot.
- Adds a `getCachedRoomMembers` method that calls the Rust SDK's `Room.membersNoSync()`, returning the currently cached members for a room, which is a lot faster than fetching those for large rooms.
- Add a `getUpdatedRoomMembers(withCache: Boolean)` method that fetches the updated room members, if `withCache` is `true` it'll return the cached ones first so the UI is populated ASAP.
- Add a `roomMemberMutex` to it so we can't have several attempts to update the room members at the same time. Also, the default behaviour is to discard a new update while a previous one is in progress, not enqueue it. With a queue we'd end up with loading members several times in a very short amount of time for no good reason when we navigate to the room details or room member list screens.
- In `RoomDetailsPresenter`, only update room members when the node is created to prevent unneeded reloads when navigating back to it.
- When searching room members, allow it to search in `prevMembers` too, as we'll have those cached values while loading new ones.

## Motivation and context

Loading room members was extremely slow in very large rooms. With this, the data might not be always up to date, but it'll load way faster.

## Tests

<!-- Explain how you tested your development -->

- Go into a large room, like `#matrix:matrix.org`.
- Go into the room settings -> members.
- The members should take ~30s max to load, depending on your device. For me, previously it was ~1:40min.
- Exit the members screen and the room completely.
- Go back into the room and into its member list. It should load instantly, or almost.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
