### PR TITLE
Add an empty state to the room list

### DIFF
--- a/changelog.d/2330.feature
+++ b/changelog.d/2330.feature
@@ -1,0 +1,1 @@
+Add empty state to the room list.

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -32,6 +33,7 @@ import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.api.NetworkStatus
 import io.element.android.features.roomlist.impl.datasource.InviteStateDataSource
 import io.element.android.features.roomlist.impl.datasource.RoomListDataSource
+import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.snackbar.collectSnackbarMessageAsState
@@ -68,7 +70,9 @@ class RoomListPresenter @Inject constructor(
         val matrixUser: MutableState<MatrixUser?> = rememberSaveable {
             mutableStateOf(null)
         }
-        val roomList by roomListDataSource.allRooms.collectAsState()
+        val roomList by produceState(initialValue = AsyncData.Loading()) {
+            roomListDataSource.allRooms.collect { value = AsyncData.Success(it) }
+        }
         val filteredRoomList by roomListDataSource.filteredRooms.collectAsState()
         val filter by roomListDataSource.filter.collectAsState()
         val networkConnectionStatus by networkMonitor.connectivity.collectAsState()

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -19,6 +19,7 @@ package io.element.android.features.roomlist.impl
 import androidx.compose.runtime.Immutable
 import io.element.android.features.leaveroom.api.LeaveRoomState
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
+import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarMessage
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.user.MatrixUser
@@ -28,7 +29,7 @@ import kotlinx.collections.immutable.ImmutableList
 data class RoomListState(
     val matrixUser: MatrixUser?,
     val showAvatarIndicator: Boolean,
-    val roomList: ImmutableList<RoomListRoomSummary>,
+    val roomList: AsyncData<ImmutableList<RoomListRoomSummary>>,
     val filter: String?,
     val filteredRoomList: ImmutableList<RoomListRoomSummary>,
     val displayVerificationPrompt: Boolean,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
@@ -18,6 +18,7 @@ package io.element.android.features.roomlist.impl
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.leaveroom.api.aLeaveRoomState
+import io.element.android.features.roomlist.impl.datasource.RoomListRoomSummaryFactory
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.features.roomlist.impl.model.aRoomListRoomSummary
 import io.element.android.libraries.architecture.AsyncData
@@ -51,7 +52,7 @@ open class RoomListStateProvider : PreviewParameterProvider<RoomListState> {
             ),
             aRoomListState().copy(displayRecoveryKeyPrompt = true),
             aRoomListState().copy(roomList = AsyncData.Success(persistentListOf())),
-            aRoomListState().copy(roomList = AsyncData.Loading()),
+            aRoomListState().copy(roomList = AsyncData.Loading(prevData = RoomListRoomSummaryFactory.createFakeList())),
         )
 }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.leaveroom.api.aLeaveRoomState
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.features.roomlist.impl.model.aRoomListRoomSummary
+import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarMessage
@@ -49,13 +50,15 @@ open class RoomListStateProvider : PreviewParameterProvider<RoomListState> {
                 )
             ),
             aRoomListState().copy(displayRecoveryKeyPrompt = true),
