### PR TITLE
Remove unnecessary `Room.updateMembers()` calls.

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -295,8 +295,6 @@ class MessagesPresenter @AssistedInject constructor(
     private fun CoroutineScope.reinviteOtherUser(inviteProgress: MutableState<AsyncData<Unit>>) = launch(dispatchers.io) {
         inviteProgress.value = AsyncData.Loading()
         runCatching {
-            room.updateMembers()
-
             val memberList = when (val memberState = room.membersStateFlow.value) {
                 is MatrixRoomMembersState.Ready -> memberState.roomMembers
                 is MatrixRoomMembersState.Error -> memberState.prevRoomMembers.orEmpty()

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.lifecycle.Lifecycle
 import im.vector.app.features.analytics.plan.Interaction
 import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomPresenter
@@ -34,7 +33,6 @@ import io.element.android.features.roomdetails.impl.members.details.RoomMemberDe
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.MatrixClient

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -92,13 +92,6 @@ class RoomDetailsPresenter @Inject constructor(
             }
         }
 
-        // Update room members only when first presenting the node
-        OnLifecycleEvent { _, event ->
-            if (event == Lifecycle.Event.ON_CREATE) {
-                scope.launch { room.updateMembers() }
-            }
-        }
-
         val membersState by room.membersStateFlow.collectAsState()
         val canInvite by getCanInvite(membersState)
         val canEditName by getCanSendState(membersState, StateEventType.ROOM_NAME)

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersNode.kt
@@ -80,8 +80,6 @@ class RoomInviteMembersNode @AssistedInject constructor(
                             body = context.getString(CommonStrings.common_unable_to_invite_message),
                         )
                     }
-
-                    room.updateMembers()
                 }
             }
         )

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
@@ -67,7 +67,9 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
             }
         }
         LaunchedEffect(Unit) {
-            room.updateMembers()
+            // Update room member info when opening this screen
+            // We don't need to assign the result as it will be automatically propagated by `room.getRoomMemberAsState`
+            room.getUpdatedMember(roomMemberId)
         }
 
         fun handleEvents(event: RoomMemberDetailsEvents) {
@@ -133,7 +135,7 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
             .fold(
                 onSuccess = {
                     isBlockedState.value = AsyncData.Success(true)
-                    room.updateMembers()
+                    room.getUpdatedMember(userId)
                 },
                 onFailure = {
                     isBlockedState.value = AsyncData.Failure(it, false)
@@ -147,7 +149,7 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
             .fold(
                 onSuccess = {
                     isBlockedState.value = AsyncData.Success(false)
-                    room.updateMembers()
+                    room.getUpdatedMember(userId)
                 },
                 onFailure = {
                     isBlockedState.value = AsyncData.Failure(it, true)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -86,6 +86,11 @@ interface MatrixRoom : Closeable {
      */
     suspend fun updateMembers()
 
+    /**
+     * Will return an updated member or an error.
+     */
+    suspend fun getUpdatedMember(userId: UserId): Result<RoomMember>
+
     suspend fun updateRoomNotificationSettings(): Result<Unit>
 
     val syncUpdateFlow: StateFlow<Long>

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -230,6 +230,12 @@ class RustMatrixRoom(
         roomMemberListFetcher.fetchRoomMembers(source = source)
     }
 
+    override suspend fun getUpdatedMember(userId: UserId): Result<RoomMember> = withContext(roomDispatcher) {
+        runCatching {
+            RoomMemberMapper.map(innerRoom.member(userId.value))
+        }
+    }
+
     override suspend fun userDisplayName(userId: UserId): Result<String?> = withContext(roomDispatcher) {
         runCatching {
             innerRoom.memberDisplayName(userId.value)

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -91,7 +91,7 @@ class FakeMatrixRoom(
     private var userDisplayNameResult = Result.success<String?>(null)
     private var userAvatarUrlResult = Result.success<String?>(null)
     private var userRoleResult = Result.success(RoomMember.Role.USER)
-    private var updateMembersResult: Result<Unit> = Result.success(Unit)
+    private var getRoomMemberResult = Result.failure<RoomMember>(IllegalStateException("Member not found"))
     private var joinRoomResult = Result.success(Unit)
     private var inviteUserResult = Result.success(Unit)
     private var canInviteResult = Result.success(true)
@@ -194,6 +194,10 @@ class FakeMatrixRoom(
         MutableStateFlow(MatrixRoomNotificationSettingsState.Unknown)
 
     override suspend fun updateMembers() = Unit
+
+    override suspend fun getUpdatedMember(userId: UserId): Result<RoomMember> {
+        return getRoomMemberResult
+    }
 
     override suspend fun updateRoomNotificationSettings(): Result<Unit> = simulateLongTask {
         val notificationSettings = notificationSettingsService.getRoomNotificationSettings(roomId, isEncrypted, isOneToOne).getOrThrow()
@@ -532,8 +536,8 @@ class FakeMatrixRoom(
         membersStateFlow.value = state
     }
 
-    fun givenUpdateMembersResult(result: Result<Unit>) {
-        updateMembersResult = result
+    fun givenGetRoomMemberResult(result: Result<RoomMember>) {
+        getRoomMemberResult = result
     }
 
     fun givenUserDisplayNameResult(displayName: Result<String?>) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Remove unnecessary `Room.updateMembers()` calls.

Some of them can be directly removed since we have a way to automatically get member info updates based on membership changes.

Others can be replaced by a simpler `getUpdatedMember(userId)` method. This might still do a full member sync, but it's quite unlikely, and even if it does it we won't have to map every fetched user before we can use the result.

## Motivation and context

After testing the improved room member list and `updateMembers()` sometimes causing 45MB of data to be loaded for the Matrix HQ room, I want to reduce these calls as much as possible. It should also improve performance since we avoid unnecessary data mapping.

## Tests

There should be no changes. I tested the following flows:

- In a DM, have the other user leave the room. Then tap on the message composer to re-invite them.
- Open the room details screen of a user, block and unblock them.
- Invite a new user to a room.
- Open the room member list.

As far as I could tell they all still worked as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
