### PR TITLE
Remove session preferences on logout.

### DIFF
--- a/changelog.d/+remove-session-preferences-on-logout.misc
+++ b/changelog.d/+remove-session-preferences-on-logout.misc
@@ -1,0 +1,1 @@
+Remove session preferences on user log out.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Listens to session status in `DefaultSessionPreferencesStoreFactory` and both remove the preferences from its cache and from disk when a user is logged out.

## Motivation and context

We should remove session preferences when the user logs out.

## Tests

- Log in using an account.
- Go to settings -> advanced settings -> disable 'read receipts'.
- Log out.
- Log in again.
- Go to settings -> advanced settings -> 'read receipts' should be enabled again.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
