### PR TITLE
Restore MarkdownTextInput contents

### DIFF
--- a/changelog.d/2896.bugfix
+++ b/changelog.d/2896.bugfix
@@ -1,0 +1,1 @@
+Set auto captilization, multiline and autocompletion flags for the markdown EditText.

--- a/changelog.d/2898.bugfix
+++ b/changelog.d/2898.bugfix
@@ -1,0 +1,1 @@
+Restoree Markdown text input contents when returning to the room screen.

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -62,11 +62,11 @@ import io.element.android.libraries.permissions.api.PermissionsEvents
 import io.element.android.libraries.permissions.api.PermissionsPresenter
 import io.element.android.libraries.textcomposer.mentions.ResolvedMentionSuggestion
 import io.element.android.libraries.textcomposer.mentions.rememberMentionSpanProvider
-import io.element.android.libraries.textcomposer.model.MarkdownTextEditorState
 import io.element.android.libraries.textcomposer.model.Message
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.libraries.textcomposer.model.Suggestion
 import io.element.android.libraries.textcomposer.model.TextEditorState
+import io.element.android.libraries.textcomposer.model.rememberMarkdownTextEditorState
 import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -132,7 +132,7 @@ class MessageComposerPresenter @Inject constructor(
         if (isTesting) {
             richTextEditorState.isReadyToProcessActions = true
         }
-        val markdownTextEditorState = remember { MarkdownTextEditorState(initialText = null, initialFocus = false) }
+        val markdownTextEditorState = rememberMarkdownTextEditorState(initialText = null, initialFocus = false)
 
         var isMentionsEnabled by remember { mutableStateOf(false) }
         LaunchedEffect(Unit) {

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.textcomposer.components.markdown
 
 import android.graphics.Color
 import android.text.Editable
+import android.text.InputType
 import android.text.Selection
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -59,6 +60,10 @@ fun MarkdownTextInput(
                 setPadding(0)
                 setBackgroundColor(Color.TRANSPARENT)
                 setText(state.text.value())
+                inputType = InputType.TYPE_CLASS_TEXT or
+                    InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
+                    InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+                    InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
                 if (canUpdateState) {
                     setSelection(state.selection.first, state.selection.last)
                     setOnFocusChangeListener { _, hasFocus ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Add a `MarkdownTextInputStateSaver` to keep its contents when going to a sub-screen and coming back to it (these are not drafts).
- Also add default text flags for the MD composer.

## Motivation and context

Fixes #2898.
Fixes #2896.

## Screenshots / GIFs

https://github.com/element-hq/element-x-android/assets/480955/11e769ba-0f77-457c-9346-f3e31559f0b4

## Tests

<!-- Explain how you tested your development -->

- Go to any room.
- Type something in the message composer.
- Open another screen (room info, other user's details, call, etc.).
- The unfinished message should be there when you come back to the room screen.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
