### PR TITLE
Improve UX on notification setting changes

### DIFF
--- a/changelog.d/1647.bugfix
+++ b/changelog.d/1647.bugfix
@@ -1,0 +1,1 @@
+Improve UX on notification setting changes.

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsPresenter.kt
@@ -29,7 +29,8 @@ import androidx.compose.runtime.setValue
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
-import io.element.android.libraries.architecture.runCatchingUpdatingState
+import io.element.android.libraries.architecture.runUpdatingState
+import io.element.android.libraries.architecture.runUpdatingStateNoSuccess
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
@@ -74,7 +75,7 @@ class NotificationSettingsPresenter @Inject constructor(
 
         LaunchedEffect(Unit) {
             fetchSettings(matrixSettings)
-            observeNotificationSettings(matrixSettings)
+            observeNotificationSettings(matrixSettings, changeNotificationSettingAction)
         }
 
         // List of PushProvider -> Distributor
@@ -172,11 +173,15 @@ class NotificationSettingsPresenter @Inject constructor(
     }
 
     @OptIn(FlowPreview::class)
-    private fun CoroutineScope.observeNotificationSettings(target: MutableState<NotificationSettingsState.MatrixSettings>) {
+    private fun CoroutineScope.observeNotificationSettings(
+        target: MutableState<NotificationSettingsState.MatrixSettings>,
+        changeNotificationSettingAction: MutableState<AsyncAction<Unit>>,
+    ) {
         notificationSettingsService.notificationSettingsChangeFlow
             .debounce(0.5.seconds)
             .onEach {
                 fetchSettings(target)
+                changeNotificationSettingAction.value = AsyncAction.Uninitialized
             }
             .launchIn(this)
     }
@@ -238,21 +243,21 @@ class NotificationSettingsPresenter @Inject constructor(
     }
 
     private fun CoroutineScope.setAtRoomNotificationsEnabled(enabled: Boolean, action: MutableState<AsyncAction<Unit>>) = launch {
-        suspend {
-            notificationSettingsService.setRoomMentionEnabled(enabled).getOrThrow()
-        }.runCatchingUpdatingState(action)
+        action.runUpdatingStateNoSuccess {
+            notificationSettingsService.setRoomMentionEnabled(enabled)
+        }
     }
 
     private fun CoroutineScope.setCallNotificationsEnabled(enabled: Boolean, action: MutableState<AsyncAction<Unit>>) = launch {
-        suspend {
-            notificationSettingsService.setCallEnabled(enabled).getOrThrow()
-        }.runCatchingUpdatingState(action)
+        action.runUpdatingStateNoSuccess {
+            notificationSettingsService.setCallEnabled(enabled)
+        }
     }
 
     private fun CoroutineScope.setInviteForMeNotificationsEnabled(enabled: Boolean, action: MutableState<AsyncAction<Unit>>) = launch {
-        suspend {
-            notificationSettingsService.setInviteForMeEnabled(enabled).getOrThrow()
-        }.runCatchingUpdatingState(action)
+        action.runUpdatingStateNoSuccess {
+            notificationSettingsService.setInviteForMeEnabled(enabled)
+        }
     }
 
     private fun CoroutineScope.setNotificationsEnabled(userPushStore: UserPushStore, enabled: Boolean) = launch {

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/NotificationSettingsPresenter.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.setValue
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
-import io.element.android.libraries.architecture.runUpdatingState
 import io.element.android.libraries.architecture.runUpdatingStateNoSuccess
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsEvents.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsEvents.kt
@@ -19,7 +19,7 @@ package io.element.android.features.roomdetails.impl.notificationsettings
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 
 sealed interface RoomNotificationSettingsEvents {
-    data class RoomNotificationModeChanged(val mode: RoomNotificationMode) : RoomNotificationSettingsEvents
+    data class ChangeRoomNotificationMode(val mode: RoomNotificationMode) : RoomNotificationSettingsEvents
     data class SetNotificationMode(val isDefault: Boolean) : RoomNotificationSettingsEvents
     data object DeleteCustomNotification : RoomNotificationSettingsEvents
     data object ClearSetNotificationError : RoomNotificationSettingsEvents

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenter.kt
@@ -95,7 +95,7 @@ class RoomNotificationSettingsPresenter @AssistedInject constructor(
 
         fun handleEvents(event: RoomNotificationSettingsEvents) {
             when (event) {
-                is RoomNotificationSettingsEvents.RoomNotificationModeChanged -> {
+                is RoomNotificationSettingsEvents.ChangeRoomNotificationMode -> {
                     localCoroutineScope.setRoomNotificationMode(event.mode, pendingRoomNotificationMode, pendingSetDefault, setNotificationSettingAction)
                 }
                 is RoomNotificationSettingsEvents.SetNotificationMode -> {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenter.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.runCatchingUpdatingState
+import io.element.android.libraries.core.coroutine.suspendWithMinimumDuration
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
@@ -171,7 +172,7 @@ class RoomNotificationSettingsPresenter @AssistedInject constructor(
         pendingDefaultState: MutableState<Boolean?>,
         action: MutableState<AsyncAction<Unit>>
     ) = launch {
-        suspend {
+        suspendWithMinimumDuration {
             pendingModeState.value = mode
             pendingDefaultState.value = false
             val result = notificationSettingsService.setRoomNotificationMode(room.roomId, mode)
@@ -187,7 +188,7 @@ class RoomNotificationSettingsPresenter @AssistedInject constructor(
         action: MutableState<AsyncAction<Unit>>,
         pendingDefaultState: MutableState<Boolean?>
     ) = launch {
-        suspend {
+        suspendWithMinimumDuration {
             pendingDefaultState.value = true
             val result = notificationSettingsService.restoreDefaultRoomNotificationMode(room.roomId)
             if (result.isFailure) {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
@@ -149,7 +149,7 @@ private fun RoomSpecificNotificationSettingsView(
                         enabled = !state.displayIsDefault.orTrue(),
                         displayMentionsOnlyDisclaimer = state.displayMentionsOnlyDisclaimer,
                         onSelectOption = {
-                            state.eventSink(RoomNotificationSettingsEvents.RoomNotificationModeChanged(it.mode))
+                            state.eventSink(RoomNotificationSettingsEvents.ChangeRoomNotificationMode(it.mode))
                         },
                     )
                 }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/UserDefinedRoomNotificationSettingsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/UserDefinedRoomNotificationSettingsView.kt
@@ -68,7 +68,7 @@ fun UserDefinedRoomNotificationSettingsView(
                     enabled = !state.displayIsDefault.orTrue(),
                     displayMentionsOnlyDisclaimer = state.displayMentionsOnlyDisclaimer,
                     onSelectOption = {
-                        state.eventSink(RoomNotificationSettingsEvents.RoomNotificationModeChanged(it.mode))
+                        state.eventSink(RoomNotificationSettingsEvents.ChangeRoomNotificationMode(it.mode))
                     },
                 )
             }

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/notificationsettings/RoomNotificationSettingsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/notificationsettings/RoomNotificationSettingsPresenterTest.kt
@@ -55,7 +55,7 @@ class RoomNotificationSettingsPresenterTest {
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
-            awaitItem().eventSink(RoomNotificationSettingsEvents.RoomNotificationModeChanged(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
+            awaitItem().eventSink(RoomNotificationSettingsEvents.ChangeRoomNotificationMode(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
             val updatedState = consumeItemsUntilPredicate {
                 it.roomNotificationSettings.dataOrNull()?.mode == RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY
             }.last()
@@ -129,7 +129,7 @@ class RoomNotificationSettingsPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            initialState.eventSink(RoomNotificationSettingsEvents.RoomNotificationModeChanged(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
+            initialState.eventSink(RoomNotificationSettingsEvents.ChangeRoomNotificationMode(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
             initialState.eventSink(RoomNotificationSettingsEvents.SetNotificationMode(true))
             val defaultState = consumeItemsUntilPredicate {
                 it.roomNotificationSettings.dataOrNull()?.mode == RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY
@@ -148,7 +148,7 @@ class RoomNotificationSettingsPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            initialState.eventSink(RoomNotificationSettingsEvents.RoomNotificationModeChanged(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
+            initialState.eventSink(RoomNotificationSettingsEvents.ChangeRoomNotificationMode(RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY))
             initialState.eventSink(RoomNotificationSettingsEvents.SetNotificationMode(true))
             val failedState = consumeItemsUntilPredicate {
                 it.restoreDefaultAction.isFailure()

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/AsyncAction.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/AsyncAction.kt
@@ -126,6 +126,24 @@ suspend inline fun <T> MutableState<AsyncAction<T>>.runUpdatingState(
 )
 
 /**
+ * Run the given block and update the state accordingly, using only Loading and Failure states.
+ * It's up to the caller to manage the Success state.
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T> MutableState<AsyncAction<T>>.runUpdatingStateNoSuccess(
+    resultBlock: () -> Result<Unit>,
+): Result<Unit> {
+    contract {
+        callsInPlace(resultBlock, InvocationKind.EXACTLY_ONCE)
+    }
+    value = AsyncAction.Loading
+    return resultBlock()
+        .onFailure { failure ->
+            value = AsyncAction.Failure(failure)
+        }
+}
+
+/**
  * Calls the specified [Result]-returning function [resultBlock]
  * encapsulating its progress and return value into an [AsyncAction] while
  * posting its updates to the MutableState [state].

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/Suspend.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/Suspend.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.core.coroutine
+
+import kotlinx.coroutines.delay
+import kotlin.system.measureTimeMillis
+
+fun suspendWithMinimumDuration(
+    minimumDurationMillis: Long = 500,
+    block: suspend () -> Unit
+) = suspend {
+    val duration = measureTimeMillis {
+        block()
+    }
+    delay(minimumDurationMillis - duration)
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the demo below:
- 2 first screens: ensure that the toggle is updated at the same time that the Progress dialog is hidden. In this case, the process is taking time so there is no need to ensure a minimal process duration.
- last screen (room notification setting) Ensure that the progress dialog is displayed at least 500ms to avoid flickering.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #1647 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

![NotificationSettingChange](https://github.com/element-hq/element-x-android/assets/3940906/6a3b10df-2354-40bf-86ea-9ced10fc2b09)

## Tests

<!-- Explain how you tested your development -->

- Play with the notification settings.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
