### PR TITLE
UX cleanup: DM details screen

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsView.kt
@@ -49,7 +49,6 @@ import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.leaveroom.api.LeaveRoomView
 import io.element.android.features.userprofile.shared.UserProfileHeaderSection
-import io.element.android.features.userprofile.shared.UserProfileMainActionsSection
 import io.element.android.features.userprofile.shared.blockuser.BlockUserDialogs
 import io.element.android.features.userprofile.shared.blockuser.BlockUserSection
 import io.element.android.libraries.architecture.coverage.ExcludeFromCoverage
@@ -153,7 +152,12 @@ fun RoomDetailsView(
                             openAvatarPreview(member.getBestName(), avatarUrl)
                         },
                     )
-                    UserProfileMainActionsSection(onShareUser = ::onShareMember)
+                    MainActionsSection(
+                        state = state,
+                        onShareRoom = onShareRoom,
+                        onInvitePeople = invitePeople,
+                        onCall = onJoinCallClicked,
+                    )
                 }
             }
             Spacer(Modifier.height(18.dp))
@@ -295,18 +299,21 @@ private fun MainActionsSection(
                 onClick = onCall,
             )
         }
-        if (state.roomType is RoomDetailsType.Room && state.canInvite) {
+        if (state.roomType is RoomDetailsType.Room) {
+            if (state.canInvite) {
+                MainActionButton(
+                    title = stringResource(CommonStrings.action_invite),
+                    imageVector = CompoundIcons.UserAdd(),
+                    onClick = onInvitePeople,
+                )
+            }
+            // Share CTA should be hidden for DMs
             MainActionButton(
-                title = stringResource(CommonStrings.action_invite),
-                imageVector = CompoundIcons.UserAdd(),
-                onClick = onInvitePeople,
+                title = stringResource(CommonStrings.action_share),
+                imageVector = CompoundIcons.ShareAndroid(),
+                onClick = onShareRoom
             )
         }
-        MainActionButton(
-            title = stringResource(CommonStrings.action_share),
-            imageVector = CompoundIcons.ShareAndroid(),
-            onClick = onShareRoom
-        )
     }
 }
 

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsViewTest.kt
@@ -66,19 +66,6 @@ class RoomDetailsViewTest {
         }
     }
 
-    @Test
-    fun `click on share member invokes expected callback`() {
-        val state = aDmRoomDetailsState()
-        val roomMember = (state.roomType as RoomDetailsType.Dm).roomMember
-        ensureCalledOnceWithParam(roomMember) { callback ->
-            rule.setRoomDetailView(
-                state = aDmRoomDetailsState(),
-                onShareMember = callback,
-            )
-            rule.clickOn(CommonStrings.action_share)
-        }
-    }
-
     @Config(qualifiers = "h1024dp")
     @Test
     fun `click on room members invokes expected callback`() {

--- a/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileMainActionsSection.kt
+++ b/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileMainActionsSection.kt
@@ -19,16 +19,21 @@ package io.element.android.features.userprofile.shared
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.libraries.designsystem.components.button.MainActionButton
 import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun UserProfileMainActionsSection(onShareUser: () -> Unit, modifier: Modifier = Modifier) {
-    Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+    Row(
+        modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
         MainActionButton(
             title = stringResource(CommonStrings.action_share),
             imageVector = CompoundIcons.ShareAndroid(),

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetailsDark_null_RoomDetailsDark--1_3_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetailsDark_null_RoomDetailsDark--1_3_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92e67efa400e387c6eaab1933b763d01a711030ec582c9bb01d6b75f925db660
-size 42570
+oid sha256:0e1a3a63380ed457edaf6c5e992238647724e1f6e64e0d0693b279b7e93c8be9
+size 43338

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetailsDark_null_RoomDetailsDark--1_3_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetailsDark_null_RoomDetailsDark--1_3_null_6,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92e67efa400e387c6eaab1933b763d01a711030ec582c9bb01d6b75f925db660
-size 42570
+oid sha256:0e1a3a63380ed457edaf6c5e992238647724e1f6e64e0d0693b279b7e93c8be9
+size 43338

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_5,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_5,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:883e53d8ad2f6da6e3002274d5d808081e89242b43ec398d1366e986b7329d71
-size 43849
+oid sha256:6aacd02b8bc6b9cd63bfd7e49e2f1feacdee4290495905246b81d29622f1ef6b
+size 44611

--- a/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_6,NEXUS_5,1.0,en].png
+++ b/tests/uitests/src/test/snapshots/images/ui_S_t[f.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_6,NEXUS_5,1.0,en].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:883e53d8ad2f6da6e3002274d5d808081e89242b43ec398d1366e986b7329d71
-size 43849
+oid sha256:6aacd02b8bc6b9cd63bfd7e49e2f1feacdee4290495905246b81d29622f1ef6b
+size 44611


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : UX cleanup.

## Content

- Reuse `MainActionsSection` for DMs too, hiding the Share CTA in that case.
- Make sure the 'Share' CTA is hidden for DMs.

## Motivation and context

Closes #2815.

## Screenshots / GIFs

|Before|After|
|-|-|
|![](https://media.githubusercontent.com/media/element-hq/element-x-android/46b22d7db764143284e80a50eb97c89946878257/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_5%2CNEXUS_5%2C1.0%2Cen%5D.png)|![](https://media.githubusercontent.com/media/element-hq/element-x-android/7d616cee64e7faf64dd1ca86c15090200ffbcfac/tests/uitests/src/test/snapshots/images/ui_S_t%5Bf.roomdetails.impl_RoomDetails_null_RoomDetails--0_2_null_5%2CNEXUS_5%2C1.0%2Cen%5D.png)|

## Tests

<!-- Explain how you tested your development -->

- Go to a DM.
- Check the UI matches the new screenshots.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
