### PR TITLE
Always use method aRichTextEditorState instead of invoking the constructor

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerStateProvider.kt
@@ -22,6 +22,7 @@ import io.element.android.features.messages.impl.mentions.MentionSuggestion
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
+import io.element.android.libraries.textcomposer.aRichTextEditorState
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.wysiwyg.compose.RichTextEditorState
 import kotlinx.collections.immutable.ImmutableList
@@ -35,7 +36,7 @@ open class MessageComposerStateProvider : PreviewParameterProvider<MessageCompos
 }
 
 fun aMessageComposerState(
-    richTextEditorState: RichTextEditorState = RichTextEditorState(""),
+    richTextEditorState: RichTextEditorState = aRichTextEditorState(),
     isFullScreen: Boolean = false,
     mode: MessageComposerMode = MessageComposerMode.Normal,
     showTextFormatting: Boolean = false,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -637,7 +637,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    aRichTextEditorState(initialText = "A message without focus", initialFocus = false),
+                    aRichTextEditorState(initialText = "A message without focus"),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Normal,
                     enableTextFormatting = true,
@@ -654,7 +654,7 @@ internal fun TextComposerSimplePreview() = ElementPreview {
 internal fun TextComposerFormattingPreview() = ElementPreview {
     PreviewColumn(items = persistentListOf({
         ATextComposer(
-            aRichTextEditorState(initialText = "", initialFocus = false),
+            aRichTextEditorState(),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -664,7 +664,7 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         )
     }, {
         ATextComposer(
-            aRichTextEditorState(initialText = "A message", initialFocus = false),
+            aRichTextEditorState(initialText = "A message"),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
             composerMode = MessageComposerMode.Normal,
@@ -676,7 +676,6 @@ internal fun TextComposerFormattingPreview() = ElementPreview {
         ATextComposer(
             aRichTextEditorState(
                 initialText = "A message\nWith several lines\nTo preview larger textfields and long lines with overflow",
-                initialFocus = false
             ),
             voiceMessageState = VoiceMessageState.Idle,
             showTextFormatting = true,
@@ -710,7 +709,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
         items = persistentListOf(
             {
                 ATextComposer(
-                    aRichTextEditorState(""),
+                    aRichTextEditorState(),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = false,
@@ -728,7 +727,7 @@ internal fun TextComposerReplyPreview() = ElementPreview {
             },
             {
                 ATextComposer(
-                    RichTextEditorState(""),
+                    aRichTextEditorState(),
                     voiceMessageState = VoiceMessageState.Idle,
                     composerMode = MessageComposerMode.Reply(
                         isThreaded = true,
@@ -839,7 +838,7 @@ internal fun TextComposerVoicePreview() = ElementPreview {
     fun VoicePreview(
         voiceMessageState: VoiceMessageState
     ) = ATextComposer(
-        RichTextEditorState("", initialFocus = true),
+        aRichTextEditorState(initialFocus = true),
         voiceMessageState = voiceMessageState,
         composerMode = MessageComposerMode.Normal,
         enableTextFormatting = true,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
@@ -35,6 +35,7 @@ import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.textcomposer.R
 import io.element.android.libraries.textcomposer.TextComposerLinkDialog
+import io.element.android.libraries.textcomposer.aRichTextEditorState
 import io.element.android.wysiwyg.compose.RichTextEditorState
 import io.element.android.wysiwyg.view.models.InlineFormat
 import io.element.android.wysiwyg.view.models.LinkAction
@@ -209,5 +210,5 @@ private fun ActionState?.toButtonState(): FormattingOptionState =
 @PreviewsDayNight
 @Composable
 internal fun TextFormattingPreview() = ElementPreview {
-    TextFormatting(state = RichTextEditorState())
+    TextFormatting(state = aRichTextEditorState())
 }


### PR DESCRIPTION
(Doing some cleanup on my local branch)

Always use method aRichTextEditorState instead of invoking the constructor directly, and remove parameter when it's the default value.