### PR TITLE
Enable support for Android per-app language preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,10 @@ android {
             buildConfigField("String", "FLAVOR_DESCRIPTION", "\"FDroid\"")
         }
     }
+
+    androidResources {
+        generateLocaleConfig = true
+    }
 }
 
 androidComponents {

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unqualifiedResLocale=en

--- a/changelog.d/2795.feature
+++ b/changelog.d/2795.feature
@@ -1,0 +1,1 @@
+Enable support for Android per-app language preferences


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This PR does the few changes necessary to support this system feature on Android 13 and newer devices. This does not add in-app language settings or a method for Android 12 and older users to set a per-app language, but this can be done later using androidx.appcompat APIs.

## Motivation and context

Users would like to set a different language than their system default for Element X. This PR would at least allow users with Android 13 or newer to use their system settings to change the language to their preferences until (and after) an in-app UI is created.

## Screenshots / GIFs

![image](https://github.com/element-hq/element-x-android/assets/4409524/3b3f5963-3943-40b4-bc2a-e6ba0aa31de7)

## Tests

- Installed debug build
- Opened app info
- Checked that the language settings existed
- Checked that switching to another language (for example German) also reflected to a change in language in-app
- Made sure the app still works on API 23, and nothing has changed

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 15 (Beta 1.2), 6

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR

I would like to sign-off privately.