### PR TITLE
Make sure the selection in the plain text editor is inside the text bounds

### DIFF
--- a/changelog.d/2959.bugfix
+++ b/changelog.d/2959.bugfix
@@ -1,0 +1,1 @@
+Fix crash when restoring the selection values in the plain text editor.

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
@@ -90,13 +90,15 @@ fun MarkdownTextInput(
                 tag = TestTags.plainTextEditor.value // Needed for UI tests
                 setPadding(0)
                 setBackgroundColor(Color.TRANSPARENT)
-                setText(state.text.value())
+                val text = state.text.value()
+                setText(text)
                 inputType = InputType.TYPE_CLASS_TEXT or
                     InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
                     InputType.TYPE_TEXT_FLAG_MULTI_LINE or
                     InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
                 if (canUpdateState) {
-                    setSelection(state.selection.first, state.selection.last)
+                    val textRange = 0..text.length
+                    setSelection(state.selection.first.coerceIn(textRange), state.selection.last.coerceIn(textRange))
                     setOnFocusChangeListener { _, hasFocus ->
                         state.hasFocus = hasFocus
                     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Coerce the selection to apply to the text inside the text bounds.

## Motivation and context

Fixes a crash seen in the Play Store reports.

## Tests

I'm not entirely sure on how to trigger this, to be honest. It happens on the view creation, so those values have to be broken before any user interaction, and that could only happen on state restoration, when coming back from another screen. However, I tried navigating while selecting some text and it worked fine.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
