### PR TITLE
Remove modifier parameter in private methods

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/icon/IconPreview.kt
+++ b/app/src/main/kotlin/io/element/android/x/icon/IconPreview.kt
@@ -35,10 +35,8 @@ import io.element.android.x.R
 
 @Preview
 @Composable
-internal fun IconPreview(
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier) {
+internal fun IconPreview() {
+    Box {
         Image(painter = painterResource(id = R.mipmap.ic_launcher_background), contentDescription = null)
         Image(painter = painterResource(id = R.mipmap.ic_launcher_foreground), contentDescription = null)
     }
@@ -46,10 +44,8 @@ internal fun IconPreview(
 
 @Preview
 @Composable
-internal fun RoundIconPreview(
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.clip(shape = CircleShape)) {
+internal fun RoundIconPreview() {
+    Box(modifier = Modifier.clip(shape = CircleShape)) {
         Image(painter = painterResource(id = R.mipmap.ic_launcher_background), contentDescription = null)
         Image(painter = painterResource(id = R.mipmap.ic_launcher_foreground), contentDescription = null)
     }
@@ -57,11 +53,9 @@ internal fun RoundIconPreview(
 
 @Preview
 @Composable
-internal fun MonochromeIconPreview(
-    modifier: Modifier = Modifier,
-) {
+internal fun MonochromeIconPreview() {
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(108.dp)
             .background(Color(0xFF2F3133))
             .clip(shape = RoundedCornerShape(32.dp)),

--- a/appnav/src/main/kotlin/io/element/android/appnav/room/LoadingRoomNodeView.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/LoadingRoomNodeView.kt
@@ -84,10 +84,8 @@ fun LoadingRoomNodeView(
 @Composable
 private fun LoadingRoomTopBar(
     onBackClicked: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     TopAppBar(
-        modifier = modifier,
         navigationIcon = {
             BackButton(onClick = onBackClicked)
         },

--- a/features/analytics/impl/src/main/kotlin/io/element/android/features/analytics/impl/AnalyticsOptInView.kt
+++ b/features/analytics/impl/src/main/kotlin/io/element/android/features/analytics/impl/AnalyticsOptInView.kt
@@ -99,10 +99,8 @@ private const val LINK_TAG = "link"
 private fun AnalyticsOptInHeader(
     state: AnalyticsOptInState,
     onClickTerms: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         IconTitleSubtitleMolecule(
@@ -139,9 +137,9 @@ private fun AnalyticsOptInHeader(
 }
 
 @Composable
-private fun CheckIcon(modifier: Modifier = Modifier) {
+private fun CheckIcon() {
     Icon(
-        modifier = modifier
+        modifier = Modifier
             .size(20.dp)
             .background(color = MaterialTheme.colorScheme.background, shape = CircleShape)
             .padding(2.dp),
@@ -152,11 +150,9 @@ private fun CheckIcon(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun AnalyticsOptInContent(
-    modifier: Modifier = Modifier,
-) {
+private fun AnalyticsOptInContent() {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         contentAlignment = BiasAlignment(
             horizontalBias = 0f,
             verticalBias = -0.4f
@@ -188,11 +184,8 @@ private fun AnalyticsOptInContent(
 private fun AnalyticsOptInFooter(
     onTermsAccepted: () -> Unit,
     onTermsDeclined: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    ButtonColumnMolecule(
-        modifier = modifier,
-    ) {
+    ButtonColumnMolecule {
         Button(
             text = stringResource(id = CommonStrings.action_ok),
             onClick = onTermsAccepted,

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeopleView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/addpeople/AddPeopleView.kt
@@ -88,10 +88,8 @@ private fun AddPeopleViewTopBar(
     hasSelectedUsers: Boolean,
     onBackPressed: () -> Unit,
     onNextPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(id = R.string.screen_create_room_add_people_title),

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -18,7 +18,6 @@ package io.element.android.features.createroom.impl.configureroom
 
 import android.net.Uri
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -38,8 +37,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -52,6 +49,7 @@ import io.element.android.libraries.designsystem.components.LabelledTextField
 import io.element.android.libraries.designsystem.components.async.AsyncActionView
 import io.element.android.libraries.designsystem.components.async.AsyncActionViewDefaults
 import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.modifiers.clearFocusOnTap
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.aliasScreenTitle
@@ -256,13 +254,6 @@ private fun RoomPrivacyOptions(
         }
     }
 }
-
-private fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier =
-    pointerInput(Unit) {
-        detectTapGestures(onTap = {
-            focusManager.clearFocus()
-        })
-    }
 
 @PreviewsDayNight
 @Composable

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -173,10 +173,8 @@ private fun ConfigureRoomToolbar(
     isNextActionEnabled: Boolean,
     onBackPressed: () -> Unit,
     onNextPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(R.string.screen_create_room_title),

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/root/CreateRoomRootView.kt
@@ -117,10 +117,8 @@ fun CreateRoomRootView(
 @Composable
 private fun CreateRoomRootViewTopBar(
     onClosePressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(id = CommonStrings.action_start_chat),
@@ -141,9 +139,8 @@ private fun CreateRoomActionButtonsList(
     state: CreateRoomRootState,
     onNewRoomClicked: () -> Unit,
     onInvitePeopleClicked: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
+    Column {
         CreateRoomActionButton(
             iconRes = CompoundDrawables.ic_plus,
             text = stringResource(id = R.string.screen_create_room_action_create_room),
@@ -162,10 +159,9 @@ private fun CreateRoomActionButton(
     @DrawableRes iconRes: Int,
     text: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
             .clickable { onClick() }

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/notifications/NotificationsOptInView.kt
@@ -67,7 +67,7 @@ fun NotificationsOptInView(
         header = { NotificationsOptInHeader(modifier = Modifier.padding(top = 60.dp, bottom = 12.dp)) },
         footer = { NotificationsOptInFooter(state) },
     ) {
-        NotificationsOptInContent(modifier = Modifier.fillMaxWidth())
+        NotificationsOptInContent()
     }
 }
 
@@ -104,10 +104,8 @@ private fun NotificationsOptInFooter(state: NotificationsOptInState) {
 }
 
 @Composable
-private fun NotificationsOptInContent(
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+private fun NotificationsOptInContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             verticalArrangement = Arrangement.spacedBy(
                 16.dp,
@@ -144,10 +142,8 @@ private fun NotificationRow(
     avatarColorsId: String,
     firstRowPercent: Float,
     secondRowPercent: Float,
-    modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = modifier,
         color = ElementTheme.colors.bgCanvasDisabled,
         shape = RoundedCornerShape(14.dp),
         shadowElevation = 2.dp,

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/components/PinEntryTextField.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/components/PinEntryTextField.kt
@@ -66,10 +66,8 @@ fun PinEntryTextField(
 private fun PinEntryRow(
     pinEntry: PinEntry,
     isSecured: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     FlowRow(
-        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -83,7 +81,6 @@ private fun PinEntryRow(
 private fun PinDigitView(
     digit: PinDigit,
     isSecured: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(8.dp)
     val appearanceModifier = when (digit) {
@@ -95,7 +92,7 @@ private fun PinDigitView(
         }
     }
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(48.dp)
             .then(appearanceModifier),
         contentAlignment = Alignment.Center,

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/biometric/SetupBiometricView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/biometric/SetupBiometricView.kt
@@ -57,13 +57,12 @@ fun SetupBiometricView(
 }
 
 @Composable
-private fun SetupBiometricHeader(modifier: Modifier = Modifier) {
+private fun SetupBiometricHeader() {
     val biometricAuth = stringResource(id = R.string.screen_app_lock_biometric_authentication)
     IconTitleSubtitleMolecule(
         iconImageVector = Icons.Default.Fingerprint,
         title = stringResource(id = R.string.screen_app_lock_settings_enable_biometric_unlock),
         subTitle = stringResource(id = R.string.screen_app_lock_setup_biometric_unlock_subtitle, biometricAuth),
-        modifier = modifier
     )
 }
 
@@ -71,11 +70,8 @@ private fun SetupBiometricHeader(modifier: Modifier = Modifier) {
 private fun SetupBiometricFooter(
     onAllowClicked: () -> Unit,
     onSkipClicked: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
-    ButtonColumnMolecule(
-        modifier = modifier,
-    ) {
+    ButtonColumnMolecule {
         val biometricAuth = stringResource(id = R.string.screen_app_lock_biometric_authentication)
         Button(
             text = stringResource(id = R.string.screen_app_lock_setup_biometric_unlock_allow_title, biometricAuth),

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
@@ -86,10 +86,8 @@ fun SetupPinView(
 private fun SetupPinHeader(
     isValidationStep: Boolean,
     appName: String,
-    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         IconTitleSubtitleMolecule(
@@ -107,7 +105,6 @@ private fun SetupPinHeader(
 @Composable
 private fun SetupPinContent(
     state: SetupPinState,
-    modifier: Modifier = Modifier,
 ) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
@@ -119,14 +116,13 @@ private fun SetupPinContent(
         onValueChange = { entry ->
             state.eventSink(SetupPinEvents.OnPinEntryChanged(entry, state.isConfirmationStep))
         },
-        modifier = modifier
+        modifier = Modifier
             .focusRequester(focusRequester)
             .padding(top = 36.dp)
             .fillMaxWidth()
     )
     if (state.setupPinFailure != null) {
         ErrorDialog(
-            modifier = modifier,
             title = state.setupPinFailure.title(),
             content = state.setupPinFailure.content(),
             onDismiss = {

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockView.kt
@@ -107,10 +107,9 @@ fun PinUnlockView(
 private fun PinUnlockPage(
     state: PinUnlockState,
     isInAppUnlock: Boolean,
-    modifier: Modifier = Modifier
 ) {
     BoxWithConstraints {
-        val commonModifier = modifier
+        val commonModifier = Modifier
             .fillMaxSize()
             .systemBarsPadding()
             .imePadding()
@@ -188,7 +187,6 @@ private fun SignOutPrompt(
     isCancellable: Boolean,
     onSignOut: () -> Unit,
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     if (isCancellable) {
         ConfirmationDialog(
@@ -196,14 +194,12 @@ private fun SignOutPrompt(
             content = stringResource(id = R.string.screen_app_lock_signout_alert_message),
             onSubmitClicked = onSignOut,
             onDismiss = onDismiss,
-            modifier = modifier,
         )
     } else {
         ErrorDialog(
             title = stringResource(id = R.string.screen_app_lock_signout_alert_title),
             content = stringResource(id = R.string.screen_app_lock_signout_alert_message),
             onDismiss = onSignOut,
-            modifier = modifier,
         )
     }
 }
@@ -258,9 +254,11 @@ private fun PinUnlockExpandedView(
 @Composable
 private fun PinDotsRow(
     pinEntry: PinEntry,
-    modifier: Modifier = Modifier,
 ) {
-    Row(modifier, horizontalArrangement = spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        horizontalArrangement = spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         for (digit in pinEntry.digits) {
             PinDot(isFilled = digit is PinDigit.Filled)
         }
@@ -270,7 +268,6 @@ private fun PinDotsRow(
 @Composable
 private fun PinDot(
     isFilled: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     val backgroundColor = if (isFilled) {
         ElementTheme.colors.iconPrimary
@@ -278,7 +275,7 @@ private fun PinDot(
         ElementTheme.colors.bgSubtlePrimary
     }
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(14.dp)
             .background(backgroundColor, CircleShape)
     )
@@ -290,7 +287,10 @@ private fun PinUnlockHeader(
     isInAppUnlock: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         if (isInAppUnlock) {
             RoundedIconAtom(imageVector = Icons.Filled.Lock)
         } else {

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypad.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypad.kt
@@ -108,14 +108,13 @@ private fun PinKeypadRow(
     models: ImmutableList<PinKeypadModel>,
     onClick: (PinKeypadModel) -> Unit,
     pinKeySize: Dp,
-    modifier: Modifier = Modifier,
     horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
 ) {
     Row(
         horizontalArrangement = horizontalArrangement,
         verticalAlignment = verticalAlignment,
-        modifier = modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth(),
     ) {
         val commonModifier = Modifier.size(pinKeySize)
         for (model in models) {

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -179,7 +179,6 @@ private fun LoginForm(
     state: LoginPasswordState,
     isLoading: Boolean,
     onSubmit: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     var loginFieldState by textFieldState(stateValue = state.formState.login)
     var passwordFieldState by textFieldState(stateValue = state.formState.password)
@@ -187,7 +186,7 @@ private fun LoginForm(
     val focusManager = LocalFocusManager.current
     val eventSink = state.eventSink
 
-    Column(modifier) {
+    Column {
         Text(
             text = stringResource(R.string.screen_login_form_header),
             modifier = Modifier.padding(start = 16.dp),

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/waitlistscreen/WaitListView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/waitlistscreen/WaitListView.kt
@@ -119,9 +119,8 @@ private fun WaitListContent(
 private fun OverallContent(
     state: WaitListState,
     onCancelClicked: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize()) {
         if (state.loginAction !is AsyncData.Success) {
             CompositionLocalProvider(LocalContentColor provides ElementTheme.colors.textOnSolidPrimary) {
                 TextButton(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -412,10 +412,9 @@ private fun MessagesViewContent(
 private fun MessagesViewComposerBottomSheetContents(
     subcomposing: Boolean,
     state: MessagesState,
-    modifier: Modifier = Modifier,
 ) {
     if (state.userHasPermissionToSendMessage) {
-        Column(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             MentionSuggestionsPickerView(
                 modifier = Modifier
                     .heightIn(max = 230.dp)
@@ -443,7 +442,7 @@ private fun MessagesViewComposerBottomSheetContents(
             )
         }
     } else {
-        CantSendMessageBanner(modifier = modifier)
+        CantSendMessageBanner()
     }
 }
 
@@ -456,10 +455,8 @@ private fun MessagesViewTopBar(
     onRoomDetailsClicked: () -> Unit,
     onJoinCallClicked: () -> Unit,
     onBackPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         navigationIcon = {
             BackButton(onClick = onBackPressed)
         },
@@ -497,7 +494,6 @@ private fun MessagesViewTopBar(
 
 @Composable
 private fun JoinCallMenuItem(
-    modifier: Modifier = Modifier,
     onJoinCallClicked: () -> Unit,
 ) {
     Material3Button(
@@ -507,7 +503,7 @@ private fun JoinCallMenuItem(
             containerColor = ElementTheme.colors.iconAccentTertiary
         ),
         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
-        modifier = modifier.heightIn(min = 36.dp),
+        modifier = Modifier.heightIn(min = 36.dp),
     ) {
         Icon(
             modifier = Modifier.size(20.dp),
@@ -545,11 +541,9 @@ private fun RoomAvatarAndNameRow(
 }
 
 @Composable
-private fun CantSendMessageBanner(
-    modifier: Modifier = Modifier,
-) {
+private fun CantSendMessageBanner() {
     Row(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.secondary)
             .padding(16.dp),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
@@ -337,7 +337,6 @@ private fun EmojiButton(
     emoji: String,
     isHighlighted: Boolean,
     onClicked: (String) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val backgroundColor = if (isHighlighted) {
         ElementTheme.colors.bgActionPrimaryRest
@@ -350,7 +349,7 @@ private fun EmojiButton(
         stringResource(id = CommonStrings.a11y_react_with, emoji)
     }
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(48.dp)
             .background(backgroundColor, CircleShape)
             .clearAndSetSemantics {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
@@ -118,10 +118,9 @@ private fun AttachmentPreviewContent(
     attachment: Attachment,
     onSendClicked: () -> Unit,
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .padding(top = 24.dp)
     ) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/AttachmentsBottomSheet.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/AttachmentsBottomSheet.kt
@@ -101,10 +101,9 @@ private fun AttachmentSourcePickerMenu(
     onSendLocationClicked: () -> Unit,
     onCreatePollClicked: () -> Unit,
     enableTextFormatting: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .navigationBarsPadding()
             .imePadding()
     ) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionButton.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionButton.kt
@@ -126,9 +126,8 @@ private val ADD_EMOJI_SIZE = 16.dp
 @Composable
 private fun TextContent(
     text: String,
-    modifier: Modifier = Modifier,
 ) = Text(
-    modifier = modifier
+    modifier = Modifier
         .height(REACTION_EMOJI_LINE_HEIGHT.toDp()),
     text = text,
     style = ElementTheme.typography.fontBodyMdRegular,
@@ -138,27 +137,24 @@ private fun TextContent(
 @Composable
 private fun IconContent(
     @DrawableRes resourceId: Int,
-    modifier: Modifier = Modifier
 ) = Icon(
     resourceId = resourceId,
     contentDescription = stringResource(id = R.string.screen_room_timeline_add_reaction),
     tint = ElementTheme.materialColors.secondary,
-    modifier = modifier
+    modifier = Modifier
         .size(ADD_EMOJI_SIZE)
 )
 
 @Composable
 private fun ReactionContent(
     reaction: AggregatedReaction,
-    modifier: Modifier = Modifier,
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
-    modifier = modifier,
 ) {
     // Check if this is a custom reaction (MSC4027)
     if (reaction.key.startsWith("mxc://")) {
         AsyncImage(
-            modifier = modifier
+            modifier = Modifier
                 .heightIn(min = REACTION_EMOJI_LINE_HEIGHT.toDp(), max = REACTION_EMOJI_LINE_HEIGHT.toDp())
                 .aspectRatio(REACTION_IMAGE_ASPECT_RATIO, false),
             model = MediaRequestData(MediaSource(reaction.key), MediaRequestData.Kind.Content),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/reactionsummary/ReactionSummaryView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/reactionsummary/ReactionSummaryView.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -106,7 +107,6 @@ fun ReactionSummaryView(
 @Composable
 private fun SheetContent(
     summary: ReactionSummaryState.Summary,
-    modifier: Modifier = Modifier,
 ) {
     val animationScope = rememberCoroutineScope()
     var selectedReactionKey: String by rememberSaveable { mutableStateOf(summary.selectedKey) }
@@ -127,9 +127,8 @@ private fun SheetContent(
     }
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .fillMaxHeight()
+        modifier = Modifier
+            .fillMaxSize()
     ) {
         LazyRow(
             state = reactionListState,
@@ -172,7 +171,6 @@ private fun AggregatedReactionButton(
     reaction: AggregatedReaction,
     isHighlighted: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val buttonColor = if (isHighlighted) {
         ElementTheme.colors.bgActionPrimaryRest
@@ -188,7 +186,7 @@ private fun AggregatedReactionButton(
 
     val roundedCornerShape = RoundedCornerShape(corner = CornerSize(percent = 50))
     Surface(
-        modifier = modifier
+        modifier = Modifier
             .background(buttonColor, roundedCornerShape)
             .clip(roundedCornerShape)
             .clickable(onClick = onClick)
@@ -238,10 +236,9 @@ private fun SenderRow(
     name: String,
     userId: String,
     sentTime: String,
-    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 56.dp)
             .padding(start = 16.dp, top = 4.dp, end = 16.dp, bottom = 4.dp),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/debug/EventDebugInfoView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/debug/EventDebugInfoView.kt
@@ -125,11 +125,10 @@ fun EventDebugInfoView(
 private fun CollapsibleSection(
     title: String,
     text: String,
-    modifier: Modifier = Modifier,
     initiallyExpanded: Boolean = false,
 ) {
     var isExpanded by remember { mutableStateOf(initiallyExpanded) }
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
                 .clickable { isExpanded = !isExpanded }

--- a/features/networkmonitor/api/src/main/kotlin/io/element/android/features/networkmonitor/api/ui/ConnectivityIndicatorView.kt
+++ b/features/networkmonitor/api/src/main/kotlin/io/element/android/features/networkmonitor/api/ui/ConnectivityIndicatorView.kt
@@ -37,7 +37,6 @@ import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 @Composable
 fun ConnectivityIndicatorView(
     isOnline: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     val isIndicatorVisible = remember { MutableTransitionState(!isOnline) }.apply { targetState = !isOnline }
     val isStatusBarPaddingVisible = remember { MutableTransitionState(isOnline) }.apply { targetState = isOnline }
@@ -48,7 +47,7 @@ fun ConnectivityIndicatorView(
         enter = fadeIn() + expandVertically(),
         exit = fadeOut() + shrinkVertically(),
     ) {
-        Indicator(modifier)
+        Indicator()
     }
 
     // Show missing status bar padding when the indicator is not visible
@@ -57,7 +56,7 @@ fun ConnectivityIndicatorView(
         enter = fadeIn() + expandVertically(),
         exit = fadeOut() + shrinkVertically(),
     ) {
-        StatusBarPaddingSpacer(modifier)
+        StatusBarPaddingSpacer()
     }
 }
 

--- a/features/onboarding/impl/src/main/kotlin/io/element/android/features/onboarding/impl/OnBoardingView.kt
+++ b/features/onboarding/impl/src/main/kotlin/io/element/android/features/onboarding/impl/OnBoardingView.kt
@@ -93,10 +93,9 @@ fun OnBoardingView(
 private fun OnBoardingContent(
     state: OnBoardingState,
     onOpenDeveloperSettings: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
     ) {
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -158,9 +157,8 @@ private fun OnBoardingButtons(
     onSignIn: () -> Unit,
     onCreateAccount: () -> Unit,
     onReportProblem: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    ButtonColumnMolecule(modifier = modifier) {
+    ButtonColumnMolecule {
         val signInButtonStringRes = if (state.canLoginWithQrCode || state.canCreateAccount) {
             R.string.screen_onboarding_sign_in_manually
         } else {

--- a/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/pollcontent/PollContentView.kt
+++ b/features/poll/api/src/main/kotlin/io/element/android/features/poll/api/pollcontent/PollContentView.kt
@@ -143,10 +143,8 @@ fun PollContentView(
 private fun PollTitle(
     title: String,
     isPollEnded: Boolean,
-    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         if (isPollEnded) {
@@ -173,10 +171,9 @@ private fun PollTitle(
 private fun PollAnswers(
     answerItems: ImmutableList<PollAnswerItem>,
     onAnswerSelected: (PollAnswer) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.selectableGroup(),
+        modifier = Modifier.selectableGroup(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         answerItems.forEach {
@@ -197,10 +194,9 @@ private fun PollAnswers(
 @Composable
 private fun ColumnScope.DisclosedPollBottomNotice(
     votesCount: Int,
-    modifier: Modifier = Modifier
 ) {
     Text(
-        modifier = modifier.align(Alignment.End),
+        modifier = Modifier.align(Alignment.End),
         style = ElementTheme.typography.fontBodyXsRegular,
         color = ElementTheme.colors.textSecondary,
         text = stringResource(CommonStrings.common_poll_total_votes, votesCount),
@@ -208,11 +204,9 @@ private fun ColumnScope.DisclosedPollBottomNotice(
 }
 
 @Composable
-private fun ColumnScope.UndisclosedPollBottomNotice(
-    modifier: Modifier = Modifier
-) {
+private fun ColumnScope.UndisclosedPollBottomNotice() {
     Text(
-        modifier = modifier
+        modifier = Modifier
             .align(Alignment.Start)
             .padding(start = 34.dp),
         style = ElementTheme.typography.fontBodyXsRegular,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -92,9 +92,8 @@ fun DeveloperSettingsView(
 @Composable
 private fun ElementCallCategory(
     state: DeveloperSettingsState,
-    modifier: Modifier = Modifier,
 ) {
-    PreferenceCategory(modifier = modifier, title = "Element Call", showDivider = true) {
+    PreferenceCategory(title = "Element Call", showDivider = true) {
         val callUrlState = state.customElementCallBaseUrlState
         fun isUsingDefaultUrl(value: String?): Boolean {
             return value.isNullOrEmpty() || value == callUrlState.defaultUrl
@@ -120,14 +119,12 @@ private fun ElementCallCategory(
 @Composable
 private fun FeatureListContent(
     state: DeveloperSettingsState,
-    modifier: Modifier = Modifier
 ) {
     fun onFeatureEnabled(feature: FeatureUiModel, isEnabled: Boolean) {
         state.eventSink(DeveloperSettingsEvents.UpdateEnabledFeature(feature, isEnabled))
     }
 
     FeatureListView(
-        modifier = modifier,
         features = state.features,
         onCheckedChange = ::onFeatureEnabled,
     )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/tracing/ConfigureTracingView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/tracing/ConfigureTracingView.kt
@@ -141,14 +141,12 @@ fun ConfigureTracingView(
 @Composable
 private fun CrateListContent(
     state: ConfigureTracingState,
-    modifier: Modifier = Modifier
 ) {
     fun onLogLevelChange(target: Target, logLevel: LogLevel) {
         state.eventSink(ConfigureTracingEvents.UpdateFilter(target, logLevel))
     }
 
     TargetAndLogLevelListView(
-        modifier = modifier,
         data = state.targetsToLogLevel,
         onLogLevelChange = ::onLogLevelChange,
     )
@@ -158,11 +156,8 @@ private fun CrateListContent(
 private fun TargetAndLogLevelListView(
     data: ImmutableMap<Target, LogLevel>,
     onLogLevelChange: (Target, LogLevel) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier,
-    ) {
+    Column {
         data.forEach { item ->
             fun onLogLevelChange(logLevel: LogLevel) {
                 onLogLevelChange(item.key, logLevel)
@@ -182,10 +177,8 @@ private fun TargetAndLogLevelView(
     target: Target,
     logLevel: LogLevel,
     onLogLevelChange: (LogLevel) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     ListItem(
-        modifier = modifier,
         headlineContent = { Text(text = target.filter.takeIf { it.isNotEmpty() } ?: "(common)") },
         trailingContent = ListItemContent.Custom {
             LogLevelDropdownMenu(
@@ -200,10 +193,9 @@ private fun TargetAndLogLevelView(
 private fun LogLevelDropdownMenu(
     logLevel: LogLevel,
     onLogLevelChange: (LogLevel) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Box(modifier = modifier) {
+    Box {
         DropdownMenuItem(
             modifier = Modifier.widthIn(max = 120.dp),
             text = { Text(text = logLevel.filter) },

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsView.kt
@@ -99,7 +99,6 @@ private fun NotificationSettingsContentView(
     // TODO We are removing the call notification toggle until support for call notifications has been added
 //    onCallsNotificationsChanged: (Boolean) -> Unit,
     onInviteForMeNotificationsChanged: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     if (systemSettings.appNotificationsEnabled && !systemSettings.systemNotificationsEnabled) {
@@ -117,7 +116,6 @@ private fun NotificationSettingsContentView(
     }
 
     PreferenceSwitch(
-        modifier = modifier,
         title = stringResource(id = R.string.screen_notification_settings_enable_notifications),
         isChecked = systemSettings.appNotificationsEnabled,
         switchAlignment = Alignment.Top,
@@ -182,10 +180,8 @@ private fun InvalidNotificationSettingsView(
     showError: Boolean,
     onContinueClicked: () -> Unit,
     onDismissError: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     DialogLikeBannerMolecule(
-        modifier = modifier,
         title = stringResource(R.string.screen_notification_settings_configuration_mismatch),
         content = stringResource(R.string.screen_notification_settings_configuration_mismatch_description),
         onSubmitClicked = onContinueClicked,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/user/editprofile/EditUserProfileView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/user/editprofile/EditUserProfileView.kt
@@ -16,7 +16,6 @@
 
 package io.element.android.features.preferences.impl.user.editprofile
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,8 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -48,6 +45,7 @@ import io.element.android.libraries.designsystem.components.async.AsyncActionVie
 import io.element.android.libraries.designsystem.components.async.AsyncActionViewDefaults
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.modifiers.clearFocusOnTap
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.aliasScreenTitle
@@ -165,13 +163,6 @@ fun EditUserProfileView(
         state = state.cameraPermissionState,
     )
 }
-
-private fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier =
-    pointerInput(Unit) {
-        detectTapGestures(onTap = {
-            focusManager.clearFocus()
-        })
-    }
 
 @PreviewsDayNight
 @Composable

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -204,12 +204,10 @@ private fun RoomDetailsTopBar(
     goBack: () -> Unit,
     onActionClicked: (RoomDetailsAction) -> Unit,
     showEdit: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
     TopAppBar(
-        modifier = modifier,
         title = { },
         navigationIcon = { BackButton(onClick = goBack) },
         actions = {
@@ -237,8 +235,14 @@ private fun RoomDetailsTopBar(
 }
 
 @Composable
-private fun MainActionsSection(state: RoomDetailsState, onShareRoom: () -> Unit, modifier: Modifier = Modifier) {
-    Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+private fun MainActionsSection(
+    state: RoomDetailsState,
+    onShareRoom: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
         val roomNotificationSettings = state.roomNotificationSettings
         if (state.canShowNotificationSettings && roomNotificationSettings != null) {
             if (roomNotificationSettings.mode == RoomNotificationMode.MUTE) {
@@ -275,10 +279,9 @@ private fun RoomHeaderSection(
     roomName: String,
     roomAlias: String?,
     openAvatarPreview: (url: String) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -312,9 +315,8 @@ private fun RoomHeaderSection(
 private fun TopicSection(
     roomTopic: RoomTopicState,
     onActionClicked: (RoomDetailsAction) -> Unit,
-    modifier: Modifier = Modifier
 ) {
-    PreferenceCategory(title = stringResource(CommonStrings.common_topic), modifier = modifier) {
+    PreferenceCategory(title = stringResource(CommonStrings.common_topic)) {
         if (roomTopic is RoomTopicState.CanAddTopic) {
             PreferenceText(
                 title = stringResource(R.string.screen_room_details_add_topic_title),
@@ -338,14 +340,13 @@ private fun TopicSection(
 private fun NotificationSection(
     isDefaultMode: Boolean,
     openRoomNotificationSettings: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     val subtitle = if (isDefaultMode) {
         stringResource(R.string.screen_room_details_notification_mode_default)
     } else {
         stringResource(R.string.screen_room_details_notification_mode_custom)
     }
-    PreferenceCategory(modifier = modifier) {
+    PreferenceCategory {
         ListItem(
             headlineContent = { Text(text = stringResource(R.string.screen_room_details_notification_title)) },
             supportingContent = { Text(text = subtitle) },
@@ -359,9 +360,8 @@ private fun NotificationSection(
 private fun MembersSection(
     memberCount: Long,
     openRoomMemberList: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    PreferenceCategory(modifier = modifier) {
+    PreferenceCategory {
         ListItem(
             headlineContent = { Text(stringResource(CommonStrings.common_people)) },
             leadingContent = ListItemContent.Icon(IconSource.Resource(CommonDrawables.ic_user)),
@@ -374,9 +374,8 @@ private fun MembersSection(
 @Composable
 private fun InviteSection(
     invitePeople: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    PreferenceCategory(modifier = modifier) {
+    PreferenceCategory {
         ListItem(
             headlineContent = { Text(stringResource(R.string.screen_room_details_invite_people_title)) },
             leadingContent = ListItemContent.Icon(IconSource.Resource(CommonDrawables.ic_user_add)),
@@ -388,9 +387,8 @@ private fun InviteSection(
 @Composable
 private fun PollsSection(
     openPollHistory: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    PreferenceCategory(modifier = modifier) {
+    PreferenceCategory {
         ListItem(
             headlineContent = { Text(stringResource(R.string.screen_polls_history_title)) },
             leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Polls)),
@@ -400,8 +398,8 @@ private fun PollsSection(
 }
 
 @Composable
-private fun SecuritySection(modifier: Modifier = Modifier) {
-    PreferenceCategory(title = stringResource(R.string.screen_room_details_security_title), modifier = modifier) {
+private fun SecuritySection() {
+    PreferenceCategory(title = stringResource(R.string.screen_room_details_security_title)) {
         ListItem(
             headlineContent = { Text(stringResource(R.string.screen_room_details_encryption_enabled_title)) },
             supportingContent = { Text(stringResource(R.string.screen_room_details_encryption_enabled_subtitle)) },
@@ -411,15 +409,17 @@ private fun SecuritySection(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun OtherActionsSection(isDm: Boolean, onLeaveRoom: () -> Unit, modifier: Modifier = Modifier) {
-    PreferenceCategory(showDivider = false, modifier = modifier) {
+private fun OtherActionsSection(isDm: Boolean, onLeaveRoom: () -> Unit) {
+    PreferenceCategory(showDivider = false) {
         ListItem(
             headlineContent = {
-                val leaveText = stringResource(id = if (isDm) {
-                    R.string.screen_room_details_leave_conversation_title
-                } else {
-                    R.string.screen_room_details_leave_room_title
-                })
+                val leaveText = stringResource(
+                    id = if (isDm) {
+                        R.string.screen_room_details_leave_conversation_title
+                    } else {
+                        R.string.screen_room_details_leave_room_title
+                    }
+                )
                 Text(leaveText)
             },
             leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Leave)),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/blockuser/BlockUserSection.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/blockuser/BlockUserSection.kt
@@ -39,8 +39,8 @@ import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
-internal fun BlockUserSection(state: RoomMemberDetailsState, modifier: Modifier = Modifier) {
-    PreferenceCategory(showDivider = false, modifier = modifier) {
+internal fun BlockUserSection(state: RoomMemberDetailsState) {
+    PreferenceCategory(showDivider = false) {
         when (state.isBlocked) {
             is AsyncData.Failure -> PreferenceBlockUser(isBlocked = state.isBlocked.prevData, isLoading = false, eventSink = state.eventSink)
             is AsyncData.Loading -> PreferenceBlockUser(isBlocked = state.isBlocked.prevData, isLoading = true, eventSink = state.eventSink)
@@ -70,7 +70,6 @@ private fun PreferenceBlockUser(
     isBlocked: Boolean?,
     isLoading: Boolean,
     eventSink: (RoomMemberDetailsEvents) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val loadingCurrentValue = @Composable {
         CircularProgressIndicator(
@@ -87,7 +86,6 @@ private fun PreferenceBlockUser(
             onClick = { if (!isLoading) eventSink(RoomMemberDetailsEvents.UnblockUser(needsConfirmation = true)) },
             trailingContent = if (isLoading) ListItemContent.Custom(loadingCurrentValue) else null,
             style = ListItemStyle.Primary,
-            modifier = modifier,
         )
     } else {
         ListItem(
@@ -96,7 +94,6 @@ private fun PreferenceBlockUser(
             style = ListItemStyle.Destructive,
             onClick = { if (!isLoading) eventSink(RoomMemberDetailsEvents.BlockUser(needsConfirmation = true)) },
             trailingContent = if (isLoading) ListItemContent.Custom(loadingCurrentValue) else null,
-            modifier = modifier,
         )
     }
 }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditView.kt
@@ -193,10 +193,8 @@ fun RoomDetailsEditView(
 private fun LabelledReadOnlyField(
     title: String,
     value: String,
-    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditView.kt
@@ -18,7 +18,6 @@
 
 package io.element.android.features.roomdetails.impl.edit
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -38,8 +37,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -52,6 +49,7 @@ import io.element.android.libraries.designsystem.components.async.AsyncActionVie
 import io.element.android.libraries.designsystem.components.async.AsyncActionViewDefaults
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.components.button.BackButton
+import io.element.android.libraries.designsystem.modifiers.clearFocusOnTap
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.aliasScreenTitle
@@ -212,13 +210,6 @@ private fun LabelledReadOnlyField(
         )
     }
 }
-
-private fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier =
-    pointerInput(Unit) {
-        detectTapGestures(onTap = {
-            focusManager.clearFocus()
-        })
-    }
 
 @PreviewsDayNight
 @Composable

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersView.kt
@@ -115,10 +115,8 @@ private fun RoomInviteMembersTopBar(
     canSend: Boolean,
     onBackPressed: () -> Unit,
     onSubmitPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(R.string.screen_room_details_invite_people_title),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListView.kt
@@ -194,10 +194,8 @@ private fun RoomMemberListTopBar(
     canInvite: Boolean,
     onBackPressed: () -> Unit,
     onInvitePressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(CommonStrings.common_people),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsView.kt
@@ -108,14 +108,12 @@ fun RoomMemberDetailsView(
 @Composable
 private fun StartDMSection(
     onStartDMClicked: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
     ListItem(
         headlineContent = { Text(stringResource(CommonStrings.common_direct_chat)) },
         leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Chat)),
         style = ListItemStyle.Primary,
         onClick = onStartDMClicked,
-        modifier = modifier,
     )
 }
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
@@ -178,10 +178,8 @@ private fun RoomSpecificNotificationSettingsView(
 @Composable
 private fun RoomNotificationSettingsTopBar(
     onBackPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = stringResource(R.string.screen_room_details_notification_title),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/UserDefinedRoomNotificationSettingsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/UserDefinedRoomNotificationSettingsView.kt
@@ -103,10 +103,8 @@ fun UserDefinedRoomNotificationSettingsView(
 private fun UserDefinedRoomNotificationSettingsTopBar(
     roomName: String,
     onBackPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         title = {
             Text(
                 text = roomName,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchResultView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchResultView.kt
@@ -103,7 +103,6 @@ private fun RoomListSearchResultContent(
     state: RoomListState,
     onRoomClicked: (RoomId) -> Unit,
     onRoomLongClicked: (RoomListRoomSummary) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     val borderColor = MaterialTheme.colorScheme.tertiary
     val strokeWidth = 1.dp
@@ -115,7 +114,6 @@ private fun RoomListSearchResultContent(
         onRoomClicked(room.roomId)
     }
     Scaffold(
-        modifier = modifier,
         topBar = {
             TopAppBar(
                 modifier = Modifier.drawBehind {

--- a/features/signedout/impl/src/main/kotlin/io/element/android/features/signedout/impl/SignedOutView.kt
+++ b/features/signedout/impl/src/main/kotlin/io/element/android/features/signedout/impl/SignedOutView.kt
@@ -78,11 +78,9 @@ private fun SignedOutHeader(state: SignedOutState) {
 }
 
 @Composable
-private fun SignedOutContent(
-    modifier: Modifier = Modifier,
-) {
+private fun SignedOutContent() {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         contentAlignment = BiasAlignment(
             horizontalBias = 0f,
             verticalBias = -0.4f
@@ -112,12 +110,9 @@ private fun SignedOutContent(
 
 @Composable
 private fun SignedOutFooter(
-    modifier: Modifier = Modifier,
     onSignInAgain: () -> Unit,
 ) {
-    ButtonColumnMolecule(
-        modifier = modifier,
-    ) {
+    ButtonColumnMolecule {
         Button(
             text = stringResource(id = CommonStrings.action_sign_in_again),
             onClick = onSignInAgain,

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionView.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionView.kt
@@ -94,7 +94,7 @@ fun VerifySelfSessionView(
 }
 
 @Composable
-private fun HeaderContent(verificationFlowStep: FlowStep, modifier: Modifier = Modifier) {
+private fun HeaderContent(verificationFlowStep: FlowStep) {
     val iconResourceId = when (verificationFlowStep) {
         FlowStep.Initial -> R.drawable.ic_verification_devices
         FlowStep.Canceled -> R.drawable.ic_verification_warning
@@ -125,7 +125,7 @@ private fun HeaderContent(verificationFlowStep: FlowStep, modifier: Modifier = M
     }
 
     IconTitleSubtitleMolecule(
-        modifier = modifier.padding(top = 60.dp),
+        modifier = Modifier.padding(top = 60.dp),
         iconResourceId = iconResourceId,
         title = stringResource(id = titleTextId),
         subTitle = stringResource(id = subtitleTextId)
@@ -133,8 +133,8 @@ private fun HeaderContent(verificationFlowStep: FlowStep, modifier: Modifier = M
 }
 
 @Composable
-private fun Content(flowState: FlowStep, modifier: Modifier = Modifier) {
-    Column(modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+private fun Content(flowState: FlowStep) {
+    Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
         when (flowState) {
             FlowStep.Initial, FlowStep.Ready, FlowStep.Canceled, FlowStep.Completed -> Unit
             FlowStep.AwaitingOtherDeviceResponse -> ContentWaiting()
@@ -144,19 +144,19 @@ private fun Content(flowState: FlowStep, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ContentWaiting(modifier: Modifier = Modifier) {
-    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+private fun ContentWaiting() {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
         CircularProgressIndicator()
     }
 }
 
 @Composable
-private fun ContentVerifying(verificationFlowStep: FlowStep.Verifying, modifier: Modifier = Modifier) {
+private fun ContentVerifying(verificationFlowStep: FlowStep.Verifying) {
     when (verificationFlowStep.data) {
         is SessionVerificationData.Decimals -> {
             val text = verificationFlowStep.data.decimals.joinToString(separator = " - ") { it.toString() }
             Text(
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 text = text,
                 style = ElementTheme.typography.fontHeadingLgBold,
                 color = MaterialTheme.colorScheme.primary,
@@ -167,7 +167,7 @@ private fun ContentVerifying(verificationFlowStep: FlowStep.Verifying, modifier:
             // We want each row to have up to 4 emojis
             val rows = verificationFlowStep.data.emojis.chunked(4)
             Column(
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(40.dp),
             ) {
                 rows.forEach { emojis ->

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/SunsetPage.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/SunsetPage.kt
@@ -115,10 +115,8 @@ fun SunsetPage(
 
 @OptIn(CoreColorToken::class)
 @Composable
-private fun SunsetBackground(
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier.fillMaxSize()) {
+private fun SunsetBackground() {
+    Column(modifier = Modifier.fillMaxSize()) {
         // The top background colors are the opposite of the current theme ones
         val topBackgroundColor = if (ElementTheme.isLightTheme) {
             DarkColorTokens.colorThemeBg

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BlurHashAsyncImage.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BlurHashAsyncImage.kt
@@ -73,7 +73,6 @@ fun BlurHashAsyncImage(
 @Composable
 private fun BlurHashImage(
     blurHash: String?,
-    modifier: Modifier = Modifier,
     contentDescription: String? = null,
     contentScale: ContentScale = ContentScale.Fit,
 ) {
@@ -91,7 +90,7 @@ private fun BlurHashImage(
     }
     bitmapState.value?.let { bitmap ->
         Image(
-            modifier = modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             bitmap = bitmap.asImageBitmap(),
             contentScale = contentScale,
             contentDescription = contentDescription

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ConfirmationDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ConfirmationDialog.kt
@@ -65,7 +65,6 @@ private fun ConfirmationDialogContent(
     cancelText: String,
     onSubmitClicked: () -> Unit,
     onCancelClicked: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String? = null,
     thirdButtonText: String? = null,
     onThirdButtonClicked: () -> Unit = {},
@@ -73,7 +72,6 @@ private fun ConfirmationDialogContent(
     icon: @Composable (() -> Unit)? = null,
 ) {
     SimpleAlertDialogContent(
-        modifier = modifier,
         title = title,
         content = content,
         submitText = submitText,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ErrorDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ErrorDialog.kt
@@ -51,12 +51,10 @@ fun ErrorDialog(
 private fun ErrorDialogContent(
     content: String,
     onSubmitClicked: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String = ErrorDialogDefaults.title,
     submitText: String = ErrorDialogDefaults.submitText,
 ) {
     SimpleAlertDialogContent(
-        modifier = modifier,
         title = title,
         content = content,
         submitText = submitText,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ListDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/ListDialog.kt
@@ -80,7 +80,6 @@ private fun ListDialogContent(
     onSubmitClicked: () -> Unit,
     cancelText: String,
     submitText: String,
-    modifier: Modifier = Modifier,
     title: String? = null,
     enabled: Boolean = true,
     subtitle: @Composable (() -> Unit)? = null,
@@ -88,7 +87,6 @@ private fun ListDialogContent(
     SimpleAlertDialogContent(
         title = title,
         subtitle = subtitle,
-        modifier = modifier,
         cancelText = cancelText,
         submitText = submitText,
         onCancelClicked = onDismissRequest,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/MultipleSelectionDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/MultipleSelectionDialog.kt
@@ -84,7 +84,6 @@ private fun MultipleSelectionDialogContent(
     onConfirmClicked: (List<Int>) -> Unit,
     dismissButtonTitle: String,
     onDismissRequest: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String? = null,
     initialSelected: ImmutableList<Int> = persistentListOf(),
     subtitle: @Composable (() -> Unit)? = null,
@@ -96,7 +95,6 @@ private fun MultipleSelectionDialogContent(
     SimpleAlertDialogContent(
         title = title,
         subtitle = subtitle,
-        modifier = modifier,
         submitText = confirmButtonTitle,
         onSubmitClicked = {
             onConfirmClicked(selectedOptionIndexes.toList())

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/RetryDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/RetryDialog.kt
@@ -56,13 +56,11 @@ private fun RetryDialogContent(
     content: String,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String = RetryDialogDefaults.title,
     retryText: String = RetryDialogDefaults.retryText,
     dismissText: String = RetryDialogDefaults.dismissText,
 ) {
     SimpleAlertDialogContent(
-        modifier = modifier,
         title = title,
         content = content,
         submitText = retryText,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/SingleSelectionDialog.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/dialogs/SingleSelectionDialog.kt
@@ -79,7 +79,6 @@ private fun SingleSelectionDialogContent(
     onOptionSelected: (Int) -> Unit,
     dismissButtonTitle: String,
     onDismissRequest: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String? = null,
     initialSelection: Int? = null,
     subtitle: @Composable (() -> Unit)? = null,
@@ -87,7 +86,6 @@ private fun SingleSelectionDialogContent(
     SimpleAlertDialogContent(
         title = title,
         subtitle = subtitle,
-        modifier = modifier,
         submitText = dismissButtonTitle,
         onSubmitClicked = onDismissRequest,
         applyPaddingToContents = false,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceCategory.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceCategory.kt
@@ -52,9 +52,9 @@ fun PreferenceCategory(
 }
 
 @Composable
-private fun PreferenceCategoryTitle(title: String, modifier: Modifier = Modifier) {
+private fun PreferenceCategoryTitle(title: String) {
     Text(
-        modifier = modifier.padding(
+        modifier = Modifier.padding(
             top = 20.dp,
             bottom = 8.dp,
             start = preferencePaddingHorizontal,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferencePage.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferencePage.kt
@@ -80,10 +80,8 @@ fun PreferencePage(
 private fun PreferenceTopAppBar(
     title: String,
     onBackPressed: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        modifier = modifier,
         navigationIcon = {
             BackButton(onClick = onBackPressed)
         },

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceTextField.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceTextField.kt
@@ -91,7 +91,6 @@ private fun TextFieldDialog(
     onDismissRequest: () -> Unit,
     value: String?,
     placeholder: String?,
-    modifier: Modifier = Modifier,
     validation: (String?) -> Boolean = { true },
     onValidationErrorMessage: String? = null,
     autoSelectOnDisplay: Boolean = true,
@@ -110,7 +109,6 @@ private fun TextFieldDialog(
         onSubmit = { onSubmit(textFieldContents.text) },
         onDismissRequest = onDismissRequest,
         enabled = canSubmit,
-        modifier = modifier,
     ) {
         item {
             TextFieldListItem(

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/icons/IconsPreview.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/icons/IconsPreview.kt
@@ -98,11 +98,9 @@ private fun IconsPreview(
     title: String,
     iconsList: ImmutableList<Int>,
     iconNameTransform: (String) -> String,
-    modifier: Modifier = Modifier,
 ) = ElementPreview {
     val context = LocalContext.current
     Column(
-        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         Text(

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ClearFocusOnTap.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ClearFocusOnTap.kt
@@ -21,9 +21,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
 
-fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier =
+fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier = then(
     pointerInput(Unit) {
         detectTapGestures(onTap = {
             focusManager.clearFocus()
         })
     }
+)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ClearFocusOnTap.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/ClearFocusOnTap.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.designsystem.modifiers
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.pointer.pointerInput
+
+fun Modifier.clearFocusOnTap(focusManager: FocusManager): Modifier =
+    pointerInput(Unit) {
+        detectTapGestures(onTap = {
+            focusManager.clearFocus()
+        })
+    }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/AlertDialogContent.kt
@@ -55,7 +55,6 @@ internal fun SimpleAlertDialogContent(
     content: String,
     submitText: String,
     onSubmitClicked: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String? = null,
     subtitle: @Composable (() -> Unit)? = null,
     destructiveSubmit: Boolean = false,
@@ -67,7 +66,6 @@ internal fun SimpleAlertDialogContent(
     icon: @Composable (() -> Unit)? = null,
 ) {
     SimpleAlertDialogContent(
-        modifier = modifier,
         icon = icon,
         title = title,
         subtitle = subtitle,
@@ -92,7 +90,6 @@ internal fun SimpleAlertDialogContent(
 internal fun SimpleAlertDialogContent(
     submitText: String,
     onSubmitClicked: () -> Unit,
-    modifier: Modifier = Modifier,
     title: String? = null,
     subtitle: @Composable (() -> Unit)? = null,
     destructiveSubmit: Boolean = false,
@@ -148,7 +145,6 @@ internal fun SimpleAlertDialogContent(
                 }
             }
         },
-        modifier = modifier,
         title = title?.let { titleText ->
             @Composable {
                 Text(
@@ -192,11 +188,9 @@ internal fun AlertDialogContent(
     iconContentColor: Color,
     titleContentColor: Color,
     textContentColor: Color,
-    modifier: Modifier = Modifier,
     applyPaddingToContents: Boolean = true,
 ) {
     Surface(
-        modifier = modifier,
         shape = shape,
         color = containerColor,
         tonalElevation = tonalElevation,

--- a/libraries/featureflag/ui/src/main/kotlin/io/element/android/libraries/featureflag/ui/FeatureListView.kt
+++ b/libraries/featureflag/ui/src/main/kotlin/io/element/android/libraries/featureflag/ui/FeatureListView.kt
@@ -49,13 +49,11 @@ fun FeatureListView(
 private fun FeaturePreferenceView(
     feature: FeatureUiModel,
     onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     PreferenceCheckbox(
         title = feature.title,
         supportingText = feature.description,
         isChecked = feature.isEnabled,
-        modifier = modifier,
         onCheckedChange = onCheckedChange
     )
 }

--- a/libraries/mediaviewer/api/src/main/kotlin/io/element/android/libraries/mediaviewer/api/local/pdf/PdfViewer.kt
+++ b/libraries/mediaviewer/api/src/main/kotlin/io/element/android/libraries/mediaviewer/api/local/pdf/PdfViewer.kt
@@ -86,7 +86,6 @@ private fun PdfPagesView(
 @Composable
 private fun PdfPageView(
     pdfPage: PdfPage,
-    modifier: Modifier = Modifier,
 ) {
     val pdfPageState by pdfPage.stateFlow.collectAsState()
     DisposableEffect(pdfPage) {
@@ -101,12 +100,12 @@ private fun PdfPageView(
                 bitmap = state.bitmap.asImageBitmap(),
                 contentDescription = stringResource(id = CommonStrings.a11y_page_n, pdfPage.pageIndex),
                 contentScale = ContentScale.FillWidth,
-                modifier = modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth()
             )
         }
         is PdfPage.State.Loading -> {
             Box(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .height(state.height.toDp())
                     .background(color = Color.White)

--- a/libraries/mediaviewer/api/src/main/kotlin/io/element/android/libraries/mediaviewer/api/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/api/src/main/kotlin/io/element/android/libraries/mediaviewer/api/viewer/MediaViewerView.kt
@@ -259,10 +259,8 @@ private fun ErrorView(
     errorMessage: String,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     RetryDialog(
-        modifier = modifier,
         content = errorMessage,
         onRetry = onRetry,
         onDismiss = onDismiss

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
@@ -209,10 +209,9 @@ private fun RoomSummaryView(
     summary: RoomSummaryDetails,
     isSelected: Boolean,
     onSelection: (RoomSummaryDetails) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
+        modifier = Modifier
             .clickable { onSelection(summary) }
             .fillMaxWidth()
             .padding(start = 16.dp, end = 4.dp)

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -405,14 +405,13 @@ private fun TextInput(
     onError: (Throwable) -> Unit,
     onTyping: (Boolean) -> Unit,
     onRichContentSelected: ((Uri) -> Unit)?,
-    modifier: Modifier = Modifier,
 ) {
     val bgColor = ElementTheme.colors.bgSubtleSecondary
     val borderColor = ElementTheme.colors.borderDisabled
     val roundedCorners = textInputRoundedCornerShape(composerMode = composerMode)
 
     Column(
-        modifier = modifier
+        modifier = Modifier
             .clip(roundedCorners)
             .border(0.5.dp, borderColor, roundedCorners)
             .background(color = bgColor)
@@ -464,15 +463,14 @@ private fun TextInput(
 private fun ComposerModeView(
     composerMode: MessageComposerMode,
     onResetComposerMode: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     when (composerMode) {
         is MessageComposerMode.Edit -> {
-            EditingModeView(onResetComposerMode = onResetComposerMode, modifier = modifier)
+            EditingModeView(onResetComposerMode = onResetComposerMode)
         }
         is MessageComposerMode.Reply -> {
             ReplyToModeView(
-                modifier = modifier.padding(8.dp),
+                modifier = Modifier.padding(8.dp),
                 senderName = composerMode.senderName,
                 text = composerMode.defaultContent,
                 attachmentThumbnailInfo = composerMode.attachmentThumbnailInfo,
@@ -486,12 +484,11 @@ private fun ComposerModeView(
 @Composable
 private fun EditingModeView(
     onResetComposerMode: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .padding(start = 12.dp)
     ) {
@@ -881,11 +878,8 @@ internal fun TextComposerVoicePreview() = ElementPreview {
 @Composable
 private fun PreviewColumn(
     items: ImmutableList<@Composable () -> Unit>,
-    modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-    ) {
+    Column {
         items.forEach { item ->
             Box(
                 modifier = Modifier.height(IntrinsicSize.Min)

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
@@ -43,6 +43,7 @@ import io.element.android.wysiwyg.view.models.LinkAction
 import kotlinx.coroutines.launch
 import uniffi.wysiwyg_composer.ActionState
 import uniffi.wysiwyg_composer.ComposerAction
+
 @Composable
 internal fun TextFormatting(
     state: RichTextEditorState,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessagePreview.kt
@@ -124,11 +124,10 @@ private fun PlayerButton(
     type: PlayerButtonType,
     enabled: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     IconButton(
         onClick = onClick,
-        modifier = modifier
+        modifier = Modifier
             .background(color = ElementTheme.colors.bgCanvasDefault, shape = CircleShape)
             .size(30.dp),
         enabled = enabled,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessageRecording.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessageRecording.kt
@@ -88,9 +88,7 @@ internal fun VoiceMessageRecording(
 }
 
 @Composable
-private fun RedRecordingDot(
-    modifier: Modifier = Modifier,
-) {
+private fun RedRecordingDot() {
     val infiniteTransition = rememberInfiniteTransition("RedRecordingDot")
     val alpha by infiniteTransition.animateFloat(
         initialValue = 1f,
@@ -102,7 +100,7 @@ private fun RedRecordingDot(
         label = "RedRecordingDotAlpha",
     )
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(8.dp)
             .alpha(alpha)
             .background(color = ElementTheme.colors.textCriticalPrimary, shape = CircleShape)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other : improve test coverage

## Content

<!-- Describe shortly what has been changed -->
This PR removes the `Modifier` parameter in private methods when it never take other values than the default one.
There is a right balance to find between following Compose UI recommendation to provide a Modifier in the parameter list and improving the coverage result. When the Modifier is never passed into parameter, the line appears as uncovered for instance here:

<img width="579" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/a339846f-c19b-4fe9-a748-b9352635dfbb">

With this change, the coverage is improved because it removes what may be considered as false positive. If necessary, it's still possible to add the parameter back.

As a bonus, it fixes some mistakes in the existing code, that may appears if a Modifier was actually set.

<img width="326" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/8feb2a57-88b2-4341-900c-3cd304fb928a">

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Improve test coverage and so reduce risk of regression

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No UI change

## Tests

<!-- Explain how you tested your development -->

- No behavior change.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
