### PR TITLE
Ensure progress indicator is removed when a user is unblocked

### DIFF
--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersView.kt
@@ -100,6 +100,11 @@ fun BlockedUsersView(
                     }
                 }
             }
+            is AsyncAction.Success -> {
+                LaunchedEffect(state.unblockUserAction) {
+                    asyncIndicatorState.clear()
+                }
+            }
             is AsyncAction.Confirming -> {
                 ConfirmationDialog(
                     title = stringResource(R.string.screen_blocked_users_unblock_alert_title),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

`clear()` the `AsyncIndicatorState` when a user is successfully unblocked.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android-rageshakes/issues/1656.

## Tests

<!-- Explain how you tested your development -->

- Unblock a blocked user.

The progress indicator should disappear quickly.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
