### PR TITLE
Typing notification rendering

### DIFF
--- a/changelog.d/2242.feature
+++ b/changelog.d/2242.feature
@@ -1,0 +1,1 @@
+Rendering typing notification

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -59,6 +59,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemUnknownContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVoiceContent
+import io.element.android.features.messages.impl.typing.TypingNotificationPresenter
 import io.element.android.features.messages.impl.utils.messagesummary.MessageSummaryFormatter
 import io.element.android.features.messages.impl.voicemessages.composer.VoiceMessageComposerPresenter
 import io.element.android.features.networkmonitor.api.NetworkMonitor
@@ -97,6 +98,7 @@ class MessagesPresenter @AssistedInject constructor(
     private val composerPresenter: MessageComposerPresenter,
     private val voiceMessageComposerPresenter: VoiceMessageComposerPresenter,
     timelinePresenterFactory: TimelinePresenter.Factory,
+    private val typingNotificationPresenter: TypingNotificationPresenter,
     private val actionListPresenter: ActionListPresenter,
     private val customReactionPresenter: CustomReactionPresenter,
     private val reactionSummaryPresenter: ReactionSummaryPresenter,
@@ -129,6 +131,7 @@ class MessagesPresenter @AssistedInject constructor(
         val composerState = composerPresenter.present()
         val voiceMessageComposerState = voiceMessageComposerPresenter.present()
         val timelineState = timelinePresenter.present()
+        val typingNotificationState = typingNotificationPresenter.present()
         val actionListState = actionListPresenter.present()
         val customReactionState = customReactionPresenter.present()
         val reactionSummaryState = reactionSummaryPresenter.present()
@@ -233,6 +236,7 @@ class MessagesPresenter @AssistedInject constructor(
             composerState = composerState,
             voiceMessageComposerState = voiceMessageComposerState,
             timelineState = timelineState,
+            typingNotificationState = typingNotificationState,
             actionListState = actionListState,
             customReactionState = customReactionState,
             reactionSummaryState = reactionSummaryState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesState.kt
@@ -24,6 +24,7 @@ import io.element.android.features.messages.impl.timeline.components.customreact
 import io.element.android.features.messages.impl.timeline.components.reactionsummary.ReactionSummaryState
 import io.element.android.features.messages.impl.timeline.components.receipt.bottomsheet.ReadReceiptBottomSheetState
 import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuState
+import io.element.android.features.messages.impl.typing.TypingNotificationState
 import io.element.android.features.messages.impl.voicemessages.composer.VoiceMessageComposerState
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
@@ -42,6 +43,7 @@ data class MessagesState(
     val composerState: MessageComposerState,
     val voiceMessageComposerState: VoiceMessageComposerState,
     val timelineState: TimelineState,
+    val typingNotificationState: TypingNotificationState,
     val actionListState: ActionListState,
     val customReactionState: CustomReactionState,
     val reactionSummaryState: ReactionSummaryState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -31,6 +31,7 @@ import io.element.android.features.messages.impl.timeline.components.reactionsum
 import io.element.android.features.messages.impl.timeline.components.receipt.bottomsheet.ReadReceiptBottomSheetState
 import io.element.android.features.messages.impl.timeline.components.retrysendmenu.RetrySendMenuState
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
+import io.element.android.features.messages.impl.typing.aTypingNotificationState
 import io.element.android.features.messages.impl.voicemessages.composer.VoiceMessageComposerState
 import io.element.android.features.messages.impl.voicemessages.composer.aVoiceMessageComposerState
 import io.element.android.features.messages.impl.voicemessages.composer.aVoiceMessagePreviewState
@@ -117,6 +118,7 @@ fun aMessagesState(
     timelineState = aTimelineState(
         timelineItems = aTimelineItemList(aTimelineItemTextContent()),
     ),
+    typingNotificationState = aTypingNotificationState(),
     retrySendMenuState = RetrySendMenuState(
         selectedEvent = null,
         eventSink = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -125,6 +125,7 @@ fun MessagesView(
     onCreatePollClicked: () -> Unit,
     onJoinCallClicked: () -> Unit,
     modifier: Modifier = Modifier,
+    forceJumpToBottomVisibility: Boolean = false
 ) {
     OnLifecycleEvent { _, event ->
         state.voiceMessageComposerState.eventSink(VoiceMessageComposerEvents.LifecycleEvent(event))
@@ -224,6 +225,7 @@ fun MessagesView(
                 onSwipeToReply = { targetEvent ->
                     state.eventSink(MessagesEvents.HandleAction(TimelineItemAction.Reply, targetEvent))
                 },
+                forceJumpToBottomVisibility = forceJumpToBottomVisibility,
             )
         },
         snackbarHost = {
@@ -324,6 +326,7 @@ private fun MessagesViewContent(
     onTimestampClicked: (TimelineItem.Event) -> Unit,
     onSendLocationClicked: () -> Unit,
     onCreatePollClicked: () -> Unit,
+    forceJumpToBottomVisibility: Boolean,
     modifier: Modifier = Modifier,
     onSwipeToReply: (TimelineItem.Event) -> Unit,
 ) {
@@ -394,6 +397,7 @@ private fun MessagesViewContent(
                     onMoreReactionsClicked = onMoreReactionsClicked,
                     onReadReceiptClick = onReadReceiptClick,
                     onSwipeToReply = onSwipeToReply,
+                    forceJumpToBottomVisibility = forceJumpToBottomVisibility,
                 )
             },
             sheetContent = { subcomposing: Boolean ->
@@ -574,5 +578,6 @@ internal fun MessagesViewPreview(@PreviewParameter(MessagesStateProvider::class)
         onSendLocationClicked = {},
         onCreatePollClicked = {},
         onJoinCallClicked = {},
+        forceJumpToBottomVisibility = true,
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -384,6 +384,7 @@ private fun MessagesViewContent(
                     modifier = Modifier.padding(paddingValues),
                     state = state.timelineState,
                     roomName = state.roomName.dataOrNull(),
+                    typingNotificationState = state.typingNotificationState,
                     onMessageClicked = onMessageClicked,
                     onMessageLongClicked = onMessageLongClicked,
                     onUserDataClicked = onUserDataClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -62,6 +62,9 @@ import io.element.android.features.messages.impl.timeline.model.NewEventState
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContentProvider
+import io.element.android.features.messages.impl.typing.TypingNotificationState
+import io.element.android.features.messages.impl.typing.TypingNotificationView
+import io.element.android.features.messages.impl.typing.aTypingNotificationState
 import io.element.android.libraries.designsystem.animation.alphaAnimation
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -75,6 +78,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun TimelineView(
     state: TimelineState,
+    typingNotificationState: TypingNotificationState,
     roomName: String?,
     onUserDataClicked: (UserId) -> Unit,
     onMessageClicked: (TimelineItem.Event) -> Unit,
@@ -112,6 +116,9 @@ fun TimelineView(
             reverseLayout = true,
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
+            item {
+                TypingNotificationView(state = typingNotificationState)
+            }
             items(
                 items = state.timelineItems,
                 contentType = { timelineItem -> timelineItem.contentType() },
@@ -256,6 +263,7 @@ internal fun TimelineViewPreview(
         TimelineView(
             state = aTimelineState(timelineItems),
             roomName = null,
+            typingNotificationState = aTypingNotificationState(),
             onMessageClicked = {},
             onTimestampClicked = {},
             onUserDataClicked = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -90,6 +89,7 @@ fun TimelineView(
     onMoreReactionsClicked: (TimelineItem.Event) -> Unit,
     onReadReceiptClick: (TimelineItem.Event) -> Unit,
     modifier: Modifier = Modifier,
+    forceJumpToBottomVisibility: Boolean = false
 ) {
     fun onReachedLoadMore() {
         state.eventSink(TimelineEvents.LoadMore)
@@ -164,6 +164,7 @@ fun TimelineView(
         TimelineScrollHelper(
             isTimelineEmpty = state.timelineItems.isEmpty(),
             lazyListState = lazyListState,
+            forceJumpToBottomVisibility = forceJumpToBottomVisibility,
             newEventState = state.newEventState,
             onScrollFinishedAt = ::onScrollFinishedAt
         )
@@ -175,6 +176,7 @@ private fun BoxScope.TimelineScrollHelper(
     isTimelineEmpty: Boolean,
     lazyListState: LazyListState,
     newEventState: NewEventState,
+    forceJumpToBottomVisibility: Boolean,
     onScrollFinishedAt: (Int) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -212,7 +214,7 @@ private fun BoxScope.TimelineScrollHelper(
 
     JumpToBottomButton(
         // Use inverse of canAutoScroll otherwise we might briefly see the before the scroll animation is triggered
-        isVisible = !canAutoScroll,
+        isVisible = !canAutoScroll || forceJumpToBottomVisibility,
         modifier = Modifier
             .align(Alignment.BottomEnd)
             .padding(end = 24.dp, bottom = 12.dp),
@@ -228,7 +230,7 @@ private fun JumpToBottomButton(
 ) {
     AnimatedVisibility(
         modifier = modifier,
-        visible = isVisible || LocalInspectionMode.current,
+        visible = isVisible,
         enter = scaleIn(animationSpec = tween(100)),
         exit = scaleOut(animationSpec = tween(100)),
     ) {
@@ -273,6 +275,7 @@ internal fun TimelineViewPreview(
             onMoreReactionsClicked = {},
             onSwipeToReply = {},
             onReadReceiptClick = {},
+            forceJumpToBottomVisibility = true,
         )
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/MessagesViewWithTypingPreview.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/MessagesViewWithTypingPreview.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import androidx.compose.runtime.Composable
+import io.element.android.features.messages.impl.MessagesView
+import io.element.android.features.messages.impl.aMessagesState
+import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+
+@PreviewsDayNight
+@Composable
+internal fun MessagesViewWithTypingPreview() = ElementPreview {
+    MessagesView(
+        state = aMessagesState().copy(
+            typingNotificationState = aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice"),
+                    aTypingRoomMember(displayName = "Bob"),
+                ),
+            ),
+        ),
+        onBackPressed = {},
+        onRoomDetailsClicked = {},
+        onEventClicked = { false },
+        onPreviewAttachments = {},
+        onUserDataClicked = {},
+        onSendLocationClicked = {},
+        onCreatePollClicked = {},
+        onJoinCallClicked = {},
+    )
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenter.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.MatrixRoom
+import io.element.android.libraries.matrix.api.room.RoomMember
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.room.roomMembers
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+class TypingNotificationPresenter @Inject constructor(
+    private val room: MatrixRoom,
+) : Presenter<TypingNotificationState> {
+    @Composable
+    override fun present(): TypingNotificationState {
+        var typingMembers by remember { mutableStateOf(emptyList<RoomMember>()) }
+        LaunchedEffect(Unit) {
+            combine(room.roomTypingMembersFlow, room.membersStateFlow) { typingMembers, membersState ->
+                typingMembers
+                    .map { userId ->
+                        membersState.roomMembers()
+                            ?.firstOrNull { roomMember -> roomMember.userId == userId }
+                            ?: createDefaultRoomMemberForTyping(userId)
+                    }
+            }
+                .distinctUntilChanged()
+                .onEach { members ->
+                    typingMembers = members
+                }
+                .launchIn(this)
+        }
+
+        return TypingNotificationState(
+            typingMembers = typingMembers.toImmutableList(),
+        )
+    }
+}
+
+/**
+ * Create a default [RoomMember] for typing events.
+ * In this case, only the userId will be used for rendering, other fields are not used, but keep them
+ * as close as possible to the actual data.
+ */
+private fun createDefaultRoomMemberForTyping(userId: UserId): RoomMember {
+    return RoomMember(
+        userId = userId,
+        displayName = null,
+        avatarUrl = null,
+        membership = RoomMembershipState.JOIN,
+        isNameAmbiguous = false,
+        powerLevel = 0,
+        normalizedPowerLevel = 0,
+        isIgnored = false,
+    )
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenter.kt
@@ -18,10 +18,12 @@ package io.element.android.features.messages.impl.typing
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import io.element.android.features.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
@@ -29,6 +31,7 @@ import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.room.roomMembers
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -37,29 +40,40 @@ import javax.inject.Inject
 
 class TypingNotificationPresenter @Inject constructor(
     private val room: MatrixRoom,
+    private val sessionPreferencesStore: SessionPreferencesStore,
 ) : Presenter<TypingNotificationState> {
     @Composable
     override fun present(): TypingNotificationState {
-        var typingMembers by remember { mutableStateOf(emptyList<RoomMember>()) }
-        LaunchedEffect(Unit) {
-            combine(room.roomTypingMembersFlow, room.membersStateFlow) { typingMembers, membersState ->
-                typingMembers
-                    .map { userId ->
-                        membersState.roomMembers()
-                            ?.firstOrNull { roomMember -> roomMember.userId == userId }
-                            ?: createDefaultRoomMemberForTyping(userId)
-                    }
+        val typingMembersState = remember { mutableStateOf(emptyList<RoomMember>()) }
+        val renderTypingNotifications by sessionPreferencesStore.isRenderTypingNotificationsEnabled().collectAsState(initial = true)
+        LaunchedEffect(renderTypingNotifications) {
+            if (renderTypingNotifications) {
+                observeRoomTypingMembers(typingMembersState)
+            } else {
+                typingMembersState.value = emptyList()
             }
-                .distinctUntilChanged()
-                .onEach { members ->
-                    typingMembers = members
-                }
-                .launchIn(this)
         }
 
         return TypingNotificationState(
-            typingMembers = typingMembers.toImmutableList(),
+            renderTypingNotifications = renderTypingNotifications,
+            typingMembers = typingMembersState.value.toImmutableList(),
         )
+    }
+
+    private fun CoroutineScope.observeRoomTypingMembers(typingMembersState: MutableState<List<RoomMember>>) {
+        combine(room.roomTypingMembersFlow, room.membersStateFlow) { typingMembers, membersState ->
+            typingMembers
+                .map { userId ->
+                    membersState.roomMembers()
+                        ?.firstOrNull { roomMember -> roomMember.userId == userId }
+                        ?: createDefaultRoomMemberForTyping(userId)
+                }
+        }
+            .distinctUntilChanged()
+            .onEach { members ->
+                typingMembersState.value = members
+            }
+            .launchIn(this)
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import io.element.android.libraries.matrix.api.room.RoomMember
+import kotlinx.collections.immutable.ImmutableList
+
+data class TypingNotificationState(
+    val typingMembers: ImmutableList<RoomMember>,
+)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationState.kt
@@ -20,5 +20,6 @@ import io.element.android.libraries.matrix.api.room.RoomMember
 import kotlinx.collections.immutable.ImmutableList
 
 data class TypingNotificationState(
+    val renderTypingNotifications: Boolean,
     val typingMembers: ImmutableList<RoomMember>,
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.RoomMember
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import kotlinx.collections.immutable.toImmutableList
+
+class TypingNotificationStateProvider : PreviewParameterProvider<TypingNotificationState> {
+    override val values: Sequence<TypingNotificationState>
+        get() = sequenceOf(
+            aTypingNotificationState(),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice"),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice", isNameAmbiguous = true),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice"),
+                    aTypingRoomMember(displayName = "Bob"),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice"),
+                    aTypingRoomMember(displayName = "Bob"),
+                    aTypingRoomMember(displayName = "Charlie"),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice"),
+                    aTypingRoomMember(displayName = "Bob"),
+                    aTypingRoomMember(displayName = "Charlie"),
+                    aTypingRoomMember(displayName = "Dan"),
+                    aTypingRoomMember(displayName = "Eve"),
+                ),
+            ),
+            aTypingNotificationState(
+                typingMembers = listOf(
+                    aTypingRoomMember(displayName = "Alice with a very long display name"),
+                ),
+            ),
+        )
+}
+
+internal fun aTypingNotificationState(
+    typingMembers: List<RoomMember> = emptyList(),
+) = TypingNotificationState(
+    typingMembers = typingMembers.toImmutableList(),
+)
+
+internal fun aTypingRoomMember(
+    userId: UserId = UserId("@alice:example.com"),
+    displayName: String? = null,
+    isNameAmbiguous: Boolean = false,
+): RoomMember {
+    return RoomMember(
+        userId = userId,
+        displayName = displayName,
+        avatarUrl = null,
+        membership = RoomMembershipState.JOIN,
+        isNameAmbiguous = isNameAmbiguous,
+        powerLevel = 0,
+        normalizedPowerLevel = 0,
+        isIgnored = false,
+    )
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
@@ -65,7 +65,7 @@ class TypingNotificationStateProvider : PreviewParameterProvider<TypingNotificat
             ),
             aTypingNotificationState(
                 typingMembers = listOf(
-                    aTypingRoomMember(displayName = "Alice with a very long display name"),
+                    aTypingRoomMember(displayName = "Alice with a very long display name which means that it will be truncated"),
                 ),
             ),
         )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationStateProvider.kt
@@ -74,6 +74,7 @@ class TypingNotificationStateProvider : PreviewParameterProvider<TypingNotificat
 internal fun aTypingNotificationState(
     typingMembers: List<RoomMember> = emptyList(),
 ) = TypingNotificationState(
+    renderTypingNotifications = true,
     typingMembers = typingMembers.toImmutableList(),
 )
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import io.element.android.compound.theme.ElementTheme
+import io.element.android.features.messages.impl.R
+import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.matrix.api.room.RoomMember
+
+@Composable
+fun TypingNotificationView(
+    state: TypingNotificationState,
+    modifier: Modifier = Modifier,
+) {
+    if (state.typingMembers.isEmpty()) return
+    val typingNotificationText = computeTypingNotificationText(state.typingMembers)
+    Text(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 68.dp, vertical = 2.dp),
+        text = typingNotificationText,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        style = ElementTheme.typography.fontBodySmRegular,
+        color = ElementTheme.colors.textSecondary,
+    )
+}
+
+@Composable
+private fun computeTypingNotificationText(typingMembers: List<RoomMember>): AnnotatedString {
+    val names = when (typingMembers.size) {
+        0 -> "" // Cannot happen
+        1 -> typingMembers[0].disambiguatedDisplayName
+        2 -> stringResource(
+            id = R.string.screen_room_typing_two_members,
+            typingMembers[0].disambiguatedDisplayName,
+            typingMembers[1].disambiguatedDisplayName,
+        )
+        else -> pluralStringResource(
+            id = R.plurals.screen_room_typing_many_members,
+            count = typingMembers.size - 2,
+            typingMembers[0].disambiguatedDisplayName,
+            typingMembers[1].disambiguatedDisplayName,
+            typingMembers.size - 2,
+        )
+    }
+    // Get the translated string with a fake pattern
+    val tmpString = pluralStringResource(
+        id = R.plurals.screen_room_typing_notification,
+        count = typingMembers.size,
+        "<>",
+    )
+    // Split the string in 3 parts
+    val parts = tmpString.split("<>")
+    // And rebuild the string with the names
+    return buildAnnotatedString {
+        append(parts[0])
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+            append(names)
+        }
+        append(parts[1])
+    }
+}
+
+@PreviewsDayNight
+@Composable
+internal fun TypingNotificationViewPreview(
+    @PreviewParameter(TypingNotificationStateProvider::class) state: TypingNotificationState,
+) = ElementPreview {
+    TypingNotificationView(
+        state = state,
+    )
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
@@ -36,6 +36,7 @@ import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.matrix.api.room.RoomMember
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun TypingNotificationView(
@@ -57,7 +58,7 @@ fun TypingNotificationView(
 }
 
 @Composable
-private fun computeTypingNotificationText(typingMembers: List<RoomMember>): AnnotatedString {
+private fun computeTypingNotificationText(typingMembers: ImmutableList<RoomMember>): AnnotatedString {
     val names = when (typingMembers.size) {
         0 -> "" // Cannot happen
         1 -> typingMembers[0].disambiguatedDisplayName

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
@@ -42,7 +42,7 @@ fun TypingNotificationView(
     state: TypingNotificationState,
     modifier: Modifier = Modifier,
 ) {
-    if (state.typingMembers.isEmpty()) return
+    if (state.typingMembers.isEmpty() || !state.renderTypingNotifications) return
     val typingNotificationText = computeTypingNotificationText(state.typingMembers)
     Text(
         modifier = modifier

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationView.kt
@@ -47,7 +47,7 @@ fun TypingNotificationView(
     Text(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 68.dp, vertical = 2.dp),
+            .padding(horizontal = 24.dp, vertical = 2.dp),
         text = typingNotificationText,
         overflow = TextOverflow.Ellipsis,
         maxLines = 1,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
@@ -42,6 +42,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemPollContent
+import io.element.android.features.messages.impl.typing.TypingNotificationPresenter
 import io.element.android.features.messages.impl.voicemessages.composer.VoiceMessageComposerPlayer
 import io.element.android.features.messages.impl.voicemessages.composer.VoiceMessageComposerPresenter
 import io.element.android.features.messages.impl.voicemessages.timeline.FakeRedactedVoiceMessageManager
@@ -730,6 +731,7 @@ class MessagesPresenterTest {
             }
         }
         val actionListPresenter = ActionListPresenter(appPreferencesStore = appPreferencesStore)
+        val typingNotificationPresenter = TypingNotificationPresenter(matrixRoom)
         val readReceiptBottomSheetPresenter = ReadReceiptBottomSheetPresenter()
         val customReactionPresenter = CustomReactionPresenter(emojibaseProvider = FakeEmojibaseProvider())
         val reactionSummaryPresenter = ReactionSummaryPresenter(room = matrixRoom)
@@ -739,6 +741,7 @@ class MessagesPresenterTest {
             composerPresenter = messageComposerPresenter,
             voiceMessageComposerPresenter = voiceMessageComposerPresenter,
             timelinePresenterFactory = timelinePresenterFactory,
+            typingNotificationPresenter = typingNotificationPresenter,
             actionListPresenter = actionListPresenter,
             customReactionPresenter = customReactionPresenter,
             reactionSummaryPresenter = reactionSummaryPresenter,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
@@ -731,7 +731,10 @@ class MessagesPresenterTest {
             }
         }
         val actionListPresenter = ActionListPresenter(appPreferencesStore = appPreferencesStore)
-        val typingNotificationPresenter = TypingNotificationPresenter(matrixRoom)
+        val typingNotificationPresenter = TypingNotificationPresenter(
+            room = matrixRoom,
+            sessionPreferencesStore = sessionPreferencesStore,
+        )
         val readReceiptBottomSheetPresenter = ReadReceiptBottomSheetPresenter()
         val customReactionPresenter = CustomReactionPresenter(emojibaseProvider = FakeEmojibaseProvider())
         val reactionSummaryPresenter = ReactionSummaryPresenter(room = matrixRoom)

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -19,6 +19,7 @@ package io.element.android.features.messages.impl.timeline
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.features.messages.impl.typing.aTypingNotificationState
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.EnsureNeverCalledWithTwoParams
 import io.element.android.tests.testutils.EventsRecorder
@@ -41,6 +42,7 @@ class TimelineViewTest {
                         hasMoreToLoadBackwards = true,
                     )
                 ),
+                typingNotificationState = aTypingNotificationState(),
                 roomName = null,
                 onUserDataClicked = EnsureNeverCalledWithParam(),
                 onMessageClicked = EnsureNeverCalledWithParam(),
@@ -67,6 +69,7 @@ class TimelineViewTest {
                         hasMoreToLoadBackwards = false,
                     )
                 ),
+                typingNotificationState = aTypingNotificationState(),
                 roomName = null,
                 onUserDataClicked = EnsureNeverCalledWithParam(),
                 onMessageClicked = EnsureNeverCalledWithParam(),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenterTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.typing
+
+import app.cash.molecule.RecompositionMode
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.MatrixRoom
+import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
+import io.element.android.libraries.matrix.api.room.RoomMember
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.A_USER_ID_3
+import io.element.android.libraries.matrix.test.A_USER_ID_4
+import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import io.element.android.libraries.matrix.test.room.aRoomInfo
+import io.element.android.tests.testutils.WarmUpRule
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+@Suppress("LargeClass")
+class TypingNotificationPresenterTest {
+    @get:Rule
+    val warmUpRule = WarmUpRule()
+
+    @Test
+    fun `present - initial state`() = runTest {
+        val presenter = createPresenter()
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.typingMembers).isEmpty()
+        }
+    }
+
+    @Test
+    fun `present - state is updated when a member is typing, member is not known`() = runTest {
+        val aDefaultRoomMember = createDefaultRoomMember(A_USER_ID_2)
+        val room = FakeMatrixRoom()
+        val presenter = createPresenter(matrixRoom = room)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.typingMembers).isEmpty()
+            room.givenRoomTypingMembers(listOf(A_USER_ID_2))
+            val oneMemberTypingState = awaitItem()
+            assertThat(oneMemberTypingState.typingMembers.size).isEqualTo(1)
+            assertThat(oneMemberTypingState.typingMembers.first()).isEqualTo(aDefaultRoomMember)
+            // User stops typing
+            room.givenRoomTypingMembers(emptyList())
+            val finalState = awaitItem()
+            assertThat(finalState.typingMembers).isEmpty()
+        }
+    }
+
+    @Test
+    fun `present - state is updated when a member is typing, member is known`() = runTest {
+        val aKnownRoomMember = createKnownRoomMember(userId = A_USER_ID_2)
+        val room = FakeMatrixRoom().apply {
+            givenRoomMembersState(
+                MatrixRoomMembersState.Ready(
+                    listOf(
+                        createKnownRoomMember(A_USER_ID),
+                        aKnownRoomMember,
+                        createKnownRoomMember(A_USER_ID_3),
+                        createKnownRoomMember(A_USER_ID_4),
+                    ).toImmutableList()
+                )
+            )
+        }
+        val presenter = createPresenter(matrixRoom = room)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.typingMembers).isEmpty()
+            room.givenRoomTypingMembers(listOf(A_USER_ID_2))
+            val oneMemberTypingState = awaitItem()
+            assertThat(oneMemberTypingState.typingMembers.size).isEqualTo(1)
+            assertThat(oneMemberTypingState.typingMembers.first()).isEqualTo(aKnownRoomMember)
+            // User stops typing
+            room.givenRoomTypingMembers(emptyList())
+            val finalState = awaitItem()
+            assertThat(finalState.typingMembers).isEmpty()
+        }
+    }
+
+    @Test
+    fun `present - state is updated when a member is typing, member is not known, then known`() = runTest {
+        val aDefaultRoomMember = createDefaultRoomMember(A_USER_ID_2)
+        val aKnownRoomMember = createKnownRoomMember(A_USER_ID_2)
+        val room = FakeMatrixRoom()
+        val presenter = createPresenter(matrixRoom = room)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.typingMembers).isEmpty()
+            room.givenRoomTypingMembers(listOf(A_USER_ID_2))
+            val oneMemberTypingState = awaitItem()
+            assertThat(oneMemberTypingState.typingMembers.size).isEqualTo(1)
+            assertThat(oneMemberTypingState.typingMembers.first()).isEqualTo(aDefaultRoomMember)
+            // User is getting known
+            room.givenRoomMembersState(
+                MatrixRoomMembersState.Ready(
+                    listOf(aKnownRoomMember).toImmutableList()
+                )
+            )
+            val finalState = awaitItem()
+            assertThat(finalState.typingMembers.first()).isEqualTo(aKnownRoomMember)
+        }
+    }
+
+    private fun createPresenter(
+        matrixRoom: MatrixRoom = FakeMatrixRoom().apply {
+            givenRoomInfo(aRoomInfo(id = roomId.value, name = ""))
+        },
+    ): TypingNotificationPresenter {
+        return TypingNotificationPresenter(
+            room = matrixRoom,
+        )
+    }
+
+    private fun createDefaultRoomMember(
+        userId: UserId,
+    ) = RoomMember(
+        userId = userId,
+        displayName = null,
+        avatarUrl = null,
+        membership = RoomMembershipState.JOIN,
+        isNameAmbiguous = false,
+        powerLevel = 0,
+        normalizedPowerLevel = 0,
+        isIgnored = false,
+    )
+
+    private fun createKnownRoomMember(
+        userId: UserId,
+    ) = RoomMember(
+        userId = userId,
+        displayName = "Alice Doe",
+        avatarUrl = "an_avatar_url",
+        membership = RoomMembershipState.JOIN,
+        isNameAmbiguous = true,
+        powerLevel = 0,
+        normalizedPowerLevel = 0,
+        isIgnored = false,
+    )
+}

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/typing/TypingNotificationPresenterTest.kt
@@ -178,12 +178,10 @@ class TypingNotificationPresenterTest {
         sessionPreferencesStore: SessionPreferencesStore = InMemorySessionPreferencesStore(
             isRenderTypingNotificationsEnabled = true
         ),
-    ): TypingNotificationPresenter {
-        return TypingNotificationPresenter(
-            room = matrixRoom,
-            sessionPreferencesStore = sessionPreferencesStore,
-        )
-    }
+    ) = TypingNotificationPresenter(
+        room = matrixRoom,
+        sessionPreferencesStore = sessionPreferencesStore,
+    )
 
     private fun createDefaultRoomMember(
         userId: UserId,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -57,6 +57,7 @@ interface MatrixRoom : Closeable {
     val isDm: Boolean get() = isDirect && isOneToOne
 
     val roomInfoFlow: Flow<MatrixRoomInfo>
+    val roomTypingMembersFlow: Flow<List<UserId>>
 
     /**
      * A one-to-one is a room with exactly 2 members.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMember.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMember.kt
@@ -27,7 +27,19 @@ data class RoomMember(
     val powerLevel: Long,
     val normalizedPowerLevel: Long,
     val isIgnored: Boolean,
-)
+) {
+    /**
+     * Disambiguated display name for the RoomMember.
+     * If the display name is null, the user ID is returned.
+     * If the display name is ambiguous, the user ID is appended in parentheses.
+     * Otherwise, the display name is returned.
+     */
+    val disambiguatedDisplayName: String = when {
+        displayName == null -> userId.value
+        isNameAmbiguous -> "$displayName ($userId)"
+        else -> displayName
+    }
+}
 
 enum class RoomMembershipState {
     BAN,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -124,7 +124,8 @@ class RustMatrixRoom(
                 channel.trySend(
                     typingUserIds
                         .filter { it != sessionData.userId }
-                        .map(::UserId))
+                        .map(::UserId)
+                )
             }
         })
     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -120,9 +120,9 @@ class RustMatrixRoom(
             channel.trySend(initial)
         }
         innerRoom.subscribeToTypingNotifications(object : TypingNotificationsListener {
-            override fun call(typingUsers: List<String>) {
+            override fun call(typingUserIds: List<String>) {
                 channel.trySend(
-                    typingUsers
+                    typingUserIds
                         .filter { it != sessionData.userId }
                         .map(::UserId))
             }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -73,6 +73,7 @@ import org.matrix.rustcomponents.sdk.RoomInfoListener
 import org.matrix.rustcomponents.sdk.RoomListItem
 import org.matrix.rustcomponents.sdk.RoomMessageEventContentWithoutRelation
 import org.matrix.rustcomponents.sdk.SendAttachmentJoinHandle
+import org.matrix.rustcomponents.sdk.TypingNotificationsListener
 import org.matrix.rustcomponents.sdk.WidgetCapabilities
 import org.matrix.rustcomponents.sdk.WidgetCapabilitiesProvider
 import org.matrix.rustcomponents.sdk.messageEventContentFromHtml
@@ -109,6 +110,21 @@ class RustMatrixRoom(
         innerRoom.subscribeToRoomInfoUpdates(object : RoomInfoListener {
             override fun call(roomInfo: RoomInfo) {
                 channel.trySend(matrixRoomInfoMapper.map(roomInfo))
+            }
+        })
+    }
+
+    override val roomTypingMembersFlow: Flow<List<UserId>> = mxCallbackFlow {
+        launch {
+            val initial = emptyList<UserId>()
+            channel.trySend(initial)
+        }
+        innerRoom.subscribeToTypingNotifications(object : TypingNotificationsListener {
+            override fun call(typingUsers: List<String>) {
+                channel.trySend(
+                    typingUsers
+                        .filter { it != sessionData.userId }
+                        .map(::UserId))
             }
         })
     }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -170,6 +170,9 @@ class FakeMatrixRoom(
     private val _roomInfoFlow: MutableSharedFlow<MatrixRoomInfo> = MutableSharedFlow(replay = 1)
     override val roomInfoFlow: Flow<MatrixRoomInfo> = _roomInfoFlow
 
+    private val _roomTypingMembersFlow: MutableSharedFlow<List<UserId>> = MutableSharedFlow(replay = 1)
+    override val roomTypingMembersFlow: Flow<List<UserId>> = _roomTypingMembersFlow
+
     override val membersStateFlow: MutableStateFlow<MatrixRoomMembersState> = MutableStateFlow(MatrixRoomMembersState.Unknown)
 
     override val roomNotificationSettingsStateFlow: MutableStateFlow<MatrixRoomNotificationSettingsState> =
@@ -588,6 +591,10 @@ class FakeMatrixRoom(
 
     fun givenRoomInfo(roomInfo: MatrixRoomInfo) {
         _roomInfoFlow.tryEmit(roomInfo)
+    }
+
+    fun givenRoomTypingMembers(typingMembers: List<UserId>) {
+        _roomTypingMembersFlow.tryEmit(typingMembers)
     }
 }
 

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_MessagesViewWithTyping_null_MessagesViewWithTyping-Day-59_59_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_MessagesViewWithTyping_null_MessagesViewWithTyping-Day-59_59_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dda5041c16d690fe8e0c13aaca813a06acbcee8e9ab6268256ad8925defe5d0
+size 55428

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_MessagesViewWithTyping_null_MessagesViewWithTyping-Night-59_60_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_MessagesViewWithTyping_null_MessagesViewWithTyping-Night-59_60_null,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6946a2d952a72e29aaa54543ce0e8a73b7ab7c6db2c6fd23ac833fa7f61f8425
+size 54141

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb0d3bfcfd75cbd75fd9270ff1dc27090e5dbac79ca8db8a46d91a4c12bc966b
+size 4457

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff84eecce0c3e489e0596c524a361e277679fc0f6b1c3f3011e50bb666074574
+size 8953

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46396fd61ca8188bf3ea7745dee0456f3f944c2a1fcbf04402cfb1127d8bbef
+size 6856

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:272038adab5288f287dcf81c815de34945092ca20c67dad15b7e0a3715663be4
+size 9932

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3200b2363f50db05157314f5c5d9d491ffb51860e66ffe28bd4c024b6857dda0
+size 8161

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3409d9e8e10bae9e90f2f9088897261619ecd8d0e6e32441671396d50fed8ac0
+size 8940

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ca0ccfd706c8dca696481f7d1f60de83ed15435b1096c46d9dc79e21573817b
+size 9265

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_7,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Day-60_60_null_7,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18f8d2c5c872598293ac759a074e88ba38062e54ca9348a12aff62f3d91c34f4
+size 11149

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_0,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_0,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c89ac73df77c2bccb0c2aa80cee1420f78e7d07f0eda89a90bffef55e8cf753
+size 4464

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_1,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_1,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5c002a4929aa725cf22ca46840ff3374efe4c4e1757e3b76c3a064911525ce6
+size 8875

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_2,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_2,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a227b3aca2f20d895c483ca72e3c3b49a3b6263e01f10cd59dda7147f750ecc8
+size 6840

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_3,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_3,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2d151892e95c633ef8bd6960f32eca0e00b2ddbcaba01cbca830fea356471f9
+size 9877

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3e0ec1f6946fa12c56d17f7ff72e7fca50ad52e41864b0351a36842a220df02
+size 8093

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_5,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ed8a9b93f09875de225096a7c7c044840c603c31e0f525522f5be13fa116a8
+size 8786

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_6,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32087f3ad5e63e8075d2b981881ba36e7fb36464a10b3d7506ed1cf6d00c2e3d
+size 9106

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_7,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.typing_TypingNotificationView_null_TypingNotificationView-Night-60_61_null_7,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:833aa5ba2891ca8a0f81534ca2b36b6971dc851a2842507b1ae3f2f5b701961f
+size 11004


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Render typing notification in the timeline. `Share presence` must be enabled.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2242 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
See recorded ones

## Tests

<!-- Explain how you tested your development -->

- From another Matrix client able to send typing notification, User A start typing in a room
- From EXA, User B in the same room can now observe that User A is typing.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
