### PR TITLE
Upload app id and clean version to bug reports

### DIFF
--- a/changelog.d/2829.bugfix
+++ b/changelog.d/2829.bugfix
@@ -1,0 +1,1 @@
+Add missing `app_id` and `Version` properties to bug reports.

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -161,6 +161,9 @@ class DefaultBugReporter @Inject constructor(
                         .addFormDataPart("sdk_sha", sdkMetadata.sdkGitSha)
                         .addFormDataPart("local_time", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))
                         .addFormDataPart("utc_time", LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME))
+                        .addFormDataPart("app_id", buildMeta.applicationId)
+                        // Nightly versions have a custom version name suffix that we should remove for the bug report
+                        .addFormDataPart("Version", buildMeta.versionName.replace("-nightly", ""))
                     currentTracingFilter?.let {
                         builder.addFormDataPart("tracing_filter", it)
                     }

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -154,6 +154,6 @@ class DefaultBugReporterTest {
     }
 
     companion object {
-        private const val EXPECTED_NUMBER_OF_PROGRESS_VALUE = 15
+        private const val EXPECTED_NUMBER_OF_PROGRESS_VALUE = 17
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Add `app_id` property to bug reports so we can know if it's a debug, nightly or release version.
- Send a `Version` property with the plain version of the app (i.e. `0.4.11`, without any suffix).

## Motivation and context

It should help differentiating versions in rageshakes, up to these changes only the user agent had any versioning info.

## Tests

Bug report correctly uploaded to https://github.com/element-hq/element-x-android-rageshakes/issues/1995.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
