### PR TITLE
Remove Room moderation feature flag

### DIFF
--- a/.maestro/tests/assertions/assertSessionVerificationDisplayed.yaml
+++ b/.maestro/tests/assertions/assertSessionVerificationDisplayed.yaml
@@ -2,4 +2,4 @@ appId: ${MAESTRO_APP_ID}
 ---
 - extendedWaitUntil:
     visible: "Confirm that it's you"
-    timeout: 10000
+    timeout: 20000

--- a/changelog.d/2678.misc
+++ b/changelog.d/2678.misc
@@ -1,0 +1,1 @@
+Enable room moderation feature.

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -78,10 +78,6 @@ class RoomDetailsPresenter @Inject constructor(
         val roomTopic by remember { derivedStateOf { roomInfo?.topic ?: room.topic } }
         val isFavorite by remember { derivedStateOf { roomInfo?.isFavorite.orFalse() } }
 
-        val isRoomModerationEnabled by produceState(initialValue = false) {
-            value = featureFlagService.isFeatureEnabled(FeatureFlags.RoomModeration)
-        }
-
         LaunchedEffect(Unit) {
             canShowNotificationSettings.value = featureFlagService.isFeatureEnabled(FeatureFlags.NotificationSettings)
             if (canShowNotificationSettings.value) {
@@ -147,7 +143,7 @@ class RoomDetailsPresenter @Inject constructor(
             leaveRoomState = leaveRoomState,
             roomNotificationSettings = roomNotificationSettingsState.roomNotificationSettings(),
             isFavorite = isFavorite,
-            displayRolesAndPermissionsSettings = isRoomModerationEnabled && !room.isDm && isUserAdmin,
+            displayRolesAndPermissionsSettings = !room.isDm && isUserAdmin,
             eventSink = ::handleEvents,
         )
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenter.kt
@@ -34,8 +34,6 @@ import io.element.android.features.roomdetails.impl.members.moderation.RoomMembe
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
@@ -50,7 +48,6 @@ class RoomMemberListPresenter @AssistedInject constructor(
     private val room: MatrixRoom,
     private val roomMemberListDataSource: RoomMemberListDataSource,
     private val coroutineDispatchers: CoroutineDispatchers,
-    private val featureFlagService: FeatureFlagService,
     private val roomMembersModerationPresenter: RoomMembersModerationPresenter,
     @Assisted private val navigator: RoomMemberListNavigator,
 ) : Presenter<RoomMemberListState> {
@@ -74,15 +71,7 @@ class RoomMemberListPresenter @AssistedInject constructor(
             value = room.canInvite().getOrElse { false }
         }
 
-        val isRoomModerationEnabled by produceState(initialValue = false) {
-            value = featureFlagService.isFeatureEnabled(FeatureFlags.RoomModeration)
-        }
-
-        val roomModerationState = if (isRoomModerationEnabled) {
-            roomMembersModerationPresenter.present()
-        } else {
-            remember { roomMembersModerationPresenter.dummyState() }
-        }
+        val roomModerationState = roomMembersModerationPresenter.present()
 
         // Ensure we load the latest data when entering this screen
         LaunchedEffect(Unit) {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/DefaultRoomMembersModerationPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/DefaultRoomMembersModerationPresenter.kt
@@ -31,8 +31,6 @@ import io.element.android.libraries.architecture.runUpdatingState
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.extensions.finally
 import io.element.android.libraries.di.RoomScope
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
@@ -51,7 +49,6 @@ import javax.inject.Inject
 @ContributesBinding(RoomScope::class)
 class DefaultRoomMembersModerationPresenter @Inject constructor(
     private val room: MatrixRoom,
-    private val featureFlagService: FeatureFlagService,
     private val dispatchers: CoroutineDispatchers,
     private val analyticsService: AnalyticsService,
 ) : RoomMembersModerationPresenter {
@@ -61,9 +58,8 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
     private suspend fun canKick() = room.canKick().getOrDefault(false)
 
     override suspend fun canDisplayModerationActions(): Boolean {
-        val isRoomModerationEnabled = featureFlagService.isFeatureEnabled(FeatureFlags.RoomModeration)
         val isDm = room.isDm && room.isEncrypted
-        return isRoomModerationEnabled && !isDm && (canBan() || canKick())
+        return !isDm && (canBan() || canKick())
     }
 
     @Composable
@@ -76,7 +72,7 @@ class DefaultRoomMembersModerationPresenter @Inject constructor(
         val unbanUserAsyncAction = remember { mutableStateOf(AsyncAction.Uninitialized as AsyncAction<Unit>) }
 
         val canDisplayBannedUsers by produceState(initialValue = false) {
-            value = featureFlagService.isFeatureEnabled(FeatureFlags.RoomModeration) && !room.isDm && canBan()
+            value = !room.isDm && canBan()
         }
 
         fun handleEvent(event: RoomMembersModerationEvents) {

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/RoomMemberListPresenterTests.kt
@@ -32,9 +32,6 @@ import io.element.android.features.roomdetails.impl.members.moderation.aRoomMemb
 import io.element.android.features.roomdetails.members.moderation.FakeRoomMembersModerationPresenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
-import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
@@ -241,14 +238,12 @@ private fun TestScope.createPresenter(
     coroutineDispatchers: CoroutineDispatchers = testCoroutineDispatchers(useUnconfinedTestDispatcher = true),
     matrixRoom: MatrixRoom = FakeMatrixRoom(),
     roomMemberListDataSource: RoomMemberListDataSource = createDataSource(coroutineDispatchers = coroutineDispatchers),
-    featureFlagService: FeatureFlagService = FakeFeatureFlagService(initialState = mapOf(FeatureFlags.RoomModeration.key to true)),
     moderationPresenter: FakeRoomMembersModerationPresenter = FakeRoomMembersModerationPresenter(),
     navigator: RoomMemberListNavigator = object : RoomMemberListNavigator { }
 ) = RoomMemberListPresenter(
     room = matrixRoom,
     roomMemberListDataSource = roomMemberListDataSource,
     coroutineDispatchers = coroutineDispatchers,
-    featureFlagService = featureFlagService,
     roomMembersModerationPresenter = moderationPresenter,
     navigator = navigator
 )

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/moderation/DefaultRoomMembersModerationPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/moderation/DefaultRoomMembersModerationPresenterTests.kt
@@ -28,8 +28,6 @@ import io.element.android.features.roomdetails.impl.members.moderation.Moderatio
 import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationEvents
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.featureflag.api.FeatureFlags
-import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
@@ -45,13 +43,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class DefaultRoomMembersModerationPresenterTests {
-    @Test
-    fun `canDisplayModerationActions - when feature flag is disabled returns false`() = runTest {
-        val featureFlagService = FakeFeatureFlagService(initialState = mapOf(FeatureFlags.RoomModeration.key to false))
-        val presenter = createDefaultRoomMembersModerationPresenter(featureFlagService = featureFlagService)
-        assertThat(presenter.canDisplayModerationActions()).isFalse()
-    }
-
     @Test
     fun `canDisplayModerationActions - when room is DM is false`() = runTest {
         val room = FakeMatrixRoom(isDirect = true, isPublic = true, isOneToOne = true).apply {
@@ -309,13 +300,11 @@ class DefaultRoomMembersModerationPresenterTests {
 
     private fun TestScope.createDefaultRoomMembersModerationPresenter(
         matrixRoom: FakeMatrixRoom = FakeMatrixRoom(),
-        featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(initialState = mapOf(FeatureFlags.RoomModeration.key to true)),
         dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
         analyticsService: FakeAnalyticsService = FakeAnalyticsService(),
     ): DefaultRoomMembersModerationPresenter {
         return DefaultRoomMembersModerationPresenter(
             room = matrixRoom,
-            featureFlagService = featureFlagService,
             dispatchers = dispatchers,
             analyticsService = analyticsService,
         )

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -82,13 +82,6 @@ enum class FeatureFlags(
         defaultValue = true,
         isFinished = false,
     ),
-    RoomModeration(
-        key = "feature.roomModeration",
-        title = "Room moderation",
-        description = "Add moderation features to the room for users with permissions",
-        defaultValue = true,
-        isFinished = true,
-    ),
     RoomDirectorySearch(
         key = "feature.roomdirectorysearch",
         title = "Room directory search",

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -87,7 +87,7 @@ enum class FeatureFlags(
         title = "Room moderation",
         description = "Add moderation features to the room for users with permissions",
         defaultValue = true,
-        isFinished = false,
+        isFinished = true,
     ),
     RoomDirectorySearch(
         key = "feature.roomdirectorysearch",

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -41,7 +41,7 @@ class StaticFeatureFlagProvider @Inject constructor() :
                 FeatureFlags.Mentions -> true
                 FeatureFlags.MarkAsUnread -> true
                 FeatureFlags.RoomListFilters -> true
-                FeatureFlags.RoomModeration -> false
+                FeatureFlags.RoomModeration -> true
                 FeatureFlags.RoomDirectorySearch -> false
             }
         } else {

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/StaticFeatureFlagProvider.kt
@@ -41,7 +41,6 @@ class StaticFeatureFlagProvider @Inject constructor() :
                 FeatureFlags.Mentions -> true
                 FeatureFlags.MarkAsUnread -> true
                 FeatureFlags.RoomListFilters -> true
-                FeatureFlags.RoomModeration -> true
                 FeatureFlags.RoomDirectorySearch -> false
             }
         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Removes the feature flag for room moderation, to make this feature available to everyone.

## Motivation and context

The feature is complete and validated.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room where you're and admin.
- You should have access to room moderation.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
