### PR TITLE
Make logs less verbose, especially for sliding sync

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ApplicationConfig.kt
@@ -40,4 +40,9 @@ object ApplicationConfig {
      * For Element, the value is "Element". We use the same name for desktop and mobile for now.
      */
     const val DESKTOP_APPLICATION_NAME: String = "Element"
+
+    /**
+     * The maximum size of the upload request. Default value is just below CloudFlare's max request size.
+     */
+    const val MAX_LOG_UPLOAD_SIZE = 50 * 1024 * 1024L
 }

--- a/changelog.d/2825.bugfix
+++ b/changelog.d/2825.bugfix
@@ -1,0 +1,1 @@
+Make log less verbose, make sure we upload as many log files as possible before reaching the request size limit of the bug reporting service, discard older logs if they don't fit.

--- a/features/rageshake/impl/build.gradle.kts
+++ b/features/rageshake/impl/build.gradle.kts
@@ -38,6 +38,7 @@ anvil {
 dependencies {
     implementation(projects.anvilannotations)
     anvil(projects.anvilcodegen)
+    implementation(projects.appconfig)
     implementation(projects.services.toolbox.api)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/bugreport/BugReportPresenter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/bugreport/BugReportPresenter.kt
@@ -96,6 +96,7 @@ class BugReportPresenter @Inject constructor(
                     if (formState.value.description.length < 10) {
                         sendingAction.value = AsyncAction.Failure(BugReportFormError.DescriptionTooShort)
                     } else {
+                        sendingAction.value = AsyncAction.Loading
                         appCoroutineScope.sendBugReport(formState.value, crashInfo.isNotEmpty(), uploadListener)
                     }
                 }

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -21,6 +21,7 @@ import android.os.Build
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.appconfig.ApplicationConfig
 import io.element.android.features.rageshake.api.crash.CrashDataStore
 import io.element.android.features.rageshake.api.reporter.BugReporter
 import io.element.android.features.rageshake.api.reporter.BugReporterListener
@@ -83,7 +84,6 @@ class DefaultBugReporter @Inject constructor(
         // filenames
         private const val LOG_CAT_FILENAME = "logcat.log"
         private const val LOG_DIRECTORY_NAME = "logs"
-        private const val BUFFER_SIZE = 1024 * 1024 * 50
     }
 
     // the pending bug report call
@@ -120,7 +120,7 @@ class DefaultBugReporter @Inject constructor(
                 val gzippedFiles = ArrayList<File>()
 
                 if (withDevicesLogs) {
-                    val files = getLogFiles()
+                    val files = getLogFiles().sortedByDescending { it.lastModified() }
                     files.mapNotNullTo(gzippedFiles) { f ->
                         when {
                             isCancelled -> null
@@ -131,11 +131,12 @@ class DefaultBugReporter @Inject constructor(
                     files.deleteAllExceptMostRecent()
                 }
 
+
                 if (!isCancelled && (withCrashLogs || withDevicesLogs)) {
                     saveLogCat()
                     val gzippedLogcat = compressFile(logCatErrFile)
                     if (null != gzippedLogcat) {
-                        if (gzippedFiles.size == 0) {
+                        if (gzippedFiles.isEmpty()) {
                             gzippedFiles.add(gzippedLogcat)
                         } else {
                             gzippedFiles.add(0, gzippedLogcat)
@@ -166,10 +167,18 @@ class DefaultBugReporter @Inject constructor(
                     }
 
                     // add the gzipped files, don't cancel the whole upload if only some file failed to upload
+                    var totalUploadedSize = 0L
                     var uploadedSomeLogs = false
                     for (file in gzippedFiles) {
                         try {
-                            builder.addFormDataPart("compressed-log", file.name, file.asRequestBody(MimeTypes.OctetStream.toMediaTypeOrNull()))
+                            val requestBody = file.asRequestBody(MimeTypes.OctetStream.toMediaTypeOrNull())
+                            totalUploadedSize += requestBody.contentLength()
+                            // If we are about to upload more than the max request size, stop here
+                            if (totalUploadedSize > ApplicationConfig.MAX_LOG_UPLOAD_SIZE) {
+                                Timber.e("Could not upload file ${file.name} because it would exceed the max request size")
+                                break
+                            }
+                            builder.addFormDataPart("compressed-log", file.name, requestBody)
                             uploadedSomeLogs = true
                         } catch (e: CancellationException) {
                             throw e
@@ -411,7 +420,7 @@ class DefaultBugReporter @Inject constructor(
             val separator = System.getProperty("line.separator")
             logcatProc.inputStream
                 .reader()
-                .buffered(BUFFER_SIZE)
+                .buffered(ApplicationConfig.MAX_LOG_UPLOAD_SIZE.toInt())
                 .forEachLine { line ->
                     streamWriter.append(line)
                     streamWriter.append(separator)

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -131,7 +131,6 @@ class DefaultBugReporter @Inject constructor(
                     files.deleteAllExceptMostRecent()
                 }
 
-
                 if (!isCancelled && (withCrashLogs || withDevicesLogs)) {
                     saveLogCat()
                     val gzippedLogcat = compressFile(logCatErrFile)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingFilterConfiguration.kt
@@ -27,9 +27,9 @@ data class TracingFilterConfiguration(
         Target.MATRIX_SDK_CRYPTO to LogLevel.DEBUG,
         Target.MATRIX_SDK_CRYPTO_ACCOUNT to LogLevel.TRACE,
         Target.MATRIX_SDK_HTTP_CLIENT to LogLevel.DEBUG,
-        Target.MATRIX_SDK_SLIDING_SYNC to LogLevel.TRACE,
-        Target.MATRIX_SDK_BASE_SLIDING_SYNC to LogLevel.TRACE,
-        Target.MATRIX_SDK_UI_TIMELINE to LogLevel.TRACE,
+        Target.MATRIX_SDK_SLIDING_SYNC to LogLevel.INFO,
+        Target.MATRIX_SDK_BASE_SLIDING_SYNC to LogLevel.INFO,
+        Target.MATRIX_SDK_UI_TIMELINE to LogLevel.INFO,
     )
 
     fun getLogLevel(target: Target): LogLevel {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Make sliding sync and timeline logs from the Rust SDK less verbose.

## Motivation and context

Some users (i.e. @frebib) were having issues uploading their logs with the new rotation config. It seems like our logs are way more verbose than the iOS ones.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