+            aRoomListState().copy(roomList = AsyncData.Success(persistentListOf())),
+            aRoomListState().copy(roomList = AsyncData.Loading()),
         )
 }
 
 internal fun aRoomListState() = RoomListState(
     matrixUser = MatrixUser(userId = UserId("@id:domain"), displayName = "User#1"),
     showAvatarIndicator = false,
-    roomList = aRoomListRoomSummaryList(),
+    roomList = AsyncData.Success(aRoomListRoomSummaryList()),
     filter = "filter",
     filteredRoomList = aRoomListRoomSummaryList(),
     hasNetworkConnection = true,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -220,7 +221,6 @@ private fun RoomListContent(
             )
         },
         content = { padding ->
-            println(state.roomList)
             if (state.roomList is AsyncData.Success && state.roomList.data.isEmpty()) {
                 EmptyRoomListView(onCreateRoomClicked)
             } else {
@@ -230,6 +230,8 @@ private fun RoomListContent(
                         .consumeWindowInsets(padding)
                         .nestedScroll(nestedScrollConnection),
                     state = lazyListState,
+                    // FAB height is 56dp, bottom padding is 16dp, we add 8dp as extra margin -> 56+16+8 = 80
+                    contentPadding = PaddingValues(bottom = 80.dp)
                 ) {
                     when {
                         state.displayVerificationPrompt -> {
@@ -260,6 +262,7 @@ private fun RoomListContent(
                     itemsIndexed(
                         items = roomList,
                         contentType = { _, room -> room.contentType() },
+                        key = { _, room -> room.roomId.value }
                     ) { index, room ->
                         RoomSummaryRow(
                             room = room,
@@ -269,11 +272,6 @@ private fun RoomListContent(
                         if (index != roomList.lastIndex) {
                             HorizontalDivider()
                         }
-                    }
-                    // Add a last Spacer item to ensure that the FAB does not hide the last room item
-                    // FAB height is 56dp, bottom padding is 16dp, we add 8dp as extra margin -> 56+16+8 = 80
-                    item {
-                        Spacer(modifier = Modifier.height(80.dp))
                     }
                 }
             }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
@@ -115,7 +115,7 @@ class RoomListDataSource @Inject constructor(
     private suspend fun buildAndEmitAllRooms(roomSummaries: List<RoomSummary>) {
         if (diffCache.isEmpty()) {
             _allRooms.emit(
-                roomListRoomSummaryFactory.createFakeList()
+                RoomListRoomSummaryFactory.createFakeList()
             )
         } else {
             val roomListRoomSummaries = ArrayList<RoomListRoomSummary>()
@@ -135,7 +135,7 @@ class RoomListDataSource @Inject constructor(
 
     private fun buildAndCacheItem(roomSummaries: List<RoomSummary>, index: Int): RoomListRoomSummary? {
         val roomListRoomSummary = when (val roomSummary = roomSummaries.getOrNull(index)) {
-            is RoomSummary.Empty -> roomListRoomSummaryFactory.createPlaceholder(roomSummary.identifier)
+            is RoomSummary.Empty -> RoomListRoomSummaryFactory.createPlaceholder(roomSummary.identifier)
             is RoomSummary.Filled -> roomListRoomSummaryFactory.create(roomSummary)
             null -> null
         }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
+import io.element.android.libraries.matrix.api.roomlist.RoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
 import kotlinx.collections.immutable.ImmutableList
@@ -113,10 +114,9 @@ class RoomListDataSource @Inject constructor(
     }
 
     private suspend fun buildAndEmitAllRooms(roomSummaries: List<RoomSummary>) {
-        if (diffCache.isEmpty()) {
-            _allRooms.emit(
-                RoomListRoomSummaryFactory.createFakeList()
-            )
+        if (diffCache.isEmpty() && roomListService.allRooms.loadingState.value is RoomList.LoadingState.NotLoaded) {
+            // If the room list is not loaded, we emit a fake placeholders list
+            _allRooms.emit(RoomListRoomSummaryFactory.createFakeList())
         } else {
             val roomListRoomSummaries = ArrayList<RoomListRoomSummary>()
             for (index in diffCache.indices()) {

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
@@ -28,7 +28,9 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -52,7 +54,7 @@ class RoomListDataSource @Inject constructor(
     }
 
     private val _filter = MutableStateFlow("")
-    private val _allRooms = MutableStateFlow<ImmutableList<RoomListRoomSummary>>(persistentListOf())
+    private val _allRooms = MutableSharedFlow<ImmutableList<RoomListRoomSummary>>(replay = 1)
     private val _filteredRooms = MutableStateFlow<ImmutableList<RoomListRoomSummary>>(persistentListOf())
 
     private val lock = Mutex()
@@ -90,7 +92,7 @@ class RoomListDataSource @Inject constructor(
     }
 
     val filter: StateFlow<String> = _filter
-    val allRooms: StateFlow<ImmutableList<RoomListRoomSummary>> = _allRooms
+    val allRooms: SharedFlow<ImmutableList<RoomListRoomSummary>> = _allRooms
     val filteredRooms: StateFlow<ImmutableList<RoomListRoomSummary>> = _filteredRooms
 
     @OptIn(FlowPreview::class)

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListRoomSummaryFactory.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListRoomSummaryFactory.kt
@@ -32,28 +32,30 @@ class RoomListRoomSummaryFactory @Inject constructor(
     private val lastMessageTimestampFormatter: LastMessageTimestampFormatter,
     private val roomLastMessageFormatter: RoomLastMessageFormatter,
 ) {
-    fun createPlaceholder(id: String): RoomListRoomSummary {
-        return RoomListRoomSummary(
-            id = id,
-            roomId = RoomId("!aRoom:domain"),
-            isPlaceholder = true,
-            name = "Short name",
-            timestamp = "hh:mm",
-            lastMessage = "Last message for placeholder",
-            avatarData = AvatarData(id, "S", size = AvatarSize.RoomListItem),
-            numberOfUnreadMessages = 0,
-            numberOfUnreadMentions = 0,
-            numberOfUnreadNotifications = 0,
-            userDefinedNotificationMode = null,
-            hasRoomCall = false,
-            isDm = false,
-        )
-    }
+    companion object {
+        fun createPlaceholder(id: String): RoomListRoomSummary {
+            return RoomListRoomSummary(
+                id = id,
+                roomId = RoomId(id),
+                isPlaceholder = true,
+                name = "Short name",
+                timestamp = "hh:mm",
+                lastMessage = "Last message for placeholder",
+                avatarData = AvatarData(id, "S", size = AvatarSize.RoomListItem),
+                numberOfUnreadMessages = 0,
+                numberOfUnreadMentions = 0,
+                numberOfUnreadNotifications = 0,
+                userDefinedNotificationMode = null,
+                hasRoomCall = false,
+                isDm = false,
+            )
+        }
 
-    fun createFakeList(): ImmutableList<RoomListRoomSummary> {
-        return List(16) {
-            createPlaceholder("!fakeRoom$it:domain")
-        }.toImmutableList()
+        fun createFakeList(): ImmutableList<RoomListRoomSummary> {
+            return List(16) {
+                createPlaceholder("!fakeRoom$it:domain")
+            }.toImmutableList()
+        }
     }
 
     fun create(roomSummary: RoomSummary.Filled): RoomListRoomSummary {

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_10,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_10,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f0dfd19b21ff2ba1fdbb423578f71e4d28a01d84bc7e1a41a1027b1b2d09db3
+size 55268

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_11,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_11,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2fb4ca138fefc4d4c4e09d3c1c403bea3f54aa226bba6a836711f21093e06b6
+size 51707

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_10,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_10,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ab5f276868ad19ac4c5f6bbce92286bd6a846c77b91cb8c76d12a9d6aeca31c
+size 57171

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_11,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_11,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aecfc26c04a2c1d16ae9d00a85388ac6497190c743b8b6b37b40c4337c216216
+size 53371


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Make `RoomListDataSource.allRooms` a `SharedFlow` so we can know when we don't have a value yet.
- Map its output in `RoomListPresenter` to `AsyncData`.
- Display the new empty state when the room list has loaded and has no items.
- Use `contentPadding` for the room list bottom padding instead of an extra item.
- Make the room list use a key for recycling components. This *may* cause crashes, but at least we'll know something is wrong with the room list.

## Motivation and context

Closes #2330.

## Screenshots / GIFs

|Light|Dark|
|-|-|
| ![](https://media.githubusercontent.com/media/element-hq/element-x-android/8060c870f1c1247212d186be3a5bfc7e70ba9d25/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_10%2CNEXUS_5%2C1.0%2Cen%5D.png) | ![](https://media.githubusercontent.com/media/element-hq/element-x-android/8060c870f1c1247212d186be3a5bfc7e70ba9d25/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_10%2CNEXUS_5%2C1.0%2Cen%5D.png) |
|![](https://media.githubusercontent.com/media/element-hq/element-x-android/8060c870f1c1247212d186be3a5bfc7e70ba9d25/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomlist.impl_RoomListView_null_RoomListView-Day-3_4_null_11%2CNEXUS_5%2C1.0%2Cen%5D.png)|![](https://media.githubusercontent.com/media/element-hq/element-x-android/8060c870f1c1247212d186be3a5bfc7e70ba9d25/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomlist.impl_RoomListView_null_RoomListView-Night-3_5_null_11%2CNEXUS_5%2C1.0%2Cen%5D.png)|

## Tests

- Log into the app with a freshly created account, or leave all rooms in your current one.
- The empty state view should appear, the 'start chat' button should work.
- Join a room.
- The empty state view should be gone.
- 
## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 14 & 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
