### PR TITLE
Do not use a key for the LazyColumn.

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -259,10 +259,11 @@ private fun RoomListContent(
                     }
 
                     val roomList = state.roomList.dataOrNull().orEmpty()
+                    // Note: do not use a key for the LazyColumn, or the scroll will not behave as expected if a room
+                    // is moved to the top of the list.
                     itemsIndexed(
                         items = roomList,
                         contentType = { _, room -> room.contentType() },
-                        key = { _, room -> room.roomId.value }
                     ) { index, room ->
                         RoomSummaryRow(
                             room = room,


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Do not use a key for the LazyColumn or the scroll will not behave as expected if a room is moved to the top of the list.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix a crash since the SDK may provide several times the same room, so the LazyList is complaining that the key is not unique. This duplication will be fixed later in the SDK.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Scroll to the bottom of a rather large room list (> 50 rooms)
- Without this PR, there is a crash
- With this PR the last room may be displayed twice (and this has to be fixed SDK side)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
