### PR TITLE
Provide serverNames when available and fix issue around analytics

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -37,6 +37,7 @@ import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.operation.replace
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.anvilannotations.ContributesNode
 import io.element.android.appnav.loggedin.LoggedInNode
 import io.element.android.appnav.room.RoomFlowNode
@@ -197,6 +198,8 @@ class LoggedInFlowNode @AssistedInject constructor(
         @Parcelize
         data class Room(
             val roomIdOrAlias: RoomIdOrAlias,
+            val serverNames: List<String> = emptyList(),
+            val trigger: JoinedRoom.Trigger? = null,
             val roomDescription: RoomDescription? = null,
             val initialElement: RoomNavigationTarget = RoomNavigationTarget.Messages()
         ) : NavTarget
@@ -292,8 +295,9 @@ class LoggedInFlowNode @AssistedInject constructor(
                                 backstack.push(
                                     NavTarget.Room(
                                         roomIdOrAlias = data.roomIdOrAlias,
+                                        serverNames = data.viaParameters,
+                                        trigger = JoinedRoom.Trigger.Timeline,
                                         initialElement = RoomNavigationTarget.Messages(data.eventId),
-                                        // TODO Use the viaParameters
                                     )
                                 )
                             }
@@ -311,6 +315,8 @@ class LoggedInFlowNode @AssistedInject constructor(
                 val inputs = RoomFlowNode.Inputs(
                     roomIdOrAlias = navTarget.roomIdOrAlias,
                     roomDescription = Optional.ofNullable(navTarget.roomDescription),
+                    serverNames = navTarget.serverNames,
+                    trigger = Optional.ofNullable(navTarget.trigger),
                     initialElement = navTarget.initialElement
                 )
                 createNode<RoomFlowNode>(buildContext, plugins = listOf(inputs, callback))
@@ -371,7 +377,13 @@ class LoggedInFlowNode @AssistedInject constructor(
                 roomDirectoryEntryPoint.nodeBuilder(this, buildContext)
                     .callback(object : RoomDirectoryEntryPoint.Callback {
                         override fun onResultClicked(roomDescription: RoomDescription) {
-                            backstack.push(NavTarget.Room(roomDescription.roomId.toRoomIdOrAlias(), roomDescription))
+                            backstack.push(
+                                NavTarget.Room(
+                                    roomIdOrAlias = roomDescription.roomId.toRoomIdOrAlias(),
+                                    roomDescription = roomDescription,
+                                    trigger = JoinedRoom.Trigger.RoomDirectory,
+                                )
+                            )
                         }
                     })
                     .build()
@@ -379,7 +391,12 @@ class LoggedInFlowNode @AssistedInject constructor(
         }
     }
 
-    suspend fun attachRoom(roomIdOrAlias: RoomIdOrAlias, eventId: EventId? = null) {
+    suspend fun attachRoom(
+        roomIdOrAlias: RoomIdOrAlias,
+        serverNames: List<String> = emptyList(),
+        trigger: JoinedRoom.Trigger? = null,
+        eventId: EventId? = null,
+    ) {
         waitForNavTargetAttached { navTarget ->
             navTarget is NavTarget.RoomList
         }
@@ -387,6 +404,8 @@ class LoggedInFlowNode @AssistedInject constructor(
             backstack.push(
                 NavTarget.Room(
                     roomIdOrAlias = roomIdOrAlias,
+                    serverNames = serverNames,
+                    trigger = trigger,
                     initialElement = RoomNavigationTarget.Messages(
                         focusedEventId = eventId
                     )

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -34,6 +34,7 @@ import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.anvilannotations.ContributesNode
 import io.element.android.appnav.di.MatrixClientsHolder
 import io.element.android.appnav.intent.IntentResolver
@@ -295,6 +296,8 @@ class RootFlowNode @AssistedInject constructor(
                     is PermalinkData.RoomLink -> {
                         attachRoom(
                             roomIdOrAlias = permalinkData.roomIdOrAlias,
+                            trigger = JoinedRoom.Trigger.MobilePermalink,
+                            serverNames = permalinkData.viaParameters,
                             eventId = permalinkData.eventId,
                         )
                     }

--- a/changelog.d/2843.misc
+++ b/changelog.d/2843.misc
@@ -1,0 +1,1 @@
+Use via parameters when joining a room from permalink.

--- a/features/invite/api/build.gradle.kts
+++ b/features/invite/api/build.gradle.kts
@@ -25,4 +25,5 @@ android {
 dependencies {
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)
+    implementation(projects.services.analytics.api)
 }

--- a/features/joinroom/api/build.gradle.kts
+++ b/features/joinroom/api/build.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)
     implementation(projects.features.roomdirectory.api)
+    implementation(projects.services.analytics.api)
 }

--- a/features/joinroom/api/src/main/kotlin/io/element/android/features/joinroom/api/JoinRoomEntryPoint.kt
+++ b/features/joinroom/api/src/main/kotlin/io/element/android/features/joinroom/api/JoinRoomEntryPoint.kt
@@ -18,6 +18,7 @@ package io.element.android.features.joinroom.api
 
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.features.roomdirectory.api.RoomDescription
 import io.element.android.libraries.architecture.FeatureEntryPoint
 import io.element.android.libraries.architecture.NodeInputs
@@ -32,5 +33,7 @@ interface JoinRoomEntryPoint : FeatureEntryPoint {
         val roomId: RoomId,
         val roomIdOrAlias: RoomIdOrAlias,
         val roomDescription: Optional<RoomDescription>,
+        val serverNames: List<String>,
+        val trigger: JoinedRoom.Trigger,
     ) : NodeInputs
 }

--- a/features/joinroom/impl/build.gradle.kts
+++ b/features/joinroom/impl/build.gradle.kts
@@ -44,9 +44,10 @@ dependencies {
     implementation(projects.libraries.matrix.api)
     implementation(projects.libraries.matrixui)
     implementation(projects.libraries.designsystem)
+    implementation(projects.libraries.uiStrings)
     implementation(projects.features.invite.api)
     implementation(projects.features.roomdirectory.api)
-    implementation(projects.libraries.uiStrings)
+    implementation(projects.services.analytics.api)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomNode.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomNode.kt
@@ -41,6 +41,8 @@ class JoinRoomNode @AssistedInject constructor(
         inputs.roomId,
         inputs.roomIdOrAlias,
         inputs.roomDescription,
+        inputs.serverNames,
+        inputs.trigger,
     )
 
     @Composable
@@ -49,6 +51,7 @@ class JoinRoomNode @AssistedInject constructor(
         JoinRoomView(
             state = state,
             onBackPressed = ::navigateUp,
+            onJoinSuccess = ::navigateUp,
             onKnockSuccess = ::navigateUp,
             modifier = modifier
         )

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomState.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomState.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.matrix.ui.model.InviteSender
 data class JoinRoomState(
     val contentState: ContentState,
     val acceptDeclineInviteState: AcceptDeclineInviteState,
+    val joinAction: AsyncAction<Unit>,
     val knockAction: AsyncAction<Unit>,
     val applicationName: String,
     val eventSink: (JoinRoomEvents) -> Unit

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomStateProvider.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomStateProvider.kt
@@ -125,11 +125,13 @@ fun aLoadedContentState(
 fun aJoinRoomState(
     contentState: ContentState = aLoadedContentState(),
     acceptDeclineInviteState: AcceptDeclineInviteState = anAcceptDeclineInviteState(),
+    joinAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     knockAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     eventSink: (JoinRoomEvents) -> Unit = {}
 ) = JoinRoomState(
     contentState = contentState,
     acceptDeclineInviteState = acceptDeclineInviteState,
+    joinAction = joinAction,
     knockAction = knockAction,
     applicationName = "AppName",
     eventSink = eventSink

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomView.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomView.kt
@@ -66,6 +66,7 @@ import io.element.android.libraries.ui.strings.CommonStrings
 fun JoinRoomView(
     state: JoinRoomState,
     onBackPressed: () -> Unit,
+    onJoinSuccess: () -> Unit,
     onKnockSuccess: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -108,7 +109,11 @@ fun JoinRoomView(
             }
         )
     }
-
+    AsyncActionView(
+        async = state.joinAction,
+        onSuccess = { onJoinSuccess() },
+        onErrorDismiss = { state.eventSink(JoinRoomEvents.ClearError) },
+    )
     AsyncActionView(
         async = state.knockAction,
         onSuccess = { onKnockSuccess() },
@@ -323,6 +328,7 @@ internal fun JoinRoomViewPreview(@PreviewParameter(JoinRoomStateProvider::class)
     JoinRoomView(
         state = state,
         onBackPressed = { },
+        onJoinSuccess = { },
         onKnockSuccess = { },
     )
 }

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
@@ -19,6 +19,7 @@ package io.element.android.features.joinroom.impl.di
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.joinroom.impl.JoinRoomPresenter
 import io.element.android.features.roomdirectory.api.RoomDescription
@@ -28,6 +29,7 @@ import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
+import io.element.android.libraries.matrix.api.room.join.JoinRoom
 import java.util.Optional
 
 @Module
@@ -36,6 +38,7 @@ object JoinRoomModule {
     @Provides
     fun providesJoinRoomPresenterFactory(
         client: MatrixClient,
+        joinRoom: JoinRoom,
         knockRoom: KnockRoom,
         acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState>,
         buildMeta: BuildMeta,
@@ -45,12 +48,17 @@ object JoinRoomModule {
                 roomId: RoomId,
                 roomIdOrAlias: RoomIdOrAlias,
                 roomDescription: Optional<RoomDescription>,
+                serverNames: List<String>,
+                trigger: JoinedRoom.Trigger,
             ): JoinRoomPresenter {
                 return JoinRoomPresenter(
                     roomId = roomId,
                     roomIdOrAlias = roomIdOrAlias,
                     roomDescription = roomDescription,
+                    serverNames = serverNames,
+                    trigger = trigger,
                     matrixClient = client,
+                    joinRoom = joinRoom,
                     knockRoom = knockRoom,
                     acceptDeclineInvitePresenter = acceptDeclineInvitePresenter,
                     buildMeta = buildMeta,

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.joinroom.impl
 
 import com.google.common.truth.Truth.assertThat
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.features.invite.api.response.AcceptDeclineInviteEvents
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.invite.api.response.anAcceptDeclineInviteState
@@ -36,10 +37,12 @@ import io.element.android.libraries.matrix.api.room.preview.RoomPreview
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
+import io.element.android.libraries.matrix.test.A_SERVER_LIST
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.matrix.test.room.aRoomInfo
 import io.element.android.libraries.matrix.test.room.aRoomMember
+import io.element.android.libraries.matrix.test.room.join.FakeJoinRoom
 import io.element.android.libraries.matrix.ui.model.toInviteSender
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.lambda.assert
@@ -170,6 +173,59 @@ class JoinRoomPresenterTest {
                         listOf(value(AcceptDeclineInviteEvents.AcceptInvite(inviteData))),
                         listOf(value(AcceptDeclineInviteEvents.DeclineInvite(inviteData))),
                     )
+            }
+        }
+    }
+
+    @Test
+    fun `present - when room is joined with success, all the parameters are provided`() = runTest {
+        val aTrigger = JoinedRoom.Trigger.MobilePermalink
+        val joinRoomLambda = lambdaRecorder { _: RoomId, _: List<String>, _: JoinedRoom.Trigger ->
+            Result.success(Unit)
+        }
+        val presenter = createJoinRoomPresenter(
+            trigger = aTrigger,
+            serverNames = A_SERVER_LIST,
+            joinRoomLambda = joinRoomLambda,
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().also { state ->
+                state.eventSink(JoinRoomEvents.JoinRoom)
+            }
+            awaitItem().also { state ->
+                assertThat(state.joinAction).isEqualTo(AsyncAction.Loading)
+            }
+            awaitItem().also { state ->
+                assertThat(state.joinAction).isEqualTo(AsyncAction.Success(Unit))
+            }
+            joinRoomLambda.assertions()
+                .isCalledOnce()
+                .with(value(A_ROOM_ID), value(A_SERVER_LIST), value(aTrigger))
+        }
+    }
+
+    @Test
+    fun `present - when room is joined with error, it is possible to clear the error`() = runTest {
+        val presenter = createJoinRoomPresenter(
+            joinRoomLambda = { _, _, _ ->
+                Result.failure(AN_EXCEPTION)
+            },
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().also { state ->
+                state.eventSink(JoinRoomEvents.JoinRoom)
+            }
+            awaitItem().also { state ->
+                assertThat(state.joinAction).isEqualTo(AsyncAction.Loading)
+            }
+            awaitItem().also { state ->
+                assertThat(state.joinAction).isEqualTo(AsyncAction.Failure(AN_EXCEPTION))
+                state.eventSink(JoinRoomEvents.ClearError)
+            }
+            awaitItem().also { state ->
+                assertThat(state.joinAction).isEqualTo(AsyncAction.Uninitialized)
             }
         }
     }
@@ -415,7 +471,12 @@ class JoinRoomPresenterTest {
     private fun createJoinRoomPresenter(
         roomId: RoomId = A_ROOM_ID,
         roomDescription: Optional<RoomDescription> = Optional.empty(),
+        serverNames: List<String> = emptyList(),
+        trigger: JoinedRoom.Trigger = JoinedRoom.Trigger.Invite,
         matrixClient: MatrixClient = FakeMatrixClient(),
+        joinRoomLambda: (RoomId, List<String>, JoinedRoom.Trigger) -> Result<Unit> = { _, _, _ ->
+            Result.success(Unit)
+        },
         knockRoom: KnockRoom = FakeKnockRoom(),
         buildMeta: BuildMeta = aBuildMeta(applicationName = "AppName"),
         acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState> = Presenter { anAcceptDeclineInviteState() }
@@ -424,7 +485,10 @@ class JoinRoomPresenterTest {
             roomId = roomId,
             roomIdOrAlias = roomId.toRoomIdOrAlias(),
             roomDescription = roomDescription,
+            serverNames = serverNames,
+            trigger = trigger,
             matrixClient = matrixClient,
+            joinRoom = FakeJoinRoom(joinRoomLambda),
             knockRoom = knockRoom,
             buildMeta = buildMeta,
             acceptDeclineInvitePresenter = acceptDeclineInvitePresenter

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomViewTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomViewTest.kt
@@ -92,6 +92,34 @@ class JoinRoomViewTest {
     }
 
     @Test
+    fun `clicking on closing Join error emits the expected Event`() {
+        val eventsRecorder = EventsRecorder<JoinRoomEvents>()
+        rule.setJoinRoomView(
+            aJoinRoomState(
+                contentState = aLoadedContentState(joinAuthorisationStatus = JoinAuthorisationStatus.CanKnock),
+                joinAction = AsyncAction.Failure(Exception("Error")),
+                eventSink = eventsRecorder,
+            ),
+        )
+        rule.clickOn(CommonStrings.action_ok)
+        eventsRecorder.assertSingle(JoinRoomEvents.ClearError)
+    }
+
+    @Test
+    fun `when joining room is successful, the expected callback is invoked`() {
+        val eventsRecorder = EventsRecorder<JoinRoomEvents>(expectEvents = false)
+        ensureCalledOnce {
+            rule.setJoinRoomView(
+                aJoinRoomState(
+                    joinAction = AsyncAction.Success(Unit),
+                    eventSink = eventsRecorder,
+                ),
+                onJoinSuccess = it
+            )
+        }
+    }
+
+    @Test
     fun `clicking on Accept invitation IsInvited room emits the expected Event`() {
         val eventsRecorder = EventsRecorder<JoinRoomEvents>()
         rule.setJoinRoomView(
@@ -149,12 +177,14 @@ class JoinRoomViewTest {
 private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setJoinRoomView(
     state: JoinRoomState,
     onBackPressed: () -> Unit = EnsureNeverCalled(),
+    onJoinSuccess: () -> Unit = EnsureNeverCalled(),
     onKnockSuccess: () -> Unit = EnsureNeverCalled(),
 ) {
     setContent {
         JoinRoomView(
             state = state,
             onBackPressed = onBackPressed,
+            onJoinSuccess = onJoinSuccess,
             onKnockSuccess = onKnockSuccess,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
@@ -47,6 +47,7 @@ import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.di.RoomScope
+import io.element.android.libraries.matrix.api.analytics.toAnalyticsViewRoom
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.UserId
@@ -57,7 +58,6 @@ import io.element.android.libraries.matrix.api.room.alias.matches
 import io.element.android.libraries.matrix.api.timeline.item.TimelineItemDebugInfo
 import io.element.android.libraries.mediaplayer.api.MediaPlayer
 import io.element.android.services.analytics.api.AnalyticsService
-import io.element.android.services.analytics.api.extensions.toAnalyticsViewRoom
 import kotlinx.collections.immutable.ImmutableList
 
 @ContributesNode(RoomScope::class)

--- a/features/roomaliasresolver/api/src/main/kotlin/io/element/android/features/roomaliasesolver/api/RoomAliasResolverEntryPoint.kt
+++ b/features/roomaliasresolver/api/src/main/kotlin/io/element/android/features/roomaliasesolver/api/RoomAliasResolverEntryPoint.kt
@@ -22,7 +22,7 @@ import com.bumble.appyx.core.plugin.Plugin
 import io.element.android.libraries.architecture.FeatureEntryPoint
 import io.element.android.libraries.architecture.NodeInputs
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 
 interface RoomAliasResolverEntryPoint : FeatureEntryPoint {
     fun nodeBuilder(parentNode: Node, buildContext: BuildContext): NodeBuilder
@@ -34,7 +34,7 @@ interface RoomAliasResolverEntryPoint : FeatureEntryPoint {
     }
 
     interface Callback : Plugin {
-        fun onAliasResolved(roomId: RoomId)
+        fun onAliasResolved(data: ResolvedRoomAlias)
     }
 
     data class Params(

--- a/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverNode.kt
+++ b/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverNode.kt
@@ -28,7 +28,7 @@ import io.element.android.anvilannotations.ContributesNode
 import io.element.android.features.roomaliasesolver.api.RoomAliasResolverEntryPoint
 import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 
 @ContributesNode(SessionScope::class)
 class RoomAliasResolverNode @AssistedInject constructor(
@@ -42,8 +42,8 @@ class RoomAliasResolverNode @AssistedInject constructor(
         inputs.roomAlias
     )
 
-    private fun onAliasResolved(roomId: RoomId) {
-        plugins<RoomAliasResolverEntryPoint.Callback>().forEach { it.onAliasResolved(roomId) }
+    private fun onAliasResolved(data: ResolvedRoomAlias) {
+        plugins<RoomAliasResolverEntryPoint.Callback>().forEach { it.onAliasResolved(data) }
     }
 
     @Composable

--- a/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenter.kt
+++ b/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenter.kt
@@ -29,7 +29,7 @@ import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.runCatchingUpdatingState
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -46,7 +46,7 @@ class RoomAliasResolverPresenter @AssistedInject constructor(
     @Composable
     override fun present(): RoomAliasResolverState {
         val coroutineScope = rememberCoroutineScope()
-        val resolveState: MutableState<AsyncData<RoomId>> = remember { mutableStateOf(AsyncData.Uninitialized) }
+        val resolveState: MutableState<AsyncData<ResolvedRoomAlias>> = remember { mutableStateOf(AsyncData.Uninitialized) }
         LaunchedEffect(Unit) {
             resolveAlias(resolveState)
         }
@@ -64,7 +64,7 @@ class RoomAliasResolverPresenter @AssistedInject constructor(
         )
     }
 
-    private fun CoroutineScope.resolveAlias(resolveState: MutableState<AsyncData<RoomId>>) = launch {
+    private fun CoroutineScope.resolveAlias(resolveState: MutableState<AsyncData<ResolvedRoomAlias>>) = launch {
         suspend {
             matrixClient.resolveRoomAlias(roomAlias).getOrThrow()
         }.runCatchingUpdatingState(resolveState)

--- a/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverStateProvider.kt
+++ b/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverStateProvider.kt
@@ -19,7 +19,7 @@ package io.element.android.features.roomaliasresolver.impl
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 
 open class RoomAliasResolverStateProvider : PreviewParameterProvider<RoomAliasResolverState> {
     override val values: Sequence<RoomAliasResolverState>
@@ -36,7 +36,7 @@ open class RoomAliasResolverStateProvider : PreviewParameterProvider<RoomAliasRe
 
 fun aRoomAliasResolverState(
     roomAlias: RoomAlias = A_ROOM_ALIAS,
-    resolveState: AsyncData<RoomId> = AsyncData.Uninitialized,
+    resolveState: AsyncData<ResolvedRoomAlias> = AsyncData.Uninitialized,
     eventSink: (RoomAliasResolverEvents) -> Unit = {}
 ) = RoomAliasResolverState(
     roomAlias = roomAlias,

--- a/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverView.kt
+++ b/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverView.kt
@@ -49,14 +49,14 @@ import io.element.android.libraries.designsystem.theme.components.ButtonSize
 import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
-import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun RoomAliasResolverView(
     state: RoomAliasResolverState,
     onBackPressed: () -> Unit,
-    onAliasResolved: (RoomId) -> Unit,
+    onAliasResolved: (ResolvedRoomAlias) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val latestOnAliasResolved by rememberUpdatedState(onAliasResolved)

--- a/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenterTest.kt
+++ b/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenterTest.kt
@@ -22,9 +22,12 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomAlias
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_ROOM_ALIAS
 import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SERVER_LIST
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.tests.testutils.WarmUpRule
 import kotlinx.coroutines.test.runTest
@@ -48,8 +51,9 @@ class RoomAliasResolverPresenterTest {
 
     @Test
     fun `present - resolve alias to roomId`() = runTest {
+        val result = aResolvedRoomAlias()
         val client = FakeMatrixClient(
-            resolveRoomAliasResult = { Result.success(A_ROOM_ID) }
+            resolveRoomAliasResult = { Result.success(result) }
         )
         val presenter = createPresenter(matrixClient = client)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -59,7 +63,7 @@ class RoomAliasResolverPresenterTest {
             assertThat(awaitItem().resolveState.isLoading()).isTrue()
             val resultState = awaitItem()
             assertThat(resultState.roomAlias).isEqualTo(A_ROOM_ALIAS)
-            assertThat(resultState.resolveState.dataOrNull()).isEqualTo(A_ROOM_ID)
+            assertThat(resultState.resolveState.dataOrNull()).isEqualTo(result)
         }
     }
 
@@ -92,3 +96,11 @@ class RoomAliasResolverPresenterTest {
         matrixClient = matrixClient,
     )
 }
+
+internal fun aResolvedRoomAlias(
+    roomId: RoomId = A_ROOM_ID,
+    servers: List<String> = A_SERVER_LIST,
+) = ResolvedRoomAlias(
+    roomId = roomId,
+    servers = servers,
+)

--- a/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverViewTest.kt
+++ b/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverViewTest.kt
@@ -21,8 +21,7 @@ import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.libraries.architecture.AsyncData
-import io.element.android.libraries.matrix.api.core.RoomId
-import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
@@ -69,11 +68,12 @@ class RoomAliasResolverViewTest {
 
     @Test
     fun `success state invokes the expected Callback`() {
+        val result = aResolvedRoomAlias()
         val eventsRecorder = EventsRecorder<RoomAliasResolverEvents>(expectEvents = false)
-        ensureCalledOnceWithParam(A_ROOM_ID) {
+        ensureCalledOnceWithParam(result) {
             rule.setRoomAliasResolverView(
                 aRoomAliasResolverState(
-                    resolveState = AsyncData.Success(A_ROOM_ID),
+                    resolveState = AsyncData.Success(result),
                     eventSink = eventsRecorder,
                 ),
                 onAliasResolved = it,
@@ -85,7 +85,7 @@ class RoomAliasResolverViewTest {
 private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setRoomAliasResolverView(
     state: RoomAliasResolverState,
     onBackPressed: () -> Unit = EnsureNeverCalled(),
-    onAliasResolved: (RoomId) -> Unit = EnsureNeverCalledWithParam(),
+    onAliasResolved: (ResolvedRoomAlias) -> Unit = EnsureNeverCalledWithParam(),
 ) {
     setContent {
         RoomAliasResolverView(

--- a/features/roomdirectory/impl/build.gradle.kts
+++ b/features/roomdirectory/impl/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.uiStrings)
     implementation(projects.libraries.testtags)
+    implementation(projects.services.analytics.api)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.androidx.compose.ui.test.junit)

--- a/libraries/matrix/api/build.gradle.kts
+++ b/libraries/matrix/api/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.dagger)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
+    implementation(projects.services.analytics.api)
     implementation(libs.serialization.json)
     api(projects.libraries.sessionStorage.api)
     implementation(libs.coroutines.core)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.matrix.api.room.preview.RoomPreview
 import io.element.android.libraries.matrix.api.roomdirectory.RoomDirectoryService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
@@ -66,6 +67,7 @@ interface MatrixClient : Closeable {
     suspend fun uploadAvatar(mimeType: String, data: ByteArray): Result<Unit>
     suspend fun removeAvatar(): Result<Unit>
     suspend fun joinRoom(roomId: RoomId): Result<Unit>
+    suspend fun joinRoomByIdOrAlias(roomId: RoomId, serverNames: List<String>): Result<Unit>
     suspend fun knockRoom(roomId: RoomId): Result<Unit>
     fun syncService(): SyncService
     fun sessionVerificationService(): SessionVerificationService
@@ -102,6 +104,6 @@ interface MatrixClient : Closeable {
 
     suspend fun trackRecentlyVisitedRoom(roomId: RoomId): Result<Unit>
     suspend fun getRecentlyVisitedRooms(): Result<List<RoomId>>
-    suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<RoomId>
+    suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<ResolvedRoomAlias>
     suspend fun getRoomPreview(roomIdOrAlias: RoomIdOrAlias): Result<RoomPreview>
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/analytics/ViewRoomExt.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/analytics/ViewRoomExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package io.element.android.services.analytics.api.extensions
+package io.element.android.libraries.matrix.api.analytics
 
 import im.vector.app.features.analytics.plan.ViewRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 
-fun MatrixRoom.toAnalyticsViewRoom(trigger: ViewRoom.Trigger? = null, selectedSpace: MatrixRoom? = null, viaKeyboard: Boolean? = null): ViewRoom {
+fun MatrixRoom.toAnalyticsViewRoom(
+    trigger: ViewRoom.Trigger? = null,
+    selectedSpace: MatrixRoom? = null,
+    viaKeyboard: Boolean? = null,
+): ViewRoom {
     val activeSpace = selectedSpace?.toActiveSpace() ?: ViewRoom.ActiveSpace.Home
 
     return ViewRoom(

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/alias/ResolvedRoomAlias.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/alias/ResolvedRoomAlias.kt
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-package io.element.android.features.roomdirectory.impl.root
+package io.element.android.libraries.matrix.api.room.alias
 
-import io.element.android.features.roomdirectory.impl.root.di.JoinRoom
 import io.element.android.libraries.matrix.api.core.RoomId
 
-class FakeJoinRoom(
-    var lambda: (RoomId) -> Result<Unit> = { Result.success(Unit) }
-) : JoinRoom {
-    override suspend fun invoke(roomId: RoomId) = lambda(roomId)
-}
+/**
+ * Information about a room, that was resolved from a room alias.
+ */
+data class ResolvedRoomAlias(
+    /**
+     * The room ID that the alias resolved to.
+     */
+    val roomId: RoomId,
+    /**
+     * A list of servers that can be used to find the room by its room ID.
+     */
+    val servers: List<String>
+)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/join/JoinRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/join/JoinRoom.kt
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package io.element.android.features.roomaliasresolver.impl
+package io.element.android.libraries.matrix.api.room.join
 
-import androidx.compose.runtime.Immutable
-import io.element.android.libraries.architecture.AsyncData
-import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
+import im.vector.app.features.analytics.plan.JoinedRoom
+import io.element.android.libraries.matrix.api.core.RoomId
 
-@Immutable
-data class RoomAliasResolverState(
-    val roomAlias: RoomAlias,
-    val resolveState: AsyncData<ResolvedRoomAlias>,
-    val eventSink: (RoomAliasResolverEvents) -> Unit
-)
+interface JoinRoom {
+    suspend operator fun invoke(
+        roomId: RoomId,
+        serverNames: List<String>,
+        trigger: JoinedRoom.Trigger,
+    ): Result<Unit>
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -39,6 +39,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.matrix.api.room.preview.RoomPreview
 import io.element.android.libraries.matrix.api.roomdirectory.RoomDirectoryService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
@@ -443,6 +444,23 @@ class RustMatrixClient(
         }
     }
 
+    override suspend fun joinRoomByIdOrAlias(
+        roomId: RoomId,
+        serverNames: List<String>,
+    ): Result<Unit> = withContext(sessionDispatcher) {
+        runCatching {
+            client.joinRoomByIdOrAlias(
+                roomIdOrAlias = roomId.value,
+                serverNames = serverNames,
+            ).destroy()
+            try {
+                awaitRoom(roomId, 10.seconds)
+            } catch (e: Exception) {
+                Timber.e(e, "Timeout waiting for the room to be available in the room list")
+            }
+        }
+    }
+
     override suspend fun knockRoom(roomId: RoomId): Result<Unit> {
         return Result.failure(NotImplementedError("Not yet implemented"))
     }
@@ -459,9 +477,13 @@ class RustMatrixClient(
         }
     }
 
-    override suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<RoomId> = withContext(sessionDispatcher) {
+    override suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<ResolvedRoomAlias> = withContext(sessionDispatcher) {
         runCatching {
-            client.resolveRoomAlias(roomAlias.value).roomId.let(::RoomId)
+            val result = client.resolveRoomAlias(roomAlias.value)
+            ResolvedRoomAlias(
+                roomId = RoomId(result.roomId),
+                servers = result.servers,
+            )
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/JoinedRoomExt.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/JoinedRoomExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package io.element.android.services.analytics.api.extensions
+package io.element.android.libraries.matrix.impl.analytics
 
 import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 
-fun Long?.toAnalyticsRoomSize(): JoinedRoom.RoomSize {
+private fun Long?.toAnalyticsRoomSize(): JoinedRoom.RoomSize {
     return when (this) {
         null,
         2L -> JoinedRoom.RoomSize.Two

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoom.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.room.join
+
+import com.squareup.anvil.annotations.ContributesBinding
+import im.vector.app.features.analytics.plan.JoinedRoom
+import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.join.JoinRoom
+import io.element.android.libraries.matrix.impl.analytics.toAnalyticsJoinedRoom
+import io.element.android.services.analytics.api.AnalyticsService
+import javax.inject.Inject
+
+@ContributesBinding(SessionScope::class)
+class DefaultJoinRoom @Inject constructor(
+    private val client: MatrixClient,
+    private val analyticsService: AnalyticsService,
+) : JoinRoom {
+    override suspend fun invoke(
+        roomId: RoomId,
+        serverNames: List<String>,
+        trigger: JoinedRoom.Trigger,
+    ): Result<Unit> {
+        return if (serverNames.isEmpty()) {
+            client.joinRoom(roomId)
+        } else {
+            client.joinRoomByIdOrAlias(roomId, serverNames)
+        }.onSuccess {
+            client.getRoom(roomId)?.use { room ->
+                analyticsService.capture(room.toAnalyticsJoinedRoom(trigger))
+            }
+        }
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoomTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoomTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.room.join
+
+import com.google.common.truth.Truth.assertThat
+import im.vector.app.features.analytics.plan.JoinedRoom
+import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.impl.analytics.toAnalyticsJoinedRoom
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SERVER_LIST
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import io.element.android.services.analytics.test.FakeAnalyticsService
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultJoinRoomTest {
+    @Test
+    fun `when there is no server names, the classic join room API is used`() = runTest {
+        val joinRoomLambda = lambdaRecorder { _: RoomId -> Result.success(Unit) }
+        val joinRoomByIdOrAliasLambda = lambdaRecorder { _: RoomId, _: List<String> -> Result.success(Unit) }
+        val roomResult = FakeMatrixRoom()
+        val aTrigger = JoinedRoom.Trigger.MobilePermalink
+        val client: MatrixClient = FakeMatrixClient().also {
+            it.joinRoomLambda = joinRoomLambda
+            it.joinRoomByIdOrAliasLambda = joinRoomByIdOrAliasLambda
+            it.givenGetRoomResult(
+                roomId = A_ROOM_ID,
+                result = roomResult
+            )
+        }
+        val analyticsService = FakeAnalyticsService()
+        val sut = DefaultJoinRoom(
+            client = client,
+            analyticsService = analyticsService,
+        )
+        sut.invoke(A_ROOM_ID, emptyList(), aTrigger)
+        joinRoomByIdOrAliasLambda
+            .assertions()
+            .isNeverCalled()
+        joinRoomLambda
+            .assertions()
+            .isCalledExactly(1)
+            .withSequence(
+                listOf(value(A_ROOM_ID))
+            )
+        assertThat(analyticsService.capturedEvents).containsExactly(
+            roomResult.toAnalyticsJoinedRoom(aTrigger)
+        )
+    }
+
+    @Test
+    fun `when server names are available, joinRoomByIdOrAlias API is used`() = runTest {
+        val joinRoomLambda = lambdaRecorder { _: RoomId -> Result.success(Unit) }
+        val joinRoomByIdOrAliasLambda = lambdaRecorder { _: RoomId, _: List<String> -> Result.success(Unit) }
+        val roomResult = FakeMatrixRoom()
+        val aTrigger = JoinedRoom.Trigger.MobilePermalink
+        val client: MatrixClient = FakeMatrixClient().also {
+            it.joinRoomLambda = joinRoomLambda
+            it.joinRoomByIdOrAliasLambda = joinRoomByIdOrAliasLambda
+            it.givenGetRoomResult(
+                roomId = A_ROOM_ID,
+                result = roomResult
+            )
+        }
+        val analyticsService = FakeAnalyticsService()
+        val sut = DefaultJoinRoom(
+            client = client,
+            analyticsService = analyticsService,
+        )
+        sut.invoke(A_ROOM_ID, A_SERVER_LIST, aTrigger)
+        joinRoomByIdOrAliasLambda
+            .assertions()
+            .isCalledExactly(1)
+            .withSequence(
+                listOf(value(A_ROOM_ID), value(A_SERVER_LIST))
+            )
+        joinRoomLambda
+            .assertions()
+            .isNeverCalled()
+        assertThat(analyticsService.capturedEvents).containsExactly(
+            roomResult.toAnalyticsJoinedRoom(aTrigger)
+        )
+    }
+}

--- a/libraries/matrix/test/build.gradle.kts
+++ b/libraries/matrix/test/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(projects.libraries.matrix.api)
     api(libs.coroutines.core)
     implementation(libs.coroutines.test)
+    implementation(projects.services.analytics.api)
     implementation(projects.tests.testutils)
     implementation(libs.kotlinx.collections.immutable)
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -33,6 +33,7 @@ import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.matrix.api.room.preview.RoomPreview
 import io.element.android.libraries.matrix.api.roomdirectory.RoomDirectoryService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
@@ -76,7 +77,7 @@ class FakeMatrixClient(
     private val encryptionService: FakeEncryptionService = FakeEncryptionService(),
     private val roomDirectoryService: RoomDirectoryService = FakeRoomDirectoryService(),
     private val accountManagementUrlString: Result<String?> = Result.success(null),
-    private val resolveRoomAliasResult: (RoomAlias) -> Result<RoomId> = { Result.success(A_ROOM_ID) },
+    private val resolveRoomAliasResult: (RoomAlias) -> Result<ResolvedRoomAlias> = { Result.success(ResolvedRoomAlias(A_ROOM_ID, emptyList())) },
     private val getRoomPreviewResult: (RoomIdOrAlias) -> Result<RoomPreview> = { Result.failure(AN_EXCEPTION) },
 ) : MatrixClient {
     var setDisplayNameCalled: Boolean = false
@@ -104,6 +105,9 @@ class FakeMatrixClient(
     private var uploadAvatarResult: Result<Unit> = Result.success(Unit)
     private var removeAvatarResult: Result<Unit> = Result.success(Unit)
     var joinRoomLambda: (RoomId) -> Result<Unit> = {
+        Result.success(Unit)
+    }
+    var joinRoomByIdOrAliasLambda: (RoomId, List<String>) -> Result<Unit> = { _, _ ->
         Result.success(Unit)
     }
     var knockRoomLambda: (RoomId) -> Result<Unit> = {
@@ -201,6 +205,10 @@ class FakeMatrixClient(
 
     override suspend fun joinRoom(roomId: RoomId): Result<Unit> = joinRoomLambda(roomId)
 
+    override suspend fun joinRoomByIdOrAlias(roomId: RoomId, serverNames: List<String>): Result<Unit> {
+        return joinRoomByIdOrAliasLambda(roomId, serverNames)
+    }
+
     override suspend fun knockRoom(roomId: RoomId): Result<Unit> = knockRoomLambda(roomId)
 
     override fun sessionVerificationService(): SessionVerificationService = sessionVerificationService
@@ -285,7 +293,7 @@ class FakeMatrixClient(
         return Result.success(Unit)
     }
 
-    override suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<RoomId> = simulateLongTask {
+    override suspend fun resolveRoomAlias(roomAlias: RoomAlias): Result<ResolvedRoomAlias> = simulateLongTask {
         resolveRoomAliasResult(roomAlias)
     }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/TestData.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/TestData.kt
@@ -76,3 +76,5 @@ val A_THROWABLE = Throwable(A_FAILURE_REASON)
 val AN_EXCEPTION = Exception(A_FAILURE_REASON)
 
 const val A_RECOVERY_KEY = "1234 5678"
+
+val A_SERVER_LIST = listOf("server1", "server2")

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/join/FakeJoinRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/join/FakeJoinRoom.kt
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package io.element.android.features.roomdirectory.impl.root.di
+package io.element.android.libraries.matrix.test.room.join
 
-import com.squareup.anvil.annotations.ContributesBinding
-import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.matrix.api.MatrixClient
+import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.libraries.matrix.api.core.RoomId
-import javax.inject.Inject
+import io.element.android.libraries.matrix.api.room.join.JoinRoom
+import io.element.android.tests.testutils.simulateLongTask
 
-interface JoinRoom {
-    suspend operator fun invoke(roomId: RoomId): Result<Unit>
-}
-
-@ContributesBinding(SessionScope::class)
-class DefaultJoinRoom @Inject constructor(private val client: MatrixClient) : JoinRoom {
-    override suspend fun invoke(roomId: RoomId) = client.joinRoom(roomId)
+class FakeJoinRoom(
+    var lambda: (RoomId, List<String>, JoinedRoom.Trigger) -> Result<Unit>
+) : JoinRoom {
+    override suspend fun invoke(
+        roomId: RoomId,
+        serverNames: List<String>,
+        trigger: JoinedRoom.Trigger,
+    ): Result<Unit> = simulateLongTask {
+        lambda(roomId, serverNames, trigger)
+    }
 }

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -50,6 +50,7 @@ import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.timeline.Timeline
+import io.element.android.libraries.matrix.impl.room.join.DefaultJoinRoom
 import io.element.android.libraries.preferences.impl.store.DefaultSessionPreferencesStore
 import io.element.android.libraries.push.test.notifications.FakeNotificationDrawerManager
 import io.element.android.services.analytics.noop.NoopAnalyticsService
@@ -134,7 +135,7 @@ class RoomListScreen(
         ),
         acceptDeclineInvitePresenter = AcceptDeclineInvitePresenter(
             client = matrixClient,
-            analyticsService = NoopAnalyticsService(),
+            joinRoom = DefaultJoinRoom(matrixClient, NoopAnalyticsService()),
             notificationDrawerManager = FakeNotificationDrawerManager(),
         ),
         analyticsService = NoopAnalyticsService(),

--- a/services/analytics/api/build.gradle.kts
+++ b/services/analytics/api/build.gradle.kts
@@ -25,6 +25,5 @@ dependencies {
     api(projects.services.analyticsproviders.api)
     api(projects.services.toolbox.api)
     implementation(libs.coroutines.core)
-    implementation(projects.libraries.matrix.api)
     implementation(projects.libraries.core)
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

The `serverNames` (AKA as via parameter) was not provided to the join room API.

This PR ensure that it is provided by using the new API `joinRoomByIdOrAlias`.

This is centralized in `DefaultJoinRoom`, which is also taking care of the analytics. Previously `AcceptDeclineInvitePresenter` was always used to join a Room and so `JoinedRoom.Trigger.Invite` was always sent to analytics, which was not correct.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Give more chance for the join room to work, if the homerver does not know the RoomId.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

- Join a room using a permalink
- Join a room when invited 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
