### PR TITLE
Enable trace logging for the Olm Account

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
@@ -25,6 +25,7 @@ data class TracingFilterConfiguration(
     private val targetsToLogLevel: Map<Target, LogLevel> = mapOf(
         Target.HYPER to LogLevel.WARN,
         Target.MATRIX_SDK_CRYPTO to LogLevel.DEBUG,
+        Target.MATRIX_SDK_CRYPTO_ACCOUNT to LogLevel.TRACE,
         Target.MATRIX_SDK_HTTP_CLIENT to LogLevel.DEBUG,
         Target.MATRIX_SDK_SLIDING_SYNC to LogLevel.TRACE,
         Target.MATRIX_SDK_BASE_SLIDING_SYNC to LogLevel.TRACE,
@@ -58,6 +59,7 @@ enum class Target(open val filter: String) {
     MATRIX_SDK_FFI("matrix_sdk_ffi"),
     MATRIX_SDK_UNIFFI_API("matrix_sdk_ffi::uniffi_api"),
     MATRIX_SDK_CRYPTO("matrix_sdk_crypto"),
+    MATRIX_SDK_CRYPTO_ACCOUNT("matrix_sdk_crypto::olm::account"),
     MATRIX_SDK("matrix_sdk"),
     MATRIX_SDK_HTTP_CLIENT("matrix_sdk::http_client"),
     MATRIX_SDK_CLIENT("matrix_sdk::client"),


### PR DESCRIPTION
This should help us to track down UTD sources, it ensures that we log the state of a Olm session when we try to decrypt an `m.olm.*` to-device message.

This should be applied after we update to https://github.com/matrix-org/matrix-rust-sdk/pull/3100.

Matching EX-iOS PR: https://github.com/element-hq/element-x-ios/pull/2427