### PR TITLE
Try to understand what's causing the memory leaks we see in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options="-Xmx3g"
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true --no-daemon
 
 jobs:
   debug:
@@ -41,20 +41,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Assemble debug Gplay APK
+      - name: Assemble debug APKs
         if: ${{ matrix.variant == 'debug' }}
         env:
           ELEMENT_ANDROID_MAPTILER_API_KEY: ${{ secrets.MAPTILER_KEY }}
           ELEMENT_ANDROID_MAPTILER_LIGHT_MAP_ID: ${{ secrets.MAPTILER_LIGHT_MAP_ID }}
           ELEMENT_ANDROID_MAPTILER_DARK_MAP_ID: ${{ secrets.MAPTILER_DARK_MAP_ID }}
-        run: ./gradlew :app:assembleGplayDebug -PallWarningsAsErrors=true $CI_GRADLE_ARG_PROPERTIES
-      - name: Assemble debug Fdroid APK
-        if: ${{ matrix.variant == 'debug' }}
-        env:
-         ELEMENT_ANDROID_MAPTILER_API_KEY: ${{ secrets.MAPTILER_KEY }}
-         ELEMENT_ANDROID_MAPTILER_LIGHT_MAP_ID: ${{ secrets.MAPTILER_LIGHT_MAP_ID }}
-         ELEMENT_ANDROID_MAPTILER_DARK_MAP_ID: ${{ secrets.MAPTILER_DARK_MAP_ID }}
-        run: ./gradlew app:assembleFDroidDebug -PallWarningsAsErrors=true $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:assembleGplayDebug app:assembleFDroidDebug -PallWarningsAsErrors=true $CI_GRADLE_ARG_PROPERTIES
       - name: Upload debug APKs
         if: ${{ matrix.variant == 'debug' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true
 
 jobs:
   debug:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -9,7 +9,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:
   build-apk:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options="-Xmx3g"
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:
   nightly:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 4 * * *"
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -8,7 +8,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx3g" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -9,7 +9,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true
 
 jobs:
   nightlyReports:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8  --no-daemon -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:
   checkScript:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:
   checkScript:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -88,6 +88,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+      - name: Build Gplay Debug
+        run: ./gradlew :app:assembleGplayDebug $CI_GRADLE_ARG_PROPERTIES
+      - name: Build Fdroid Debug
+        run: ./gradlew :app:assembleFdroidDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Run lint
         run: ./gradlew :app:lintGplayDebug :app:lintFdroidDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Upload reports

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -89,9 +89,9 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Build Gplay Debug
-        run: ./gradlew :app:assembleGplayDebug $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:compileGplayDebugKotlin $CI_GRADLE_ARG_PROPERTIES
       - name: Build Fdroid Debug
-        run: ./gradlew :app:assembleFdroidDebug $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:compileFdroidDebugKotlin $CI_GRADLE_ARG_PROPERTIES
       - name: Run lint
         run: ./gradlew :app:lintGplayDebug :app:lintFdroidDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Upload reports

--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -7,7 +7,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx5g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dsonar.gradle.skipCompile=true
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx5g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dsonar.gradle.skipCompile=true
 
 jobs:
   record:

--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -7,7 +7,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx5g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dsonar.gradle.skipCompile=true
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dsonar.gradle.skipCompile=true
 
 jobs:
   record:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --no-daemon -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --no-daemon -Dsonar.gradle.skipCompile=true
 
 jobs:
   gplay:

--- a/.github/workflows/scripts/recordScreenshots.sh
+++ b/.github/workflows/scripts/recordScreenshots.sh
@@ -62,10 +62,10 @@ if [[ -z ${REPO} ]]; then
 fi
 
 echo "Deleting previous screenshots"
-./gradlew removeOldSnapshots --stacktrace -PpreDexEnable=false --max-workers 4 --warn
+./gradlew removeOldSnapshots --stacktrace -PpreDexEnable=false --warn
 
 echo "Record screenshots"
-./gradlew recordPaparazziDebug --stacktrace -PpreDexEnable=false --max-workers 4 --warn
+./gradlew recordPaparazziDebug --stacktrace -PpreDexEnable=false --warn
 
 echo "Committing changes"
 git config http.sslVerify false

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,10 +36,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-      - name: Print free RAM
-        run: free -h
-      - name: Build projects
-        run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
+      - name: Build Gplay Debug
+        run: ./gradlew :app:assembleGplayDebug $CI_GRADLE_ARG_PROPERTIES
+      - name: Build Fdroid Debug
+        run: ./gradlew :app:assembleFdroidDebug $CI_GRADLE_ARG_PROPERTIES
+      - name: Build Sample
+        run: ./gradlew :samples:minimal:assembleDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Build library fixtures
         run: ./gradlew assembleDebug createFullJarDebugTestFixtures $CI_GRADLE_ARG_PROPERTIES
       - name: Build app fixtures

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxMetaspaceSize=512m -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --warn -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:
   sonar:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
   GROUP: ${{ format('sonar-{0}', github.ref) }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,6 +11,7 @@ on:
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxMetaspaceSize=512m -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
+  GROUP: ${{ format('sonar-{0}', github.ref) }}
 
 jobs:
   sonar:
@@ -18,9 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     # Allow all jobs on main and develop. Just one per PR.
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && format('sonar-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('sonar-develop-{0}', github.sha) || format('sonar-{0}', github.ref) }}
-      cancel-in-progress: true
+      group: ${{ format('sonar-{0}', github.ref) }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
     steps:
+      - name: Print concurrency group
+        run: "echo Concurrency group: $GROUP"
       - uses: actions/checkout@v4
         with:
           # Ensure we are building the branch and not the branch after being merged on develop

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
   GROUP: ${{ format('sonar-{0}', github.ref) }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -XX:MaxMetaspaceSize=512m -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
   GROUP: ${{ format('sonar-{0}', github.ref) }}
 
@@ -22,8 +22,6 @@ jobs:
       group: ${{ format('sonar-{0}', github.ref) }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
     steps:
-      - name: Print concurrency group
-        run: "echo Concurrency group: $GROUP"
       - uses: actions/checkout@v4
         with:
           # Ensure we are building the branch and not the branch after being merged on develop

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx6g
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true
   GROUP: ${{ format('sonar-{0}', github.ref) }}
 
 jobs:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,7 +36,11 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
       - name: Build projects
-        run: ./gradlew assembleDebug createFullJarDebugTestFixtures :app:createFullJarGplayDebugTestFixtures $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
+      - name: Build library fixtures
+        run: ./gradlew assembleDebug createFullJarDebugTestFixtures $CI_GRADLE_ARG_PROPERTIES
+      - name: Build app fixtures
+        run: ./gradlew :app:createFullJarGplayDebugTestFixtures $CI_GRADLE_ARG_PROPERTIES
       - name: 🔊 Publish results to Sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,6 +36,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
+      - name: Print free RAM
+        run: free -h
       - name: Build projects
         run: ./gradlew assembleDebug $CI_GRADLE_ARG_PROPERTIES
       - name: Build library fixtures

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false -Dsonar.gradle.skipCompile=true
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 # Enrich gradle.properties for CI/CD
 env:
-  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.incremental=false -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 --warn -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 8 -Dsonar.gradle.skipCompile=true
 
 jobs:
   tests:

--- a/plugins/src/main/kotlin/extension/CommonExtension.kt
+++ b/plugins/src/main/kotlin/extension/CommonExtension.kt
@@ -46,7 +46,7 @@ fun CommonExtension<*, *, *, *, *, *>.androidConfig(project: Project) {
 
     lint {
         lintConfig = File("${project.rootDir}/tools/lint/lint.xml")
-        checkDependencies = true
+        checkDependencies = false
         abortOnError = true
         ignoreTestFixturesSources = true
         checkGeneratedSources = false

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -52,7 +52,7 @@ tasks.withType(KotlinCompilationTask::class.java) {
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
-        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
-        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
+        logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+        logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -47,9 +47,11 @@ dependencies {
 
 tasks.register("logMemoryUsage") {
     doFirst {
+        val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
-        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
-        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+        val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        val usedMemory = totalMemory - freeMemory
+        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
     }
 }
 

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -22,6 +22,7 @@ import extension.commonDependencies
 import extension.composeConfig
 import extension.composeDependencies
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 val libs = the<LibrariesForLibs>()
 plugins {
@@ -42,4 +43,17 @@ dependencies {
     commonDependencies(libs)
     composeDependencies(libs)
     coreLibraryDesugaring(libs.android.desugar)
+}
+
+tasks.register("logMemoryUsage") {
+    doFirst {
+        val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
+        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+    }
+}
+
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -45,17 +45,14 @@ dependencies {
     coreLibraryDesugaring(libs.android.desugar)
 }
 
-tasks.register("logMemoryUsage") {
-    doFirst {
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    doLast {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$maxMemory MB")
+        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
     }
-}
-
-tasks.withType(KotlinCompilationTask::class.java) {
-    logger.warn("Configuring Kotlin compilation task $path:$name")
-    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-application.gradle.kts
@@ -17,6 +17,7 @@
 /**
  * This will generate the plugin "io.element.android-compose-application" to use by app and samples modules
  */
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import extension.androidConfig
 import extension.commonDependencies
 import extension.composeConfig
@@ -48,11 +49,26 @@ dependencies {
 tasks.withType(KotlinCompilationTask::class.java) {
     logger.warn("Configuring Kotlin compilation task $path:$name")
     doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+tasks.withType(AndroidLintAnalysisTask::class.java) {
+    logger.warn("Configuring Android Lint task $path:$name")
+    doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+private fun Task.logResourcesUsage(memory: Boolean, disk: Boolean) {
+    if (memory) {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+    }
+    if (disk) {
         logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -45,17 +45,15 @@ dependencies {
     coreLibraryDesugaring(libs.android.desugar)
 }
 
-tasks.register("logMemoryUsage") {
-    doFirst {
+
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    doLast {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$maxMemory MB")
+        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
     }
-}
-
-tasks.withType(KotlinCompilationTask::class.java) {
-    logger.warn("Configuring Kotlin compilation task $path:$name")
-    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -17,6 +17,7 @@
 /**
  * This will generate the plugin "io.element.android-compose-library", used in android library with compose modules.
  */
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import extension.androidConfig
 import extension.commonDependencies
 import extension.composeConfig
@@ -49,11 +50,26 @@ dependencies {
 tasks.withType(KotlinCompilationTask::class.java) {
     logger.warn("Configuring Kotlin compilation task $path:$name")
     doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+tasks.withType(AndroidLintAnalysisTask::class.java) {
+    logger.warn("Configuring Android Lint task $path:$name")
+    doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+private fun Task.logResourcesUsage(memory: Boolean, disk: Boolean) {
+    if (memory) {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+    }
+    if (disk) {
         logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -47,9 +47,11 @@ dependencies {
 
 tasks.register("logMemoryUsage") {
     doFirst {
+        val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
-        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
-        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+        val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        val usedMemory = totalMemory - freeMemory
+        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
     }
 }
 

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -53,7 +53,7 @@ tasks.withType(KotlinCompilationTask::class.java) {
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
-        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
-        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
+        logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+        logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }

--- a/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-compose-library.gradle.kts
@@ -22,6 +22,7 @@ import extension.commonDependencies
 import extension.composeConfig
 import extension.composeDependencies
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 val libs = the<LibrariesForLibs>()
 plugins {
@@ -42,4 +43,17 @@ dependencies {
     commonDependencies(libs)
     composeDependencies(libs)
     coreLibraryDesugaring(libs.android.desugar)
+}
+
+tasks.register("logMemoryUsage") {
+    doFirst {
+        val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
+        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+    }
+}
+
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -48,7 +48,7 @@ tasks.withType(KotlinCompilationTask::class.java) {
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
-        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
-        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
+        logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+        logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -41,17 +41,14 @@ dependencies {
     coreLibraryDesugaring(libs.android.desugar)
 }
 
-tasks.register("logMemoryUsage") {
-    doFirst {
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    doLast {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$maxMemory MB")
+        logger.warn("Free disk space: ${File(".").freeSpace / 1024 / 1024} MB")
     }
-}
-
-tasks.withType(KotlinCompilationTask::class.java) {
-    logger.warn("Configuring Kotlin compilation task $path:$name")
-    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -43,9 +43,11 @@ dependencies {
 
 tasks.register("logMemoryUsage") {
     doFirst {
+        val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
-        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
-        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+        val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        val usedMemory = totalMemory - freeMemory
+        logger.warn("Memory usage: $usedMemory/$maxMemory MB")
     }
 }
 

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -20,6 +20,7 @@
 import extension.androidConfig
 import extension.commonDependencies
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 val libs = the<LibrariesForLibs>()
 plugins {
@@ -38,4 +39,17 @@ android {
 dependencies {
     commonDependencies(libs)
     coreLibraryDesugaring(libs.android.desugar)
+}
+
+tasks.register("logMemoryUsage") {
+    doFirst {
+        val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
+        val currentMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
+        logger.warn("Memory usage: $currentMemory/$maxMemory MB")
+    }
+}
+
+tasks.withType(KotlinCompilationTask::class.java) {
+    logger.warn("Configuring Kotlin compilation task $path:$name")
+    finalizedBy("logMemoryUsage")
 }

--- a/plugins/src/main/kotlin/io.element.android-library.gradle.kts
+++ b/plugins/src/main/kotlin/io.element.android-library.gradle.kts
@@ -17,6 +17,7 @@
 /**
  * This will generate the plugin "io.element.android-library", used in android library without compose modules.
  */
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import extension.androidConfig
 import extension.commonDependencies
 import org.gradle.accessors.dm.LibrariesForLibs
@@ -44,11 +45,26 @@ dependencies {
 tasks.withType(KotlinCompilationTask::class.java) {
     logger.warn("Configuring Kotlin compilation task $path:$name")
     doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+tasks.withType(AndroidLintAnalysisTask::class.java) {
+    logger.warn("Configuring Android Lint task $path:$name")
+    doLast {
+        logResourcesUsage(memory = true, disk = false)
+    }
+}
+
+private fun Task.logResourcesUsage(memory: Boolean, disk: Boolean) {
+    if (memory) {
         val freeMemory = Runtime.getRuntime().freeMemory() / 1024 / 1024
         val maxMemory = Runtime.getRuntime().maxMemory() / 1024 / 1024
         val totalMemory = Runtime.getRuntime().totalMemory() / 1024 / 1024
         val usedMemory = totalMemory - freeMemory
         logger.warn("Memory usage: $usedMemory/$totalMemory (max: $maxMemory) MB")
+    }
+    if (disk) {
         logger.warn("Free disk space: ${rootDir.freeSpace / 1024 / 1024} MB")
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
