### PR TITLE
Add clear gradle cache flow

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,35 @@
+name: Clear Gradle Cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every nights at 4
+    - cron: "0 4 * * *"
+
+# Enrich gradle.properties for CI/CD
+env:
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseParallelGC
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --warn
+
+jobs:
+  tests:
+    name: Clear Gradle cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⏬ Checkout with LFS
+        uses: nschloe/action-cached-lfs-checkout@v1.2.2
+      - name: ☕️ Use JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+      - name: Configure gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+          gradle-home-cache-cleanup: true
+
+        # This should build the project and run the tests, and the build files will be used to diff with the cache
+      - name: ⚙️ Build the GPlay debug variant, run unit tests
+        run: ./gradlew :app:assembleGplayDebug test $CI_GRADLE_ARG_PROPERTIES

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Configure gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
           gradle-home-cache-cleanup: true
 
         # This should build the project and run the tests, and the build files will be used to diff with the cache


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Creates a new 'Clear Gradle Cache' CI workflow that will run most of the tasks we usually use to generate some intermediate build files and cache that will be diffed agains the stored one so unused files can be removed from it.

The task can run either manually or each day at 4AM (1h before the nightlies).

## Motivation and context

At the moment, the Gradle cache contains several GB of data,  and after GH silently reduced the available disk space for runners we're experiencing issues in some flows. This should free some space.

## Tests

We can't know if it solves the issue until it's merged.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
