### PR TITLE
When linkifying HTML messages, give priority to explicit link tags

### DIFF
--- a/changelog.d/2291.bugfix
+++ b/changelog.d/2291.bugfix
@@ -1,0 +1,1 @@
+Make sure explicit links in messages take priority over links found by linkification (urls, emails, phone numbers, etc.)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -268,12 +268,16 @@ class TimelineItemContentMessageFactory @Inject constructor(
         }
         // Find and set as URLSpans any links present in the text
         LinkifyCompat.addLinks(this, Linkify.WEB_URLS or Linkify.PHONE_NUMBERS or Linkify.EMAIL_ADDRESSES)
-        // Restore old spans if they don't conflict with the new ones
+        // Restore old spans, remove new ones if there is a conflict
         for ((urlSpan, location) in oldURLSpans) {
             val (start, end) = location
-            if (getSpans<URLSpan>(start, end).isEmpty()) {
-                setSpan(urlSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            val addedSpans = getSpans<URLSpan>(start, end).orEmpty()
+            if (addedSpans.isNotEmpty()) {
+                for (span in addedSpans) {
+                    removeSpan(span)
+                }
             }
+            setSpan(urlSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
         return this
     }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactoryTest.kt
@@ -16,7 +16,9 @@
 
 package io.element.android.features.messages.impl.timeline.factories.event
 
+import android.net.Uri
 import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.URLSpan
 import androidx.core.text.buildSpannedString
@@ -46,6 +48,7 @@ import io.element.android.libraries.matrix.api.media.ImageInfo
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.media.ThumbnailInfo
 import io.element.android.libraries.matrix.api.media.VideoInfo
+import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EmoteMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.FileMessageType
@@ -641,6 +644,31 @@ class TimelineItemContentMessageFactoryTest {
         assertThat((result as TimelineItemEmoteContent).formattedBody).isEqualTo(SpannableString("* Bob formatted"))
     }
 
+    @Test
+    fun `a message with existing URLSpans keeps it after linkification`() = runTest {
+        val expectedSpanned = SpannableStringBuilder().apply {
+            append("Test ")
+            inSpans(URLSpan("https://www.example.org")) {
+                append("me@matrix.org")
+            }
+        }
+        val sut = createTimelineItemContentMessageFactory(
+            htmlConverterTransform = { expectedSpanned },
+            permalinkParser = FakePermalinkParser { PermalinkData.FallbackLink(Uri.EMPTY) }
+        )
+        val result = sut.create(
+            content = createMessageContent(
+                type = TextMessageType(
+                    body = "Test [me@matrix.org](https://www.example.org)",
+                    formatted = FormattedBody(MessageFormat.HTML, "Test <a href=\"https://www.example.org\">me@matrix.org</a>")
+                )
+            ),
+            senderDisambiguatedDisplayName = "Bob",
+            eventId = AN_EVENT_ID,
+        )
+        assertThat((result as TimelineItemTextContent).formattedBody).isEqualTo(expectedSpanned)
+    }
+
     private fun createMessageContent(
         body: String = "Body",
         inReplyTo: InReplyTo? = null,
@@ -660,12 +688,13 @@ class TimelineItemContentMessageFactoryTest {
     private fun createTimelineItemContentMessageFactory(
         featureFlagService: FeatureFlagService = FakeFeatureFlagService(),
         htmlConverterTransform: (String) -> CharSequence = { it },
+        permalinkParser: FakePermalinkParser = FakePermalinkParser(),
     ) = TimelineItemContentMessageFactory(
         fileSizeFormatter = FakeFileSizeFormatter(),
         fileExtensionExtractor = FileExtensionExtractorWithoutValidation(),
         featureFlagService = featureFlagService,
         htmlConverterProvider = FakeHtmlConverterProvider(htmlConverterTransform),
-        permalinkParser = FakePermalinkParser(),
+        permalinkParser = permalinkParser,
     )
 
     private fun createStickerContent(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- When linkification creates a new link from the HTML contents, remove it if it conflicts with an existing explicit link.

## Motivation and context

Should fix #2291.

The method used for restoring URLSpans removed by the linkification process gave priority to the newly found links instead of the existing links the sender had explicitly set, which is wrong.

Also, it was especially hard to debug because the issue was focused in phone number being linkified and the detection of those phone numbers depend on the region code returned by the `TelephonyManager` service, which will vary from one device to another. It's a lot easier to spot with emails, i.e.

## Tests

<!-- Explain how you tested your development -->

- From EW or some other client, send a message like `[test me@matrix.org](https://example.com)` or its HTML equivalent.
- From the app, open it. It should open `https://example.com`. Previously `me@matrix.org` would get linkified and replace the link to the website.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
