### PR TITLE
Fix crash about several DataStores using the same file

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/DefaultSessionComponentFactory.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/DefaultSessionComponentFactory.kt
@@ -27,9 +27,6 @@ class DefaultSessionComponentFactory @Inject constructor(
     private val sessionComponentBuilder: SessionComponent.Builder
 ) : SessionComponentFactory {
     override fun create(client: MatrixClient): Any {
-        return sessionComponentBuilder
-            .client(client)
-            .sessionCoroutineScope(client.sessionCoroutineScope)
-            .build()
+        return sessionComponentBuilder.client(client).build()
     }
 }

--- a/app/src/main/kotlin/io/element/android/x/di/DefaultSessionComponentFactory.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/DefaultSessionComponentFactory.kt
@@ -27,6 +27,9 @@ class DefaultSessionComponentFactory @Inject constructor(
     private val sessionComponentBuilder: SessionComponent.Builder
 ) : SessionComponentFactory {
     override fun create(client: MatrixClient): Any {
-        return sessionComponentBuilder.client(client).build()
+        return sessionComponentBuilder
+            .client(client)
+            .sessionCoroutineScope(client.sessionCoroutineScope)
+            .build()
     }
 }

--- a/app/src/main/kotlin/io/element/android/x/di/SessionComponent.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/SessionComponent.kt
@@ -24,9 +24,7 @@ import io.element.android.libraries.architecture.NodeFactoriesBindings
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.di.SingleIn
-import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.MatrixClient
-import kotlinx.coroutines.CoroutineScope
 
 @SingleIn(SessionScope::class)
 @MergeSubcomponent(SessionScope::class)
