### PR TITLE
Improve room filtering behavior.

### DIFF
--- a/changelog.d/3083.bugfix
+++ b/changelog.d/3083.bugfix
@@ -1,0 +1,1 @@
+Improve room filters behavior

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -56,7 +56,6 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.testtags.TestTags
 import io.element.android.libraries.testtags.testTag
-import timber.log.Timber
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/filters/RoomListFiltersView.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,8 +35,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,6 +56,7 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.testtags.TestTags
 import io.element.android.libraries.testtags.testTag
+import timber.log.Timber
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -66,7 +72,31 @@ fun RoomListFiltersView(
         state.eventSink(RoomListFiltersEvents.ToggleFilter(filter))
     }
 
+    var scrollToStart by remember { mutableIntStateOf(0) }
     val lazyListState = rememberLazyListState()
+    LaunchedEffect(scrollToStart) {
+        // Scroll until the first item start to be displayed
+        // Since all items have different size, there is no way to compute the amount of
+        // pixel to scroll to go directly to the start of the row.
+        // But IRL it should only happen for one item.
+        while (lazyListState.firstVisibleItemIndex > 0) {
+            lazyListState.animateScrollBy(
+                value = -(lazyListState.firstVisibleItemScrollOffset + 1f),
+                animationSpec = spring(
+                    stiffness = Spring.StiffnessMediumLow,
+                )
+            )
+        }
+        // Then scroll to the start of the list, a bit faster, to fully reveal the first
+        // item, which can be the close button to reset filter, or the first item
+        // if the user has scroll a bit before clicking on the close button.
+        lazyListState.animateScrollBy(
+            value = -lazyListState.firstVisibleItemScrollOffset.toFloat(),
+            animationSpec = spring(
+                stiffness = Spring.StiffnessMedium,
+            )
+        )
+    }
     val previousFilters = remember { mutableStateOf(listOf<RoomListFilter>()) }
     LazyRow(
         contentPadding = PaddingValues(start = 8.dp, end = 16.dp),
@@ -84,6 +114,9 @@ fun RoomListFiltersView(
                     onClick = {
                         previousFilters.value = state.selectedFilters()
                         onClearFiltersClick()
+                        // When clearing filter, we want to ensure that the list
+                        // of filters is scrolled to the start.
+                        scrollToStart++
                     }
                 )
             }
@@ -100,6 +133,10 @@ fun RoomListFiltersView(
                     onClick = {
                         previousFilters.value = state.selectedFilters()
                         onToggleFilter(it)
+                        // When selecting a filter, we want to scroll to the start of the list
+                        if (filterWithSelection.isSelected.not()) {
+                            scrollToStart++
+                        }
                     },
                 )
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure that when clicking on filter "Favorite" in the room list, the list of filter is rendered correctly.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Improve UX

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

 -->

|Before|After|
|-|-|
|![RoomFilterBefore](https://github.com/element-hq/element-x-android/assets/3940906/7e0f1a70-0fc9-4925-8396-5634e114f73e)|![RoomFilter](https://github.com/element-hq/element-x-android/assets/3940906/ab9d9b06-0a6e-49e8-9941-018f326eba9c)|

## Tests

<!-- Explain how you tested your development -->

- Open the room list and play with the filters:
    - scroll to the right and click on Favorites
    - when the "close" button is displayed, scroll a bit and then click on it.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
