### PR TITLE
Open the keyboard (and keep it opened) when creating a poll.

### DIFF
--- a/changelog.d/2329.bugfix
+++ b/changelog.d/2329.bugfix
@@ -1,0 +1,1 @@
+Open the keyboard (and keep it opened) when creating a poll.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -194,7 +193,12 @@ fun MessagesView(
                     roomName = state.roomName.dataOrNull(),
                     roomAvatar = state.roomAvatar.dataOrNull(),
                     callState = state.callState,
-                    onBackPressed = onBackPressed,
+                    onBackPressed = {
+                        // Since the textfield is now based on an Android view, this is no longer done automatically.
+                        // We need to hide the keyboard when navigating out of this screen.
+                        localView.hideKeyboard()
+                        onBackPressed()
+                    },
                     onRoomDetailsClicked = onRoomDetailsClicked,
                     onJoinCallClicked = onJoinCallClicked,
                 )
@@ -260,14 +264,6 @@ fun MessagesView(
         onUserDataClicked = onUserDataClicked,
     )
     ReinviteDialog(state = state)
-
-    // Since the textfield is now based on an Android view, this is no longer done automatically.
-    // We need to hide the keyboard automatically when navigating out of this screen.
-    DisposableEffect(Unit) {
-        onDispose {
-            localView.hideKeyboard()
-        }
-    }
 }
 
 @Composable


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Open the keyboard (and keep it opened) when creating a poll.

The Poll screen correctly requestFocus on the question field, but actually the keyboard was hidden later from the MessagesView.

Actually replace a Disposable effect by a action to close the keyboard in the `onBackPressed` callback.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2329 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start a poll from a timeline and observe that the keyboard is opened and stays opened
- Go back to the timeline
- Click on the composer to open the keyboard
- Click on back top start action to go back to the room list
- observe that the keyboard is closed automatically (so no regression on this)

I did more test to see if the keyboard may stay open when it should not, but I did not find any case with that.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
