### PR TITLE
Unencrypted people are still people too

### DIFF
--- a/changelog.d/3071.bugfix
+++ b/changelog.d/3071.bugfix
@@ -1,0 +1,1 @@
+Unencrypted DMs are now treated as DMs in the room details screen

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
@@ -58,7 +58,7 @@ fun MatrixRoom.getDirectRoomMember(roomMembersState: MatrixRoomMembersState): St
     return remember(roomMembersState) {
         derivedStateOf {
             roomMembers
-                ?.takeIf { it.size == 2 && isDirect && isEncrypted }
+                ?.takeIf { it.size == 2 && isDirect }
                 ?.find { it.userId != sessionId }
         }
     }


### PR DESCRIPTION
Treat unencrypted direct rooms with 2 members as "direct" chats, the same as encrypted DM chats would be.

Fixes: https://github.com/element-hq/element-x-android/issues/3071
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Unencrypted DMs are now treated as DMs in the room details screen

## Motivation and context

Unencrypted people are still people too

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20240622-010032~2](https://github.com/element-hq/element-x-android/assets/775104/0e07f274-479d-411b-be96-cf9a4670711d)|![Screenshot_20240622-010230~2](https://github.com/element-hq/element-x-android/assets/775104/afc7cf64-1af5-4dde-9da6-3be520d0c80d)|

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Whatever the latest thing is on a Pixel 8

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
