### PR TITLE
Hide blocked users list when there are no blocked users

### DIFF
--- a/changelog.d/2198.bugfix
+++ b/changelog.d/2198.bugfix
@@ -1,0 +1,1 @@
+Hide blocked users list when there are no blocked users.

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import io.element.android.features.logout.api.direct.DirectLogoutPresenter
@@ -39,6 +40,8 @@ import io.element.android.libraries.matrix.api.user.getCurrentUser
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -86,6 +89,12 @@ class PreferencesRootPresenter @Inject constructor(
             mutableStateOf(null)
         }
 
+        val showBlockedUsersItem by produceState(initialValue = false) {
+            matrixClient.ignoredUsersFlow
+                .onEach { value = it.isNotEmpty() }
+                .launchIn(this)
+        }
+
         val directLogoutState = directLogoutPresenter.present()
 
         LaunchedEffect(Unit) {
@@ -106,6 +115,7 @@ class PreferencesRootPresenter @Inject constructor(
             showDeveloperSettings = showDeveloperSettings,
             showNotificationSettings = showNotificationSettings.value,
             showLockScreenSettings = showLockScreenSettings.value,
+            showBlockedUsersItem = showBlockedUsersItem,
             directLogoutState = directLogoutState,
             snackbarMessage = snackbarMessage,
         )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootState.kt
@@ -33,6 +33,7 @@ data class PreferencesRootState(
     val showDeveloperSettings: Boolean,
     val showLockScreenSettings: Boolean,
     val showNotificationSettings: Boolean,
+    val showBlockedUsersItem: Boolean,
     val directLogoutState: DirectLogoutState,
     val snackbarMessage: SnackbarMessage?,
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootStateProvider.kt
@@ -33,6 +33,7 @@ fun aPreferencesRootState() = PreferencesRootState(
     showDeveloperSettings = true,
     showNotificationSettings = true,
     showLockScreenSettings = true,
+    showBlockedUsersItem = true,
     snackbarMessage = SnackbarMessage(CommonStrings.common_verification_complete),
     directLogoutState = aDirectLogoutState(),
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootView.kt
@@ -122,11 +122,13 @@ fun PreferencesRootView(
                 onClick = onOpenNotificationSettings,
             )
         }
-        ListItem(
-            headlineContent = { Text(stringResource(id = CommonStrings.common_blocked_users)) },
-            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Block())),
-            onClick = onOpenBlockedUsers,
-        )
+        if (state.showBlockedUsersItem) {
+            ListItem(
+                headlineContent = { Text(stringResource(id = CommonStrings.common_blocked_users)) },
+                leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Block())),
+                onClick = onOpenBlockedUsers,
+            )
+        }
         ListItem(
             headlineContent = { Text(stringResource(id = CommonStrings.common_report_a_problem)) },
             leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.ChatProblem())),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Only display blocked user list item from the app settings when there are blocked users.

## Motivation and context

Closes #2469.

## Tests

Check the item is hidden when you have no blocked users and it's displayed again when you block at least one.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
