### PR TITLE
Session falsely displayed as 'verified' with no internet connection

### DIFF
--- a/changelog.d/2884.bugfix
+++ b/changelog.d/2884.bugfix
@@ -1,0 +1,1 @@
+Session falsely displayed as 'verified' with no internet connection.

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/root/PreferencesRootPresenter.kt
@@ -74,7 +74,7 @@ class PreferencesRootPresenter @Inject constructor(
         }
 
         // We should display the 'complete verification' option if the current session can be verified
-        val canVerifyUserSession by sessionVerificationService.canVerifySessionFlow.collectAsState(false)
+        val canVerifyUserSession by sessionVerificationService.needsSessionVerification.collectAsState(false)
 
         val showSecureBackupIndicator by indicatorService.showSettingChatBackupIndicator()
 

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTests.kt
@@ -140,7 +140,7 @@ class RoomListPresenterTests {
         }.test {
             val initialState = awaitItem()
             assertThat(initialState.showAvatarIndicator).isTrue()
-            sessionVerificationService.givenCanVerifySession(false)
+            sessionVerificationService.givenNeedsSessionVerification(false)
             encryptionService.emitBackupState(BackupState.ENABLED)
             val finalState = awaitItem()
             assertThat(finalState.showAvatarIndicator).isFalse()
@@ -282,7 +282,7 @@ class RoomListPresenterTests {
             roomListService = roomListService,
             encryptionService = encryptionService,
             sessionVerificationService = FakeSessionVerificationService().apply {
-                givenCanVerifySession(false)
+                givenNeedsSessionVerification(false)
             },
             syncService = FakeSyncService(initialState = SyncState.Running)
         )

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionPresenter.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionPresenter.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import com.freeletics.flowredux.compose.rememberStateAndDispatch
 import io.element.android.features.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.architecture.AsyncData
@@ -61,7 +60,7 @@ class VerifySelfSessionPresenter @Inject constructor(
         val recoveryState by encryptionService.recoveryStateStateFlow.collectAsState()
         val stateAndDispatch = stateMachine.rememberStateAndDispatch()
         val skipVerification by sessionPreferencesStore.isSessionVerificationSkipped().collectAsState(initial = false)
-        val needsVerification by sessionVerificationService.canVerifySessionFlow.collectAsState(initial = true)
+        val needsVerification by sessionVerificationService.needsSessionVerification.collectAsState(initial = true)
         val verificationFlowStep by remember {
             derivedStateOf {
                 when {

--- a/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionPresenterTests.kt
+++ b/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionPresenterTests.kt
@@ -296,8 +296,7 @@ class VerifySelfSessionPresenterTests {
     @Test
     fun `present - When verification is not needed, the flow is completed`() = runTest {
         val service = FakeSessionVerificationService().apply {
-            givenCanVerifySession(false)
-            givenIsReady(true)
+            givenNeedsSessionVerification(false)
             givenVerifiedStatus(SessionVerifiedStatus.Verified)
             givenVerificationFlowState(VerificationFlowState.Finished)
         }

--- a/libraries/indicator/impl/src/main/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorService.kt
+++ b/libraries/indicator/impl/src/main/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorService.kt
@@ -38,7 +38,7 @@ class DefaultIndicatorService @Inject constructor(
 ) : IndicatorService {
     @Composable
     override fun showRoomListTopBarIndicator(): State<Boolean> {
-        val canVerifySession by sessionVerificationService.canVerifySessionFlow.collectAsState(initial = false)
+        val canVerifySession by sessionVerificationService.needsSessionVerification.collectAsState(initial = false)
         val settingChatBackupIndicator = showSettingChatBackupIndicator()
 
         return remember {

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
@@ -39,7 +39,7 @@ interface SessionVerificationService {
     val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus>
 
     /**
-     * Returns whether the current session needs to be verified and the SDK is ready to start the verification.
+     * Returns whether the current session needs to be verified.
      */
     val canVerifySessionFlow: Flow<Boolean>
 

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/verification/SessionVerificationService.kt
@@ -27,12 +27,6 @@ interface SessionVerificationService {
     val verificationFlowState: StateFlow<VerificationFlowState>
 
     /**
-     * The internal service that checks verification can only run after the initial sync.
-     * This [StateFlow] will notify consumers when the service is ready to be used.
-     */
-    val isReady: StateFlow<Boolean>
-
-    /**
      * Returns whether the current verification status is either: [SessionVerifiedStatus.Unknown], [SessionVerifiedStatus.NotVerified]
      * or [SessionVerifiedStatus.Verified].
      */
@@ -41,7 +35,7 @@ interface SessionVerificationService {
     /**
      * Returns whether the current session needs to be verified.
      */
-    val canVerifySessionFlow: Flow<Boolean>
+    val needsSessionVerification: Flow<Boolean>
 
     /**
      * Request verification of the current session.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
@@ -30,8 +30,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -82,8 +82,8 @@ class RustSessionVerificationService(
 
     override val isReady = isSyncServiceReady.stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
 
-    override val canVerifySessionFlow = combine(sessionVerifiedStatus, isReady) { verificationStatus, isReady ->
-        isReady && verificationStatus == SessionVerifiedStatus.NotVerified
+    override val canVerifySessionFlow = sessionVerifiedStatus.map { verificationStatus ->
+        verificationStatus == SessionVerifiedStatus.NotVerified
     }
 
     init {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
@@ -80,9 +80,13 @@ class RustSessionVerificationService(
     private val _sessionVerifiedStatus = MutableStateFlow<SessionVerifiedStatus>(SessionVerifiedStatus.Unknown)
     override val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus> = _sessionVerifiedStatus.asStateFlow()
 
-    override val isReady = isSyncServiceReady.stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
+    /**
+     * The internal service that checks verification can only run after the initial sync.
+     * This [StateFlow] will notify consumers when the service is ready to be used.
+     */
+    private val isReady = isSyncServiceReady.stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
 
-    override val canVerifySessionFlow = sessionVerifiedStatus.map { verificationStatus ->
+    override val needsSessionVerification = sessionVerifiedStatus.map { verificationStatus ->
         verificationStatus == SessionVerifiedStatus.NotVerified
     }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/verification/FakeSessionVerificationService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/verification/FakeSessionVerificationService.kt
@@ -25,17 +25,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class FakeSessionVerificationService : SessionVerificationService {
-    private val _isReady = MutableStateFlow(false)
     private val _sessionVerifiedStatus = MutableStateFlow<SessionVerifiedStatus>(SessionVerifiedStatus.Unknown)
     private var _verificationFlowState = MutableStateFlow<VerificationFlowState>(VerificationFlowState.Initial)
-    private var _canVerifySessionFlow = MutableStateFlow(true)
+    private var _needsSessionVerification = MutableStateFlow(true)
     var shouldFail = false
 
     override val verificationFlowState: StateFlow<VerificationFlowState> = _verificationFlowState
     override val sessionVerifiedStatus: StateFlow<SessionVerifiedStatus> = _sessionVerifiedStatus
-    override val canVerifySessionFlow: Flow<Boolean> = _canVerifySessionFlow
-
-    override val isReady: StateFlow<Boolean> = _isReady
+    override val needsSessionVerification: Flow<Boolean> = _needsSessionVerification
 
     override suspend fun requestVerification() {
         if (!shouldFail) {
@@ -85,12 +82,8 @@ class FakeSessionVerificationService : SessionVerificationService {
         _verificationFlowState.value = state
     }
 
-    fun givenCanVerifySession(canVerify: Boolean) {
-        _canVerifySessionFlow.value = canVerify
-    }
-
-    fun givenIsReady(value: Boolean) {
-        _isReady.value = value
+    fun givenNeedsSessionVerification(needsVerification: Boolean) {
+        _needsSessionVerification.value = needsVerification
     }
 
     override suspend fun reset() {


### PR DESCRIPTION
Remove the need to wait for `isReady` for `SessionVerificationService.canVerifySessionFlow` to fix this.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Remove the need to check whether the sliding sync state is running to have a 'needs to verify' state.

## Motivation and context

When no internet connection was found or the sliding sync process wasn't running, sessions were falsely being displayed in UI as verified although they were unverified.

## Screenshots / GIFs

https://github.com/element-hq/element-x-android/assets/480955/7352db62-a85d-4b2a-93ad-8a09ed9b913c

## Tests

- Log into an account.
- When getting into the 'verify your session' screen, disable every source of internet connection.
- If it doesn't get into the 'device verified' screen, it's working.

I couldn't find any side effects, but it might be worth it double checking those.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
