### PR TITLE
Fall back to initials avatar when image avatar doesn't work

### DIFF
--- a/changelog.d/2667.bugfix
+++ b/changelog.d/2667.bugfix
@@ -1,0 +1,1 @@
+Fall back to name-based generated avatars when image avatars don't load.

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,12 +33,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.designsystem.colors.AvatarColorsProvider
 import io.element.android.libraries.designsystem.preview.ElementThemedPreview
 import io.element.android.libraries.designsystem.preview.PreviewGroup
-import io.element.android.libraries.designsystem.preview.debugPlaceholderAvatar
 import io.element.android.libraries.designsystem.text.toSp
 import io.element.android.libraries.designsystem.theme.components.Text
 import timber.log.Timber
@@ -71,16 +73,23 @@ private fun ImageAvatar(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
 ) {
-    AsyncImage(
+    SubcomposeAsyncImage(
         model = avatarData,
-        onError = {
-            Timber.e(it.result.throwable, "Error loading avatar $it\n${it.result}")
-        },
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
-        placeholder = debugPlaceholderAvatar(),
         modifier = modifier
-    )
+    ) {
+        when (val state = painter.state) {
+            is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
+            is AsyncImagePainter.State.Error -> {
+                SideEffect {
+                    Timber.e(state.result.throwable, "Error loading avatar $state\n${state.result}")
+                }
+                InitialsAvatar(avatarData = avatarData)
+            }
+            else -> InitialsAvatar(avatarData = avatarData)
+        }
+    }
 }
 
 @Composable

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
@@ -28,11 +28,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
@@ -40,6 +42,7 @@ import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.designsystem.colors.AvatarColorsProvider
 import io.element.android.libraries.designsystem.preview.ElementThemedPreview
 import io.element.android.libraries.designsystem.preview.PreviewGroup
+import io.element.android.libraries.designsystem.preview.debugPlaceholderAvatar
 import io.element.android.libraries.designsystem.text.toSp
 import io.element.android.libraries.designsystem.theme.components.Text
 import timber.log.Timber
@@ -73,21 +76,32 @@ private fun ImageAvatar(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
 ) {
-    SubcomposeAsyncImage(
-        model = avatarData,
-        contentDescription = contentDescription,
-        contentScale = ContentScale.Crop,
-        modifier = modifier
-    ) {
-        when (val state = painter.state) {
-            is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
-            is AsyncImagePainter.State.Error -> {
-                SideEffect {
-                    Timber.e(state.result.throwable, "Error loading avatar $state\n${state.result}")
+    if (LocalInspectionMode.current) {
+        // For compose previews, use debugPlaceholderAvatar()
+        // instead of falling back to initials avatar on load failure
+        AsyncImage(
+            model = avatarData,
+            contentDescription = contentDescription,
+            placeholder = debugPlaceholderAvatar(),
+            modifier = modifier
+        )
+    } else {
+        SubcomposeAsyncImage(
+            model = avatarData,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+        ) {
+            when (val state = painter.state) {
+                is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
+                is AsyncImagePainter.State.Error -> {
+                    SideEffect {
+                        Timber.e(state.result.throwable, "Error loading avatar $state\n${state.result}")
+                    }
+                    InitialsAvatar(avatarData = avatarData)
                 }
-                InitialsAvatar(avatarData = avatarData)
+                else -> InitialsAvatar(avatarData = avatarData)
             }
-            else -> InitialsAvatar(avatarData = avatarData)
         }
     }
 }


### PR DESCRIPTION
Initially I had it implemented such that it would only fallback on error, but actually it's nice to have also while loading if it takes a while to load the avatar.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

`SubcomposeAsyncImage` allows us to render the image or something else based on the render state, so we can render the initials avatar if the image doesn't load successfully

## Motivation and context

[I heard in the Element X chat that Element wants to have this](https://matrix.to/#/!aCvOWKNDeXXpPgquKq:matrix.org/$S3-zfWI4zOKVWb2vNwXMHe1A5ZIm9ABqX7k0mCzLOhM?via=matrix.org&via=envs.net&via=tchncs.de) (I had this in SchildiChat for a while already)

## Screenshots / GIFs

Imagine some name-based fallback avatars in the roomlist like before, but also for contacts with broken mxc url

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

- Tell somebody you're chatting with to run `/myroomavatar mxc://broken` on desktop
- Observe their (lack of) avatar (before: would stay empty, now: falls back to initials avatar)

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR

## Sign-off

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>