### PR TITLE
Fix Poll history 'Load more' button alignment

### DIFF
--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryStateProvider.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryStateProvider.kt
@@ -41,6 +41,11 @@ class PollHistoryStateProvider : PreviewParameterProvider<PollHistoryState> {
                 activeFilter = PollHistoryFilter.PAST,
                 currentItems = emptyList(),
             ),
+            aPollHistoryState(
+                activeFilter = PollHistoryFilter.PAST,
+                currentItems = emptyList(),
+                hasMoreToLoad = true,
+            ),
         )
 }
 

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryView.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/history/PollHistoryView.kt
@@ -191,6 +191,7 @@ private fun PollHistoryList(
                 Column(
                     modifier = Modifier.fillParentMaxSize().padding(bottom = 24.dp),
                     verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     val emptyStringResource = if (filter == PollHistoryFilter.PAST) {
                         stringResource(R.string.screen_polls_history_empty_past)

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.poll.impl.history_PollHistoryView_null_PollHistoryView-Day-1_2_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.poll.impl.history_PollHistoryView_null_PollHistoryView-Day-1_2_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:821058570014a0418b22eb4119122b595f802cabeffcabe30c9085b1485ab2c2
+size 19568

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.poll.impl.history_PollHistoryView_null_PollHistoryView-Night-1_3_null_4,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.poll.impl.history_PollHistoryView_null_PollHistoryView-Night-1_3_null_4,NEXUS_5,1.0,en].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a174fd40ab7fa21541c6cf2e25edbe3f286c5aaf7103ec8cf6c4dbc94bba373e
+size 18512


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Center align 'Load more' button in poll history screen.
- Add an extra preview to make sure it works as expected.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android-rageshakes/issues/1685

## Screenshots / GIFs

In the PR.

## Tests

The new screenshot should be enough.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
