### PR TITLE
Correctly format notification text for reply in a thread #2568

### DIFF
--- a/changelog.d/2568.bugfix
+++ b/changelog.d/2568.bugfix
@@ -1,0 +1,1 @@
+ Fix issue on text in notification for reply in thread.

--- a/libraries/matrixui/build.gradle.kts
+++ b/libraries/matrixui/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(projects.libraries.matrix.api)
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.core)
+    implementation(projects.services.toolbox.api)
     implementation(projects.libraries.uiStrings)
     implementation(libs.coil.compose)
     implementation(libs.coil.gif)
@@ -47,4 +48,5 @@ dependencies {
     testImplementation(libs.test.junit)
     testImplementation(libs.test.truth)
     testImplementation(libs.test.robolectric)
+    testImplementation(projects.services.toolbox.test)
 }

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrixui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrixui/messages/ToPlainTextTest.kt
@@ -129,7 +129,8 @@ class ToPlainTextTest {
             body = "> <@user:matrix.org> message\n\nreply",
             formatted = FormattedBody(
                 format = MessageFormat.HTML,
-                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> <a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
+                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> " +
+                    "<a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
             )
         )
         // toPlainText() will not include the content of the message being replied to
@@ -142,7 +143,8 @@ class ToPlainTextTest {
             body = "> <@user:matrix.org> message\n\nreply",
             formatted = FormattedBody(
                 format = MessageFormat.HTML,
-                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> <a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
+                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> " +
+                    "<a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
             )
         )
         val stringProvider = FakeStringProvider("En réponse à @user:matrix.org")

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrixui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrixui/messages/ToPlainTextTest.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.FormattedBody
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
 import io.element.android.libraries.matrix.ui.messages.toPlainText
+import io.element.android.services.toolbox.test.strings.FakeStringProvider
 import org.jsoup.Jsoup
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -120,5 +121,31 @@ class ToPlainTextTest {
             )
         )
         assertThat(messageType.toPlainText()).isEqualTo("This is the fallback text")
+    }
+
+    @Test
+    fun `TextMessageType toPlainText - returns the correct content for reply in thread`() {
+        val messageType = TextMessageType(
+            body = "> <@user:matrix.org> message\n\nreply",
+            formatted = FormattedBody(
+                format = MessageFormat.HTML,
+                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> <a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
+            )
+        )
+        // toPlainText() will not include the content of the message being replied to
+        assertThat(messageType.toPlainText()).isEqualTo("In reply to @user:matrix.org: reply")
+    }
+
+    @Test
+    fun `TextMessageType toPlainText - returns the correct i18n content for reply in thread`() {
+        val messageType = TextMessageType(
+            body = "> <@user:matrix.org> message\n\nreply",
+            formatted = FormattedBody(
+                format = MessageFormat.HTML,
+                body = "<mx-reply><blockquote><a href=\"https://matrix.to/#/!roomId:matrix.org/\$eventId\">In reply to</a> <a href=\"https://matrix.to/#/@user:matrix.org\">@user:matrix.org</a><br>message</blockquote></mx-reply>reply"
+            )
+        )
+        val stringProvider = FakeStringProvider("En réponse à @user:matrix.org")
+        assertThat(messageType.toPlainText(stringProvider = stringProvider)).isEqualTo("En réponse à @user:matrix.org: reply")
     }
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotifiableEventResolver.kt
@@ -252,7 +252,7 @@ class NotifiableEventResolver @Inject constructor(
             is ImageMessageType -> messageType.body
             is StickerMessageType -> messageType.body
             is NoticeMessageType -> messageType.body
-            is TextMessageType -> messageType.toPlainText()
+            is TextMessageType -> messageType.toPlainText(stringProvider)
             is VideoMessageType -> messageType.body
             is LocationMessageType -> messageType.body
             is OtherMessageType -> messageType.body


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure `PlainTextNodeVisitor` correctly format `mx-reply` content.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #2568

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See #2568

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
