### PR TITLE
Reaction emoji search / Sending freeform reactions

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesEvents.kt
@@ -22,7 +22,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 
 sealed interface MessagesEvents {
     data class HandleAction(val action: TimelineItemAction, val event: TimelineItem.Event) : MessagesEvents
-    data class ToggleReaction(val emoji: String, val eventId: EventId) : MessagesEvents
+    data class ToggleReaction(val reaction: String, val eventId: EventId) : MessagesEvents
     data class InviteDialogDismissed(val action: InviteDialogAction) : MessagesEvents
     data object Dismiss : MessagesEvents
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesPresenter.kt
@@ -196,7 +196,7 @@ class MessagesPresenter @AssistedInject constructor(
                     )
                 }
                 is MessagesEvents.ToggleReaction -> {
-                    localCoroutineScope.toggleReaction(event.emoji, event.eventId)
+                    localCoroutineScope.toggleReaction(event.reaction, event.eventId)
                 }
                 is MessagesEvents.InviteDialogDismissed -> {
                     hasDismissedInviteDialog = true

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesStateProvider.kt
@@ -27,6 +27,7 @@ import io.element.android.features.messages.impl.timeline.aTimelineItemList
 import io.element.android.features.messages.impl.timeline.aTimelineState
 import io.element.android.features.messages.impl.timeline.components.customreaction.CustomReactionEvents
 import io.element.android.features.messages.impl.timeline.components.customreaction.CustomReactionState
+import io.element.android.features.messages.impl.timeline.components.customreaction.EmojiPickerState
 import io.element.android.features.messages.impl.timeline.components.reactionsummary.ReactionSummaryEvents
 import io.element.android.features.messages.impl.timeline.components.reactionsummary.ReactionSummaryState
 import io.element.android.features.messages.impl.timeline.components.receipt.bottomsheet.ReadReceiptBottomSheetEvents
@@ -42,6 +43,7 @@ import io.element.android.features.messages.impl.voicemessages.composer.aVoiceMe
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.textcomposer.aRichTextEditorState
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
@@ -163,6 +165,7 @@ fun aCustomReactionState(
     target = target,
     selectedEmoji = persistentSetOf(),
     eventSink = eventSink,
+    searchState = EmojiPickerState(false, false, "", SearchBarResultState.Initial()) {}
 )
 
 fun aReadReceiptBottomSheetState(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -72,6 +72,7 @@ import io.element.android.features.messages.impl.messagecomposer.MessageComposer
 import io.element.android.features.messages.impl.timeline.TimelineView
 import io.element.android.features.messages.impl.timeline.components.customreaction.CustomReactionBottomSheet
 import io.element.android.features.messages.impl.timeline.components.customreaction.CustomReactionEvents
+import io.element.android.features.messages.impl.timeline.components.customreaction.CustomReactionState
 import io.element.android.features.messages.impl.timeline.components.reactionsummary.ReactionSummaryEvents
 import io.element.android.features.messages.impl.timeline.components.reactionsummary.ReactionSummaryView
 import io.element.android.features.messages.impl.timeline.components.receipt.bottomsheet.ReadReceiptBottomSheet
@@ -92,6 +93,7 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.components.button.BackButton
 import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
+import io.element.android.libraries.designsystem.modifiers.applyIf
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.BottomSheetDragHandle
@@ -332,7 +334,11 @@ private fun MessagesViewContent(
         modifier = modifier
             .fillMaxSize()
             .navigationBarsPadding()
-            .imePadding(),
+            .applyIf(
+                // Disable imePadding() when reaction picker is open to prevent the chat moving behind the bottom sheet
+                condition = state.customReactionState.target is CustomReactionState.Target.None,
+                ifTrue = { imePadding() }
+            )
     ) {
         AttachmentsBottomSheet(
             state = state.composerState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -258,6 +258,9 @@ fun MessagesView(
         state = state.customReactionState,
         onEmojiSelected = { eventId, emoji ->
             state.eventSink(MessagesEvents.ToggleReaction(emoji.unicode, eventId))
+        },
+        onReactionSelected = { eventId, reaction ->
+            state.eventSink(MessagesEvents.ToggleReaction(reaction, eventId))
         }
     )
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionButton.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessagesReactionButton.kt
@@ -111,12 +111,16 @@ fun MessagesReactionButton(
 
 @Immutable
 sealed interface MessagesReactionsButtonContent {
-    data class Text(val text: String) : MessagesReactionsButtonContent
+    data class Text(val text: String, val highlight: Boolean = false) : MessagesReactionsButtonContent
     data class Icon(@DrawableRes val resourceId: Int) : MessagesReactionsButtonContent
 
     data class Reaction(val reaction: AggregatedReaction) : MessagesReactionsButtonContent
 
-    val isHighlighted get() = this is Reaction && reaction.isHighlighted
+    val isHighlighted get() = when(this) {
+        is Reaction -> reaction.isHighlighted
+        is Text -> highlight
+        else -> false
+    }
 }
 
 internal val REACTION_EMOJI_LINE_HEIGHT = 20.sp

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
@@ -16,13 +16,22 @@
 
 package io.element.android.features.messages.impl.timeline.components.customreaction
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import io.element.android.emojibasebindings.Emoji
+import io.element.android.libraries.androidutils.ui.hideKeyboard
 import io.element.android.libraries.designsystem.theme.components.ModalBottomSheet
 import io.element.android.libraries.designsystem.theme.components.hide
 import io.element.android.libraries.matrix.api.core.EventId
@@ -34,15 +43,18 @@ fun CustomReactionBottomSheet(
     onEmojiSelected: (EventId, Emoji) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = state.searchState.startActive)
     val coroutineScope = rememberCoroutineScope()
     val target = state.target as? CustomReactionState.Target.Success
+    val localView = LocalView.current
 
     fun onDismiss() {
+        localView.hideKeyboard()
         state.eventSink(CustomReactionEvents.DismissCustomReactionSheet)
     }
 
     fun onEmojiSelectedDismiss(emoji: Emoji) {
+        localView.hideKeyboard()
         if (target?.event?.eventId == null) return
         sheetState.hide(coroutineScope) {
             state.eventSink(CustomReactionEvents.DismissCustomReactionSheet)
@@ -55,11 +67,22 @@ fun CustomReactionBottomSheet(
             onDismissRequest = ::onDismiss,
             sheetState = sheetState,
             modifier = modifier
+                .heightIn(min = if (state.searchState.isSearchActive) (LocalConfiguration.current.screenHeightDp).dp else Dp.Unspecified)
+                .pointerInput(state.searchState.isSearchActive) {
+                    awaitEachGesture {
+                        // For any unconsumed pointer event in this sheet, deactivate the search field and hide the keyboard
+                        awaitFirstDown(requireUnconsumed = true)
+                        if (state.searchState.isSearchActive) {
+                            state.searchState.eventSink(EmojiPickerEvents.OnSearchActiveChanged(false))
+                        }
+                    }
+                }
         ) {
             EmojiPicker(
                 onEmojiSelected = ::onEmojiSelectedDismiss,
                 emojibaseStore = target.emojibaseStore,
                 selectedEmojis = state.selectedEmoji,
+                state = state.searchState,
                 modifier = Modifier.fillMaxSize(),
             )
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
@@ -41,6 +41,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 fun CustomReactionBottomSheet(
     state: CustomReactionState,
     onEmojiSelected: (EventId, Emoji) -> Unit,
+    onReactionSelected: (EventId, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = state.searchState.startActive)
@@ -62,6 +63,14 @@ fun CustomReactionBottomSheet(
         }
     }
 
+    fun onReactionSelectedDismiss(reaction: String) {
+        if (target?.event?.eventId == null) return
+        sheetState.hide(coroutineScope) {
+            state.eventSink(CustomReactionEvents.DismissCustomReactionSheet)
+            onReactionSelected(target.event.eventId, reaction)
+        }
+    }
+
     if (target?.emojibaseStore != null && target.event.eventId != null) {
         ModalBottomSheet(
             onDismissRequest = ::onDismiss,
@@ -80,6 +89,7 @@ fun CustomReactionBottomSheet(
         ) {
             EmojiPicker(
                 onEmojiSelected = ::onEmojiSelectedDismiss,
+                onReactionSelected = ::onReactionSelectedDismiss,
                 emojibaseStore = target.emojibaseStore,
                 selectedEmojis = state.selectedEmoji,
                 state = state.searchState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionPresenter.kt
@@ -73,7 +73,7 @@ class CustomReactionPresenter @Inject constructor(
         return CustomReactionState(
             target = target.value,
             selectedEmoji = selectedEmoji,
-            eventSink = { handleEvents(it) },
+            eventSink = ::handleEvents,
             searchState = searchState,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionState.kt
@@ -24,6 +24,7 @@ data class CustomReactionState(
     val target: Target,
     val selectedEmoji: ImmutableSet<String>,
     val eventSink: (CustomReactionEvents) -> Unit,
+    val searchState: EmojiPickerState,
 ) {
     sealed interface Target {
         data object None : Target

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPicker.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPicker.kt
@@ -17,35 +17,61 @@
 package io.element.android.features.messages.impl.timeline.components.customreaction
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.emojibasebindings.Emoji
 import io.element.android.emojibasebindings.EmojibaseCategory
 import io.element.android.emojibasebindings.EmojibaseDatasource
 import io.element.android.emojibasebindings.EmojibaseStore
+import io.element.android.emojibasebindings.allEmojis
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.toSp
+import io.element.android.libraries.designsystem.theme.components.ElementSearchBarDefaults
 import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.designsystem.theme.components.IconButton
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
+import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.ui.strings.CommonStrings
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.launch
@@ -56,54 +82,187 @@ fun EmojiPicker(
     onEmojiSelected: (Emoji) -> Unit,
     emojibaseStore: EmojibaseStore,
     selectedEmojis: ImmutableSet<String>,
+    state: EmojiPickerState,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val categories = remember { emojibaseStore.categories }
     val pagerState = rememberPagerState(pageCount = { EmojibaseCategory.entries.size })
+    val searchFocusRequester = remember { FocusRequester() }
+
     Column(modifier) {
-        SecondaryTabRow(
-            selectedTabIndex = pagerState.currentPage,
-        ) {
-            EmojibaseCategory.entries.forEachIndexed { index, category ->
-                Tab(
-                    icon = {
-                        Icon(
-                            imageVector = category.icon,
-                            contentDescription = stringResource(id = category.title)
-                        )
-                    },
-                    selected = pagerState.currentPage == index,
-                    onClick = {
-                        coroutineScope.launch { pagerState.animateScrollToPage(index) }
+        EmojiPickerSearchBar(
+            query = state.searchQuery,
+            active = state.isSearchActive,
+            onActiveChange = { state.eventSink(EmojiPickerEvents.OnSearchActiveChanged(it)) },
+            onQueryChange = { state.eventSink(EmojiPickerEvents.UpdateSearchQuery(it)) },
+            focusRequester = searchFocusRequester,
+        )
+
+        Column(
+            modifier = Modifier
+                .pointerInput(state.isSearchActive) {
+                    awaitEachGesture {
+                        // For any consumed pointer event in this column, deactivate the search field
+                        awaitFirstDown(requireUnconsumed = false)
+                        if (state.isSearchActive) {
+                            state.eventSink(EmojiPickerEvents.OnSearchActiveChanged(false))
+                        }
                     }
-                )
+                }
+        ) {
+            if (state.searchQuery.isEmpty()) {
+                SecondaryTabRow(
+                    selectedTabIndex = pagerState.currentPage,
+                ) {
+                    EmojibaseCategory.entries.forEachIndexed { index, category ->
+                        Tab(icon = {
+                            Icon(
+                                imageVector = category.icon, contentDescription = stringResource(id = category.title)
+                            )
+                        }, selected = pagerState.currentPage == index, onClick = {
+                            coroutineScope.launch { pagerState.animateScrollToPage(index) }
+                        })
+                    }
+                }
+
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { index ->
+                    val category = EmojibaseCategory.entries[index]
+                    val emojis = categories[category] ?: listOf()
+                    EmojiGrid(emojis = emojis, selectedEmojis = selectedEmojis, onEmojiSelected = onEmojiSelected)
+                }
+            } else {
+                when (state.searchResults) {
+                    is SearchBarResultState.Results<ImmutableList<Emoji>> -> {
+                        EmojiGrid(
+                            emojis = state.searchResults.results,
+                            selectedEmojis = selectedEmojis,
+                            onEmojiSelected = onEmojiSelected,
+                        )
+                    }
+
+                    is SearchBarResultState.NoResultsFound<ImmutableList<Emoji>> -> {
+                        // No results found, show a message
+                        Spacer(Modifier.size(80.dp))
+
+                        Text(
+                            text = stringResource(CommonStrings.common_no_results),
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    else -> {
+                        // Not searching - nothing to show.
+                    }
+                }
             }
         }
+    }
 
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxWidth(),
-        ) { index ->
-            val category = EmojibaseCategory.entries[index]
-            val emojis = categories[category] ?: listOf()
-            LazyVerticalGrid(
-                modifier = Modifier.fillMaxSize(),
-                columns = GridCells.Adaptive(minSize = 48.dp),
-                contentPadding = PaddingValues(vertical = 10.dp, horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp)
-            ) {
-                items(emojis, key = { it.unicode }) { item ->
-                    EmojiItem(
-                        modifier = Modifier.aspectRatio(1f),
-                        item = item,
-                        isSelected = selectedEmojis.contains(item.unicode),
-                        onEmojiSelected = onEmojiSelected,
-                        emojiSize = 32.dp.toSp(),
+    // Automatically open the keyboard if search is active
+    LaunchedEffect(Unit) {
+        if (state.isSearchActive) {
+            searchFocusRequester.requestFocus()
+        }
+    }
+}
+
+@Composable
+private fun EmojiGrid(
+    emojis: List<Emoji>,
+    selectedEmojis: ImmutableSet<String>,
+    onEmojiSelected: (Emoji) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyVerticalGrid(
+        modifier = modifier.fillMaxSize(),
+        columns = GridCells.Adaptive(minSize = 48.dp),
+        contentPadding = PaddingValues(vertical = 10.dp, horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        items(emojis, key = { it.unicode }) { item ->
+            EmojiItem(
+                modifier = Modifier.aspectRatio(1f),
+                item = item,
+                isSelected = selectedEmojis.contains(item.unicode),
+                onEmojiSelected = onEmojiSelected,
+                emojiSize = 32.dp.toSp(),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EmojiPickerSearchBar(
+    query: String,
+    active: Boolean,
+    onActiveChange: (Boolean) -> Unit,
+    onQueryChange: (String) -> Unit,
+    focusRequester: FocusRequester = FocusRequester.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val focusManager = LocalFocusManager.current
+
+    TextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+            .focusRequester(focusRequester)
+            .onFocusChanged { if (it.isFocused) onActiveChange(true) },
+        placeholder = {
+            Text(text = stringResource(CommonStrings.common_search_for_emoji))
+        },
+        trailingIcon = when {
+            query.isNotEmpty() -> {
+                {
+                    IconButton(onClick = {
+                        onQueryChange("")
+                    }) {
+                        Icon(
+                            imageVector = CompoundIcons.Close(),
+                            contentDescription = stringResource(CommonStrings.action_clear),
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                {
+                    Icon(
+                        imageVector = CompoundIcons.Search(),
+                        contentDescription = stringResource(CommonStrings.action_search),
+                        tint = MaterialTheme.colorScheme.tertiary,
                     )
                 }
             }
+        },
+        shape = SearchBarDefaults.inputFieldShape,
+        singleLine = true,
+        colors = (
+            if (active) ElementSearchBarDefaults.activeColors().inputFieldColors
+            else ElementSearchBarDefaults.inactiveColors().inputFieldColors
+            )
+            .copy(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
+        interactionSource = interactionSource,
+    )
+
+    val isFocused = interactionSource.collectIsFocusedAsState().value
+    val shouldClearFocus = !active && isFocused
+    LaunchedEffect(active) {
+        if (shouldClearFocus) {
+            focusManager.clearFocus()
         }
     }
 }
@@ -115,6 +274,50 @@ internal fun EmojiPickerPreview() = ElementPreview {
         onEmojiSelected = {},
         emojibaseStore = EmojibaseDatasource().load(LocalContext.current),
         selectedEmojis = persistentSetOf("😀", "😄", "😃"),
+        state = EmojiPickerState(
+            startActive = false,
+            isSearchActive = false,
+            searchQuery = "",
+            searchResults = SearchBarResultState.Initial(),
+        ) {},
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@PreviewsDayNight
+@Composable
+internal fun EmojiPickerSearchPreview() = ElementPreview {
+    val emojibaseStore = EmojibaseDatasource().load(LocalContext.current)
+    val query = "grin"
+    EmojiPicker(
+        onEmojiSelected = {},
+        emojibaseStore = emojibaseStore,
+        selectedEmojis = persistentSetOf("😀", "😄", "😃"),
+        state = EmojiPickerState(
+            startActive = false,
+            isSearchActive = true,
+            searchQuery = query,
+            searchResults = searchEmojis(query, emojibaseStore.allEmojis)
+        ) {},
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@PreviewsDayNight
+@Composable
+internal fun EmojiPickerSearchNoMatchPreview() = ElementPreview {
+    val emojibaseStore = EmojibaseDatasource().load(LocalContext.current)
+    val query = "this is a very long string that won't match anything"
+    EmojiPicker(
+        onEmojiSelected = {},
+        emojibaseStore = emojibaseStore,
+        selectedEmojis = persistentSetOf("😀", "😄", "😃"),
+        state = EmojiPickerState(
+            startActive = false,
+            isSearchActive = true,
+            searchQuery = query,
+            searchResults = searchEmojis(query, emojibaseStore.allEmojis)
+        ) {},
         modifier = Modifier.fillMaxWidth(),
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerEvents.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerEvents.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.customreaction
+
+sealed interface EmojiPickerEvents {
+    data class OnSearchActiveChanged(val active: Boolean) : EmojiPickerEvents
+    data class UpdateSearchQuery(val query: String) : EmojiPickerEvents
+    data object Reset : EmojiPickerEvents
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerState.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.customreaction
+
+import io.element.android.emojibasebindings.Emoji
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
+import kotlinx.collections.immutable.ImmutableList
+
+data class EmojiPickerState(
+    val startActive: Boolean,
+    val isSearchActive: Boolean,
+    val searchQuery: String,
+    val searchResults: SearchBarResultState<ImmutableList<Emoji>>,
+    val eventSink: (EmojiPickerEvents) -> Unit,
+)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerStatePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerStatePresenter.kt
@@ -72,10 +72,10 @@ class EmojiPickerStatePresenter @Inject constructor(
 }
 
 fun searchEmojis(searchQuery: String, allEmojis: List<Emoji>): SearchBarResultState<List<Emoji>> {
-    if (searchQuery == "")
+    val query = searchQuery.trim()
+    if (query == "")
         return SearchBarResultState.Initial()
 
-    val query = searchQuery.trim()
     val matches = allEmojis.filter { emoji ->
         emoji.unicode == query
             || emoji.label.contains(query, true)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerStatePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/EmojiPickerStatePresenter.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.messages.impl.timeline.components.customreaction
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import io.element.android.emojibasebindings.Emoji
+import io.element.android.emojibasebindings.allEmojis
+import io.element.android.features.preferences.api.store.SessionPreferencesStore
+import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.core.bool.orFalse
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
+import kotlinx.collections.immutable.toImmutableList
+import javax.inject.Inject
+
+class EmojiPickerStatePresenter @Inject constructor(
+    private val emojibaseProvider: EmojibaseProvider,
+    private val sessionPreferencesStore: SessionPreferencesStore,
+) : Presenter<EmojiPickerState> {
+    @Composable
+    override fun present(): EmojiPickerState {
+        val startActive by sessionPreferencesStore.isReactionPickerSearchEnabled().collectAsState(initial = false)
+        var searchQuery by rememberSaveable { mutableStateOf("") }
+        var searchActive by rememberSaveable(startActive) { mutableStateOf(startActive) }
+        val searchResults = remember { mutableStateOf<SearchBarResultState<List<Emoji>>>(SearchBarResultState.Initial()) }
+
+        LaunchedEffect(searchQuery) {
+            searchResults.value = searchEmojis(searchQuery, emojibaseProvider.emojibaseStore.allEmojis)
+        }
+
+        return EmojiPickerState(
+            startActive = startActive,
+            isSearchActive = searchActive,
+            searchQuery = searchQuery,
+            searchResults = searchResults.value,
+            eventSink = {
+                when (it) {
+                    is EmojiPickerEvents.OnSearchActiveChanged -> {
+                        searchActive = it.active
+                    }
+                    is EmojiPickerEvents.UpdateSearchQuery -> {
+                        searchQuery = it.query
+                    }
+                    is EmojiPickerEvents.Reset -> {
+                        searchActive = startActive
+                        searchQuery = ""
+                    }
+                }
+            }
+        )
+    }
+}
+
+fun searchEmojis(searchQuery: String, allEmojis: List<Emoji>): SearchBarResultState<List<Emoji>> {
+    if (searchQuery == "")
+        return SearchBarResultState.Initial()
+
+    val query = searchQuery.trim()
+    val matches = allEmojis.filter { emoji ->
+        emoji.unicode == query
+            || emoji.label.contains(query, true)
+            || emoji.tags?.any { it.contains(query, true) }.orFalse()
+            || emoji.shortcodes.any { it.contains(query, true) }
+    }.toImmutableList()
+
+    return if (matches.isEmpty()) SearchBarResultState.NoResultsFound() else SearchBarResultState.Results(matches)
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/AggregatedReaction.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/AggregatedReaction.kt
@@ -25,7 +25,7 @@ import io.element.android.libraries.matrix.api.core.UserId
  * Reactions can be free text, so we need to limit the length
  * displayed on screen.
  */
-private const val MAX_DISPLAY_CHARS = 16
+internal const val MAX_REACTION_LENGTH_CHARS = 16
 
 /**
  * @property currentUserId the ID of the currently logged in user
@@ -40,10 +40,10 @@ data class AggregatedReaction(
     /**
      * The key to be displayed on screen.
      *
-     * See [MAX_DISPLAY_CHARS].
+     * See [MAX_REACTION_LENGTH_CHARS].
      */
     val displayKey: String by lazy {
-        key.ellipsize(MAX_DISPLAY_CHARS)
+        key.ellipsize(MAX_REACTION_LENGTH_CHARS)
     }
 
     /**

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
@@ -21,6 +21,7 @@ import io.element.android.compound.theme.Theme
 sealed interface AdvancedSettingsEvents {
     data class SetDeveloperModeEnabled(val enabled: Boolean) : AdvancedSettingsEvents
     data class SetSharePresenceEnabled(val enabled: Boolean) : AdvancedSettingsEvents
+    data class SetReactionPickerSearchEnabled(val enabled: Boolean) : AdvancedSettingsEvents
     data object ChangeTheme : AdvancedSettingsEvents
     data object CancelChangeTheme : AdvancedSettingsEvents
     data class SetTheme(val theme: Theme) : AdvancedSettingsEvents

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
@@ -55,6 +55,9 @@ class AdvancedSettingsPresenter @Inject constructor(
         val isSharePresenceEnabled by sessionPreferencesStore
             .isSharePresenceEnabled()
             .collectAsState(initial = true)
+        val isReactionPickerSearchEnabled by sessionPreferencesStore
+            .isReactionPickerSearchEnabled()
+            .collectAsState(initial = true)
         val theme by remember {
             appPreferencesStore.getThemeFlow().mapToTheme()
         }
@@ -124,6 +127,9 @@ class AdvancedSettingsPresenter @Inject constructor(
                 is AdvancedSettingsEvents.SetSharePresenceEnabled -> localCoroutineScope.launch {
                     sessionPreferencesStore.setSharePresence(event.enabled)
                 }
+                is AdvancedSettingsEvents.SetReactionPickerSearchEnabled -> localCoroutineScope.launch {
+                    sessionPreferencesStore.setReactionPickerSearch(event.enabled)
+                }
                 AdvancedSettingsEvents.CancelChangeTheme -> showChangeThemeDialog = false
                 AdvancedSettingsEvents.ChangeTheme -> showChangeThemeDialog = true
                 is AdvancedSettingsEvents.SetTheme -> localCoroutineScope.launch {
@@ -139,6 +145,7 @@ class AdvancedSettingsPresenter @Inject constructor(
         return AdvancedSettingsState(
             isDeveloperModeEnabled = isDeveloperModeEnabled,
             isSharePresenceEnabled = isSharePresenceEnabled,
+            isReactionPickerSearchEnabled = isReactionPickerSearchEnabled,
             theme = theme,
             showChangeThemeDialog = showChangeThemeDialog,
             currentPushDistributor = currentDistributorName,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
@@ -23,6 +23,7 @@ import kotlinx.collections.immutable.ImmutableList
 data class AdvancedSettingsState(
     val isDeveloperModeEnabled: Boolean,
     val isSharePresenceEnabled: Boolean,
+    val isReactionPickerSearchEnabled: Boolean,
     val theme: Theme,
     val showChangeThemeDialog: Boolean,
     val currentPushDistributor: AsyncAction<String>,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
@@ -37,6 +37,7 @@ open class AdvancedSettingsStateProvider : PreviewParameterProvider<AdvancedSett
 fun aAdvancedSettingsState(
     isDeveloperModeEnabled: Boolean = false,
     isSendPublicReadReceiptsEnabled: Boolean = false,
+    isReactionPickerSearchEnabled: Boolean = false,
     showChangeThemeDialog: Boolean = false,
     currentPushDistributor: AsyncAction<String> = AsyncAction.Success("Firebase"),
     availablePushDistributors: List<String> = listOf("Firebase", "ntfy"),
@@ -45,6 +46,7 @@ fun aAdvancedSettingsState(
 ) = AdvancedSettingsState(
     isDeveloperModeEnabled = isDeveloperModeEnabled,
     isSharePresenceEnabled = isSendPublicReadReceiptsEnabled,
+    isReactionPickerSearchEnabled = isReactionPickerSearchEnabled,
     theme = Theme.System,
     showChangeThemeDialog = showChangeThemeDialog,
     currentPushDistributor = currentPushDistributor,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -114,6 +114,18 @@ fun AdvancedSettingsView(
                 }
             }
         )
+        ListItem(
+            headlineContent = {
+                Text(text = stringResource(id = R.string.screen_advanced_settings_reaction_search))
+            },
+            supportingContent = {
+                Text(text = stringResource(id = R.string.screen_advanced_settings_reaction_search_description))
+            },
+            trailingContent = ListItemContent.Switch(
+                checked = state.isReactionPickerSearchEnabled,
+            ),
+            onClick = { state.eventSink(AdvancedSettingsEvents.SetReactionPickerSearchEnabled(!state.isReactionPickerSearchEnabled)) }
+        )
     }
 
     if (state.showChangeThemeDialog) {

--- a/features/preferences/impl/src/main/res/values/localazy.xml
+++ b/features/preferences/impl/src/main/res/values/localazy.xml
@@ -13,6 +13,8 @@
   <string name="screen_advanced_settings_share_presence">"Share presence"</string>
   <string name="screen_advanced_settings_share_presence_description">"If turned off, you won’t be able to send or receive read receipts or typing notifications"</string>
   <string name="screen_advanced_settings_view_source_description">"Enable option to view message source in the timeline."</string>
+  <string name="screen_advanced_settings_reaction_search">"Emoji reaction search"</string>
+  <string name="screen_advanced_settings_reaction_search_description">"Highlight the reaction search box by default when opening the reaction picker"</string>
   <string name="screen_blocked_users_empty">"You have no blocked users"</string>
   <string name="screen_blocked_users_unblock_alert_action">"Unblock"</string>
   <string name="screen_blocked_users_unblock_alert_description">"You\'ll be able to see all messages from them again."</string>

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/features/preferences/api/store/SessionPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/features/preferences/api/store/SessionPreferencesStore.kt
@@ -34,6 +34,9 @@ interface SessionPreferencesStore {
     suspend fun setRenderTypingNotifications(enabled: Boolean)
     fun isRenderTypingNotificationsEnabled(): Flow<Boolean>
 
+    suspend fun setReactionPickerSearch(enabled: Boolean)
+    fun isReactionPickerSearchEnabled(): Flow<Boolean>
+
     suspend fun setSkipSessionVerification(skip: Boolean)
     fun isSessionVerificationSkipped(): Flow<Boolean>
 

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
@@ -49,6 +49,7 @@ class DefaultSessionPreferencesStore(
     private val renderReadReceiptsKey = booleanPreferencesKey("renderReadReceipts")
     private val sendTypingNotificationsKey = booleanPreferencesKey("sendTypingNotifications")
     private val renderTypingNotificationsKey = booleanPreferencesKey("renderTypingNotifications")
+    private val reactionPickerSearchKey = booleanPreferencesKey("reactionPickerSearch")
     private val skipSessionVerification = booleanPreferencesKey("skipSessionVerification")
 
     private val dataStoreFile = storeFile(context, sessionId)
@@ -86,6 +87,9 @@ class DefaultSessionPreferencesStore(
 
     override suspend fun setRenderTypingNotifications(enabled: Boolean) = update(renderTypingNotificationsKey, enabled)
     override fun isRenderTypingNotificationsEnabled(): Flow<Boolean> = get(renderTypingNotificationsKey) { true }
+
+    override suspend fun setReactionPickerSearch(enabled: Boolean) = update(reactionPickerSearchKey, enabled)
+    override fun isReactionPickerSearchEnabled(): Flow<Boolean> = get(reactionPickerSearchKey) { false }
 
     override suspend fun setSkipSessionVerification(skip: Boolean) = update(skipSessionVerification, skip)
     override fun isSessionVerificationSkipped(): Flow<Boolean> = get(skipSessionVerification) { false }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -193,6 +193,7 @@
   <string name="common_saved_changes">"Saved changes"</string>
   <string name="common_saving">"Saving"</string>
   <string name="common_screen_lock">"Screen lock"</string>
+  <string name="common_search_for_emoji">"Search for emoji"</string>
   <string name="common_search_for_someone">"Search for someone"</string>
   <string name="common_search_results">"Search results"</string>
   <string name="common_security">"Security"</string>


### PR DESCRIPTION
Adds a search field to the reaction emoji picker, and also allows sending freeform reactions.
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

## Motivation and context

#1611

This is a pretty opinionated patch, and is likely not in a mergeable state. It's mostly provided as a proof-of-concept/starting point. I've been using this for a few months now and I cannot live without it.

Notable bugs in this implementation are the bottom sheet stalling briefly when the keyboard opens. There is an open bug ticket https://issuetracker.google.com/issues/323792322 and no resolution yet. This happens because the ModalBottomSheet has `imePadding()` unconditionally applied. A fix would be to use a different bottom sheet implementation without that.

## Screenshots / GIFs

Coming soon

## Tests

😰

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
