### PR TITLE
Add analytic events to room moderation

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
@@ -51,7 +51,7 @@ internal fun AnalyticsService.trackPermissionChangeAnalytics(initial: MatrixRoom
         capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomName, analyticsMemberRoleForPowerLevel(updated.roomName)))
     }
     if (updated.roomAvatar != initial?.roomAvatar) {
-        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomAvatar, analyticsMemberRoleForPowerLevel(updated.roomTopic)))
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomAvatar, analyticsMemberRoleForPowerLevel(updated.roomAvatar)))
     }
     if (updated.roomTopic != initial?.roomTopic) {
         capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomTopic, analyticsMemberRoleForPowerLevel(updated.roomTopic)))

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.roomdetails.impl.analytics
+
+import im.vector.app.features.analytics.plan.RoomModeration
+import io.element.android.libraries.matrix.api.room.RoomMember
+import io.element.android.libraries.matrix.api.room.powerlevels.MatrixRoomPowerLevels
+import io.element.android.services.analytics.api.AnalyticsService
+
+internal fun RoomMember.Role.toAnalyticsMemberRole(): RoomModeration.Role = when (this) {
+    RoomMember.Role.ADMIN -> RoomModeration.Role.Administrator
+    RoomMember.Role.MODERATOR -> RoomModeration.Role.Moderator
+    RoomMember.Role.USER -> RoomModeration.Role.User
+}
+
+internal fun analyticsMemberRoleForPowerLevel(powerLevel: Long): RoomModeration.Role {
+    return RoomMember.Role.forPowerLevel(powerLevel).toAnalyticsMemberRole()
+}
+
+internal fun AnalyticsService.trackPermissionChangeAnalytics(initial: MatrixRoomPowerLevels?, updated: MatrixRoomPowerLevels) {
+    if (updated.ban != initial?.ban) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsBanMembers, analyticsMemberRoleForPowerLevel(updated.ban)))
+    }
+    if (updated.invite != initial?.invite) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsInviteUsers, analyticsMemberRoleForPowerLevel(updated.invite)))
+    }
+    if (updated.kick != initial?.kick) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsKickMembers, analyticsMemberRoleForPowerLevel(updated.kick)))
+    }
+    if (updated.sendEvents != initial?.sendEvents) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsSendMessages, analyticsMemberRoleForPowerLevel(updated.sendEvents)))
+    }
+    if (updated.redactEvents != initial?.redactEvents) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRedactMessages, analyticsMemberRoleForPowerLevel(updated.redactEvents)))
+    }
+    if (updated.roomName != initial?.roomName) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomName, analyticsMemberRoleForPowerLevel(updated.roomName)))
+    }
+    if (updated.roomAvatar != initial?.roomAvatar) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomAvatar, analyticsMemberRoleForPowerLevel(updated.roomTopic)))
+    }
+    if (updated.roomTopic != initial?.roomTopic) {
+        capture(RoomModeration(RoomModeration.Action.ChangePermissionsRoomTopic, analyticsMemberRoleForPowerLevel(updated.roomTopic)))
+    }
+}

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/DefaultRoomMembersModerationPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/DefaultRoomMembersModerationPresenter.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.squareup.anvil.annotations.ContributesBinding
+import im.vector.app.features.analytics.plan.RoomModeration
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.runUpdatingState
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
@@ -38,6 +39,7 @@ import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.room.powerlevels.canBan
 import io.element.android.libraries.matrix.api.room.powerlevels.canKick
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +53,7 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
     private val room: MatrixRoom,
     private val featureFlagService: FeatureFlagService,
     private val dispatchers: CoroutineDispatchers,
+    private val analyticsService: AnalyticsService,
 ) : RoomMembersModerationPresenter {
     private var selectedMember by mutableStateOf<RoomMember?>(null)
 
@@ -150,6 +153,7 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
         userId: UserId,
         kickUserAction: MutableState<AsyncAction<Unit>>,
     ) = runActionAndWaitForMembershipChange(kickUserAction) {
+        analyticsService.capture(RoomModeration(RoomModeration.Action.KickMember))
         room.kickUser(userId).finally { selectedMember = null }
     }
 
@@ -157,6 +161,7 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
         userId: UserId,
         banUserAction: MutableState<AsyncAction<Unit>>,
     ) = runActionAndWaitForMembershipChange(banUserAction) {
+        analyticsService.capture(RoomModeration(RoomModeration.Action.BanMember))
         room.banUser(userId).finally { selectedMember = null }
     }
 
