### PR TITLE
Let role and permissions screens works for invited room members too.

### DIFF
--- a/changelog.d/3081.bugfix
+++ b/changelog.d/3081.bugfix
@@ -1,0 +1,1 @@
+ Let roles and permissions screens work for invited room members too.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoomMembersState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoomMembersState.kt
@@ -39,3 +39,7 @@ fun MatrixRoomMembersState.roomMembers(): List<RoomMember>? {
 fun MatrixRoomMembersState.joinedRoomMembers(): List<RoomMember> {
     return roomMembers().orEmpty().filter { it.membership == RoomMembershipState.JOIN }
 }
+
+fun MatrixRoomMembersState.activeRoomMembers(): List<RoomMember> {
+    return roomMembers().orEmpty().filter { it.membership.isActive() }
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/powerlevels/MatrixRoomMembersWithRole.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/powerlevels/MatrixRoomMembersWithRole.kt
@@ -18,7 +18,7 @@ package io.element.android.libraries.matrix.api.room.powerlevels
 
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
-import io.element.android.libraries.matrix.api.room.joinedRoomMembers
+import io.element.android.libraries.matrix.api.room.activeRoomMembers
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.Flow
@@ -27,14 +27,13 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 /**
- * Return a flow of the list of room members who are still in the room (with membership == RoomMembershipState.JOIN)
- * and who have the given role.
+ * Return a flow of the list of active room members who have the given role.
  */
 fun MatrixRoom.usersWithRole(role: RoomMember.Role): Flow<ImmutableList<RoomMember>> {
     return roomInfoFlow
         .map { it.userPowerLevels.filter { (_, powerLevel) -> RoomMember.Role.forPowerLevel(powerLevel) == role } }
         .combine(membersStateFlow) { powerLevels, membersState ->
-            membersState.joinedRoomMembers()
+            membersState.activeRoomMembers()
                 .filter { powerLevels.containsKey(it.userId) }
                 .toPersistentList()
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Let role and permissions screens works for invited room members too. Currently changing the role of invited people works, but the "Save" button UI is not updated and the counters are not correct.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix issues

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room
- invite someone
- go into rights/roles, Moderators (or Admins)
- select the invited person (who is still NOT in the room)
- click save

Previously: the action is performed with success, but the Save button is still enabled and attempting to leave the screen make a dialog to claim that there are unsaved change to be displayed. Also when leaving and opening the same screen, the pending member is not checked anymore.

Now: the Save button becomes disabled, and the user can leave the screen without any warning dialog.

Also: on the "Roles and permissions" screen, observe that the roles counter is now counting members who are invited.

Note: whit this change, the behavior is now similar to Element X iOS.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
