### PR TITLE
Add the user certificates as additional certificates to the ClientBuilder

### DIFF
--- a/changelog.d/2992.feature
+++ b/changelog.d/2992.feature
@@ -1,0 +1,1 @@
+Allow user-installed certificates to be used by the HTTP client

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -30,6 +30,7 @@ import io.element.android.libraries.matrix.api.auth.OidcDetails
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.impl.RustMatrixClientFactory
 import io.element.android.libraries.matrix.impl.exception.mapClientException
+import io.element.android.libraries.matrix.impl.getAdditionalCertificates
 import io.element.android.libraries.matrix.impl.keys.PassphraseGenerator
 import io.element.android.libraries.matrix.impl.mapper.toSessionData
 import io.element.android.libraries.network.useragent.UserAgentProvider
@@ -61,11 +62,12 @@ class RustMatrixAuthenticationService @Inject constructor(
     // Passphrase which will be used for new sessions. Existing sessions will use the passphrase
     // stored in the SessionData.
     private val pendingPassphrase = getDatabasePassphrase()
+    private val additionalCertificates = getAdditionalCertificates()
     private val authService: RustAuthenticationService = RustAuthenticationService(
         basePath = baseDirectory.absolutePath,
         passphrase = pendingPassphrase,
         userAgent = userAgentProvider.provide(),
-        additionalRootCertificates = emptyList(),
+        additionalRootCertificates = additionalCertificates,
         oidcConfiguration = oidcConfiguration,
         customSlidingSyncProxy = null,
         sessionDelegate = null,


### PR DESCRIPTION
Now, this is a story all about how
Certificates work in Android town
And I'd like to take a minute
Enter, close the door
I'll tell you how I've figured out the inner workings of the Keystore

Well it all boils down to the fact that Google got scared
It said, "Your certs are movin' to a place you'll never find 'em".

So the directory, user certificates are stored, is hard to find, and possibly not readable by your application[[1]]. Instead, we need to use the Keystore[[2]] API, specifically we'll need to open the `AndroidCAStore` Keystore type.

The various Keystore types are supposedly documented[[3]], but I'm failing to find a logical path that would lead you to conclude that:
1. System certificates can or should be accessed using the Keystore, specifically the `AndroidCAStore` type
2. User certificates can be found in the same Keystore type as the system certificates

So this was mostly found using random googling, swearing, and a couple of educated guesses.

[1]: https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html
[2]: https://developer.android.com/reference/java/security/KeyStore
[3]: https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#keystore-types
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

The Rust SDK, if configured to use the [`rustls`](https://github.com/rustls/rustls) crate for SSL reads the system certificates using the [`openssl-probe`](https://github.com/alexcrichton/openssl-probe) crate. The `openssl-probe` crate reads the certificates from some predefined directory. This directory doesn't contain any additional certificates the user installed on the device.

Like previously mentioned, user-installed certificates should™ be gathered via the `Keystore` API and that one might not be available from Rust land. We can't easily modify the `openssl-probe` to use the `Keystore` API so here we are doing it the dumb way. We load the certs from the Kotlin side and push them to the Rust side.

It would probably be nice to write a test for the method that gathers the certificates, but I have no idea how to do this.

This PR requires: https://github.com/matrix-org/matrix-rust-sdk/pull/3126

## Motivation and context

Sorry, no motivation was found. Somebody told me to do this.

## Screenshots / GIFs


[mitmproxy.webm](https://github.com/element-hq/element-x-android/assets/552026/8c8d72d5-7d85-44a8-af0b-1e70df88b42c)


## Tests

- Generate a fresh set of self-signed certificates using `mitmproxy`, `mitmproxy` does this automatically when it starts up the first time.
- Push the `mitmproxy` certificate to the emulated device using `adb push mitmproxy-ca-cert.cer /data/local`
- Install the certificate as a user certificate under **Security & privacy** => **More security settings** => **Encryption & credentials**
- Run `mitmproxy` in reverse proxy mode `mitmproxy --mode reverse:http://localhost:8008 -k --listen-port 8010`
- Forward the 8010 port through adb `adb reverse tcp:8010 tcp:8010`
- Try to connect to the `mitmproxy` reverse proxy using `https://localhost:8010` as the homeserver address

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

Android 14.0 ("UpsideDownCake") | x86_64 | API 34

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
