### PR TITLE
Notify of ringing call when there's an active call

### DIFF
--- a/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/notification/NotificationDataTest.kt
+++ b/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/notification/NotificationDataTest.kt
@@ -17,9 +17,8 @@
 package io.element.android.libraries.matrix.api.notification
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.libraries.matrix.test.AN_EVENT_ID
-import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.notification.aNotificationData
 import org.junit.Test
 
 class NotificationDataTest {
@@ -48,26 +47,5 @@ class NotificationDataTest {
             senderIsNameAmbiguous = true,
         )
         assertThat(sut.getDisambiguatedDisplayName(A_USER_ID)).isEqualTo("Alice (@alice:server.org)")
-    }
-
-    private fun aNotificationData(
-        senderDisplayName: String?,
-        senderIsNameAmbiguous: Boolean,
-    ): NotificationData {
-        return NotificationData(
-            eventId = AN_EVENT_ID,
-            roomId = A_ROOM_ID,
-            senderAvatarUrl = null,
-            senderDisplayName = senderDisplayName,
-            senderIsNameAmbiguous = senderIsNameAmbiguous,
-            roomAvatarUrl = null,
-            roomDisplayName = null,
-            isDirect = false,
-            isEncrypted = false,
-            isNoisy = false,
-            timestamp = 0L,
-            content = NotificationContent.MessageLike.RoomEncrypted,
-            hasMention = false,
-        )
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notification/NotificationData.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notification/NotificationData.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.test.notification
+
+import io.element.android.libraries.matrix.api.notification.NotificationContent
+import io.element.android.libraries.matrix.api.notification.NotificationData
+import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+
+fun aNotificationData(
+    senderDisplayName: String?,
+    senderIsNameAmbiguous: Boolean,
+): NotificationData {
+    return NotificationData(
+        eventId = AN_EVENT_ID,
+        roomId = A_ROOM_ID,
+        senderAvatarUrl = null,
+        senderDisplayName = senderDisplayName,
+        senderIsNameAmbiguous = senderIsNameAmbiguous,
+        roomAvatarUrl = null,
+        roomDisplayName = null,
+        isDirect = false,
+        isEncrypted = false,
+        isNoisy = false,
+        timestamp = 0L,
+        content = NotificationContent.MessageLike.RoomEncrypted,
+        hasMention = false,
+    )
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.push.impl.notifications
+
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.notification.NotificationContent
+import io.element.android.libraries.matrix.api.notification.NotificationData
+import io.element.android.libraries.matrix.api.timeline.item.event.EventType
+import io.element.android.libraries.push.impl.R
+import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
+import io.element.android.libraries.push.impl.notifications.model.NotifiableRingingCallEvent
+import io.element.android.services.toolbox.api.strings.StringProvider
+import javax.inject.Inject
+
+/**
+ * Helper to resolve a valid [NotifiableEvent] from a [NotificationData].
+ */
+interface CallNotificationEventResolver {
+    /**
+     * Resolve a call notification event from a notification data depending on whether it should be a ringing one or not.
+     * @param sessionId the current session id
+     * @param notificationData the notification data
+     * @param forceNotify `true` to force the notification to be non-ringing, `false` to use the default behaviour. Default is `false`.
+     * @return a [NotifiableEvent] if the notification data is a call notification, null otherwise
+     */
+    fun resolveEvent(sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean = false): NotifiableEvent?
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultCallNotificationEventResolver @Inject constructor(
+    private val stringProvider: StringProvider,
+) : CallNotificationEventResolver {
+    override fun resolveEvent(sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean): NotifiableEvent? {
+        val content = notificationData.content as? NotificationContent.MessageLike.CallNotify ?: return null
+        return notificationData.run {
+            if (NotifiableRingingCallEvent.shouldRing(content.type, timestamp) && !forceNotify) {
+                NotifiableRingingCallEvent(
+                    sessionId = sessionId,
+                    roomId = roomId,
+                    eventId = eventId,
+                    roomName = roomDisplayName,
+                    editedEventId = null,
+                    canBeReplaced = true,
+                    timestamp = this.timestamp,
+                    isRedacted = false,
+                    isUpdated = false,
+                    description = stringProvider.getString(R.string.notification_incoming_call),
+                    senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId),
+                    roomAvatarUrl = roomAvatarUrl,
+                    callNotifyType = content.type,
+                    senderId = content.senderId,
+                    senderAvatarUrl = senderAvatarUrl,
+                )
+            } else {
+                // Create a simple message notification event
+                buildNotifiableMessageEvent(
+                    sessionId = sessionId,
+                    senderId = content.senderId,
+                    roomId = roomId,
+                    eventId = eventId,
+                    noisy = true,
+                    timestamp = this.timestamp,
+                    senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId),
+                    body = "☎️ ${stringProvider.getString(R.string.notification_incoming_call)}",
+                    roomName = roomDisplayName,
+                    roomIsDirect = isDirect,
+                    roomAvatarPath = roomAvatarUrl,
+                    senderAvatarPath = senderAvatarUrl,
+                    type = EventType.CALL_NOTIFY,
+                )
+            }
+        }
+    }
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultOnMissedCallNotificationHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultOnMissedCallNotificationHandler.kt
@@ -18,6 +18,7 @@ package io.element.android.libraries.push.impl.notifications
 
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.api.MatrixClientProvider
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
@@ -26,8 +27,9 @@ import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class DefaultOnMissedCallNotificationHandler @Inject constructor(
+    private val matrixClientProvider: MatrixClientProvider,
     private val defaultNotificationDrawerManager: DefaultNotificationDrawerManager,
-    private val notifiableEventResolver: NotifiableEventResolver,
+    private val callNotificationEventResolver: CallNotificationEventResolver,
 ) : OnMissedCallNotificationHandler {
     override suspend fun addMissedCallNotification(
         sessionId: SessionId,
@@ -35,7 +37,18 @@ class DefaultOnMissedCallNotificationHandler @Inject constructor(
         eventId: EventId,
     ) {
         // Resolve the event and add a notification for it, at this point it should no longer be a ringing one
-        val notifiableEvent = notifiableEventResolver.resolveEvent(sessionId, roomId, eventId)
+        val notificationData = matrixClientProvider.getOrRestore(sessionId).getOrNull()
+            ?.notificationService()
+            ?.getNotification(sessionId, roomId, eventId)
+            ?.getOrNull()
+            ?: return
+
+        val notifiableEvent = callNotificationEventResolver.resolveEvent(
+            sessionId = sessionId,
+            notificationData = notificationData,
+            // Make sure the notifiable event is not a ringing one
+            forceNotify = true,
+        )
         notifiableEvent?.let { defaultNotificationDrawerManager.onNotifiableEventReceived(it) }
     }
 }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -660,6 +660,9 @@ class DefaultNotifiableEventResolverTest {
             notificationMediaRepoFactory = notificationMediaRepoFactory,
             context = context,
             permalinkParser = FakePermalinkParser(),
+            callNotificationEventResolver = DefaultCallNotificationEventResolver(
+                stringProvider = AndroidStringProvider(context.resources)
+            ),
         )
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultOnMissedCallNotificationHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultOnMissedCallNotificationHandlerTest.kt
@@ -19,11 +19,16 @@ package io.element.android.libraries.push.impl.notifications
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.matrix.test.A_USER_NAME
+import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.FakeMatrixClientProvider
+import io.element.android.libraries.matrix.test.notification.FakeNotificationService
+import io.element.android.libraries.matrix.test.notification.aNotificationData
 import io.element.android.libraries.push.impl.notifications.fake.FakeActiveNotificationsProvider
 import io.element.android.libraries.push.impl.notifications.fake.FakeNotificationDataFactory
 import io.element.android.libraries.push.impl.notifications.fake.FakeNotificationDisplayer
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
+import io.element.android.libraries.push.test.notifications.FakeCallNotificationEventResolver
 import io.element.android.libraries.push.test.notifications.FakeImageLoaderHolder
 import io.element.android.services.appnavstate.test.FakeAppNavigationStateService
 import io.element.android.tests.testutils.lambda.lambdaRecorder
@@ -47,7 +52,15 @@ class DefaultOnMissedCallNotificationHandlerTest {
         val dataFactory = FakeNotificationDataFactory(
             messageEventToNotificationsResult = lambdaRecorder { _, _, _ -> emptyList() }
         )
+        // Create a fake matrix client provider that returns a fake matrix client with a fake notification service that returns a valid notification data
+        val matrixClientProvider = FakeMatrixClientProvider(getClient = {
+            val notificationService = FakeNotificationService().apply {
+                givenGetNotificationResult(Result.success(aNotificationData(senderDisplayName = A_USER_NAME, senderIsNameAmbiguous = false)))
+            }
+            Result.success(FakeMatrixClient(notificationService = notificationService))
+        })
         val defaultOnMissedCallNotificationHandler = DefaultOnMissedCallNotificationHandler(
+            matrixClientProvider = matrixClientProvider,
             defaultNotificationDrawerManager = DefaultNotificationDrawerManager(
                 notificationManager = mockk(relaxed = true),
                 notificationRenderer = NotificationRenderer(
@@ -60,7 +73,7 @@ class DefaultOnMissedCallNotificationHandlerTest {
                 imageLoaderHolder = FakeImageLoaderHolder(),
                 activeNotificationsProvider = FakeActiveNotificationsProvider(),
             ),
-            notifiableEventResolver = FakeNotifiableEventResolver(notifiableEventResult = { _, _, _ -> aNotifiableMessageEvent() }),
+            callNotificationEventResolver = FakeCallNotificationEventResolver(resolveEventLambda = { _, _, _ -> aNotifiableMessageEvent() }),
         )
 
         defaultOnMissedCallNotificationHandler.addMissedCallNotification(

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/fixtures/NotifiableEventFixture.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/fixtures/NotifiableEventFixture.kt
@@ -104,7 +104,7 @@ fun aNotifiableMessageEvent(
     type = type,
 )
 
-fun anNotifiableCallEvent(
+fun aNotifiableCallEvent(
     sessionId: SessionId = A_SESSION_ID,
     roomId: RoomId = A_ROOM_ID,
     eventId: EventId = AN_EVENT_ID,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
@@ -37,8 +37,8 @@ import io.element.android.libraries.matrix.test.auth.FakeMatrixAuthenticationSer
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.push.impl.notifications.FakeNotifiableEventResolver
 import io.element.android.libraries.push.impl.notifications.channels.FakeNotificationChannels
+import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableCallEvent
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
-import io.element.android.libraries.push.impl.notifications.fixtures.anNotifiableCallEvent
 import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
 import io.element.android.libraries.push.impl.test.DefaultTestPush
 import io.element.android.libraries.push.impl.troubleshoot.DiagnosticPushHandler
@@ -240,7 +240,7 @@ class DefaultPushHandlerTest {
         val elementCallEntryPoint = FakeElementCallEntryPoint(handleIncomingCallResult = handleIncomingCallLambda)
         val defaultPushHandler = createDefaultPushHandler(
             elementCallEntryPoint = elementCallEntryPoint,
-            notifiableEventResult = { _, _, _ -> anNotifiableCallEvent(callNotifyType = CallNotifyType.RING, timestamp = Instant.now().toEpochMilli()) },
+            notifiableEventResult = { _, _, _ -> aNotifiableCallEvent(callNotifyType = CallNotifyType.RING, timestamp = Instant.now().toEpochMilli()) },
             incrementPushCounterResult = {},
             pushClientSecret = FakePushClientSecret(
                 getUserIdFromSecretResult = { A_USER_ID }

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/FakeCallNotificationEventResolver.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/FakeCallNotificationEventResolver.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.push.test.notifications
+
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.notification.NotificationData
+import io.element.android.libraries.push.impl.notifications.CallNotificationEventResolver
+import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
+
+class FakeCallNotificationEventResolver(
+    var resolveEventLambda: (sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean) -> NotifiableEvent? = { _, _, _ -> null },
+) : CallNotificationEventResolver {
+    override fun resolveEvent(sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean): NotifiableEvent? {
+        return resolveEventLambda(sessionId, notificationData, forceNotify)
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Makes sure the user is notified of a new call even when there is an active call though an 'incoming call' not ringing notification.

## Motivation and context

I forgot this use case.

## Tests

This can be difficult to test since you'll need 3 accounts.

- From account A call account B from a DM (it'll send a ringing notification).
- Quickly, from account C call account B too from a DM.
- An 'incoming call' notification should be displayed.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 14, 13.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
