### PR TITLE
Replace the 'answer' PendingIntent in ringing call notifications

### DIFF
--- a/changelog.d/3085.bugfix
+++ b/changelog.d/3085.bugfix
@@ -1,1 +1,1 @@
-Make sure we replace the 'asnwer call' pending intent on ringing call notifications.
+Make sure we replace the 'answer call' pending intent on ringing call notifications.

--- a/changelog.d/3085.bugfix
+++ b/changelog.d/3085.bugfix
@@ -1,0 +1,1 @@
+Make sure we replace the 'asnwer call' pending intent on ringing call notifications.

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/IntentProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/IntentProvider.kt
@@ -35,7 +35,7 @@ internal object IntentProvider {
             context,
             DefaultElementCallEntryPoint.REQUEST_CODE,
             createIntent(context, callType),
-            0,
+            PendingIntent.FLAG_CANCEL_CURRENT,
             false
         )!!
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Added the `CANCEL_CURRENT` flag to the pending intent so it's replaced.

## Motivation and context

Fixes #3085.

## Tests

<!-- Explain how you tested your development -->

- Receive a ringing call from another user. Ignore or decline it.
- Receive a new one from a different user, answer it.

The call you join should be the 2nd one, not the first one.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
