### PR TITLE
Fix layout poll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ captures/
 .idea/libraries
 # Android Studio 3 in .gitignore file.
 .idea/caches
+.idea/copilot
 .idea/inspectionProfiles
 # Shelved changes in the IDE
 .idea/shelf

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryView.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryView.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
@@ -195,7 +196,8 @@ private fun PollHistoryList(
                     text = emptyStringResource,
                     style = ElementTheme.typography.fontBodyLgRegular,
                     color = ElementTheme.colors.textSecondary,
-                    modifier = Modifier.padding(vertical = 24.dp, horizontal = 16.dp)
+                    modifier = Modifier.padding(vertical = 24.dp, horizontal = 16.dp),
+                    textAlign = TextAlign.Center,
                 )
             }
         }


### PR DESCRIPTION
Fix layout for empty poll history, only visible in some other language or on small screens, for instance in French:

<img width="572" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/f8e1e8c3-0f2c-445e-a0bf-1f1619f55878">

Now the text will be centered.