### PR TITLE
Fix grouped notifications only displaying the latest message

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/ActiveNotificationsProvider.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/ActiveNotificationsProvider.kt
@@ -44,7 +44,7 @@ class DefaultActiveNotificationsProvider @Inject constructor(
     }
 
     override fun getNotificationsForSession(sessionId: SessionId): List<StatusBarNotification> {
-        return notificationManager.activeNotifications.filter { it.groupKey == sessionId.value }
+        return notificationManager.activeNotifications.filter { it.notification.group == sessionId.value }
     }
 
     override fun getMembershipNotificationForSession(sessionId: SessionId): List<StatusBarNotification> {

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultActiveNotificationsProviderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultActiveNotificationsProviderTest.kt
@@ -16,8 +16,10 @@
 
 package io.element.android.libraries.push.impl.notifications
 
+import android.app.Notification
 import android.service.notification.StatusBarNotification
 import androidx.core.app.NotificationManagerCompat
+import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
@@ -157,8 +159,8 @@ class DefaultActiveNotificationsProviderTest {
 
     private fun aStatusBarNotification(id: Int, groupId: String, tag: String? = null) = mockk<StatusBarNotification> {
         every { this@mockk.id } returns id
-        every { this@mockk.groupKey } returns groupId
         every { this@mockk.tag } returns tag
+        every { this@mockk.notification } returns Notification.Builder(InstrumentationRegistry.getInstrumentation().targetContext).setGroup(groupId).build()
     }
 
     private fun createActiveNotificationsProvider(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

`DefaultActiveNotificationsProvider.getNotificationsForSession(sessionId)` had a broken logic for checking a notification's group and retrieving notifications from the same session.

## Motivation and context

Fixes broken notifications.

## Tests

<!-- Explain how you tested your development -->

- Receive several notifications from a room.
- If the notification contains all the new messages it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
