### PR TITLE
User display name overflows in timeline messages

### DIFF
--- a/changelog.d/2761.bugfix
+++ b/changelog.d/2761.bugfix
@@ -1,0 +1,1 @@
+User display name overflows in timeline messages when it's way too long.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/sender/SenderName.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/sender/SenderName.kt
@@ -93,6 +93,7 @@ private fun RowScope.MainText(
         text = text,
         style = style,
         color = color,
+        maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
 }
@@ -117,6 +118,7 @@ private fun RowScope.SecondaryText(
         text = text,
         style = style,
         color = MaterialTheme.colorScheme.secondary,
+        maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -701,6 +701,7 @@ internal fun TimelineItemEventRowPreview() = ElementPreview {
         sequenceOf(false, true).forEach { isMine ->
             ATimelineItemEventRow(
                 event = aTimelineItemEvent(
+                    senderDisplayName = "Sender with a super long name that should ellipsize",
                     isMine = isMine,
                     content = aTimelineItemTextContent().copy(
                         body = "A long text which will be displayed on several lines and" +

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRowLongSenderName_null_TimelineItemEventRowLongSenderName_0_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRowLongSenderName_null_TimelineItemEventRowLongSenderName_0_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d509d8fb7fe67e7ee2e04794608f5e4c9b1ec5ea309384ca25eaa0600416be5f
-size 23064
+oid sha256:777209b58d18b92e86d4ac90cb741d477793caa84bb1b2b19a3b459675bae244
+size 18276

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRow_null_TimelineItemEventRow-Day-17_17_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRow_null_TimelineItemEventRow-Day-17_17_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38d438ae9245b5e7819c3f8c741f89b395956fbb357ddf7570bc457a88a36739
-size 183329
+oid sha256:6a221ada168ff38af4e6227170ed42e3765d7fdc99f410f72a30680f006cd7f7
+size 187751

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRow_null_TimelineItemEventRow-Night-17_18_null,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.messages.impl.timeline.components_TimelineItemEventRow_null_TimelineItemEventRow-Night-17_18_null,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf66a1b76b39b8055875344db3aee4a638df738cb8f6991b55f057c7da05a1be
-size 180936
+oid sha256:57f411b632ea16f41e56eefbc6f37059f8053469fecfa4f5aaccc6edd467c10b
+size 185075


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Make `MainText` and `SecondaryText` in `SenderName` ellipsize with just 1 line.

## Motivation and context

Fixes #2761.

## Screenshots / GIFs

In the PR.

## Tests

<!-- Explain how you tested your development -->

- Checking the screenshots should be enough.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
