### PR TITLE
[Improvements] Room list filters

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersPresenter.kt
@@ -83,7 +83,7 @@ class RoomListFiltersPresenter @Inject constructor(
                         RoomListFilter.Unread -> MatrixRoomListFilter.Unread
                         RoomListFilter.Favourites -> MatrixRoomListFilter.Favorite
                     }
-                }.plus(MatrixRoomListFilter.NonLeft)
+                }
             )
             roomListService.allRooms.updateFilter(allRoomsFilter)
         }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -103,10 +103,8 @@ private fun LazyListScope.roomListFilters(
 ) {
     items(
         items = filters,
-        key = { it.ordinal },
     ) { filter ->
         RoomListFilterView(
-            modifier = Modifier.animateItemPlacement(),
             roomListFilter = filter,
             selected = selected,
             onClick = onClick,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchDataSource.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.roomlist.impl.search
+
+import io.element.android.features.roomlist.impl.datasource.RoomListRoomSummaryFactory
+import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.matrix.api.roomlist.RoomList
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
+import io.element.android.libraries.matrix.api.roomlist.RoomListService
+import io.element.android.libraries.matrix.api.roomlist.RoomSummary
+import io.element.android.libraries.matrix.api.roomlist.loadAllIncrementally
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private const val PAGE_SIZE = 30
+
+class RoomListSearchDataSource @Inject constructor(
+    roomListService: RoomListService,
+    coroutineDispatchers: CoroutineDispatchers,
+    private val roomSummaryFactory: RoomListRoomSummaryFactory,
+) {
+    private val roomList = roomListService.createRoomList(
+        pageSize = PAGE_SIZE,
+        initialFilter = RoomListFilter.None,
+        source = RoomList.Source.All,
+    )
+
+    val roomSummaries: Flow<PersistentList<RoomListRoomSummary>> = roomList.summaries
+        .map { roomSummaries ->
+            roomSummaries
+                .filterIsInstance<RoomSummary.Filled>()
+                .map(roomSummaryFactory::create)
+                .toPersistentList()
+        }
+        .flowOn(coroutineDispatchers.computation)
+
+    suspend fun setIsActive(isActive: Boolean) = coroutineScope {
+        if (isActive) {
+            roomList.loadAllIncrementally(this)
+        } else {
+            roomList.reset()
+        }
+    }
+
+    suspend fun setSearchQuery(searchQuery: String) = coroutineScope {
+        val filter = if (searchQuery.isBlank()) {
+            RoomListFilter.None
+        } else {
+            RoomListFilter.NormalizedMatchRoomName(searchQuery)
+        }
+        roomList.updateFilter(filter)
+    }
+}

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersPresenterTests.kt
@@ -69,7 +69,6 @@ class RoomListFiltersPresenterTests {
                 )
                 val roomListCurrentFilter = roomListService.allRooms.currentFilter.value as MatrixRoomListFilter.All
                 assertThat(roomListCurrentFilter.filters).containsExactly(
-                    MatrixRoomListFilter.NonLeft,
                     MatrixRoomListFilter.Category.Group,
                 )
 
@@ -86,9 +85,7 @@ class RoomListFiltersPresenterTests {
                     RoomListFilter.Favourites,
                 )
                 val roomListCurrentFilter = roomListService.allRooms.currentFilter.value as MatrixRoomListFilter.All
-                assertThat(roomListCurrentFilter.filters).containsExactly(
-                    MatrixRoomListFilter.NonLeft,
-                )
+                assertThat(roomListCurrentFilter.filters).isEmpty()
             }
         }
     }

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTests.kt
@@ -79,7 +79,7 @@ class RoomListSearchPresenterTests {
                 assertThat(
                     roomListService.allRooms.currentFilter.value
                 ).isEqualTo(
-                    RoomListFilter.None,
+                    RoomListFilter.None
                 )
                 state.eventSink(RoomListSearchEvents.QueryChanged("Search"))
             }
@@ -97,7 +97,7 @@ class RoomListSearchPresenterTests {
                 assertThat(
                     roomListService.allRooms.currentFilter.value
                 ).isEqualTo(
-                    RoomListFilter.None,
+                    RoomListFilter.None
                 )
             }
         }

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTests.kt
@@ -79,9 +79,7 @@ class RoomListSearchPresenterTests {
                 assertThat(
                     roomListService.allRooms.currentFilter.value
                 ).isEqualTo(
-                    RoomListFilter.all(
-                        RoomListFilter.None,
-                    )
+                    RoomListFilter.None,
                 )
                 state.eventSink(RoomListSearchEvents.QueryChanged("Search"))
             }
@@ -90,10 +88,7 @@ class RoomListSearchPresenterTests {
                 assertThat(
                     roomListService.allRooms.currentFilter.value
                 ).isEqualTo(
-                    RoomListFilter.all(
-                        RoomListFilter.NonLeft,
-                        RoomListFilter.NormalizedMatchRoomName("Search")
-                    )
+                    RoomListFilter.NormalizedMatchRoomName("Search")
                 )
                 state.eventSink(RoomListSearchEvents.ClearQuery)
             }
