### PR TITLE
Remove Welcome screen from the FTUE

### DIFF
--- a/.maestro/tests/account/login.yaml
+++ b/.maestro/tests/account/login.yaml
@@ -23,8 +23,6 @@ appId: ${MAESTRO_APP_ID}
 - inputText: ${MAESTRO_PASSWORD}
 - pressKey: Enter
 - tapOn: "Continue"
-- runFlow: ../assertions/assertWelcomeScreenDisplayed.yaml
-- tapOn: "Continue"
 - runFlow: ../assertions/assertAnalyticsDisplayed.yaml
 - tapOn: "Not now"
 - runFlow: ../assertions/assertHomeDisplayed.yaml

--- a/.maestro/tests/assertions/assertWelcomeScreenDisplayed.yaml
+++ b/.maestro/tests/assertions/assertWelcomeScreenDisplayed.yaml
@@ -1,6 +1,0 @@
-appId: ${MAESTRO_APP_ID}
----
-- extendedWaitUntil:
-    visible:
-      id: "welcome_screen-title"
-    timeout: 10000

--- a/changelog.d/2584.misc
+++ b/changelog.d/2584.misc
@@ -1,0 +1,1 @@
+Remove Welcome screen from the FTUE.

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
@@ -36,7 +36,6 @@ import io.element.android.features.ftue.api.FtueEntryPoint
 import io.element.android.features.ftue.impl.notifications.NotificationsOptInNode
 import io.element.android.features.ftue.impl.state.DefaultFtueState
 import io.element.android.features.ftue.impl.state.FtueStep
-import io.element.android.features.ftue.impl.welcome.WelcomeNode
 import io.element.android.features.lockscreen.api.LockScreenEntryPoint
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
@@ -74,9 +73,6 @@ class FtueFlowNode @AssistedInject constructor(
         data object Placeholder : NavTarget
 
         @Parcelize
-        data object WelcomeScreen : NavTarget
-
-        @Parcelize
         data object NotificationsOptIn : NavTarget
 
         @Parcelize
@@ -110,15 +106,6 @@ class FtueFlowNode @AssistedInject constructor(
             NavTarget.Placeholder -> {
                 createNode<PlaceholderNode>(buildContext)
             }
-            NavTarget.WelcomeScreen -> {
-                val callback = object : WelcomeNode.Callback {
-                    override fun onContinueClicked() {
-                        ftueState.setWelcomeScreenShown()
-                        lifecycleScope.launch { moveToNextStep() }
-                    }
-                }
-                createNode<WelcomeNode>(buildContext, listOf(callback))
-            }
             NavTarget.NotificationsOptIn -> {
                 val callback = object : NotificationsOptInNode.Callback {
                     override fun onNotificationsOptInFinished() {
@@ -146,9 +133,6 @@ class FtueFlowNode @AssistedInject constructor(
 
     private fun moveToNextStep() {
         when (ftueState.getNextStep()) {
-            FtueStep.WelcomeScreen -> {
-                backstack.newRoot(NavTarget.WelcomeScreen)
-            }
             FtueStep.NotificationsOptIn -> {
                 backstack.newRoot(NavTarget.NotificationsOptIn)
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : UI flow changes

## Content

- Remove `WelcomeScreen` from the FTUE flow.

## Motivation and context

Closes #2584.

## Screenshots / GIFs

A few screenshots should have been removed.

## Tests

<!-- Explain how you tested your development -->

- Log into the app.

The welcome screen, which should appear as the first step in the FTUE flow, should be gone. You should see the notification permission screen instead in API >= 33 or the analytics one in API < 33.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12, 13.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
