### PR TITLE
Fix small issue introduced in #2924.

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiver.kt
@@ -95,8 +95,8 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
 
     private fun handleMarkAsRead(sessionId: SessionId, roomId: RoomId) = appCoroutineScope.launch {
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return@launch
-        val isRenderReadReceiptsEnabled = sessionPreferencesStore.get(sessionId, this).isRenderReadReceiptsEnabled().first()
-        val receiptType = if (isRenderReadReceiptsEnabled) {
+        val isSendPublicReadReceiptsEnabled = sessionPreferencesStore.get(sessionId, this).isSendPublicReadReceiptsEnabled().first()
+        val receiptType = if (isSendPublicReadReceiptsEnabled) {
             ReceiptType.READ
         } else {
             ReceiptType.READ_PRIVATE


### PR DESCRIPTION
This code is not used yet, and also the value will always be the same for the 2 API, but let's use the correct API anyway.