### PR TITLE
Fix crash when creating an `EncryptedFile` in Android 6

### DIFF
--- a/changelog.d/2846.bugfix
+++ b/changelog.d/2846.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when trying to create an `EncryptedFile` in Android 6.

--- a/libraries/session-storage/impl/src/main/kotlin/io/element/android/libraries/sessionstorage/impl/di/SessionStorageModule.kt
+++ b/libraries/session-storage/impl/src/main/kotlin/io/element/android/libraries/sessionstorage/impl/di/SessionStorageModule.kt
@@ -35,6 +35,13 @@ object SessionStorageModule {
     fun provideMatrixDatabase(@ApplicationContext context: Context): SessionDatabase {
         val name = "session_database"
         val secretFile = context.getDatabasePath("$name.key")
+
+        // Make sure the parent directory of the key file exists, otherwise it will crash in older Android versions
+        val parentDir = secretFile.parentFile
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs()
+        }
+
         val passphraseProvider = RandomSecretPassphraseProvider(context, secretFile)
         val driver = SqlCipherDriverFactory(passphraseProvider)
             .create(SessionDatabase.Schema, "$name.db", context)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Makes sure the parent directory of the secret key file used for encrypting the session data is created before we try to create the actual key file.

## Motivation and context

Fixes #2846.

## Tests

<!-- Explain how you tested your development -->

- Do a clean install of the app on an Android 6 emulator. If it doesn't crash it's fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 6

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
