### PR TITLE
Split Maestro CI flow in 2 jobs.

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload APK as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ format('elementx-apk-maestro-{0}', github.ref) }}
+          name: elementx-apk-maestro
           path: |
             app/build/outputs/apk/gplay/debug/app-gplay-x86_64-debug.apk
           retention-days: 5
@@ -68,7 +68,7 @@ jobs:
       - name: Download APK artifact from previous job
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('elementx-apk-maestro-{0}', github.ref) }}
+          name: elementx-apk-maestro
       - uses: mobile-dev-inc/action-maestro-cloud@v1.8.1
         if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'
         with:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -65,6 +65,12 @@ jobs:
       group: ${{ format('maestro-{0}', github.ref) }}
       cancel-in-progress: true
     steps:
+      - uses: actions/checkout@v4
+        if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'
+        with:
+          # Ensure we are building the branch and not the branch after being merged on develop
+          # https://github.com/actions/checkout/issues/881
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
       - name: Download APK artifact from previous job
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: ${{ format('elementx-apk-maestro-{0}', github.ref) }}
           path: |
-            app/build/outputs/apk/debug/debug/app-gplay-x86_64-debug.apk
+            app/build/outputs/apk/gplay/debug/app-gplay-x86_64-debug.apk
           retention-days: 5
           overwrite: true
           if-no-files-found: error

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -12,12 +12,10 @@ env:
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon
 
 jobs:
-  maestro-cloud:
-    name: Maestro test suite
+  build-apk:
+    name: Build APK
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'Run-Maestro'
-    strategy:
-      fail-fast: false
     # Allow one per PR.
     concurrency:
       group: ${{ format('maestro-{0}', github.ref) }}
@@ -41,19 +39,43 @@ jobs:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
       - name: Assemble debug APK
-        run: ./gradlew :app:assembleDebug $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:assembleGplayDebug $CI_GRADLE_ARG_PROPERTIES
         if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'
         env:
           ELEMENT_ANDROID_MAPTILER_API_KEY: ${{ secrets.MAPTILER_KEY }}
           ELEMENT_ANDROID_MAPTILER_LIGHT_MAP_ID: ${{ secrets.MAPTILER_LIGHT_MAP_ID }}
           ELEMENT_ANDROID_MAPTILER_DARK_MAP_ID: ${{ secrets.MAPTILER_DARK_MAP_ID }}
+      - name: Upload APK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('elementx-apk-maestro-{0}', github.ref) }}
+          path: |
+            app/build/outputs/apk/debug/debug/app-gplay-x86_64-debug.apk
+          retention-days: 5
+          overwrite: true
+          if-no-files-found: error
+
+  maestro-cloud:
+    name: Maestro test suite
+    runs-on: ubuntu-latest
+    needs: build-apk
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'Run-Maestro'
+    # Allow one per PR.
+    concurrency:
+      group: ${{ format('maestro-{0}', github.ref) }}
+      cancel-in-progress: true
+    steps:
+      - name: Download APK artifact from previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ format('elementx-apk-maestro-{0}', github.ref) }}
       - uses: mobile-dev-inc/action-maestro-cloud@v1.8.1
         if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           # Doc says (https://github.com/mobile-dev-inc/action-maestro-cloud#android):
           # app-file should point to an x86 compatible APK file, so upload the x86_64 one (much smaller than the universal APK).
-          app-file: app/build/outputs/apk/gplay/debug/app-gplay-x86_64-debug.apk
+          app-file: app-gplay-x86_64-debug.apk
           env: |
             MAESTRO_USERNAME=maestroelement
             MAESTRO_PASSWORD=${{ secrets.MATRIX_MAESTRO_ACCOUNT_PASSWORD }}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Split the Maestro CI flow into 2 jobs.

## Motivation and context

This way, if the Maestro tests fail for some runtime reason we don't have to build the APK (~10min) again to re-test it.

## Tests

<!-- Explain how you tested your development -->

- The Maestro job should be restartable, independent from the 'Build APK' one.

A 2nd run of this job ran here: https://github.com/element-hq/element-x-android/actions/runs/9013826868/job/24765945553.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
