### PR TITLE
Bugfix : fix timeline not showing sender info

### DIFF
--- a/changelog.d/2530.bugfix
+++ b/changelog.d/2530.bugfix
@@ -1,0 +1,1 @@
+Fix timeline not showing sender info when room is marked as direct but not a 1:1 room.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -94,6 +94,7 @@ class TimelinePresenter @AssistedInject constructor(
         val timelineItems by timelineItemsFactory.collectItemsAsState()
         val paginationState by timeline.paginationState.collectAsState()
         val syncUpdateFlow = room.syncUpdateFlow.collectAsState()
+
         val userHasPermissionToSendMessage by room.canSendMessageAsState(type = MessageEventType.ROOM_MESSAGE, updateKey = syncUpdateFlow.value)
         val userHasPermissionToSendReaction by room.canSendMessageAsState(type = MessageEventType.REACTION, updateKey = syncUpdateFlow.value)
 
@@ -170,7 +171,7 @@ class TimelinePresenter @AssistedInject constructor(
         val timelineRoomInfo by remember {
             derivedStateOf {
                 TimelineRoomInfo(
-                    isDirect = room.isDirect,
+                    isDM = room.isDm,
                     userHasPermissionToSendMessage = userHasPermissionToSendMessage,
                     userHasPermissionToSendReaction = userHasPermissionToSendReaction,
                 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
@@ -38,7 +38,7 @@ data class TimelineState(
 
 @Immutable
 data class TimelineRoomInfo(
-    val isDirect: Boolean,
+    val isDM: Boolean,
     val userHasPermissionToSendMessage: Boolean,
     val userHasPermissionToSendReaction: Boolean,
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
@@ -235,10 +235,10 @@ internal fun aGroupedEvents(
 }
 
 internal fun aTimelineRoomInfo(
-    isDirect: Boolean = false,
+    isDM: Boolean = false,
     userHasPermissionToSendMessage: Boolean = true,
 ) = TimelineRoomInfo(
-    isDirect = isDirect,
+    isDM = isDM,
     userHasPermissionToSendMessage = userHasPermissionToSendMessage,
     userHasPermissionToSendReaction = true,
 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -160,7 +160,7 @@ fun TimelineView(
                         }
                     }
                 }
-                if (state.paginationState.beginningOfRoomReached && !state.timelineRoomInfo.isDirect) {
+                if (state.paginationState.beginningOfRoomReached && !state.timelineRoomInfo.isDM) {
                     item(contentType = "BeginningOfRoomReached") {
                         TimelineItemRoomBeginningView(roomName = roomName)
                     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
@@ -95,7 +95,7 @@ fun MessageEventBubble(
     fun Modifier.offsetForItem(): Modifier {
         return when {
             state.isMine -> this
-            state.timelineRoomInfo.isDirect -> this
+            state.timelineRoomInfo.isDM -> this
             else -> offset(x = BUBBLE_INCOMING_OFFSET)
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -301,7 +301,7 @@ private fun TimelineItemEventRowContent(
 
         // Sender
         val avatarStrokeSize = 3.dp
-        if (event.showSenderInformation && !timelineRoomInfo.isDirect) {
+        if (event.showSenderInformation && !timelineRoomInfo.isDM) {
             MessageSenderInformation(
                 event.safeSenderName,
                 event.senderAvatar,
@@ -371,7 +371,7 @@ private fun TimelineItemEventRowContent(
                         // In design we want a offset of 6.dp compare to the bubble, so start is 22.dp (16 + 6)
                         start = when {
                             event.isMine -> 22.dp
-                            timelineRoomInfo.isDirect -> 22.dp
+                            timelineRoomInfo.isDM -> 22.dp
                             else -> 22.dp + BUBBLE_INCOMING_OFFSET
                         },
                         end = 16.dp

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRowForDirectRoomPreview.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRowForDirectRoomPreview.kt
@@ -41,7 +41,7 @@ internal fun TimelineItemEventRowForDirectRoomPreview() = ElementPreview {
                     groupPosition = TimelineItemGroupPosition.First,
                 ),
                 timelineRoomInfo = aTimelineRoomInfo(
-                    isDirect = true,
+                    isDM = true,
                 ),
             )
             ATimelineItemEventRow(
@@ -53,7 +53,7 @@ internal fun TimelineItemEventRowForDirectRoomPreview() = ElementPreview {
                     groupPosition = TimelineItemGroupPosition.Last,
                 ),
                 timelineRoomInfo = aTimelineRoomInfo(
-                    isDirect = true,
+                    isDM = true,
                 ),
             )
         }


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Use `isDM` instead of `isDirect` to hide or not sender info.
<!-- Describe shortly what has been changed -->

## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/2530
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No changes.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
