### PR TITLE
Revert "Update dependency androidx.compose:compose-bom to v2024.02.02"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ activity = "1.8.2"
 media3 = "1.2.1"
 
 # Compose
-compose_bom = "2024.02.02"
+compose_bom = "2024.02.01"
 composecompiler = "1.5.10"
 
 # Coroutines


### PR DESCRIPTION
Reverts element-hq/element-x-android#2500

It seems like it's causing some issues with the `SearchUserBar` screenshots in Paparazzi, we need to investigate it:

```
ui.S > t[f.createroom.impl.components_UserListView_null_UserListView-Day-2_3_null_6,NEXUS_5,1.0,en] STANDARD_ERROR
    Mar 07, 2024 12:28:46 PM app.cash.paparazzi.internal.PaparazziLogger logAndroidFramework
    INFO: Settings [3]: Can't get key animator_duration_scale from content://settings/global
    Mar 07, 2024 12:28:46 PM app.cash.paparazzi.internal.PaparazziLogger error
    SEVERE: broken: View measure failed
    java.lang.ClassCastException: class io.element.android.libraries.matrix.api.user.MatrixUser cannot be cast to class io.element.android.libraries.usersearch.api.UserSearchResult (io.element.android.libraries.matrix.api.user.MatrixUser and io.element.android.libraries.usersearch.api.UserSearchResult are in unnamed module of loader 'app')
        at io.element.android.features.createroom.impl.components.SearchUserBarKt$SearchUserBar$3$1$invoke$$inlined$itemsIndexed$default$3.invoke(LazyDsl.kt:184)
        at io.element.android.features.createroom.impl.components.SearchUserBarKt$SearchUserBar$3$1$invoke$$inlined$itemsIndexed$default$3.invoke(LazyDsl.kt:183)
        at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:139)
        at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
        at androidx.compose.foundation.lazy.LazyListItemProviderImpl$Item$1.invoke(LazyListItemProvider.kt:79)
        ...
```