### PR TITLE
Improve how Talkback works with the timeline

### DIFF
--- a/changelog.d/+improve-accessibility-in-timeline.bugfix
+++ b/changelog.d/+improve-accessibility-in-timeline.bugfix
@@ -1,0 +1,1 @@
+Improve how Talkback works with the timeline. Sadly, it's still not 100% working, but there is some issue with the `LazyColumn` using `reverseLayout` that only Google can fix.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -18,7 +18,6 @@
 
 package io.element.android.features.messages.impl.timeline
 
-import android.content.Context
 import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -105,7 +104,7 @@ fun TimelineView(
     val lazyListState = rememberLazyListState()
     // Disable reverse layout when TalkBack is enabled to avoid incorrect ordering issues seen in the current Compose UI version
     val useReverseLayout = remember {
-        val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val accessibilityManager = context.getSystemService(AccessibilityManager::class.java)
         accessibilityManager.isTouchExplorationEnabled.not()
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -18,9 +18,12 @@
 
 package io.element.android.features.messages.impl.timeline
 
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Box
@@ -45,8 +48,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -64,7 +67,6 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.typing.TypingNotificationState
 import io.element.android.features.messages.impl.typing.TypingNotificationView
 import io.element.android.features.messages.impl.typing.aTypingNotificationState
-import io.element.android.libraries.designsystem.animation.alphaAnimation
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
@@ -99,7 +101,13 @@ fun TimelineView(
         state.eventSink(TimelineEvents.OnScrollFinished(firstVisibleIndex))
     }
 
+    val context = LocalContext.current
     val lazyListState = rememberLazyListState()
+    // Disable reverse layout when TalkBack is enabled to avoid incorrect ordering issues seen in the current Compose UI version
+    val useReverseLayout = remember {
+        val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        accessibilityManager.isTouchExplorationEnabled.not()
+    }
 
     @Suppress("UNUSED_PARAMETER")
     fun inReplyToClicked(eventId: EventId) {
@@ -107,67 +115,67 @@ fun TimelineView(
     }
 
     // Animate alpha when timeline is first displayed, to avoid flashes or glitching when viewing rooms
-    val alpha by alphaAnimation(label = "alpha for timeline")
-
-    Box(modifier = modifier.alpha(alpha)) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = lazyListState,
-            reverseLayout = true,
-            contentPadding = PaddingValues(vertical = 8.dp),
-        ) {
-            item {
-                TypingNotificationView(state = typingNotificationState)
-            }
-            items(
-                items = state.timelineItems,
-                contentType = { timelineItem -> timelineItem.contentType() },
-                key = { timelineItem -> timelineItem.identifier() },
-            ) { timelineItem ->
-                TimelineItemRow(
-                    timelineItem = timelineItem,
-                    timelineRoomInfo = state.timelineRoomInfo,
-                    renderReadReceipts = state.renderReadReceipts,
-                    isLastOutgoingMessage = (timelineItem as? TimelineItem.Event)?.isMine == true &&
-                        state.timelineItems.first().identifier() == timelineItem.identifier(),
-                    highlightedItem = state.highlightedEventId?.value,
-                    onClick = onMessageClicked,
-                    onLongClick = onMessageLongClicked,
-                    onUserDataClick = onUserDataClicked,
-                    inReplyToClick = ::inReplyToClicked,
-                    onReactionClick = onReactionClicked,
-                    onReactionLongClick = onReactionLongClicked,
-                    onMoreReactionsClick = onMoreReactionsClicked,
-                    onReadReceiptClick = onReadReceiptClick,
-                    onTimestampClicked = onTimestampClicked,
-                    sessionState = state.sessionState,
-                    eventSink = state.eventSink,
-                    onSwipeToReply = onSwipeToReply,
-                )
-            }
-            if (state.paginationState.hasMoreToLoadBackwards) {
-                // Do not use key parameter to avoid wrong positioning
-                item(contentType = "TimelineLoadingMoreIndicator") {
-                    TimelineLoadingMoreIndicator()
-                    LaunchedEffect(Unit) {
-                        onReachedLoadMore()
+    AnimatedVisibility(visible = true, enter = fadeIn()) {
+        Box(modifier) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                state = lazyListState,
+                reverseLayout = useReverseLayout,
+                contentPadding = PaddingValues(vertical = 8.dp),
+            ) {
+                item {
+                    TypingNotificationView(state = typingNotificationState)
+                }
+                items(
+                    items = state.timelineItems,
+                    contentType = { timelineItem -> timelineItem.contentType() },
+                    key = { timelineItem -> timelineItem.identifier() },
+                ) { timelineItem ->
+                    TimelineItemRow(
+                        timelineItem = timelineItem,
+                        timelineRoomInfo = state.timelineRoomInfo,
+                        renderReadReceipts = state.renderReadReceipts,
+                        isLastOutgoingMessage = (timelineItem as? TimelineItem.Event)?.isMine == true &&
+                            state.timelineItems.first().identifier() == timelineItem.identifier(),
+                        highlightedItem = state.highlightedEventId?.value,
+                        onClick = onMessageClicked,
+                        onLongClick = onMessageLongClicked,
+                        onUserDataClick = onUserDataClicked,
+                        inReplyToClick = ::inReplyToClicked,
+                        onReactionClick = onReactionClicked,
+                        onReactionLongClick = onReactionLongClicked,
+                        onMoreReactionsClick = onMoreReactionsClicked,
+                        onReadReceiptClick = onReadReceiptClick,
+                        onTimestampClicked = onTimestampClicked,
+                        sessionState = state.sessionState,
+                        eventSink = state.eventSink,
+                        onSwipeToReply = onSwipeToReply,
+                    )
+                }
+                if (state.paginationState.hasMoreToLoadBackwards) {
+                    // Do not use key parameter to avoid wrong positioning
+                    item(contentType = "TimelineLoadingMoreIndicator") {
+                        TimelineLoadingMoreIndicator()
+                        LaunchedEffect(Unit) {
+                            onReachedLoadMore()
+                        }
+                    }
+                }
+                if (state.paginationState.beginningOfRoomReached && !state.timelineRoomInfo.isDirect) {
+                    item(contentType = "BeginningOfRoomReached") {
+                        TimelineItemRoomBeginningView(roomName = roomName)
                     }
                 }
             }
-            if (state.paginationState.beginningOfRoomReached && !state.timelineRoomInfo.isDirect) {
-                item(contentType = "BeginningOfRoomReached") {
-                    TimelineItemRoomBeginningView(roomName = roomName)
-                }
-            }
-        }
 
-        TimelineScrollHelper(
-            isTimelineEmpty = state.timelineItems.isEmpty(),
-            lazyListState = lazyListState,
-            forceJumpToBottomVisibility = forceJumpToBottomVisibility,
-            newEventState = state.newEventState,
-            onScrollFinishedAt = ::onScrollFinishedAt
-        )
+            TimelineScrollHelper(
+                isTimelineEmpty = state.timelineItems.isEmpty(),
+                lazyListState = lazyListState,
+                forceJumpToBottomVisibility = forceJumpToBottomVisibility,
+                newEventState = state.newEventState,
+                onScrollFinishedAt = ::onScrollFinishedAt
+            )
+        }
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -112,6 +113,7 @@ import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.room.Mention
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnail
+import io.element.android.libraries.testtags.TestTags
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -312,7 +314,10 @@ private fun TimelineItemEventRowContent(
                     .zIndex(1f)
                     .clickable(onClick = onUserDataClicked)
                     // This is redundant when using talkback
-                    .clearAndSetSemantics { invisibleToUser() }
+                    .clearAndSetSemantics {
+                        invisibleToUser()
+                        testTag = TestTags.timelineItemSenderInfo.value
+                    }
             )
         }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemImageView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemImageView.kt
@@ -18,6 +18,9 @@ package io.element.android.features.messages.impl.timeline.components.event
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemImageContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemImageContentProvider
@@ -25,15 +28,17 @@ import io.element.android.libraries.designsystem.components.BlurHashAsyncImage
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.matrix.ui.media.MediaRequestData
+import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun TimelineItemImageView(
     content: TimelineItemImageContent,
     modifier: Modifier = Modifier,
 ) {
+    val description = stringResource(CommonStrings.common_image)
     TimelineItemAspectRatioBox(
         aspectRatio = content.aspectRatio,
-        modifier = modifier,
+        modifier = modifier.semantics { contentDescription = description },
     ) {
         BlurHashAsyncImage(
             model = MediaRequestData(content.preferredMediaSource, MediaRequestData.Kind.File(content.body, content.mimeType)),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.features.messages.impl.timeline.components.layout.ContentAvoidingLayout
@@ -48,7 +50,7 @@ fun TimelineItemTextView(
         val formattedBody = content.formattedBody
         val body = SpannableString(formattedBody ?: content.body)
 
-        Box(modifier) {
+        Box(modifier.semantics { contentDescription = body.toString() }) {
             EditorStyledText(
                 text = body,
                 onLinkClickedListener = onLinkClicked,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVideoView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVideoView.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContentProvider
@@ -42,9 +44,10 @@ fun TimelineItemVideoView(
     content: TimelineItemVideoContent,
     modifier: Modifier = Modifier,
 ) {
+    val description = stringResource(CommonStrings.common_image)
     TimelineItemAspectRatioBox(
         aspectRatio = content.aspectRatio,
-        modifier = modifier,
+        modifier = modifier.semantics { contentDescription = description },
         contentAlignment = Alignment.Center,
     ) {
         BlurHashAsyncImage(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
@@ -326,8 +326,7 @@ class MessagesViewTest {
                 state = state,
                 onUserDataClicked = callback,
             )
-            val senderName = (timelineItem as? TimelineItem.Event)?.senderDisplayName.orEmpty()
-            rule.onNodeWithText(senderName).performClick()
+            rule.onNodeWithTag(TestTags.timelineItemSenderInfo.value).performClick()
         }
     }
 

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -74,4 +74,9 @@ object TestTags {
     val dialogPositive = TestTag("dialog-positive")
     val dialogNegative = TestTag("dialog-negative")
     val dialogNeutral = TestTag("dialog-neutral")
+
+    /**
+     * Timeline item.
+     */
+    val timelineItemSenderInfo = TestTag("timeline_item-sender_info")
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Fix talkback not reading aloud the messages.
- Add content description to image and video events.
- Group all values in an event so it reads like `<sender>: (in reply to <prev sender>: <prev message>) <message> <timestamp>`.
- Disable 'reply to' onClick event, since it breaks talkback (clickable nodes won't merge its accessibility info with its parents). We'll eventually need to find a fix or workaround for it.

Sadly, it's still not 100% working, there is some issue with the `LazyColumn` using `reverseLayout` that only Google can fix and messes up big time with the scrolling:

https://github.com/element-hq/element-x-android/assets/480955/ea3c6695-81ad-4761-8575-22b6a1bdb0d3

## Motivation and context

The timeline wasn't usable at all for users who depend on talkback. It's a bit better now, although the scrolling issue is still present.

## Tests

- Enable talkback.
- Open the app, open a room.
- Use the forward/backwards gesture (swipe left/right) to navigate through the items and check the audio transcription makes sense.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
