### PR TITLE
Adapt to changes in SDK

### DIFF
--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration01.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration01.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
  * Remove existing logs from the device to remove any leaks of sensitive data.
  */
 @ContributesMultibinding(AppScope::class)
-open class AppMigration01 @Inject constructor(
+class AppMigration01 @Inject constructor(
     private val logFilesRemover: LogFilesRemover,
 ) : AppMigration {
     override val order: Int = 1

--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration02.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration02.kt
@@ -24,6 +24,10 @@ import io.element.android.libraries.sessionstorage.api.SessionStore
 import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
+/**
+ * This migration sets the skip session verification preference to true for all existing sessions.
+ * This way we don't force existing users to verify their session again.
+ */
 @ContributesMultibinding(AppScope::class)
 class AppMigration02 @Inject constructor(
     private val sessionStore: SessionStore,

--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03.kt
@@ -17,7 +17,6 @@
 package io.element.android.features.migration.impl.migrations
 
 import com.squareup.anvil.annotations.ContributesMultibinding
-import io.element.android.features.rageshake.api.logs.LogFilesRemover
 import io.element.android.libraries.di.AppScope
 import javax.inject.Inject
 
@@ -26,7 +25,11 @@ import javax.inject.Inject
  */
 @ContributesMultibinding(AppScope::class)
 class AppMigration03 @Inject constructor(
-    private val logFilesRemover: LogFilesRemover,
-) : AppMigration01(logFilesRemover) {
+    private val migration01: AppMigration01,
+) : AppMigration {
     override val order: Int = 3
+
+    override suspend fun migrate() {
+        migration01.migrate()
+    }
 }

--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03.kt
@@ -22,15 +22,11 @@ import io.element.android.libraries.di.AppScope
 import javax.inject.Inject
 
 /**
- * Remove existing logs from the device to remove any leaks of sensitive data.
+ * This performs the same operation as [AppMigration01], since we need to clear the local logs again.
  */
 @ContributesMultibinding(AppScope::class)
-open class AppMigration01 @Inject constructor(
+class AppMigration03 @Inject constructor(
     private val logFilesRemover: LogFilesRemover,
-) : AppMigration {
-    override val order: Int = 1
-
-    override suspend fun migrate() {
-        logFilesRemover.perform()
-    }
+) : AppMigration01(logFilesRemover) {
+    override val order: Int = 3
 }

--- a/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03Test.kt
+++ b/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03Test.kt
@@ -24,7 +24,7 @@ class AppMigration03Test {
     @Test
     fun `test migration`() = runTest {
         val logsFileRemover = FakeLogFilesRemover()
-        val migration = AppMigration03(logsFileRemover)
+        val migration = AppMigration03(migration01 = AppMigration01(logsFileRemover))
 
         migration.migrate()
 

--- a/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03Test.kt
+++ b/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration03Test.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.migration.impl.migrations
+
+import io.element.android.features.rageshake.test.logs.FakeLogFilesRemover
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AppMigration03Test {
+    @Test
+    fun `test migration`() = runTest {
+        val logsFileRemover = FakeLogFilesRemover()
+        val migration = AppMigration03(logsFileRemover)
+
+        migration.migrate()
+
+        logsFileRemover.performLambda.assertions().isCalledOnce()
+    }
+}

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -75,7 +75,7 @@ class RoomDetailsPresenter @Inject constructor(
 
         val roomAvatar by remember { derivedStateOf { roomInfo?.avatarUrl ?: room.avatarUrl } }
 
-        val roomName by remember { derivedStateOf { (roomInfo?.name ?: room.name ?: room.displayName).trim() } }
+        val roomName by remember { derivedStateOf { (roomInfo?.name ?: room.displayName).trim() } }
         val roomTopic by remember { derivedStateOf { roomInfo?.topic ?: room.topic } }
         val isFavorite by remember { derivedStateOf { roomInfo?.isFavorite.orFalse() } }
         val isPublic by remember { derivedStateOf { roomInfo?.isPublic.orFalse() } }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenter.kt
@@ -65,7 +65,7 @@ class RoomDetailsEditPresenter @Inject constructor(
         // just erase the local value when the room field has changed
         var roomAvatarUri by rememberSaveable(room.avatarUrl) { mutableStateOf(room.avatarUrl?.toUri()) }
 
-        var roomName by rememberSaveable { mutableStateOf((room.name ?: room.displayName).trim()) }
+        var roomName by rememberSaveable { mutableStateOf(room.displayName.trim()) }
         var roomTopic by rememberSaveable { mutableStateOf(room.topic?.trim()) }
 
         val saveButtonEnabled by remember(
@@ -76,7 +76,7 @@ class RoomDetailsEditPresenter @Inject constructor(
         ) {
             derivedStateOf {
                 roomAvatarUri?.toString()?.trim() != room.avatarUrl?.toUri()?.toString()?.trim() ||
-                    roomName.trim() != (room.name ?: room.displayName).trim() ||
+                    roomName.trim() != room.displayName.trim() ||
                     roomTopic.orEmpty().trim() != room.topic.orEmpty().trim()
             }
         }
@@ -168,7 +168,7 @@ class RoomDetailsEditPresenter @Inject constructor(
                     Timber.e(it, "Failed to set room topic")
                 })
             }
-            if (name.isNotEmpty() && name.trim() != room.name.orEmpty().trim()) {
+            if (name.isNotEmpty() && name.trim() != room.displayName.trim()) {
                 results.add(room.setName(name).onFailure {
                     Timber.e(it, "Failed to set room name")
                 })

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/RoomDetailsPresenterTests.kt
@@ -118,7 +118,7 @@ class RoomDetailsPresenterTests {
         presenter.test {
             val initialState = awaitItem()
             assertThat(initialState.roomId).isEqualTo(room.roomId)
-            assertThat(initialState.roomName).isEqualTo(room.name)
+            assertThat(initialState.roomName).isEqualTo(room.displayName)
             assertThat(initialState.roomAvatarUrl).isEqualTo(room.avatarUrl)
             assertThat(initialState.roomTopic).isEqualTo(RoomTopicState.ExistingTopic(room.topic!!))
             assertThat(initialState.memberCount).isEqualTo(room.joinedMemberCount)
@@ -148,7 +148,7 @@ class RoomDetailsPresenterTests {
 
     @Test
     fun `present - initial state with no room name`() = runTest {
-        val room = aMatrixRoom(name = null)
+        val room = aMatrixRoom(displayName = "")
         val presenter = createRoomDetailsPresenter(room)
         presenter.test {
             val initialState = awaitItem()
@@ -476,8 +476,7 @@ class RoomDetailsPresenterTests {
 
 fun aMatrixRoom(
     roomId: RoomId = A_ROOM_ID,
-    name: String? = A_ROOM_NAME,
-    displayName: String = "A fallback display name",
+    displayName: String = A_ROOM_NAME,
     topic: String? = "A topic",
     avatarUrl: String? = "https://matrix.org/avatar.jpg",
     isEncrypted: Boolean = true,
@@ -486,7 +485,6 @@ fun aMatrixRoom(
     notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService()
 ) = FakeMatrixRoom(
     roomId = roomId,
-    name = name,
     displayName = displayName,
     topic = topic,
     avatarUrl = avatarUrl,

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/edit/RoomDetailsEditPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/edit/RoomDetailsEditPresenterTest.kt
@@ -98,7 +98,7 @@ class RoomDetailsEditPresenterTest {
         }.test {
             val initialState = awaitItem()
             assertThat(initialState.roomId).isEqualTo(room.roomId.value)
-            assertThat(initialState.roomName).isEqualTo(room.name)
+            assertThat(initialState.roomName).isEqualTo(room.displayName)
             assertThat(initialState.roomAvatarUrl).isEqualTo(roomAvatarUri)
             assertThat(initialState.roomTopic).isEqualTo(room.topic.orEmpty())
             assertThat(initialState.avatarActions).containsExactly(
@@ -191,7 +191,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - updates state in response to changes`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
         val presenter = createRoomDetailsEditPresenter(room)
 
         moleculeFlow(RecompositionMode.Immediate) {
@@ -234,7 +234,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - obtains avatar uris from gallery`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         fakePickerProvider.givenResult(anotherAvatarUri)
 
@@ -255,7 +255,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - obtains avatar uris from camera`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         fakePickerProvider.givenResult(anotherAvatarUri)
         val fakePermissionsPresenter = FakePermissionsPresenter()
@@ -288,7 +288,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - updates save button state`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         fakePickerProvider.givenResult(roomAvatarUri)
 
@@ -340,7 +340,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - updates save button state when initial values are null`() = runTest {
-        val room = aMatrixRoom(topic = null, name = null, displayName = "fallback", avatarUrl = null)
+        val room = aMatrixRoom(topic = null, displayName = "fallback", avatarUrl = null)
 
         fakePickerProvider.givenResult(roomAvatarUri)
 
@@ -392,7 +392,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save changes room details if different`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         val presenter = createRoomDetailsEditPresenter(room)
 
@@ -417,7 +417,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save doesn't change room details if they're the same trimmed`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         val presenter = createRoomDetailsEditPresenter(room)
 
@@ -441,7 +441,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save doesn't change topic if it was unset and is now blank`() = runTest {
-        val room = aMatrixRoom(topic = null, name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = null, displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         val presenter = createRoomDetailsEditPresenter(room)
 
@@ -464,7 +464,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save doesn't change name if it's now empty`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         val presenter = createRoomDetailsEditPresenter(room)
 
@@ -487,7 +487,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save processes and sets avatar when processor returns successfully`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         givenPickerReturnsFile()
 
@@ -511,7 +511,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - save does not set avatar data if processor fails`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL)
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL)
 
         fakePickerProvider.givenResult(anotherAvatarUri)
         fakeMediaPreProcessor.givenResult(Result.failure(Throwable("Oh no")))
@@ -538,7 +538,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - sets save action to failure if name update fails`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL).apply {
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL).apply {
             givenSetNameResult(Result.failure(Throwable("!")))
         }
 
@@ -547,7 +547,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - sets save action to failure if topic update fails`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL).apply {
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL).apply {
             givenSetTopicResult(Result.failure(Throwable("!")))
         }
 
@@ -556,7 +556,7 @@ class RoomDetailsEditPresenterTest {
 
     @Test
     fun `present - sets save action to failure if removing avatar fails`() = runTest {
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL).apply {
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL).apply {
             givenRemoveAvatarResult(Result.failure(Throwable("!")))
         }
 
@@ -567,7 +567,7 @@ class RoomDetailsEditPresenterTest {
     fun `present - sets save action to failure if setting avatar fails`() = runTest {
         givenPickerReturnsFile()
 
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL).apply {
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL).apply {
             givenUpdateAvatarResult(Result.failure(Throwable("!")))
         }
 
@@ -578,7 +578,7 @@ class RoomDetailsEditPresenterTest {
     fun `present - CancelSaveChanges resets save action state`() = runTest {
         givenPickerReturnsFile()
 
-        val room = aMatrixRoom(topic = "My topic", name = "Name", avatarUrl = AN_AVATAR_URL).apply {
+        val room = aMatrixRoom(topic = "My topic", displayName = "Name", avatarUrl = AN_AVATAR_URL).apply {
             givenSetTopicResult(Result.failure(Throwable("!")))
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,7 +159,7 @@ jsoup = "org.jsoup:jsoup:1.17.2"
 appyx_core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
 molecule-runtime = "app.cash.molecule:molecule-runtime:1.4.2"
 timber = "com.jakewharton.timber:timber:5.0.1"
-matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.2.16"
+matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.2.18"
 matrix_richtexteditor = { module = "io.element.android:wysiwyg", version.ref = "wysiwyg" }
 matrix_richtexteditor_compose = { module = "io.element.android:wysiwyg-compose", version.ref = "wysiwyg" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -44,7 +44,6 @@ import java.io.File
 interface MatrixRoom : Closeable {
     val sessionId: SessionId
     val roomId: RoomId
-    val name: String?
     val displayName: String
     val alias: RoomAlias?
     val alternativeAliases: List<RoomAlias>

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomList.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomList.kt
@@ -39,14 +39,12 @@ interface RoomList {
 
     /**
      * The source of the room list data.
-     * All: all rooms except invites.
-     * Invites: only invites.
+     * All: all rooms.
      *
      * To apply some dynamic filtering on top of that, use [DynamicRoomList].
      */
     enum class Source {
-        All,
-        Invites,
+        All
     }
 
     /**

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
@@ -60,11 +60,6 @@ interface RoomListService {
     val allRooms: DynamicRoomList
 
     /**
-     * returns a [RoomList] object of all invites.
-     */
-    val invites: RoomList
-
-    /**
      * Will set the visible range of all rooms.
      * This is useful to load more data when the user scrolls down.
      */

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -96,6 +96,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.matrix.rustcomponents.sdk.BackupState
@@ -145,12 +146,7 @@ class RustMatrixClient(
         dispatchers = dispatchers,
     )
     private val notificationProcessSetup = NotificationProcessSetup.SingleProcess(syncService)
-    private val notificationClient = client.notificationClient(notificationProcessSetup)
-        .use { builder ->
-            builder
-                .filterByPushRules()
-                .finish()
-        }
+    private val notificationClient = runBlocking { client.notificationClient(notificationProcessSetup) }
     private val notificationService = RustNotificationService(sessionId, notificationClient, dispatchers, clock)
     private val notificationSettingsService = RustNotificationSettingsService(client, dispatchers)
         .apply { start() }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -461,7 +461,7 @@ class RustMatrixClient(
 
     override suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<RoomId> = withContext(sessionDispatcher) {
         runCatching {
-            client.resolveRoomAlias(roomAlias.value).let(::RoomId)
+            client.resolveRoomAlias(roomAlias.value).roomId.let(::RoomId)
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -71,7 +71,6 @@ class RustMatrixClientFactory @Inject constructor(
 
         val syncService = client.syncService()
             .withUtdHook(utdTracker)
-            .withUnifiedInvitesInRoomList(true)
             .finish()
 
         RustMatrixClient(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
@@ -38,7 +38,7 @@ class MatrixRoomInfoMapper(
     fun map(rustRoomInfo: RustRoomInfo): MatrixRoomInfo = rustRoomInfo.use {
         return MatrixRoomInfo(
             id = RoomId(it.id),
-            name = it.name,
+            name = it.displayName,
             topic = it.topic,
             avatarUrl = it.avatarUrl,
             isDirect = it.isDirect,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -191,8 +191,9 @@ class RustMatrixRoom(
         roomListItem.destroy()
     }
 
+    // TODO: delete this one, replace it with displayName
     override val name: String?
-        get() = runCatching { roomListItem.name() }.getOrDefault(null)
+        get() = runCatching { roomListItem.displayName() }.getOrDefault(null)
 
     override val displayName: String
         get() = runCatching { innerRoom.displayName() }.getOrDefault("")

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -191,10 +191,6 @@ class RustMatrixRoom(
         roomListItem.destroy()
     }
 
-    // TODO: delete this one, replace it with displayName
-    override val name: String?
-        get() = runCatching { roomListItem.displayName() }.getOrDefault(null)
-
     override val displayName: String
         get() = runCatching { innerRoom.displayName() }.getOrDefault("")
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
@@ -126,7 +126,7 @@ internal fun RoomListServiceInterface.syncIndicator(): Flow<RoomListServiceSyncI
         }
     }.buffer(Channel.UNLIMITED)
 
-internal fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItem? {
+internal suspend fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItem? {
     return try {
         room(roomId)
     } catch (exception: Exception) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
@@ -33,7 +33,7 @@ class RoomSummaryDetailsFactory(private val roomMessageFactory: RoomMessageFacto
         }
         return RoomSummaryDetails(
             roomId = RoomId(roomInfo.id),
-            name = roomInfo.name,
+            name = roomInfo.displayName,
             canonicalAlias = roomInfo.canonicalAlias?.let(::RoomAlias),
             isDirect = roomInfo.isDirect,
             avatarUrl = roomInfo.avatarUrl,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RustRoomListService.kt
@@ -58,7 +58,6 @@ internal class RustRoomListService(
         ) {
             when (source) {
                 RoomList.Source.All -> innerRoomListService.allRooms()
-                RoomList.Source.Invites -> innerRoomListService.invites()
             }
         }
     }
@@ -68,13 +67,6 @@ internal class RustRoomListService(
         coroutineContext = sessionDispatcher,
     ) {
         innerRoomListService.allRooms()
-    }
-
-    override val invites: RoomList = roomListFactory.createRoomList(
-        pageSize = Int.MAX_VALUE,
-        coroutineContext = sessionDispatcher,
-    ) {
-        innerRoomListService.invites()
     }
 
     init {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -515,7 +515,7 @@ class RustTimeline(
         }
     }
 
-    private fun fetchDetailsForEvent(eventId: EventId): Result<Unit> {
+    private suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> {
         return runCatching {
             inner.fetchDetailsForEvent(eventId.value)
         }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTests.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTests.kt
@@ -170,11 +170,7 @@ class RoomSummaryListProcessorTests {
 
         override suspend fun applyInput(input: RoomListInput) = Unit
 
-        override suspend fun invites(): RoomList {
-            return RoomList(Pointer.NULL)
-        }
-
-        override fun room(roomId: String): RoomListItem {
+        override suspend fun room(roomId: String): RoomListItem {
             return RoomListItem(Pointer.NULL)
         }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -70,7 +70,6 @@ import java.io.File
 class FakeMatrixRoom(
     override val sessionId: SessionId = A_SESSION_ID,
     override val roomId: RoomId = A_ROOM_ID,
-    override val name: String? = null,
     override val displayName: String = "",
     override val topic: String? = null,
     override val avatarUrl: String? = null,

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
@@ -28,7 +28,6 @@ class FakeRoomListService : RoomListService {
     private val allRoomSummariesFlow = MutableStateFlow<List<RoomSummary>>(emptyList())
     private val inviteRoomSummariesFlow = MutableStateFlow<List<RoomSummary>>(emptyList())
     private val allRoomsLoadingStateFlow = MutableStateFlow<RoomList.LoadingState>(RoomList.LoadingState.NotLoaded)
-    private val inviteRoomsLoadingStateFlow = MutableStateFlow<RoomList.LoadingState>(RoomList.LoadingState.NotLoaded)
     private val roomListStateFlow = MutableStateFlow<RoomListService.State>(RoomListService.State.Idle)
     private val syncIndicatorStateFlow = MutableStateFlow<RoomListService.SyncIndicator>(RoomListService.SyncIndicator.Hide)
 
@@ -42,10 +41,6 @@ class FakeRoomListService : RoomListService {
 
     suspend fun postAllRoomsLoadingState(loadingState: RoomList.LoadingState) {
         allRoomsLoadingStateFlow.emit(loadingState)
-    }
-
-    suspend fun postInviteRoomsLoadingState(loadingState: RoomList.LoadingState) {
-        inviteRoomsLoadingStateFlow.emit(loadingState)
     }
 
     suspend fun postState(state: RoomListService.State) {
@@ -66,19 +61,12 @@ class FakeRoomListService : RoomListService {
     ): DynamicRoomList {
         return when (source) {
             RoomList.Source.All -> allRooms
-            RoomList.Source.Invites -> invites
         }
     }
 
     override val allRooms = SimplePagedRoomList(
         allRoomSummariesFlow,
         allRoomsLoadingStateFlow,
-        MutableStateFlow(RoomListFilter.all())
-    )
-
-    override val invites = SimplePagedRoomList(
-        inviteRoomSummariesFlow,
-        inviteRoomsLoadingStateFlow,
         MutableStateFlow(RoomListFilter.all())
     )
 

--- a/plugins/src/main/kotlin/Versions.kt
+++ b/plugins/src/main/kotlin/Versions.kt
@@ -56,7 +56,7 @@ private const val versionMinor = 4
 // Note: even values are reserved for regular release, odd values for hotfix release.
 // When creating a hotfix, you should decrease the value, since the current value
 // is the value for the next regular release.
-private const val versionPatch = 11
+private const val versionPatch = 12
 
 object Versions {
     val versionCode = 4_000_000 + versionMajor * 1_00_00 + versionMinor * 1_00 + versionPatch


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Changes to generate the new app version:

- Bump version to `0.4.12` so we can replace the existing one in the store due to `CVE-2024-34353 / GHSA-9ggc-845v-gcgv`.
- Add migration to remove existing logs, based on `AppMigration01`.
- Bump SDK version to `0.2.18`, which contains a security fix.
- Lots of changes to to integrate the new SDK version:
    - Remove `name` from `MatrixRoom`, we should use `displayName` instead.
    - Remove separate `invites` room list.
    - Added `runBlocking` to get the now async `NotificationClient` from the Rust SDK.
    - Made some other functions `suspend`.
    - `Client.resolveRoomAlias` now returns a `roomId` and `via` parameters, we pass the `roomId`.

## Motivation and context

New release.

## Tests

You can test the general use of the app.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
