### PR TITLE
Prevent sending empty messages

### DIFF
--- a/changelog.d/995.bugfix
+++ b/changelog.d/995.bugfix
@@ -1,0 +1,1 @@
+Prevent sending empty messages.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -99,7 +99,7 @@ fun aMessagesState(
     userHasPermissionToRedactOther: Boolean = false,
     userHasPermissionToSendReaction: Boolean = true,
     composerState: MessageComposerState = aMessageComposerState(
-        richTextEditorState = RichTextEditorState("Hello", initialFocus = true),
+        richTextEditorState = RichTextEditorState(initialHtml = "Hello", initialMarkdown = "Hello", initialFocus = true),
         isFullScreen = false,
         mode = MessageComposerMode.Normal,
     ),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -43,8 +43,8 @@ import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.textcomposer.aRichTextEditorState
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
-import io.element.android.wysiwyg.compose.RichTextEditorState
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 
@@ -99,7 +99,7 @@ fun aMessagesState(
     userHasPermissionToRedactOther: Boolean = false,
     userHasPermissionToSendReaction: Boolean = true,
     composerState: MessageComposerState = aMessageComposerState(
-        richTextEditorState = RichTextEditorState(initialHtml = "Hello", initialMarkdown = "Hello", initialFocus = true),
+        richTextEditorState = aRichTextEditorState(initialText = "Hello", initialFocus = true),
         isFullScreen = false,
         mode = MessageComposerMode.Normal,
     ),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ serialization_json = "1.6.3"
 showkase = "1.0.2"
 appyx = "1.4.0"
 sqldelight = "2.0.1"
-wysiwyg = "2.31.0"
+wysiwyg = "2.32.0"
 telephoto = "0.8.0"
 
 # DI

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -172,7 +172,7 @@ fun TextComposer(
         }
     }
 
-    val canSendMessage by remember { derivedStateOf { state.messageHtml.isNotEmpty() } }
+    val canSendMessage by remember { derivedStateOf { state.messageMarkdown.isNotBlank() } }
     val sendButton = @Composable {
         SendButton(
             canSendMessage = canSendMessage,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -598,7 +598,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
         items = persistentListOf(
             {
                 ATextComposer(
-                    RichTextEditorState("", initialFocus = true),
+                    aRichTextEditorState(initialText = "", initialFocus = true),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -608,7 +608,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
+                    aRichTextEditorState(initialText = "A message", initialFocus = true),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -618,9 +618,8 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(
-                        initialHtml = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
-                        initialMarkdown = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+                    aRichTextEditorState(
+                        initialText = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
                         initialFocus = true
                     ),
                     voiceMessageState = VoiceMessageState.Idle,
@@ -632,7 +631,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message without focus", initialMarkdown = "A message without focus", initialFocus = false),
+                    aRichTextEditorState(initialText = "A message without focus", initialFocus = false),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -649,7 +648,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
 internal fun TextComposerFormattingPreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         ATextComposer(
-            RichTextEditorState("", initialFocus = false),
+            aRichTextEditorState(initialText = "", initialFocus = false),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -659,7 +658,7 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         )
     }, {
         ATextComposer(
-            RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = false),
+            aRichTextEditorState(initialText = "A message", initialFocus = false),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -689,7 +688,7 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
 internal fun TextComposerEditPreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         ATextComposer(
-            RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
+            aRichTextEditorState(initialText = "A message", initialFocus = true),
             voiceMessageState = VoiceMessageState.Idle,
             composerMode = MessageComposerMode.Edit(EventId("$1234"), "Some text", TransactionId("1234")),
             enableTextFormatting = true,
@@ -706,7 +705,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
         items = persistentListOf(
             {
                 ATextComposer(
-                    RichTextEditorState(""),
+                    aRichTextEditorState(""),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -742,7 +741,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
+                    aRichTextEditorState(initialText = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = true,
@@ -763,7 +762,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
+                    aRichTextEditorState(initialText = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -784,7 +783,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
+                    aRichTextEditorState(initialText = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -805,7 +804,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
+                    aRichTextEditorState(initialText = "A message", initialFocus = true),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -928,3 +927,14 @@ private fun ATextComposer(
         onRichContentSelected = null,
     )
 }
+
+fun aRichTextEditorState(
+    initialText: String = "",
+    initialHtml: String = initialText,
+    initialMarkdown: String = initialText,
+    initialFocus: Boolean = false,
+) = RichTextEditorState(
+    initialHtml = initialHtml,
+    initialMarkdown = initialMarkdown,
+    initialFocus = initialFocus,
+)

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -668,9 +668,8 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         )
     }, {
         ATextComposer(
-            RichTextEditorState(
-                initialHtml = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
-                initialMarkdown = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+            aRichTextEditorState(
+                initialText = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
                 initialFocus = false
             ),
             voiceMessageState = VoiceMessageState.Idle,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -608,7 +608,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message", initialFocus = true),
+                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -619,7 +619,8 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             {
                 ATextComposer(
                     RichTextEditorState(
-                        "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+                        initialHtml = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+                        initialMarkdown = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
                         initialFocus = true
                     ),
                     voiceMessageState = VoiceMessageState.Idle,
@@ -631,7 +632,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message without focus", initialFocus = false),
+                    RichTextEditorState(initialHtml = "A message without focus", initialMarkdown = "A message without focus", initialFocus = false),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -658,7 +659,7 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         )
     }, {
         ATextComposer(
-            RichTextEditorState("A message", initialFocus = false),
+            RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = false),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -668,7 +669,11 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         )
     }, {
         ATextComposer(
-            RichTextEditorState("A message\nWith several lines\nTo preview larger textfields and long lines with overflow", initialFocus = false),
+            RichTextEditorState(
+                initialHtml = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+                initialMarkdown = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
+                initialFocus = false
+            ),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -684,7 +689,7 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
 internal fun TextComposerEditPreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         ATextComposer(
-            RichTextEditorState("A message", initialFocus = true),
+            RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
             voiceMessageState = VoiceMessageState.Idle,
             composerMode = MessageComposerMode.Edit(EventId("$1234"), "Some text", TransactionId("1234")),
             enableTextFormatting = true,
@@ -737,7 +742,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message"),
+                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = true,
@@ -758,7 +763,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message"),
+                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -779,7 +784,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message"),
+                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -800,7 +805,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState("A message", initialFocus = true),
+                    RichTextEditorState(initialHtml = "A message", initialMarkdown = "A message", initialFocus = true),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Disables the send message button when the text to send is blank.

## Motivation and context

Fixes #995.

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Try adding several empty paragraphs and whitespace characters to the message textfield. If the send button is hidden, then it's working as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
