### PR TITLE
Add public device keys to rageshakes

### DIFF
--- a/changelog.d/2893.misc
+++ b/changelog.d/2893.misc
@@ -1,0 +1,1 @@
+BugReporting | Add public device keys to rageshakes

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -36,6 +36,7 @@ import okhttp3.MultipartReader
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import okio.buffer
 import okio.source
 import org.junit.Test
@@ -102,21 +103,7 @@ class DefaultBugReporterTest {
         server.start()
 
         val mockSessionStore = InMemorySessionStore().apply {
-            storeData(
-                SessionData(
-                    userId = "@foo:eample.com",
-                    deviceId = "ABCDEFGH",
-                    homeserverUrl = "example.com",
-                    accessToken = "AA",
-                    isTokenValid = true,
-                    loginType = LoginType.DIRECT,
-                    loginTimestamp = null,
-                    oidcData = null,
-                    refreshToken = null,
-                    slidingSyncProxy = null,
-                    passphrase = null
-                )
-            )
+            storeData(mockSessionData("@foo:eample.com", "ABCDEFGH"))
         }
 
         val buildMeta = aBuildMeta()
@@ -159,24 +146,7 @@ class DefaultBugReporterTest {
         )
         val request = server.takeRequest()
 
-        val boundary = request.headers["Content-Type"]!!.split("=").last()
-        val foundValues = HashMap<String, String>()
-        request.body.inputStream().source().buffer().use {
-            val multipartReader = MultipartReader(it, boundary)
-            // Just use simple parsing to detect basic properties
-            val regex = "form-data; name=\"(\\w*)\".*".toRegex()
-            multipartReader.use {
-                var part = multipartReader.nextPart()
-                while (part != null) {
-                        part.headers["Content-Disposition"]?.let { contentDisposition ->
-                        regex.find(contentDisposition)?.groupValues?.get(1)?.let { name ->
-                            foundValues.put(name, part!!.body.readUtf8())
-                        }
-                    }
-                    part = multipartReader.nextPart()
-                }
-            }
-        }
+        val foundValues = collectValuesFromFormData(request)
 
         assertThat(foundValues["app"]).isEqualTo("element-x-android")
         assertThat(foundValues["can_contact"]).isEqualTo("true")
@@ -192,6 +162,88 @@ class DefaultBugReporterTest {
         server.shutdown()
     }
 
+    @Test
+    fun `test sendBugReport should not report device_keys if not known`() = runTest {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        server.start()
+
+        val mockSessionStore = InMemorySessionStore().apply {
+            storeData(mockSessionData("@foo:eample.com", null))
+        }
+
+        val buildMeta = aBuildMeta()
+        val fakeEncryptionService = FakeEncryptionService()
+        val matrixClient = FakeMatrixClient(encryptionService = fakeEncryptionService)
+
+        fakeEncryptionService.givenDeviceKeys(null, null)
+        val sut = DefaultBugReporter(
+            context = RuntimeEnvironment.getApplication(),
+            screenshotHolder = FakeScreenshotHolder(),
+            crashDataStore = FakeCrashDataStore(),
+            coroutineDispatchers = testCoroutineDispatchers(),
+            okHttpClient = { OkHttpClient.Builder().build() },
+            userAgentProvider = DefaultUserAgentProvider(buildMeta, FakeSdkMetadata("123456789")),
+            sessionStore = mockSessionStore,
+            buildMeta = buildMeta,
+            bugReporterUrlProvider = { server.url("/") },
+            sdkMetadata = FakeSdkMetadata("123456789"),
+            matrixClientProvider = FakeMatrixClientProvider(getClient = { Result.success(matrixClient) })
+        )
+
+        sut.sendBugReport(
+            withDevicesLogs = true,
+            withCrashLogs = true,
+            withScreenshot = true,
+            theBugDescription = "a bug occurred",
+            canContact = true,
+            listener = null
+        )
+        val request = server.takeRequest()
+
+        val foundValues = collectValuesFromFormData(request)
+        assertThat(foundValues["device_keys"]).isNull()
+        server.shutdown()
+    }
+
+    private fun collectValuesFromFormData(request: RecordedRequest): HashMap<String, String> {
+        val boundary = request.headers["Content-Type"]!!.split("=").last()
+        val foundValues = HashMap<String, String>()
+        request.body.inputStream().source().buffer().use {
+            val multipartReader = MultipartReader(it, boundary)
+            // Just use simple parsing to detect basic properties
+            val regex = "form-data; name=\"(\\w*)\".*".toRegex()
+            multipartReader.use {
+                var part = multipartReader.nextPart()
+                while (part != null) {
+                    part.headers["Content-Disposition"]?.let { contentDisposition ->
+                        regex.find(contentDisposition)?.groupValues?.get(1)?.let { name ->
+                            foundValues.put(name, part!!.body.readUtf8())
+                        }
+                    }
+                    part = multipartReader.nextPart()
+                }
+            }
+        }
+        return foundValues
+    }
+
+    private fun mockSessionData(userId: String, deviceId: String) = SessionData(
+        userId = userId,
+        deviceId = deviceId,
+        homeserverUrl = "example.com",
+        accessToken = "AA",
+        isTokenValid = true,
+        loginType = LoginType.DIRECT,
+        loginTimestamp = null,
+        oidcData = null,
+        refreshToken = null,
+        slidingSyncProxy = null,
+        passphrase = null
+    )
     @Test
     fun `test sendBugReport error`() = runTest {
         val server = MockWebServer()

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -172,7 +172,7 @@ class DefaultBugReporterTest {
         server.start()
 
         val mockSessionStore = InMemorySessionStore().apply {
-            storeData(mockSessionData("@foo:eample.com", null))
+            storeData(mockSessionData("@foo:eample.com", "ABCDEFGH"))
         }
 
         val buildMeta = aBuildMeta()

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -225,7 +225,7 @@ class DefaultBugReporterTest {
         val sut = DefaultBugReporter(
             context = RuntimeEnvironment.getApplication(),
             screenshotHolder = FakeScreenshotHolder(),
-            crashDataStore = FakeCrashDataStore(),
+            crashDataStore = FakeCrashDataStore("I did crash", true),
             coroutineDispatchers = testCoroutineDispatchers(),
             okHttpClient = { OkHttpClient.Builder().build() },
             userAgentProvider = DefaultUserAgentProvider(buildMeta, FakeSdkMetadata("123456789")),
@@ -247,10 +247,11 @@ class DefaultBugReporterTest {
         val request = server.takeRequest()
 
         val foundValues = collectValuesFromFormData(request)
+        println("## FOUND VALUES $foundValues")
         assertThat(foundValues["device_keys"]).isNull()
         assertThat(foundValues["device_id"]).isEqualTo("undefined")
         assertThat(foundValues["user_id"]).isEqualTo("undefined")
-        server.shutdown()
+        assertThat(foundValues["label"]).isEqualTo("crash")
     }
 
     private fun collectValuesFromFormData(request: RecordedRequest): HashMap<String, String> {

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/EncryptionService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/EncryptionService.kt
@@ -50,4 +50,16 @@ interface EncryptionService {
      * Wait for backup upload steady state.
      */
     fun waitForBackupUploadSteadyState(): Flow<BackupUploadState>
+
+    /**
+     * Get the public curve25519 key of our own device in base64. This is usually what is
+     * called the identity key of the device.
+     */
+    suspend fun deviceCurve25519(): String?
+
+    /**
+     * Get the public ed25519 key of our own device. This is usually what is
+     * called the fingerprint of the device.
+     */
+    suspend fun deviceEd25519(): String?
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -190,4 +190,12 @@ internal class RustEncryptionService(
             it.mapRecoveryException()
         }
     }
+
+    override suspend fun deviceCurve25519(): String? {
+        return service.curve25519Key()
+    }
+
+    override suspend fun deviceEd25519(): String? {
+        return service.ed25519Key()
+    }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
@@ -39,6 +39,9 @@ class FakeEncryptionService : EncryptionService {
 
     private var enableBackupsFailure: Exception? = null
 
+    private var curve25519: String? = null
+    private var ed25519: String? = null
+
     fun givenEnableBackupsFailure(exception: Exception?) {
         enableBackupsFailure = exception
     }
@@ -93,6 +96,15 @@ class FakeEncryptionService : EncryptionService {
     override fun waitForBackupUploadSteadyState(): Flow<BackupUploadState> {
         return waitForBackupUploadSteadyStateFlow
     }
+
+    fun givenDeviceKeys(curve25519: String?, ed25519: String?) {
+        this.curve25519 = curve25519
+        this.ed25519 = ed25519
+    }
+
+    override suspend fun deviceCurve25519(): String? = curve25519
+
+    override suspend fun deviceEd25519(): String? = ed25519
 
     suspend fun emitBackupState(state: BackupState) {
         backupStateStateFlow.emit(state)


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-x-android/issues/2857

The `MatrixClientProvider` is now injected into `DefaultBugReporter`, to allow to access to new properties exposed in the `EncrytionService` (`deviceCurve25519()`, `deviceed25519()`)

I added a new test to assert the form data part added in the request by the BugReporter

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
