### PR TITLE
Room member details presenter improvement

### DIFF
--- a/changelog.d/2721.misc
+++ b/changelog.d/2721.misc
@@ -1,0 +1,1 @@
+RoomMember screen: fallback to userProfile data, if the member is not a user of the room.

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenter.kt
@@ -120,7 +120,8 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
                     onFailure = {
                         // Fallback to user profile
                         userProfile?.displayName
-                    })
+                    }
+                )
         }
 
         var userAvatar: String? by remember { mutableStateOf(roomMember?.avatarUrl ?: userProfile?.avatarUrl) }
@@ -131,7 +132,8 @@ class RoomMemberDetailsPresenter @AssistedInject constructor(
                     onFailure = {
                         // Fallback to user profile
                         userProfile?.avatarUrl
-                    })
+                    }
+                )
         }
 
         return RoomMemberDetailsState(

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/details/RoomMemberDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/members/details/RoomMemberDetailsPresenterTests.kt
@@ -31,9 +31,9 @@ import io.element.android.features.roomdetails.impl.members.details.RoomMemberDe
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState
-import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_THROWABLE
 import io.element.android.libraries.matrix.test.FakeMatrixClient
@@ -59,7 +59,7 @@ class RoomMemberDetailsPresenterTests {
         }
         val presenter = createRoomMemberDetailsPresenter(
             room = room,
-            roomMember = roomMember
+            roomMemberId = roomMember.userId
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -86,7 +86,7 @@ class RoomMemberDetailsPresenterTests {
         }
         val presenter = createRoomMemberDetailsPresenter(
             room = room,
-            roomMember = roomMember
+            roomMemberId = roomMember.userId
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -109,7 +109,7 @@ class RoomMemberDetailsPresenterTests {
         }
         val presenter = createRoomMemberDetailsPresenter(
             room = room,
-            roomMember = roomMember
+            roomMemberId = roomMember.userId
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -147,7 +147,7 @@ class RoomMemberDetailsPresenterTests {
         val roomMember = aRoomMember()
         val presenter = createRoomMemberDetailsPresenter(
             client = client,
-            roomMember = roomMember,
+            roomMemberId = roomMember.userId
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -245,11 +245,11 @@ class RoomMemberDetailsPresenterTests {
     private fun createRoomMemberDetailsPresenter(
         client: MatrixClient = FakeMatrixClient(),
         room: MatrixRoom = aMatrixRoom(),
-        roomMember: RoomMember = aRoomMember(),
+        roomMemberId: UserId = UserId("@alice:server.org"),
         startDMAction: StartDMAction = FakeStartDMAction()
     ): RoomMemberDetailsPresenter {
         return RoomMemberDetailsPresenter(
-            roomMemberId = roomMember.userId,
+            roomMemberId = roomMemberId,
             client = client,
             room = room,
             startDMAction = startDMAction

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -48,6 +48,7 @@ import io.element.android.libraries.matrix.test.verification.FakeSessionVerifica
 import io.element.android.tests.testutils.simulateLongTask
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -203,6 +204,10 @@ class FakeMatrixClient(
 
     override fun roomMembershipObserver(): RoomMembershipObserver {
         return RoomMembershipObserver()
+    }
+
+    suspend fun emitIgnoreUserList(users: List<UserId>) {
+        ignoredUsersFlow.emit(users.toImmutableList())
     }
 
     // Mocks


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
First commit: ensure that "ignore" user state is live by observing `ignoredUsersFlow`
Second commit: fallback to userProfile data, if the member is not a user of the room. (I am adding a test about it).

For instance, when clicking on `https://matrix.to/#/@Giom:matrix.org` when the user is not a member of the room:
|Before|After|
|-|-|
|<img width="298" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/c75a5abb-0c3e-4447-ad05-b1124e0e54fd">|<img width="298" alt="image" src="https://github.com/element-hq/element-x-android/assets/3940906/7cab7c1a-cc69-4c75-bbbe-de5d96c70fd1">|


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Send some user permalink to a room 
- Click on the links and see how the application behaves

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
