### PR TITLE
Don't intercept `mas.element.io` domain with our intent filters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,7 +84,11 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="*.element.io" />
+                <!-- We can't use "*.element.io" here because it'll intercept the "mas.element.io" domain too. -->
+                <data android:host="app.element.io" />
+                <data android:host="staging.element.io" />
+                <data android:host="develop.element.io" />
+                <data android:host="call.element.io" />
             </intent-filter>
             <!--
               matrix.to links


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Instead of using `*.element.io` for intent filters, use the different `element.io` existing subdomains.

## Motivation and context

Using `*.element.io`, the `mas.element.io` domain is intercepted too, preventing signing in using OIDC in the `element.io` homeserver.

## Tests

<!-- Explain how you tested your development -->

- If you can log into an `element.io` account, it works.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