@@ -102,9 +97,7 @@ class RoomListSearchPresenterTests {
                 assertThat(
                     roomListService.allRooms.currentFilter.value
                 ).isEqualTo(
-                    RoomListFilter.all(
-                        RoomListFilter.None,
-                    )
+                    RoomListFilter.None,
                 )
             }
         }
@@ -141,11 +134,13 @@ fun TestScope.createRoomListSearchPresenter(
     roomListService: RoomListService = FakeRoomListService(),
 ): RoomListSearchPresenter {
     return RoomListSearchPresenter(
-        roomListService = roomListService,
-        roomSummaryFactory = RoomListRoomSummaryFactory(
-            lastMessageTimestampFormatter = FakeLastMessageTimestampFormatter(),
-            roomLastMessageFormatter = FakeRoomLastMessageFormatter(),
+        dataSource = RoomListSearchDataSource(
+            roomListService = roomListService,
+            roomSummaryFactory = RoomListRoomSummaryFactory(
+                lastMessageTimestampFormatter = FakeLastMessageTimestampFormatter(),
+                roomLastMessageFormatter = FakeRoomLastMessageFormatter(),
             ),
-        coroutineDispatchers = testCoroutineDispatchers(),
+            coroutineDispatchers = testCoroutineDispatchers(),
+        )
     )
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
@@ -48,11 +48,6 @@ sealed interface RoomListFilter {
     ) : RoomListFilter
 
     /**
-     * A filter that matches rooms that are not left.
-     */
-    data object NonLeft : RoomListFilter
-
-    /**
      * A filter that matches rooms that are unread.
      */
     data object Unread : RoomListFilter
@@ -79,13 +74,6 @@ sealed interface RoomListFilter {
      * A filter that matches rooms with a name using a normalized match.
      */
     data class NormalizedMatchRoomName(
-        val pattern: String
-    ) : RoomListFilter
-
-    /**
-     * A filter that matches rooms with a name using a fuzzy match.
-     */
-    data class FuzzyMatchRoomName(
         val pattern: String
     ) : RoomListFilter
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
@@ -17,7 +17,6 @@
 package io.element.android.libraries.matrix.api.roomlist
 
 import androidx.compose.runtime.Immutable
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -42,13 +41,11 @@ interface RoomListService {
 
     /**
      * Creates a room list that can be used to load more rooms and filter them dynamically.
-     * @param coroutineScope the scope to use for the room list. When the scope will be closed, the room list will be closed too.
      * @param pageSize the number of rooms to load at once.
      * @param initialFilter the initial filter to apply to the rooms.
      * @param source the source of the rooms, either all rooms or invites.
      */
     fun createRoomList(
-        coroutineScope: CoroutineScope,
         pageSize: Int,
         initialFilter: RoomListFilter,
         source: RoomList.Source,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
@@ -47,7 +47,6 @@ internal class RustRoomListService(
     private val roomListFactory: RoomListFactory,
 ) : RoomListService {
     override fun createRoomList(
-        coroutineScope: CoroutineScope,
         pageSize: Int,
         initialFilter: RoomListFilter,
         source: RoomList.Source
@@ -55,7 +54,6 @@ internal class RustRoomListService(
         return roomListFactory.createRoomList(
             pageSize = pageSize,
             initialFilter = initialFilter,
-            coroutineScope = coroutineScope,
             coroutineContext = sessionDispatcher,
         ) {
             when (source) {
@@ -68,7 +66,6 @@ internal class RustRoomListService(
     override val allRooms: DynamicRoomList = roomListFactory.createRoomList(
         pageSize = DEFAULT_PAGE_SIZE,
         coroutineContext = sessionDispatcher,
-        initialFilter = RoomListFilter.all(RoomListFilter.NonLeft),
     ) {
         innerRoomListService.allRooms()
     }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTests.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTests.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.roomlist
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
+import io.element.android.libraries.matrix.test.room.aRoomSummaryDetails
+import io.element.android.libraries.matrix.test.room.aRoomSummaryFilled
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RoomListFilterTests {
+    private val regularRoom = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            isDirect = false
+        )
+    )
+    private val directRoom = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            isDirect = true
+        )
+    )
+    private val favoriteRoom = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            isFavorite = true
+        )
+    )
+    private val markedAsUnreadRoom = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            isMarkedUnread = true
+        )
+    )
+    private val unreadNotificationRoom = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            numUnreadNotifications = 1
+        )
+    )
+    private val roomToSearch = aRoomSummaryFilled(
+        aRoomSummaryDetails(
+            name = "Room to search"
+        )
+    )
+
+    private val roomSummaries = listOf(
+        regularRoom,
+        directRoom,
+        favoriteRoom,
+        markedAsUnreadRoom,
+        unreadNotificationRoom,
+        roomToSearch
+    )
+
+    @Test
+    fun `Room list filter all empty`() = runTest {
+        val filter = RoomListFilter.all()
+        assertThat(roomSummaries.filter(filter)).isEqualTo(roomSummaries)
+    }
+
+    @Test
+    fun `Room list filter none`() = runTest {
+        val filter = RoomListFilter.None
+        assertThat(roomSummaries.filter(filter)).isEmpty()
+    }
+
+    @Test
+    fun `Room list filter people`() = runTest {
+        val filter = RoomListFilter.Category.People
+        assertThat(roomSummaries.filter(filter)).containsExactly(directRoom)
+    }
+
+    @Test
+    fun `Room list filter group`() = runTest {
+        val filter = RoomListFilter.Category.Group
+        assertThat(roomSummaries.filter(filter)).containsExactly(regularRoom, favoriteRoom, markedAsUnreadRoom, unreadNotificationRoom, roomToSearch)
+    }
+
+    @Test
+    fun `Room list filter favorite`() = runTest {
+        val filter = RoomListFilter.Favorite
+        assertThat(roomSummaries.filter(filter)).containsExactly(favoriteRoom)
+    }
+
+    @Test
+    fun `Room list filter unread`() = runTest {
+        val filter = RoomListFilter.Unread
+        assertThat(roomSummaries.filter(filter)).containsExactly(markedAsUnreadRoom, unreadNotificationRoom)
+    }
+
+    @Test
+    fun `Room list filter normalized match room name`() = runTest {
+        val filter = RoomListFilter.NormalizedMatchRoomName("search")
+        assertThat(roomSummaries.filter(filter)).containsExactly(roomToSearch)
+    }
+
+    @Test
+    fun `Room list filter all with one match`() = runTest {
+        val filter = RoomListFilter.all(
+            RoomListFilter.Category.Group,
+            RoomListFilter.Favorite
+        )
+        assertThat(roomSummaries.filter(filter)).containsExactly(favoriteRoom)
+    }
+
+    @Test
+    fun `Room list filter all with no match`() = runTest {
+        val filter = RoomListFilter.all(
+            RoomListFilter.Category.People,
+            RoomListFilter.Favorite
+        )
+        assertThat(roomSummaries.filter(filter)).isEmpty()
+    }
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
@@ -21,7 +21,6 @@ import io.element.android.libraries.matrix.api.roomlist.RoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -60,7 +59,11 @@ class FakeRoomListService : RoomListService {
     var latestSlidingSyncRange: IntRange? = null
         private set
 
-    override fun createRoomList(coroutineScope: CoroutineScope, pageSize: Int, initialFilter: RoomListFilter, source: RoomList.Source): DynamicRoomList {
+    override fun createRoomList(
+        pageSize: Int,
+        initialFilter: RoomListFilter,
+        source: RoomList.Source
+    ): DynamicRoomList {
         return when (source) {
             RoomList.Source.All -> allRooms
             RoomList.Source.Invites -> invites

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -31,6 +31,7 @@ import io.element.android.features.roomlist.impl.datasource.RoomListRoomSummaryF
 import io.element.android.features.roomlist.impl.filters.RoomListFiltersPresenter
 import io.element.android.features.roomlist.impl.migration.MigrationScreenPresenter
 import io.element.android.features.roomlist.impl.migration.SharedPrefsMigrationScreenStore
+import io.element.android.features.roomlist.impl.search.RoomListSearchDataSource
 import io.element.android.features.roomlist.impl.search.RoomListSearchPresenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.dateformatter.impl.DateFormatters
@@ -112,9 +113,11 @@ class RoomListScreen(
             migrationScreenStore = SharedPrefsMigrationScreenStore(context.getSharedPreferences("migration", Context.MODE_PRIVATE))
         ),
         searchPresenter = RoomListSearchPresenter(
-            roomListService = matrixClient.roomListService,
-            roomSummaryFactory = roomListRoomSummaryFactory,
-            coroutineDispatchers = coroutineDispatchers,
+            RoomListSearchDataSource(
+                roomListService = matrixClient.roomListService,
+                roomSummaryFactory = roomListRoomSummaryFactory,
+                coroutineDispatchers = coroutineDispatchers,
+            )
         ),
         sessionPreferencesStore = DefaultSessionPreferencesStore(
             context = context,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Replaces the usage of the rust sdk filters by kotlin filters instead.
Also disable animation on filter toggling.

<!-- Describe shortly what has been changed -->

## Motivation and context
Calling `roomList.setFilter` on the rust side provokes a lot of `diffChanges` and some back and forth with the ffi.
This is way slower than using pure kotlin filtering, and also have more chances to bust the room list cache in the sdk sides.
So, this PR should speeds up a lot the experience with filterings.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
