### PR TITLE
Revert "Clear and generate new cache only when merging to `develop`"

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,34 @@
+name: Clear Gradle Cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every nights at 4
+    - cron: "0 4 * * *"
+
+# Enrich gradle.properties for CI/CD
+env:
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseParallelGC
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --warn
+
+jobs:
+  tests:
+    name: Clear Gradle cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⏬ Checkout with LFS
+        uses: nschloe/action-cached-lfs-checkout@v1.2.2
+      - name: ☕️ Use JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+      - name: Configure gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-home-cache-cleanup: true
+
+        # This should build the project and run the tests, and the build files will be used to diff with the cache
+      - name: ⚙️ Build the GPlay debug variant, run unit tests
+        run: ./gradlew :app:assembleGplayDebug test $CI_GRADLE_ARG_PROPERTIES

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-          gradle-home-cache-cleanup: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: ⚙️ Run unit tests, debug and release
         run: ./gradlew test $CI_GRADLE_ARG_PROPERTIES


### PR DESCRIPTION
Reverts element-hq/element-x-android#2549

We had some weird issues with screenshot tests and LFS after merging some PRs, this one included, so I'm reverting it to check if it fixes the issue.