### PR TITLE
Add date of modification on EXA Gallery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 * [Strings](#strings)
   * [I want to add new strings to the project](#i-want-to-add-new-strings-to-the-project)
   * [I want to help translating Element](#i-want-to-help-translating-element)
+  * [Element X Android Gallery](#element-x-android-gallery)
 * [I want to submit a PR to fix an issue](#i-want-to-submit-a-pr-to-fix-an-issue)
   * [Kotlin](#kotlin)
   * [Changelog](#changelog)
@@ -68,6 +69,14 @@ To help translating, please go to [https://localazy.com/p/element](https://local
 - If you want to fix an issue in other languages, or add a missing translation, or even add a new language, please go to [https://localazy.com/p/element](https://localazy.com/p/element).
 
 More information can be found [in this README.md](./tools/localazy/README.md).
+
+Once a language is sufficiently translated, it will be added to the app. The core team will decide when a language is sufficiently translated.
+
+### Element X Android Gallery
+
+Once added to Localazy, translations can be checked screen per screen using our tool Element X Android Gallery, available at https://element-hq.github.io/element-x-android/.
+
+Localazy syncs occur every Monday and the screenshots on this page are generated every Tuesday, so you'll have to wait to see your change appearing on Element X Android Gallery.
 
 ## I want to submit a PR to fix an issue
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Learn more about why we are building Element X in our blog post: [https://elemen
 <!--- TOC -->
 
 * [Screenshots](#screenshots)
+* [Translations](#translations)
 * [Rust SDK](#rust-sdk)
 * [Status](#status)
 * [Contributing](#contributing)
@@ -49,6 +50,16 @@ adb shell am broadcast -a com.android.systemui.demo -e command exit
 |<img src=./docs/images-lfs/screen_1_light.png width=280 />|<img src=./docs/images-lfs/screen_2_light.png width=280 />|<img src=./docs/images-lfs/screen_3_light.png width=280 />|<img src=./docs/images-lfs/screen_4_light.png width=280 />|
 |-|-|-|-|
 |<img src=./docs/images-lfs/screen_1_dark.png width=280 />|<img src=./docs/images-lfs/screen_2_dark.png width=280 />|<img src=./docs/images-lfs/screen_3_dark.png width=280 />|<img src=./docs/images-lfs/screen_4_dark.png width=280 />|
+
+## Translations
+
+Element X Android supports many languages. You can help us to translate the app in your language by joining our [Localazy project](https://localazy.com/p/element). You can also help us to improve the existing translations.
+
+Note that for now, we keep control on the French and German translations.
+
+Translations can be checked screen per screen using our tool Element X Android Gallery, available at https://element-hq.github.io/element-x-android/. Note that this page is updated every Tuesday. 
+
+More instructions about translating the application can be found at [CONTRIBUTING.md](CONTRIBUTING.md#strings).
 
 ## Rust SDK
 

--- a/screenshots/html/script.js
+++ b/screenshots/html/script.js
@@ -168,6 +168,11 @@ function addForm() {
       addTable();
   };
   form.appendChild(dateInput);
+  // Add a span with id result to display the number of lines
+  const lines = document.createElement('span');
+  lines.id = 'lines';
+  lines.textContent = "...";
+  form.appendChild(lines);
   document.getElementById('form_container').appendChild(form);
 }
 
@@ -206,6 +211,7 @@ function createImageElement(fullFile, modifiedDayTime) {
 }
 
 function addTable() {
+  var linesCounter = 0;
   // Remove any previous table
   document.getElementById('screenshots_container').innerHTML = '';
   // screenshots contains a table of screenshots, lets convert to an html table
@@ -269,6 +275,7 @@ function addTable() {
       tr.appendChild(td);
     }
     if (showAllScreenshots || hasTranslatedFiles) {
+      linesCounter++;
       // Add a header for row, if different from previous
       if (niceName != currentHeaderValue) {
         currentHeaderValue = niceName;
@@ -291,6 +298,8 @@ function addTable() {
 
   // Add the table to the div with id screenshots_container
   document.getElementById('screenshots_container').appendChild(table);
+  // Update the number of lines
+  document.getElementById('lines').textContent = `${linesCounter} lines`;
 }
 
 addForm();

--- a/tools/test/generateAllScreenshots.py
+++ b/tools/test/generateAllScreenshots.py
@@ -132,7 +132,10 @@ def generateJavascriptFile():
             simpleFile = file[:3] + "T" + file[4:-7] + l + file[-5:-4]
             translatedFile = "./screenshots/" + l + "/" + simpleFile + ".png"
             if os.path.exists(translatedFile):
-                dataForFile.append(1)
+                # Get the last modified date of the file in seconds and round to days
+                date = os.popen("git log -1 --format=%ct -- \"" + translatedFile + "\"").read().strip()
+                dateDay = int(date) // 86400
+                dataForFile.append(dateDay)
             else:
                 dataForFile.append(0)
         data.append(dataForFile)

--- a/tools/test/generateAllScreenshots.py
+++ b/tools/test/generateAllScreenshots.py
@@ -103,7 +103,7 @@ def detectRecordedLanguages():
 def computeDarkFileName(lightFileName):
     if "-Day_0" in lightFileName:
         return lightFileName.replace("-Day_0", "-Night_1")
-    match = re.match("(.*)-Day-(\d+)_(\d+)(.*)", lightFileName, flags=re.ASCII)
+    match = re.match("(.*)-Day-(\\d+)_(\\d+)(.*)", lightFileName, flags=re.ASCII)
     if match:
         return match.group(1) + "-Night-" + match.group(2) + "_" + str((int(match.group(3)) + 1)) + match.group(4)
     return ""


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Add a way to filter screenshots by date, to see only the recent changes.

Also update the title of screenshot:

<img width="1364" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/01815fe0-fabd-4f2e-a315-6de11ced4d02">

Also update the README and CONTRIBUTING documentation to give visibility on the Element X Android Gallery tool.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix 2 items of #2515 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
