### PR TITLE
FileViewer: fix coloration issue for logs files.

### DIFF
--- a/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFilePresenter.kt
+++ b/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFilePresenter.kt
@@ -49,6 +49,7 @@ class ViewFilePresenter @AssistedInject constructor(
     @Composable
     override fun present(): ViewFileState {
         val coroutineScope = rememberCoroutineScope()
+        val colorationMode = remember { name.toColorationMode() }
 
         fun handleEvent(event: ViewFileEvents) {
             when (event) {
@@ -67,6 +68,7 @@ class ViewFilePresenter @AssistedInject constructor(
         return ViewFileState(
             name = name,
             lines = lines,
+            colorationMode = colorationMode,
             eventSink = ::handleEvent,
         )
     }
@@ -77,5 +79,13 @@ class ViewFilePresenter @AssistedInject constructor(
 
     private fun CoroutineScope.save(path: String) = launch {
         fileSave.save(path)
+    }
+}
+
+private fun String.toColorationMode(): ColorationMode {
+    return when {
+        equals("logcat.log") -> ColorationMode.Logcat
+        startsWith("logs.") -> ColorationMode.Logs
+        else -> ColorationMode.None
     }
 }

--- a/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileState.kt
+++ b/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileState.kt
@@ -21,5 +21,12 @@ import io.element.android.libraries.architecture.AsyncData
 data class ViewFileState(
     val name: String,
     val lines: AsyncData<List<String>>,
+    val colorationMode: ColorationMode,
     val eventSink: (ViewFileEvents) -> Unit,
 )
+
+enum class ColorationMode {
+    Logcat,
+    Logs,
+    None,
+}

--- a/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileStateProvider.kt
+++ b/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileStateProvider.kt
@@ -51,5 +51,6 @@ fun aViewFileState(
 ) = ViewFileState(
     name = name,
     lines = lines,
+    colorationMode = ColorationMode.Logcat,
     eventSink = {},
 )

--- a/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileView.kt
+++ b/features/viewfolder/impl/src/main/kotlin/io/element/android/features/viewfolder/impl/file/ViewFileView.kt
@@ -114,6 +114,7 @@ fun ViewFileView(
                     is AsyncData.Success -> FileContent(
                         modifier = Modifier.weight(1f),
                         lines = state.lines.data.toImmutableList(),
+                        colorationMode = state.colorationMode,
                     )
                     is AsyncData.Failure -> AsyncFailure(throwable = state.lines.error, onRetry = null)
                 }
@@ -125,6 +126,7 @@ fun ViewFileView(
 @Composable
 private fun FileContent(
     lines: ImmutableList<String>,
+    colorationMode: ColorationMode,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -147,6 +149,7 @@ private fun FileContent(
                 LineRow(
                     lineNumber = index + 1,
                     line = line,
+                    colorationMode = colorationMode,
                 )
             }
         }
@@ -157,6 +160,7 @@ private fun FileContent(
 private fun LineRow(
     lineNumber: Int,
     line: String,
+    colorationMode: ColorationMode,
 ) {
     val context = LocalContext.current
     Row(
@@ -195,25 +199,41 @@ private fun LineRow(
                 }
                 .padding(horizontal = 4.dp),
             text = line,
-            color = line.toColor(),
+            color = line.toColor(colorationMode),
             style = ElementTheme.typography.fontBodyMdRegular
         )
     }
 }
 
 /**
- * Convert a logcat line to a color.
- * Ex: `01-23 13:14:50.740 25818 25818 D org.matrix.rust.sdk: elementx: SyncIndicator = Hide | RustRoomListService.kt:81`
+ * Convert a line to a color.
+ * Ex for logcat:
+ * `01-23 13:14:50.740 25818 25818 D org.matrix.rust.sdk: elementx: SyncIndicator = Hide | RustRoomListService.kt:81`
+ *                                 ^ use this char to determine the color
+ * Ex for logs:
+ * `2024-01-26T10:22:26.947416Z  WARN elementx: Restore with non-empty map | MatrixClientsHolder.kt:68`
+ *                                  ^ use this char to determine the color, see [LogLevel]
  */
 @Composable
-private fun String.toColor(): Color {
-    return when (getOrNull(31)) {
-        'D' -> Color(0xFF299999)
-        'I' -> Color(0xFFABC023)
-        'W' -> Color(0xFFBBB529)
-        'E' -> Color(0xFFFF6B68)
-        'A' -> Color(0xFFFF6B68)
-        else -> ElementTheme.colors.textPrimary
+private fun String.toColor(colorationMode: ColorationMode): Color {
+    return when (colorationMode) {
+        ColorationMode.Logcat -> when (getOrNull(31)) {
+            'D' -> Color(0xFF299999)
+            'I' -> Color(0xFFABC023)
+            'W' -> Color(0xFFBBB529)
+            'E' -> Color(0xFFFF6B68)
+            'A' -> Color(0xFFFF6B68)
+            else -> ElementTheme.colors.textPrimary
+        }
+        ColorationMode.Logs -> when (getOrNull(32)) {
+            'E' -> ElementTheme.colors.textPrimary
+            'G' -> Color(0xFF299999)
+            '0' -> Color(0xFFABC023)
+            'N' -> Color(0xFFBBB529)
+            'R' -> Color(0xFFFF6B68)
+            else -> ElementTheme.colors.textPrimary
+        }
+        ColorationMode.None -> ElementTheme.colors.textPrimary
     }
 }
 

--- a/features/viewfolder/impl/src/test/kotlin/io/element/android/features/viewfolder/test/file/ViewFilePresenterTest.kt
+++ b/features/viewfolder/impl/src/test/kotlin/io/element/android/features/viewfolder/test/file/ViewFilePresenterTest.kt
@@ -20,6 +20,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.features.viewfolder.impl.file.ColorationMode
 import io.element.android.features.viewfolder.impl.file.FileContentReader
 import io.element.android.features.viewfolder.impl.file.FileSave
 import io.element.android.features.viewfolder.impl.file.FileShare
@@ -48,10 +49,35 @@ class ViewFilePresenterTest {
             val initialState = awaitItem()
             assertThat(initialState.name).isEqualTo("aName")
             assertThat(initialState.lines).isInstanceOf(AsyncData.Loading::class.java)
+            assertThat(initialState.colorationMode).isEqualTo(ColorationMode.None)
             val loadedState = awaitItem()
             val lines = (loadedState.lines as AsyncData.Success).data
             assertThat(lines.size).isEqualTo(1)
             assertThat(lines.first()).isEqualTo("aLine")
+        }
+    }
+
+    @Test
+    fun `present - coloration mode for logcat`() = runTest {
+        val presenter = createPresenter(name = "logcat.log")
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.colorationMode).isEqualTo(ColorationMode.Logcat)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - coloration mode for logs`() = runTest {
+        val presenter = createPresenter(name = "logs.date")
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.colorationMode).isEqualTo(ColorationMode.Logs)
+            cancelAndConsumeRemainingEvents()
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Complement for #2283.
Coloration was not working for logs file filled by the SDK since the format is not the same than on logcat files.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Better readable log file.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

<img width="286" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/20085c54-f55c-4019-a62e-a93f917fe87f">

## Tests

<!-- Explain how you tested your development -->

- Open a logs file from the nightly and see that coloration does not work.
- With this PR it will work, but keep in mind that logs file are not generated on debug build.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
