### PR TITLE
Fix notification navigation

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -35,7 +35,6 @@ import com.bumble.appyx.core.plugin.plugins
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.operation.replace
-import com.bumble.appyx.navmodel.backstack.operation.singleTop
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.element.android.anvilannotations.ContributesNode
@@ -60,6 +59,7 @@ import io.element.android.features.securebackup.api.SecureBackupEntryPoint
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.architecture.createNode
+import io.element.android.libraries.architecture.waitForNavTargetAttached
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.SessionScope
@@ -363,23 +363,13 @@ class LoggedInFlowNode @AssistedInject constructor(
         }
     }
 
-    suspend fun attachRoomList() {
-        if (!canShowRoomList()) return
-        attachChild<Node> {
-            backstack.singleTop(NavTarget.RoomList)
-        }
-    }
-
     suspend fun attachRoom(roomId: RoomId) {
-        if (!canShowRoomList()) return
+        waitForNavTargetAttached { navTarget ->
+            navTarget is NavTarget.RoomList
+        }
         attachChild<RoomFlowNode> {
-            backstack.singleTop(NavTarget.RoomList)
             backstack.push(NavTarget.Room(roomId.toRoomIdOrAlias()))
         }
-    }
-
-    private fun canShowRoomList(): Boolean {
-        return ftueService.state.value is FtueState.Complete
     }
 
     @Composable

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -345,11 +345,6 @@ class LoggedInFlowNode @AssistedInject constructor(
             }
             NavTarget.Ftue -> {
                 ftueEntryPoint.nodeBuilder(this, buildContext)
-                    .callback(object : FtueEntryPoint.Callback {
-                        override fun onFtueFlowFinished() {
-                            lifecycleScope.launch { attachRoomList() }
-                        }
-                    })
                     .build()
             }
             NavTarget.RoomDirectorySearch -> {

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -386,9 +386,9 @@ class LoggedInFlowNode @AssistedInject constructor(
     override fun View(modifier: Modifier) {
         Box(modifier = modifier) {
             val lockScreenState by lockScreenStateService.lockState.collectAsState()
-            val isFtueDisplayed by ftueService.state.collectAsState()
+            val ftueState by ftueService.state.collectAsState()
             BackstackView()
-            if (isFtueDisplayed is FtueState.Complete) {
+            if (ftueState is FtueState.Complete) {
                 PermanentChild(permanentNavModel = permanentNavModel, navTarget = NavTarget.LoggedInPermanent)
             }
             if (lockScreenState == LockScreenLockState.Locked) {

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -288,7 +288,7 @@ class RootFlowNode @AssistedInject constructor(
             .attachSession()
             .apply {
                 when (deeplinkData) {
-                    is DeeplinkData.Root -> attachRoomList()
+                    is DeeplinkData.Root -> Unit // The room list will always be shown, observing FtueState
                     is DeeplinkData.Room -> attachRoom(deeplinkData.roomId)
                 }
             }

--- a/changelog.d/2778.bugfix
+++ b/changelog.d/2778.bugfix
@@ -1,0 +1,1 @@
+Ensure the application open the room when a notification is clicked.

--- a/features/ftue/api/src/main/kotlin/io/element/android/features/ftue/api/FtueEntryPoint.kt
+++ b/features/ftue/api/src/main/kotlin/io/element/android/features/ftue/api/FtueEntryPoint.kt
@@ -18,18 +18,12 @@ package io.element.android.features.ftue.api
 
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.core.plugin.Plugin
 import io.element.android.libraries.architecture.FeatureEntryPoint
 
 interface FtueEntryPoint : FeatureEntryPoint {
     fun nodeBuilder(parentNode: Node, buildContext: BuildContext): NodeBuilder
 
     interface NodeBuilder {
-        fun callback(callback: Callback): NodeBuilder
         fun build(): Node
-    }
-
-    interface Callback : Plugin {
-        fun onFtueFlowFinished()
     }
 }

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/DefaultFtueEntryPoint.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/DefaultFtueEntryPoint.kt
@@ -31,11 +31,6 @@ class DefaultFtueEntryPoint @Inject constructor() : FtueEntryPoint {
         val plugins = ArrayList<Plugin>()
 
         return object : FtueEntryPoint.NodeBuilder {
-            override fun callback(callback: FtueEntryPoint.Callback): FtueEntryPoint.NodeBuilder {
-                plugins += callback
-                return this
-            }
-
             override fun build(): Node {
                 return parentNode.createNode<FtueFlowNode>(buildContext, plugins)
             }

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
@@ -32,7 +32,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.element.android.anvilannotations.ContributesNode
 import io.element.android.features.analytics.api.AnalyticsEntryPoint
-import io.element.android.features.ftue.api.FtueEntryPoint
 import io.element.android.features.ftue.impl.notifications.NotificationsOptInNode
 import io.element.android.features.ftue.impl.sessionverification.FtueSessionVerificationFlowNode
 import io.element.android.features.ftue.impl.state.DefaultFtueService
@@ -85,8 +84,6 @@ class FtueFlowNode @AssistedInject constructor(
         @Parcelize
         data object LockScreenSetup : NavTarget
     }
-
-    private val callback = plugins.filterIsInstance<FtueEntryPoint.Callback>().firstOrNull()
 
     override fun onBuilt() {
         super.onBuilt()
@@ -157,7 +154,7 @@ class FtueFlowNode @AssistedInject constructor(
             FtueStep.LockscreenSetup -> {
                 backstack.newRoot(NavTarget.LockScreenSetup)
             }
-            null -> callback?.onFtueFlowFinished()
+            null -> Unit
         }
     }
 

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/ParentNodeExt.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/ParentNodeExt.kt
@@ -51,7 +51,7 @@ suspend inline fun <reified N : Node, NavTarget : Any> ParentNode<NavTarget>.wai
     }
 
 /**
- * Wait for a child to be attached to the parent node, only using the NavTarget
+ * Wait for a child to be attached to the parent node, only using the NavTarget.
  */
 suspend inline fun <NavTarget : Any> ParentNode<NavTarget>.waitForNavTargetAttached(crossinline predicate: (NavTarget) -> Boolean) =
     suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Rework how the navigation is handled regarding FtueState, and permalink.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #2778

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Receive a notification
- Kill the app
- Click on the notification
- If the room is displayed, the issue is fixed.

As a bonus, permalink will work (until a room or a user is displayed), even if there are Ftue step to perform and even an account to log in.

This can be tested using `deeplink.sh` combine with the internal clear cache option, which reset some Ftue steps.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
