### PR TITLE
Fix compile with noop analytics provider

### DIFF
--- a/changelog.d/2698.misc
+++ b/changelog.d/2698.misc
@@ -1,0 +1,1 @@
+Fix compile for forks that use the `noop` analytics module

--- a/services/analytics/noop/src/main/kotlin/io/element/android/services/analytics/noop/NoopScreenTracker.kt
+++ b/services/analytics/noop/src/main/kotlin/io/element/android/services/analytics/noop/NoopScreenTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
-}
 
-android {
-    namespace = "io.element.android.services.analytics.noop"
-}
+package io.element.android.services.analytics.noop
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+import androidx.compose.runtime.Composable
+import com.squareup.anvil.annotations.ContributesBinding
+import im.vector.app.features.analytics.plan.MobileScreen
+import io.element.android.libraries.di.AppScope
+import io.element.android.services.analytics.api.ScreenTracker
+import javax.inject.Inject
 
-dependencies {
-    implementation(libs.dagger)
-    implementation(projects.libraries.architecture)
-    implementation(projects.libraries.di)
-    api(projects.services.analytics.api)
+@ContributesBinding(AppScope::class)
+class NoopScreenTracker @Inject constructor() : ScreenTracker {
+    @Composable
+    override fun TrackScreen(screen: MobileScreen.ScreenName) = Unit
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add ScreenTracker impl for noop analytics

## Motivation and context

noop analytics didn't build since v0.4.8. Setting `io.element.android-compose-library` in `build.gradle.kts` is furthermore required to not make it crash after adding the NoopScreenTracker.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

In `DependencyHandleScope.kt`, switch to
```
    implementation(project(":services:analytics:noop"))
    //implementation(project(":services:analytics:impl"))
    //implementation(project(":services:analyticsproviders:posthog"))
    //implementation(project(":services:analyticsproviders:sentry"))
```
and try to compile.
Also make sure to test the "Troubleshoot notifications" screen once it compiles, if it crashes or not.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR

## Sign-off

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>