### PR TITLE
Fix analytics

### DIFF
--- a/changelog.d/2612.bugfix
+++ b/changelog.d/2612.bugfix
@@ -1,0 +1,1 @@
+Fix analytics issue around room considered as space by mistake.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -55,6 +55,7 @@ interface MatrixRoom : Closeable {
     val topic: String?
     val avatarUrl: String?
     val isEncrypted: Boolean
+    val isSpace: Boolean
     val isDirect: Boolean
     val isPublic: Boolean
     val activeMemberCount: Long

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -213,6 +213,9 @@ class RustMatrixRoom(
     override val isPublic: Boolean
         get() = innerRoom.isPublic()
 
+    override val isSpace: Boolean
+        get() = innerRoom.isSpace()
+
     override val isDirect: Boolean
         get() = innerRoom.isDirect()
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -77,6 +77,7 @@ class FakeMatrixRoom(
     override val alias: String? = null,
     override val alternativeAliases: List<String> = emptyList(),
     override val isPublic: Boolean = true,
+    override val isSpace: Boolean = false,
     override val isDirect: Boolean = false,
     override val isOneToOne: Boolean = false,
     override val joinedMemberCount: Long = 123L,

--- a/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/extensions/JoinedRoomExt.kt
+++ b/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/extensions/JoinedRoomExt.kt
@@ -17,8 +17,6 @@
 package io.element.android.services.analytics.api.extensions
 
 import im.vector.app.features.analytics.plan.JoinedRoom
-import io.element.android.libraries.core.bool.orFalse
-import io.element.android.libraries.matrix.api.core.MatrixPatterns
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 
 fun Long?.toAnalyticsRoomSize(): JoinedRoom.RoomSize {
@@ -34,9 +32,9 @@ fun Long?.toAnalyticsRoomSize(): JoinedRoom.RoomSize {
 
 fun MatrixRoom.toAnalyticsJoinedRoom(trigger: JoinedRoom.Trigger?): JoinedRoom {
     return JoinedRoom(
-        isDM = this.isDirect.orFalse(),
-        isSpace = MatrixPatterns.isSpaceId(this.roomId.value),
-        roomSize = this.joinedMemberCount.toAnalyticsRoomSize(),
+        isDM = isDirect,
+        isSpace = isSpace,
+        roomSize = joinedMemberCount.toAnalyticsRoomSize(),
         trigger = trigger
     )
 }

--- a/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/extensions/ViewRoomExt.kt
+++ b/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/extensions/ViewRoomExt.kt
@@ -17,16 +17,14 @@
 package io.element.android.services.analytics.api.extensions
 
 import im.vector.app.features.analytics.plan.ViewRoom
-import io.element.android.libraries.core.bool.orFalse
-import io.element.android.libraries.matrix.api.core.MatrixPatterns
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 
 fun MatrixRoom.toAnalyticsViewRoom(trigger: ViewRoom.Trigger? = null, selectedSpace: MatrixRoom? = null, viaKeyboard: Boolean? = null): ViewRoom {
     val activeSpace = selectedSpace?.toActiveSpace() ?: ViewRoom.ActiveSpace.Home
 
     return ViewRoom(
-        isDM = this.isDirect.orFalse(),
-        isSpace = MatrixPatterns.isSpaceId(this.roomId.value),
+        isDM = isDirect,
+        isSpace = isSpace,
         trigger = trigger,
         activeSpace = activeSpace,
         viaKeyboard = viaKeyboard


### PR DESCRIPTION
spaceId have the same syntax as roomId. Use MatrixRoom.isSpace instead of MatrixPatterns.isSpaceId (#2612)

Also remove useless orFalse() calls.

Closes #2612