@@ -164,6 +169,7 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
         userId: UserId,
         unbanUserAction: MutableState<AsyncAction<Unit>>,
     ) = runActionAndWaitForMembershipChange(unbanUserAction) {
+        analyticsService.capture(RoomModeration(RoomModeration.Action.UnbanMember))
         room.unbanUser(userId).finally { selectedMember = null }
     }
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsPresenter.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import im.vector.app.features.analytics.plan.RoomModeration
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.runUpdatingState
@@ -32,6 +33,7 @@ import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -39,6 +41,7 @@ import javax.inject.Inject
 class RolesAndPermissionsPresenter @Inject constructor(
     private val room: MatrixRoom,
     private val dispatchers: CoroutineDispatchers,
+    private val analyticsService: AnalyticsService,
 ) : Presenter<RolesAndPermissionsState> {
     @Composable
     override fun present(): RolesAndPermissionsState {
@@ -100,6 +103,7 @@ class RolesAndPermissionsPresenter @Inject constructor(
         resetPermissionsAction: MutableState<AsyncAction<Unit>>,
     ) = launch(dispatchers.io) {
         runUpdatingState(resetPermissionsAction) {
+            analyticsService.capture(RoomModeration(RoomModeration.Action.ResetPermissions))
             room.resetPowerLevels().map {}
         }
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenter.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.setValue
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import im.vector.app.features.analytics.plan.RoomModeration
+import io.element.android.features.roomdetails.impl.analytics.toAnalyticsMemberRole
 import io.element.android.features.roomdetails.impl.members.PowerLevelRoomMemberComparator
 import io.element.android.features.roomdetails.impl.members.RoomMemberListDataSource
 import io.element.android.libraries.architecture.AsyncAction
@@ -41,6 +43,7 @@ import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.user.MatrixUser
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -56,6 +59,7 @@ class ChangeRolesPresenter @AssistedInject constructor(
     @Assisted private val role: RoomMember.Role,
     private val room: MatrixRoom,
     private val dispatchers: CoroutineDispatchers,
+    private val analyticsService: AnalyticsService,
 ) : Presenter<ChangeRolesState> {
     @AssistedFactory
     interface Factory {
@@ -197,9 +201,11 @@ class ChangeRolesPresenter @AssistedInject constructor(
 
         val changes: List<UserRoleChange> = buildList {
             for (selectedUser in toAdd) {
+                analyticsService.capture(RoomModeration(RoomModeration.Action.ChangeMemberRole, role.toAnalyticsMemberRole()))
                 add(UserRoleChange(selectedUser.userId, role))
             }
             for (selectedUser in toRemove) {
+                analyticsService.capture(RoomModeration(RoomModeration.Action.ChangeMemberRole, RoomModeration.Role.User))
                 add(UserRoleChange(selectedUser.userId, RoomMember.Role.USER))
             }
         }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsPresenter.kt
@@ -27,10 +27,12 @@ import androidx.compose.runtime.setValue
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import io.element.android.features.roomdetails.impl.analytics.trackPermissionChangeAnalytics
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.powerlevels.MatrixRoomPowerLevels
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CoroutineScope
@@ -39,6 +41,7 @@ import kotlinx.coroutines.launch
 class ChangeRoomPermissionsPresenter @AssistedInject constructor(
     @Assisted private val section: ChangeRoomPermissionsSection,
     private val room: MatrixRoom,
+    private val analyticsService: AnalyticsService,
 ) : Presenter<ChangeRoomPermissionsState> {
     companion object {
         internal fun itemsForSection(section: ChangeRoomPermissionsSection) = when (section) {
@@ -135,6 +138,7 @@ class ChangeRoomPermissionsPresenter @AssistedInject constructor(
         }
         room.updatePowerLevels(updatedRoomPowerLevels)
             .onSuccess {
+                analyticsService.trackPermissionChangeAnalytics(initialPermissions, updatedRoomPowerLevels)
                 initialPermissions = currentPermissions
                 saveAction = AsyncAction.Success(Unit)
             }

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/rolesandpermissions/permissions/ChangeRoomPermissionsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/rolesandpermissions/permissions/ChangeRoomPermissionsPresenterTests.kt
@@ -191,8 +191,18 @@ class ChangeRoomPermissionsPresenterTests {
                 assertThat(currentPermissions?.roomName).isEqualTo(MODERATOR.powerLevel)
                 assertThat(saveAction).isEqualTo(AsyncAction.Success(Unit))
             }
-            assertThat(analyticsService.capturedEvents).hasSize(8)
-            assertThat(analyticsService.capturedEvents.all { it is RoomModeration }).isTrue()
+            assertThat(analyticsService.capturedEvents).containsExactlyElementsIn(
+                listOf(
+                    RoomModeration(RoomModeration.Action.ChangePermissionsRoomName, RoomModeration.Role.Moderator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsRoomAvatar, RoomModeration.Role.Moderator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsRoomTopic, RoomModeration.Role.Moderator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsSendMessages, RoomModeration.Role.Moderator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsRedactMessages, RoomModeration.Role.User),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsKickMembers, RoomModeration.Role.Administrator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsBanMembers, RoomModeration.Role.Administrator),
+                    RoomModeration(RoomModeration.Action.ChangePermissionsInviteUsers, RoomModeration.Role.Administrator),
+                )
+            )
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add analytic events to room moderation feature.

## Motivation and context

It's part of the room moderation epic.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
