### PR TITLE
Fix localazy import

### DIFF
--- a/.github/workflows/generate_github_pages.yml
+++ b/.github/workflows/generate_github_pages.yml
@@ -22,10 +22,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Run World screenshots generation script
         run: |
           ./tools/test/generateWorldScreenshots.py

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Search for invalid screenshot files
         run: ./tools/test/checkInvalidScreenshots.py
 

--- a/.github/workflows/sync-localazy.yml
+++ b/.github/workflows/sync-localazy.yml
@@ -21,10 +21,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Setup Localazy
         run: |
           curl -sS https://dist.localazy.com/debian/pubkey.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/localazy.gpg

--- a/.github/workflows/sync-sas-strings.yml
+++ b/.github/workflows/sync-sas-strings.yml
@@ -13,10 +13,10 @@ jobs:
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install Prerequisite dependencies
         run: |
           pip install requests

--- a/tools/localazy/importSupportedLocalesFromLocalazy.py
+++ b/tools/localazy/importSupportedLocalesFromLocalazy.py
@@ -27,6 +27,8 @@ def normalizeForResourceConfigurations(locale):
             return "in"
         case "zh_TW#Hant":
             return "zh-rTW"
+        case "zh#Hans":
+            return "zh-rCN"
         case _:
             return locale
 
@@ -37,6 +39,8 @@ def normalizeForLocalConfig(locale):
             return "in"
         case "zh_TW#Hant":
             return "zh-TW"
+        case "zh#Hans":
+            return "zh-CN"
         case _:
             return locale
 


### PR DESCRIPTION
[Latest Localazy sync](https://github.com/element-hq/element-x-android/actions/runs/9055194003/job/24875946486) was failing because of Python version not supporting `match` structure. The first commit fixes this. I have updated the version every where Python is used, hopefully there will be no bad side effect on the other GA.

The second commit ensure that the data for simplified Chinese are correct. I'll let the next Localazy sync run the script and update the generated file, to validate it's working as expected (it's OK locally).