### PR TITLE
Restore legacy shrinking configuration for AGP `8.4.x`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,5 +60,5 @@ android.enableBuildConfigAsBytecode=true
 # By default, the plugin applies itself to all subprojects, but we don't want that as it would cause issues with builds using local AARs
 dependency.analysis.autoapply=false
 
-# Disabled new R8 shrinking for local dependencies as it causes issues with release builds
+# Disable new R8 shrinking for local dependencies as it causes issues with release builds
 android.disableMinifyLocalDependenciesForLibraries=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,3 +59,6 @@ android.enableBuildConfigAsBytecode=true
 
 # By default, the plugin applies itself to all subprojects, but we don't want that as it would cause issues with builds using local AARs
 dependency.analysis.autoapply=false
+
+# Disabled new R8 shrinking for local dependencies as it causes issues with release builds
+android.disableMinifyLocalDependenciesForLibraries=false


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Disable the new way of shrinking code added in AGP 8.4.0.

## Motivation and context

It's causing issues with release builds and no changes in proguard rules seem to fix them.

i.e.

```
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/jorge/Developer/Element/element-x-android/app/build/outputs/mapping/gplayRelease/missing_rules.txt.
ERROR: R8: Missing class io.element.android.libraries.designsystem.atomic.atoms.ElementLogoAtomSize (referenced from: void io.element.android.features.ftue.impl.welcome.WelcomeViewKt$WelcomeView$2.invoke(androidx.compose.runtime.Composer, int) and 1 other context)
```

That `missing_rules.txt` files just contains `-dontwarn` entries that do remove the errors while building, but then the classes aren't present in the resulting APK and the app instantly crashes on boot.

Adding `--keep class io.element.android.foo.SomeMissingClass { *; }` does nothing either.

## Tests

We should be able to build nightlies again with this change.

This nightly build flow based on this branch built the apk just fine: https://github.com/element-hq/element-x-android/actions/runs/9124298023/job/25089536772

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
