### PR TITLE
Move `Konsist` tests to quality checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           name: linting-report
           path: |
-            */build/reports/**/*.*
+            **/build/reports/**/*.*
       - name: Prepare Danger
         if: always()
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,7 @@ allprojects {
 
 // Register quality check tasks.
 tasks.register("runQualityChecks") {
+    dependsOn(":tests:konsist:testDebugUnitTest")
     project.subprojects {
         // For some reason `findByName("lint")` doesn't work
         tasks.findByPath("$path:lint")?.let { dependsOn(it) }

--- a/tests/konsist/build.gradle.kts
+++ b/tests/konsist/build.gradle.kts
@@ -33,9 +33,11 @@ dependencies {
     testImplementation(projects.libraries.designsystem)
 }
 
-// Make sure Konsist tests are always run. This is needed because otherwise we'd have to either:
+// Make sure Konsist tests run for 'check' tasks. This is needed because otherwise we'd have to either:
 // - Add every single module as a dependency of this one.
 // - Move the Konsist tests to the `app` module, but the `app` module does not need to know about Konsist.
 tasks.withType<Test>().configureEach {
-    outputs.upToDateWhen { false }
+    outputs.upToDateWhen {
+        gradle.startParameter.taskNames.any { it.contains("check", ignoreCase = true).not() }
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Add `tests:konsist:testDebugUnitTest` to `runQualityChecks` as a dependency.
- Make Konsist tests be not up to date for every task with `check` (case-insensitive) in it, which includes the `runQualityChecks` one.

## Motivation and context

The Konsist tests are more of a quality of code checks than actual tests.

This change should also help us avoid running them for every single test task, including Kover ones.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
