### PR TITLE
Fix modal contents overlapping screen lock pin #2692

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,6 +138,10 @@
                 android:resource="@xml/file_providers" />
         </provider>
 
+        <activity
+            android:name="io.element.android.features.lockscreen.impl.unlock.activity.PinUnlockActivity"
+            android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"/>
+
     </application>
 
 </manifest>

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -47,9 +47,6 @@ import io.element.android.features.createroom.api.CreateRoomEntryPoint
 import io.element.android.features.ftue.api.FtueEntryPoint
 import io.element.android.features.ftue.api.state.FtueService
 import io.element.android.features.ftue.api.state.FtueState
-import io.element.android.features.lockscreen.api.LockScreenEntryPoint
-import io.element.android.features.lockscreen.api.LockScreenLockState
-import io.element.android.features.lockscreen.api.LockScreenService
 import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.api.NetworkStatus
 import io.element.android.features.preferences.api.PreferencesEntryPoint
@@ -100,8 +97,6 @@ class LoggedInFlowNode @AssistedInject constructor(
     private val coroutineScope: CoroutineScope,
     private val networkMonitor: NetworkMonitor,
     private val ftueService: FtueService,
-    private val lockScreenEntryPoint: LockScreenEntryPoint,
-    private val lockScreenStateService: LockScreenService,
     private val roomDirectoryEntryPoint: RoomDirectoryEntryPoint,
     private val matrixClient: MatrixClient,
     snackbarDispatcher: SnackbarDispatcher,
@@ -111,7 +106,7 @@ class LoggedInFlowNode @AssistedInject constructor(
         savedStateMap = buildContext.savedStateMap,
     ),
     permanentNavModel = PermanentNavModel(
-        navTargets = setOf(NavTarget.LoggedInPermanent, NavTarget.LockPermanent),
+        navTargets = setOf(NavTarget.LoggedInPermanent),
         savedStateMap = buildContext.savedStateMap,
     ),
     buildContext = buildContext,
@@ -190,9 +185,6 @@ class LoggedInFlowNode @AssistedInject constructor(
         data object LoggedInPermanent : NavTarget
 
         @Parcelize
-        data object LockPermanent : NavTarget
-
-        @Parcelize
         data object RoomList : NavTarget
 
         @Parcelize
@@ -234,11 +226,6 @@ class LoggedInFlowNode @AssistedInject constructor(
             NavTarget.Placeholder -> createNode<PlaceholderNode>(buildContext)
             NavTarget.LoggedInPermanent -> {
                 createNode<LoggedInNode>(buildContext)
-            }
-            NavTarget.LockPermanent -> {
-                lockScreenEntryPoint.nodeBuilder(this, buildContext)
-                    .target(LockScreenEntryPoint.Target.Unlock)
-                    .build()
             }
             NavTarget.RoomList -> {
                 val callback = object : RoomListEntryPoint.Callback {
@@ -430,14 +417,10 @@ class LoggedInFlowNode @AssistedInject constructor(
     @Composable
     override fun View(modifier: Modifier) {
         Box(modifier = modifier) {
-            val lockScreenState by lockScreenStateService.lockState.collectAsState()
             val ftueState by ftueService.state.collectAsState()
             BackstackView()
             if (ftueState is FtueState.Complete) {
                 PermanentChild(permanentNavModel = permanentNavModel, navTarget = NavTarget.LoggedInPermanent)
-            }
-            if (lockScreenState == LockScreenLockState.Locked) {
-                PermanentChild(permanentNavModel = permanentNavModel, navTarget = NavTarget.LockPermanent)
             }
         }
     }

--- a/changelog.d/2692.bugfix
+++ b/changelog.d/2692.bugfix
@@ -1,0 +1,1 @@
+Fix modal contents overlapping screen lock pin.

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenter.kt
@@ -29,11 +29,11 @@ import io.element.android.features.lockscreen.impl.biometric.BiometricUnlockMana
 import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.pin.model.PinEntry
 import io.element.android.features.lockscreen.impl.unlock.keypad.PinKeypadModel
+import io.element.android.features.lockscreen.impl.unlock.signout.SignOut
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.runCatchingUpdatingState
 import io.element.android.libraries.core.bool.orFalse
-import io.element.android.libraries.matrix.api.MatrixClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,7 +41,7 @@ import javax.inject.Inject
 class PinUnlockPresenter @Inject constructor(
     private val pinCodeManager: PinCodeManager,
     private val biometricUnlockManager: BiometricUnlockManager,
-    private val matrixClient: MatrixClient,
+    private val signOut: SignOut,
     private val coroutineScope: CoroutineScope,
     private val pinUnlockHelper: PinUnlockHelper,
 ) : Presenter<PinUnlockState> {
@@ -179,7 +179,7 @@ class PinUnlockPresenter @Inject constructor(
 
     private fun CoroutineScope.signOut(signOutAction: MutableState<AsyncData<String?>>) = launch {
         suspend {
-            matrixClient.logout(ignoreSdkError = true)
+            signOut()
         }.runCatchingUpdatingState(signOutAction)
     }
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/activity/PinUnlockActivity.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/activity/PinUnlockActivity.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import io.element.android.compound.theme.ElementTheme
+import io.element.android.features.lockscreen.api.LockScreenLockState
+import io.element.android.features.lockscreen.api.LockScreenService
+import io.element.android.features.lockscreen.impl.unlock.PinUnlockPresenter
+import io.element.android.features.lockscreen.impl.unlock.PinUnlockView
+import io.element.android.features.lockscreen.impl.unlock.di.PinUnlockBindings
+import io.element.android.libraries.architecture.bindings
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class PinUnlockActivity : AppCompatActivity() {
+    companion object {
+        fun newIntent(context: Context): Intent {
+            return Intent(context, PinUnlockActivity::class.java)
+        }
+    }
+
+    @Inject lateinit var presenter: PinUnlockPresenter
+    @Inject lateinit var lockScreenService: LockScreenService
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        bindings<PinUnlockBindings>().inject(this)
+        setContent {
+            ElementTheme {
+                val state = presenter.present()
+                PinUnlockView(state = state, isInAppUnlock = false)
+            }
+        }
+        lifecycleScope.launch {
+            lockScreenService.lockState.collect { state ->
+                if (state == LockScreenLockState.Unlocked) {
+                    finish()
+                }
+            }
+        }
+        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                moveTaskToBack(true)
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+}

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/di/PinUnlockBindings.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/di/PinUnlockBindings.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock.di
+
+import com.squareup.anvil.annotations.ContributesTo
+import io.element.android.features.lockscreen.impl.unlock.activity.PinUnlockActivity
+import io.element.android.libraries.di.AppScope
+
+@ContributesTo(AppScope::class)
+interface PinUnlockBindings {
+    fun inject(activity: PinUnlockActivity)
+}

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/signout/DefaultSignOut.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/signout/DefaultSignOut.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock.signout
+
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.api.MatrixClientProvider
+import io.element.android.libraries.matrix.api.auth.MatrixAuthenticationService
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class DefaultSignOut @Inject constructor(
+    private val authenticationService: MatrixAuthenticationService,
+    private val matrixClientProvider: MatrixClientProvider,
+) : SignOut {
+    override suspend fun invoke(): String? {
+        val currentSession = authenticationService.getLatestSessionId()
+        return if (currentSession != null) {
+            matrixClientProvider.getOrRestore(currentSession)
+                .getOrThrow()
+                .logout(ignoreSdkError = true)
+        } else {
+            error("No session to sign out")
+        }
+    }
+}

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/signout/SignOut.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/signout/SignOut.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock.signout
+
+interface SignOut {
+    suspend operator fun invoke(): String?
+}

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/FakeSignOut.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/FakeSignOut.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock
+
+import io.element.android.features.lockscreen.impl.unlock.signout.SignOut
+import io.element.android.tests.testutils.simulateLongTask
+
+class FakeSignOut(
+    var lambda: () -> String? = { null }
+) : SignOut {
+    override suspend fun invoke(): String? = simulateLongTask {
+        lambda()
+    }
+}

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenterTest.kt
@@ -29,7 +29,6 @@ import io.element.android.features.lockscreen.impl.pin.model.PinEntry
 import io.element.android.features.lockscreen.impl.pin.model.assertText
 import io.element.android.features.lockscreen.impl.unlock.keypad.PinKeypadModel
 import io.element.android.libraries.architecture.AsyncData
-import io.element.android.libraries.matrix.test.FakeMatrixClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -150,7 +149,7 @@ class PinUnlockPresenterTest {
         return PinUnlockPresenter(
             pinCodeManager = pinCodeManager,
             biometricUnlockManager = biometricUnlockManager,
-            matrixClient = FakeMatrixClient(),
+            signOut = FakeSignOut(),
             coroutineScope = scope,
             pinUnlockHelper = PinUnlockHelper(biometricUnlockManager, pinCodeManager),
         )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Extract PinUnlock to a separate Activity so we are sure it's always rendered on top of everything else.
<!-- Describe shortly what has been changed -->

## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/2692
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Setup a pin
- Open a modal content (dialog, bottomsheet)
- Put the app in background
- Open the app 
- You should see only the Pin unlock screen

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