@@ -35,9 +33,6 @@ interface SessionComponent : NodeFactoriesBindings {
     interface Builder {
         @BindsInstance
         fun client(matrixClient: MatrixClient): Builder
-
-        @BindsInstance
-        fun sessionCoroutineScope(@SessionCoroutineScope coroutineScope: CoroutineScope): Builder
 
         fun build(): SessionComponent
     }

--- a/app/src/main/kotlin/io/element/android/x/di/SessionComponent.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/SessionComponent.kt
@@ -24,7 +24,9 @@ import io.element.android.libraries.architecture.NodeFactoriesBindings
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.di.SingleIn
+import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.MatrixClient
+import kotlinx.coroutines.CoroutineScope
 
 @SingleIn(SessionScope::class)
 @MergeSubcomponent(SessionScope::class)
@@ -33,6 +35,10 @@ interface SessionComponent : NodeFactoriesBindings {
     interface Builder {
         @BindsInstance
         fun client(matrixClient: MatrixClient): Builder
+
+        @BindsInstance
+        fun sessionCoroutineScope(@SessionCoroutineScope coroutineScope: CoroutineScope): Builder
+
         fun build(): SessionComponent
     }
 

--- a/changelog.d/2308.bugfix
+++ b/changelog.d/2308.bugfix
@@ -1,0 +1,1 @@
+Fix 'There are multiple DataStores active for the same file' crashes

--- a/libraries/di/src/main/kotlin/io/element/android/libraries/di/annotations/SessionCoroutineScope.kt
+++ b/libraries/di/src/main/kotlin/io/element/android/libraries/di/annotations/SessionCoroutineScope.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.di.annotations
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifies a [CoroutineScope] object which represents the base coroutine scope to use for an active session.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Qualifier
+annotation class SessionCoroutineScope

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -34,12 +34,14 @@ import io.element.android.libraries.matrix.api.sync.SyncService
 import io.element.android.libraries.matrix.api.user.MatrixSearchUserResults
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
+import kotlinx.coroutines.CoroutineScope
 import java.io.Closeable
 
 interface MatrixClient : Closeable {
     val sessionId: SessionId
     val roomListService: RoomListService
     val mediaLoader: MatrixMediaLoader
+    val sessionCoroutineScope: CoroutineScope
     suspend fun getRoom(roomId: RoomId): MatrixRoom?
     suspend fun findDM(userId: UserId): RoomId?
     suspend fun ignoreUser(userId: UserId): Result<Unit>

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -102,9 +102,10 @@ class RustMatrixClient(
     private val clock: SystemClock,
 ) : MatrixClient {
     override val sessionId: UserId = UserId(client.userId())
+    override val sessionCoroutineScope = appCoroutineScope.childScope(dispatchers.main, "Session-$sessionId")
+
     private val innerRoomListService = syncService.roomListService()
     private val sessionDispatcher = dispatchers.io.limitedParallelism(64)
-    private val sessionCoroutineScope = appCoroutineScope.childScope(dispatchers.main, "Session-$sessionId")
     private val rustSyncService = RustSyncService(syncService, sessionCoroutineScope)
     private val verificationService = RustSessionVerificationService(rustSyncService, sessionCoroutineScope)
     private val pushersService = RustPushersService(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/di/SessionMatrixModule.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/di/SessionMatrixModule.kt
@@ -20,6 +20,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
@@ -27,6 +28,7 @@ import io.element.android.libraries.matrix.api.notificationsettings.Notification
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
+import kotlinx.coroutines.CoroutineScope
 
 @Module
 @ContributesTo(SessionScope::class)
@@ -59,5 +61,11 @@ object SessionMatrixModule {
     @Provides
     fun provideMediaLoader(matrixClient: MatrixClient): MatrixMediaLoader {
         return matrixClient.mediaLoader
+    }
+
+    @SessionCoroutineScope
+    @Provides
+    fun provideSessionCoroutineScope(matrixClient: MatrixClient): CoroutineScope {
+        return matrixClient.sessionCoroutineScope
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -43,10 +43,13 @@ import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
 import io.element.android.tests.testutils.simulateLongTask
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
 
 class FakeMatrixClient(
     override val sessionId: SessionId = A_SESSION_ID,
+    override val sessionCoroutineScope: CoroutineScope = TestScope(),
     private val userDisplayName: Result<String> = Result.success(A_USER_NAME),
     private val userAvatarUrl: Result<String> = Result.success(AN_AVATAR_URL),
     override val roomListService: RoomListService = FakeRoomListService(),

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
@@ -22,27 +22,19 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStoreFile
-import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.features.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.androidutils.file.safeDelete
 import io.element.android.libraries.androidutils.hash.hash
-import io.element.android.libraries.di.ApplicationContext
-import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.core.SessionId
-import io.element.android.libraries.matrix.api.user.CurrentSessionIdHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.io.File
-import javax.inject.Inject
 
-@ContributesBinding(SessionScope::class)
-@SingleIn(SessionScope::class)
-class DefaultSessionPreferencesStore @Inject constructor(
-    @ApplicationContext context: Context,
-    currentSessionIdHolder: CurrentSessionIdHolder,
+class DefaultSessionPreferencesStore(
+    context: Context,
+    sessionId: SessionId,
     @SessionCoroutineScope sessionCoroutineScope: CoroutineScope,
 ) : SessionPreferencesStore {
     companion object {
@@ -53,7 +45,7 @@ class DefaultSessionPreferencesStore @Inject constructor(
     }
     private val sendPublicReadReceiptsKey = booleanPreferencesKey("sendPublicReadReceipts")
 
-    private val dataStoreFile = storeFile(context, currentSessionIdHolder.current)
+    private val dataStoreFile = storeFile(context, sessionId)
     private val store = PreferenceDataStoreFactory.create(scope = sessionCoroutineScope) { dataStoreFile }
 
     override suspend fun setSendPublicReadReceipts(enabled: Boolean) = update(sendPublicReadReceiptsKey, enabled)

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStoreFactory.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStoreFactory.kt
@@ -31,11 +31,7 @@ class DefaultSessionPreferencesStoreFactory @Inject constructor(
 ) {
     private val cache = ConcurrentHashMap<SessionId, DefaultSessionPreferencesStore>()
 
-    fun get(sessionId: SessionId, sessionCoroutineScope: CoroutineScope) = cache.getOrPut(sessionId) {
+    fun get(sessionId: SessionId, sessionCoroutineScope: CoroutineScope): DefaultSessionPreferencesStore = cache.getOrPut(sessionId) {
         DefaultSessionPreferencesStore(context, sessionId, sessionCoroutineScope)
     }
-
-    fun remove(sessionId: SessionId) = cache.remove(sessionId)
-
-    fun clear() = cache.clear()
 }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStoreFactory.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStoreFactory.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.preferences.impl.store
+
+import android.content.Context
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.di.SingleIn
+import io.element.android.libraries.matrix.api.core.SessionId
+import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+@SingleIn(AppScope::class)
+class DefaultSessionPreferencesStoreFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val cache = ConcurrentHashMap<SessionId, DefaultSessionPreferencesStore>()
+
+    fun get(sessionId: SessionId, sessionCoroutineScope: CoroutineScope) = cache.getOrPut(sessionId) {
+        DefaultSessionPreferencesStore(context, sessionId, sessionCoroutineScope)
+    }
+
+    fun remove(sessionId: SessionId) = cache.remove(sessionId)
+
+    fun clear() = cache.clear()
+}

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/SessionPreferencesModule.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/SessionPreferencesModule.kt
@@ -21,7 +21,6 @@ import dagger.Module
 import dagger.Provides
 import io.element.android.features.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.user.CurrentSessionIdHolder
 import kotlinx.coroutines.CoroutineScope
@@ -30,7 +29,6 @@ import kotlinx.coroutines.CoroutineScope
 @ContributesTo(SessionScope::class)
 object SessionPreferencesModule {
     @Provides
-    @SingleIn(SessionScope::class)
     fun providesSessionPreferencesStore(
         defaultSessionPreferencesStoreFactory: DefaultSessionPreferencesStoreFactory,
         currentSessionIdHolder: CurrentSessionIdHolder,

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/SessionPreferencesModule.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/SessionPreferencesModule.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.preferences.impl.store
+
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import io.element.android.features.preferences.api.store.SessionPreferencesStore
+import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.di.SingleIn
+import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.matrix.api.user.CurrentSessionIdHolder
+import kotlinx.coroutines.CoroutineScope
+
+@Module
+@ContributesTo(SessionScope::class)
+object SessionPreferencesModule {
+    @Provides
+    @SingleIn(SessionScope::class)
+    fun providesSessionPreferencesStore(
+        defaultSessionPreferencesStoreFactory: DefaultSessionPreferencesStoreFactory,
+        currentSessionIdHolder: CurrentSessionIdHolder,
+        @SessionCoroutineScope sessionCoroutineScope: CoroutineScope,
+    ): SessionPreferencesStore {
+        return defaultSessionPreferencesStoreFactory
+            .get(currentSessionIdHolder.current, sessionCoroutineScope)
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Fix crash about several DataStores using the same file
	- Create `@SessionCoroutineScope` annotation to pass a session-managed coroutine scope to the DI.
	- Expose this scope from `MatrixClient`.
	- Rework SessionPreferencesStore file creation a bit. Use this coroutine scope to initialize the data store, so it's stopped when the scope is cancelled.
- Make sure the whole item in advanced settings screen triggers the toggle action, to be consistent with the rest of the app.

## Motivation and context

Fixes #2308 (I hope).

## Tests

To be honest, I'm not 100% sure how to trigger this issue. I tried logging out and in again, which was my theory for why this was happening, but sadly I couldn't reproduce the issue.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
