### PR TITLE
Add a special tracing configuration for nightlies

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -46,8 +46,13 @@ class TracingInitializer : Initializer<Unit> {
                 writesToFilesConfiguration = WriteToFilesConfiguration.Disabled
             )
         } else {
+            val config = if (BuildConfig.BUILD_TYPE == "nightly") {
+                TracingFilterConfigurations.nightly
+            } else {
+                TracingFilterConfigurations.release
+            }
             TracingConfiguration(
-                filterConfiguration = TracingFilterConfigurations.release,
+                filterConfiguration = config,
                 writesToLogcat = false,
                 writesToFilesConfiguration = WriteToFilesConfiguration.Enabled(
                     directory = bugReporter.logDirectory().absolutePath,

--- a/changelog.d/+add-special-tracing-configuration-for-nightlies.misc
+++ b/changelog.d/+add-special-tracing-configuration-for-nightlies.misc
@@ -1,0 +1,1 @@
+Add a special logging configuration for nightlies so we can get more detailed info for existing issues.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
@@ -29,6 +29,7 @@ data class TracingFilterConfiguration(
         Target.MATRIX_SDK_SLIDING_SYNC to LogLevel.TRACE,
         Target.MATRIX_SDK_BASE_SLIDING_SYNC to LogLevel.TRACE,
         Target.MATRIX_SDK_UI_TIMELINE to LogLevel.TRACE,
+        Target.MATRIX_SDK_BASE_READ_RECEIPTS to LogLevel.TRACE,
     )
 
     fun getLogLevel(target: Target): LogLevel {
@@ -37,7 +38,7 @@ data class TracingFilterConfiguration(
 
     val filter: String
         get() {
-            val fullMap = Target.values().associateWith {
+            val fullMap = Target.entries.associateWith {
                 overrides[it] ?: targetsToLogLevel[it] ?: defaultLogLevel
             }
             return fullMap.map {
@@ -64,6 +65,7 @@ enum class Target(open val filter: String) {
     MATRIX_SDK_SLIDING_SYNC("matrix_sdk::sliding_sync"),
     MATRIX_SDK_BASE_SLIDING_SYNC("matrix_sdk_base::sliding_sync"),
     MATRIX_SDK_UI_TIMELINE("matrix_sdk_ui::timeline"),
+    MATRIX_SDK_BASE_READ_RECEIPTS("matrix_sdk_base::read_receipts"),
 }
 
 enum class LogLevel(open val filter: String) {
@@ -80,6 +82,12 @@ object TracingFilterConfigurations {
             Target.ELEMENT to LogLevel.DEBUG
         ),
     )
+    val nightly = TracingFilterConfiguration(
+        overrides = mapOf(
+            Target.ELEMENT to LogLevel.TRACE,
+            Target.MATRIX_SDK_BASE_READ_RECEIPTS to LogLevel.TRACE,
+        ),
+    )
     val debug = TracingFilterConfiguration(
         overrides = mapOf(
             Target.ELEMENT to LogLevel.TRACE
@@ -89,7 +97,7 @@ object TracingFilterConfigurations {
     /**
      *  Use this method to create a custom configuration where all targets will have the same log level.
      */
-    fun custom(logLevel: LogLevel) = TracingFilterConfiguration(overrides = Target.values().associateWith { logLevel })
+    fun custom(logLevel: LogLevel) = TracingFilterConfiguration(overrides = Target.entries.associateWith { logLevel })
 
     /**
      * Use this method to override the log level of specific targets.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Adds a special tracing configuration for nightly versions of the apps so we can keep track of known issues in a better way.
- It also enables logging `MATRIX_SDK_BASE_READ_RECEIPTS` at a `TRACE` level for both debug and nightly versions, as an example of an ongoing issue.

## Motivation and context

@bnjbvr requested it.

## Tests

- Install a nightly version of the app.
- Go to report a problem and check the logs: you should see several `read_receipts` logs.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
