### PR TITLE
Bring selected filter to front

### DIFF
--- a/changelog.d/2809.bugfix
+++ b/changelog.d/2809.bugfix
@@ -1,0 +1,1 @@
+Render selected/deselected room list filters on top

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -16,6 +16,9 @@
 
 package io.element.android.features.roomlist.impl.filters
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -139,16 +142,27 @@ private fun RoomListFilterView(
     onClick: (RoomListFilter) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val background = animateColorAsState(
+        targetValue = if (selected) ElementTheme.colors.bgActionPrimaryRest else ElementTheme.colors.bgCanvasDefault,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "chip background colour",
+    )
+    val textColour = animateColorAsState(
+        targetValue = if (selected) ElementTheme.colors.textOnSolidPrimary else ElementTheme.colors.textPrimary,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "chip text colour",
+    )
+
     FilterChip(
         selected = selected,
         onClick = { onClick(roomListFilter) },
         modifier = modifier.height(36.dp),
         shape = CircleShape,
         colors = FilterChipDefaults.filterChipColors(
-            containerColor = ElementTheme.colors.bgCanvasDefault,
-            selectedContainerColor = ElementTheme.colors.bgActionPrimaryRest,
-            labelColor = ElementTheme.colors.textPrimary,
-            selectedLabelColor = ElementTheme.colors.textOnSolidPrimary,
+            containerColor = background.value,
+            selectedContainerColor = background.value,
+            labelColor = textColour.value,
+            selectedLabelColor = textColour.value
         ),
         label = {
             Text(text = stringResource(id = roomListFilter.stringResource))

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -32,12 +32,15 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -62,6 +65,7 @@ fun RoomListFiltersView(
     }
 
     val lazyListState = rememberLazyListState()
+    val previousFilters = remember { mutableStateOf(listOf<RoomListFilter>()) }
     LazyRow(
         contentPadding = PaddingValues(start = 8.dp, end = 16.dp),
         modifier = modifier.fillMaxWidth(),
@@ -75,17 +79,26 @@ fun RoomListFiltersView(
                     modifier = Modifier
                         .padding(start = 8.dp)
                         .testTag(TestTags.homeScreenClearFilters),
-                    onClick = ::onClearFiltersClicked
+                    onClick = {
+                        previousFilters.value = state.selectedFilters()
+                        onClearFiltersClicked()
+                    }
                 )
             }
         }
-        for (filterWithSelection in state.filterSelectionStates) {
+        state.filterSelectionStates.forEachIndexed { i, filterWithSelection ->
             item(filterWithSelection.filter) {
+                val zIndex = (if (previousFilters.value.contains(filterWithSelection.filter)) state.filterSelectionStates.size else 0) - i.toFloat()
                 RoomListFilterView(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .zIndex(zIndex),
                     roomListFilter = filterWithSelection.filter,
                     selected = filterWithSelection.isSelected,
-                    onClick = ::onToggleFilter,
+                    onClick = {
+                        previousFilters.value = state.selectedFilters()
+                        onToggleFilter(it)
+                    },
                 )
             }
         }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -104,13 +103,6 @@ fun RoomListFiltersView(
                     },
                 )
             }
-        }
-    }
-    LaunchedEffect(state.filterSelectionStates) {
-        // Checking for canScrollBackward is necessary for the itemPlacementAnimation to work correctly.
-        // We don't want the itemPlacementAnimation to be triggered when clearing the filters.
-        if (!state.hasAnyFilterSelected || lazyListState.canScrollBackward) {
-            lazyListState.animateScrollToItem(0)
         }
     }
 }


### PR DESCRIPTION
It looked weird before to always have the selected chip disappear and slide behind the deselected filters.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Selected filters in the room list filter bar now slide in front instead of behind when moving to the left

## Motivation and context

It looks nicer

## Screenshots / GIFs

Note that I have my animation scale set to 5x here.
After:

https://github.com/element-hq/element-x-android/assets/775104/63ec9ec9-0ee8-4aa0-afc1-76c15ab4360f

Before:

https://github.com/element-hq/element-x-android/assets/775104/81ea2b1d-3e6b-4fe6-b894-2f8b3ee38da8

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1: Open app
- Step 2: Click buttons
- Step 3: Observe

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
