### PR TITLE
Mark room as fully read when user goes back to the room list.

### DIFF
--- a/changelog.d/2281.misc
+++ b/changelog.d/2281.misc
@@ -1,0 +1,1 @@
+Send the `m.fully_read` read marker when the going back to the room list, to mark the room as read.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.messages.impl.timeline
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -128,6 +129,12 @@ class TimelinePresenter @AssistedInject constructor(
             }
         }
 
+        DisposableEffect(Unit) {
+            onDispose {
+                appScope.sendReadReceiptFullyRead()
+            }
+        }
+
         LaunchedEffect(timelineItems.size) {
             computeNewItemState(timelineItems, prevMostRecentItemId, newItemState)
         }
@@ -220,6 +227,10 @@ class TimelinePresenter @AssistedInject constructor(
                 timeline.sendReadReceipt(eventId = eventId, receiptType = readReceiptType)
             }
         }
+    }
+
+    private fun CoroutineScope.sendReadReceiptFullyRead() = launch {
+        room.markAsRead(receiptType = ReceiptType.FULLY_READ)
     }
 
     private fun getLastEventIdBeforeOrAt(index: Int, items: ImmutableList<TimelineItem>): EventId? {

--- a/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/audio/DefaultEncoder.kt
+++ b/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/audio/DefaultEncoder.kt
@@ -57,7 +57,6 @@ class DefaultEncoder @Inject constructor(
 
     override fun release() {
         encoder?.release()
-            ?: Timber.w("Can't release encoder that is not initialized")
         encoder = null
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Send `m.fully_read` read marker once the user is going back to the room list.
Second commit is just removing noise in the logs.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2281 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See #2281, hence, I did not manage to see any "New" line on my messages during the tests...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
