### PR TITLE
fix room crash

### DIFF
--- a/changelog.d/2619.bugfix
+++ b/changelog.d/2619.bugfix
@@ -1,0 +1,1 @@
+Fix crash observed when going back to the room list.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -208,16 +208,15 @@ class RustMatrixClient(
         }
     }
 
-    private val rustRoomListService: RoomListService =
-        RustRoomListService(
+    override val roomListService: RoomListService = RustRoomListService(
+        innerRoomListService = innerRoomListService,
+        sessionCoroutineScope = sessionCoroutineScope,
+        sessionDispatcher = sessionDispatcher,
+        roomListFactory = RoomListFactory(
             innerRoomListService = innerRoomListService,
             sessionCoroutineScope = sessionCoroutineScope,
-            sessionDispatcher = sessionDispatcher,
-            roomListFactory = RoomListFactory(
-                innerRoomListService = innerRoomListService,
-                sessionCoroutineScope = sessionCoroutineScope,
-            ),
-        )
+        ),
+    )
 
     private val eventFilters = TimelineEventTypeFilter.exclude(
         listOf(
@@ -238,12 +237,11 @@ class RustMatrixClient(
         ).map(FilterTimelineEventType::State)
     )
 
-    override val roomListService: RoomListService
-        get() = rustRoomListService
-
-    private val rustMediaLoader = RustMediaLoader(baseCacheDirectory, dispatchers, client)
-    override val mediaLoader: MatrixMediaLoader
-        get() = rustMediaLoader
+    override val mediaLoader: MatrixMediaLoader = RustMediaLoader(
+        baseCacheDirectory = baseCacheDirectory,
+        dispatchers = dispatchers,
+        innerClient = client,
+    )
 
     private val roomMembershipObserver = RoomMembershipObserver()
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -182,48 +182,40 @@ class RustMatrixRoom(
     }
 
     override val name: String?
-        get() {
-            return roomListItem.name()
-        }
+        get() = runCatching { roomListItem.name() }.getOrDefault(null)
 
     override val displayName: String
-        get() {
-            return innerRoom.displayName()
-        }
+        get() = runCatching { innerRoom.displayName() }.getOrDefault("")
 
     override val topic: String?
-        get() {
-            return innerRoom.topic()
-        }
+        get() = runCatching { innerRoom.topic() }.getOrDefault(null)
 
     override val avatarUrl: String?
-        get() {
-            return roomListItem.avatarUrl() ?: innerRoom.avatarUrl()
-        }
+        get() = runCatching { roomListItem.avatarUrl() ?: innerRoom.avatarUrl() }.getOrDefault(null)
 
     override val isEncrypted: Boolean
         get() = runCatching { innerRoom.isEncrypted() }.getOrDefault(false)
 
     override val alias: String?
-        get() = innerRoom.canonicalAlias()
+        get() = runCatching { innerRoom.canonicalAlias() }.getOrDefault(null)
 
     override val alternativeAliases: List<String>
-        get() = innerRoom.alternativeAliases()
+        get() = runCatching { innerRoom.alternativeAliases() }.getOrDefault(emptyList())
 
     override val isPublic: Boolean
-        get() = innerRoom.isPublic()
+        get() = runCatching { innerRoom.isPublic() }.getOrDefault(false)
 
     override val isSpace: Boolean
-        get() = innerRoom.isSpace()
+        get() = runCatching { innerRoom.isSpace() }.getOrDefault(false)
 
     override val isDirect: Boolean
-        get() = innerRoom.isDirect()
+        get() = runCatching { innerRoom.isDirect() }.getOrDefault(false)
 
     override val joinedMemberCount: Long
-        get() = innerRoom.joinedMembersCount().toLong()
+        get() = runCatching { innerRoom.joinedMembersCount().toLong() }.getOrDefault(0)
 
     override val activeMemberCount: Long
-        get() = innerRoom.activeMembersCount().toLong()
+        get() = runCatching { innerRoom.activeMembersCount().toLong() }.getOrDefault(0)
 
     override suspend fun updateMembers() {
         val useCache = membersStateFlow.value is MatrixRoomMembersState.Unknown


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
First commit: fix crash observed when going back to the room list.
Second commit: small cleanup on RustMatrixClient.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2619 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

To repro the crash, it's possible to add `Thread.sleep(1000)` at the beginning of the second `mapLatest` in `RustMatrixTimeline.timelineItems`. Then open the room, and go back to the room list. The application will crash. With this fix it's not the case anymore.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
