### PR TITLE
Fix `@room` mentions crashing in debug builds

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -88,16 +88,16 @@ private fun updateMentionSpans(text: CharSequence?, cache: RoomMemberProfilesCac
         for (mentionSpan in text.getMentionSpans()) {
             when (mentionSpan.type) {
                 MentionSpan.Type.USER -> {
-                    if (mentionSpan.rawValue != "@room") {
-                        val displayName = cache.getDisplayName(UserId(mentionSpan.rawValue)) ?: mentionSpan.rawValue
-                        if (mentionSpan.text != displayName) {
-                            changedContents = true
-                            mentionSpan.text = displayName
-                        }
+                    val displayName = cache.getDisplayName(UserId(mentionSpan.rawValue)) ?: mentionSpan.rawValue
+                    if (mentionSpan.text != displayName) {
+                        changedContents = true
+                        mentionSpan.text = displayName
                     }
                 }
+                // There's no need to do anything for `@room` pills
+                MentionSpan.Type.EVERYONE -> Unit
                 // Nothing yet for room mentions
-                else -> Unit
+                MentionSpan.Type.ROOM -> Unit
             }
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -88,10 +88,12 @@ private fun updateMentionSpans(text: CharSequence?, cache: RoomMemberProfilesCac
         for (mentionSpan in text.getMentionSpans()) {
             when (mentionSpan.type) {
                 MentionSpan.Type.USER -> {
-                    val displayName = cache.getDisplayName(UserId(mentionSpan.rawValue)) ?: mentionSpan.rawValue
-                    if (mentionSpan.text != displayName) {
-                        changedContents = true
-                        mentionSpan.text = displayName
+                    if (mentionSpan.rawValue != "@room") {
+                        val displayName = cache.getDisplayName(UserId(mentionSpan.rawValue)) ?: mentionSpan.rawValue
+                        if (mentionSpan.text != displayName) {
+                            changedContents = true
+                            mentionSpan.text = displayName
+                        }
                     }
                 }
                 // Nothing yet for room mentions

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/mentions/MentionSpan.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/mentions/MentionSpan.kt
@@ -87,6 +87,7 @@ class MentionSpan(
                         append("#")
                     }
                 }
+                Type.EVERYONE -> Unit
             }
             append(mentionText.substring(0, min(mentionText.length, MAX_LENGTH)))
             if (mentionText.length > MAX_LENGTH) {
@@ -98,6 +99,7 @@ class MentionSpan(
     enum class Type {
         USER,
         ROOM,
+        EVERYONE,
     }
 }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/mentions/MentionSpanProvider.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/mentions/MentionSpanProvider.kt
@@ -108,7 +108,7 @@ class MentionSpanProvider @AssistedInject constructor(
                 MentionSpan(
                     text = text,
                     rawValue = "@room",
-                    type = MentionSpan.Type.USER,
+                    type = MentionSpan.Type.EVERYONE,
                     backgroundColor = otherBackgroundColor,
                     textColor = otherTextColor,
                     startPadding = startPaddingPx,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/MarkdownTextEditorState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/MarkdownTextEditorState.kt
@@ -93,13 +93,16 @@ class MarkdownTextEditorState(
                     for (mention in mentions.reversed()) {
                         val start = charSequence.getSpanStart(mention)
                         val end = charSequence.getSpanEnd(mention)
-                        if (mention.type == MentionSpan.Type.USER) {
-                            if (mention.rawValue == "@room") {
-                                replace(start, end, "@room")
-                            } else {
+                        when (mention.type) {
+                            MentionSpan.Type.USER -> {
                                 val link = permalinkBuilder.permalinkForUser(UserId(mention.rawValue)).getOrNull() ?: continue
                                 replace(start, end, "[${mention.rawValue}]($link)")
                             }
+                            MentionSpan.Type.EVERYONE -> {
+                                replace(start, end, "@room")
+                            }
+                            // Nothing to do here yet
+                            MentionSpan.Type.ROOM -> Unit
                         }
                     }
                 }
@@ -114,14 +117,9 @@ class MarkdownTextEditorState(
         val mentionSpans = text.getSpans<MentionSpan>(0, text.length)
         return mentionSpans.mapNotNull { mentionSpan ->
             when (mentionSpan.type) {
-                MentionSpan.Type.USER -> {
-                    if (mentionSpan.rawValue == "@room") {
-                        Mention.AtRoom
-                    } else {
-                        Mention.User(UserId(mentionSpan.rawValue))
-                    }
-                }
-                else -> null
+                MentionSpan.Type.USER -> Mention.User(UserId(mentionSpan.rawValue))
+                MentionSpan.Type.EVERYONE -> Mention.AtRoom
+                MentionSpan.Type.ROOM -> null
             }
         }
     }

--- a/libraries/textcomposer/impl/src/test/kotlin/io/element/android/libraries/textcomposer/impl/model/MarkdownTextEditorStateTest.kt
+++ b/libraries/textcomposer/impl/src/test/kotlin/io/element/android/libraries/textcomposer/impl/model/MarkdownTextEditorStateTest.kt
@@ -156,7 +156,7 @@ class MarkdownTextEditorStateTest {
 
     private fun aMarkdownTextWithMentions(): CharSequence {
         val userMentionSpan = MentionSpan("@Alice", "@alice:matrix.org", MentionSpan.Type.USER, 0, 0, 0, 0)
-        val atRoomMentionSpan = MentionSpan("@room", "@room", MentionSpan.Type.USER, 0, 0, 0, 0)
+        val atRoomMentionSpan = MentionSpan("@room", "@room", MentionSpan.Type.EVERYONE, 0, 0, 0, 0)
         return buildSpannedString {
             append("Hello ")
             inSpans(userMentionSpan) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Skip the room member cache if the `rawValue` (original text) of the mention is `@room`.

## Motivation and context

`@room` is not a valid `UserId` and incorrectly trying to parse it as so caused a crash in debug builds.

## Tests

With a debug build:

- Open a room where you can mention everyone with `@room`.
- Enable text formatting.
- Add an `@room` mention.

If it doesn't crash it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
