### PR TITLE
Use IO dispatcher for cleanup in bug reporter

### DIFF
--- a/changelog.d/3086.bugfix
+++ b/changelog.d/3086.bugfix
@@ -1,0 +1,1 @@
+Make sure we don't use the main dispatcher while closing the bug report request, as it can lead to crashes in strict mode.

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -282,11 +282,13 @@ class DefaultBugReporter @Inject constructor(
                 listener.onUploadFailed(serverError)
             }
         } finally {
-            // delete the generated files when the bug report process has finished
-            for (file in bugReportFiles) {
-                file.safeDelete()
+            withContext(coroutineDispatchers.io) {
+                // delete the generated files when the bug report process has finished
+                for (file in bugReportFiles) {
+                    file.safeDelete()
+                }
+                response?.close()
             }
-            response?.close()
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Run the cleanup after sending a bug report in the IO dispatcher.

## Motivation and context

Fixes #3086 (I hope).

## Tests

I couldn't reproduce this even with strict mode enabled, but the instruction should be:

- In the OS developer options enable strict mode.
- Send a test bug report.
- If it doesn't crash after sending, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
