### PR TITLE
Auth : fix restore session when there is no network.

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -16,7 +16,6 @@
 
 package io.element.android.libraries.matrix.impl
 
-import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.di.CacheDirectory
 import io.element.android.libraries.matrix.impl.analytics.UtdTracker
@@ -48,7 +47,7 @@ class RustMatrixClientFactory @Inject constructor(
 ) {
     suspend fun create(sessionData: SessionData): RustMatrixClient = withContext(coroutineDispatchers.io) {
         val client = getBaseClientBuilder(sessionData.sessionPath, sessionData.passphrase)
-            .serverNameOrHomeserverUrl(sessionData.homeserverUrl)
+            .homeserverUrl(sessionData.homeserverUrl)
             .username(sessionData.userId)
             .use { it.build() }
 
@@ -70,11 +69,15 @@ class RustMatrixClientFactory @Inject constructor(
         )
     }
 
-    internal fun getBaseClientBuilder(sessionPath: String, passphrase: String?): ClientBuilder {
+    internal fun getBaseClientBuilder(
+        sessionPath: String,
+        passphrase: String?,
+        slidingSyncProxy: String? = null,
+    ): ClientBuilder {
         return ClientBuilder()
             .sessionPath(sessionPath)
             .passphrase(passphrase)
-            .slidingSyncProxy(AuthenticationConfig.SLIDING_SYNC_PROXY_URL)
+            .slidingSyncProxy(slidingSyncProxy)
             .userAgent(userAgentProvider.provide())
             .addRootCertificates(userCertificatesProvider.provides())
             .autoEnableBackups(true)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -17,6 +17,7 @@
 package io.element.android.libraries.matrix.impl.auth
 
 import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.di.AppScope
@@ -205,7 +206,11 @@ class RustMatrixAuthenticationService @Inject constructor(
     override suspend fun loginWithQrCode(qrCodeData: MatrixQrCodeLoginData, progress: (QrCodeLoginStep) -> Unit) =
         withContext(coroutineDispatchers.io) {
             runCatching {
-                val client = rustMatrixClientFactory.getBaseClientBuilder(sessionPath, pendingPassphrase)
+                val client = rustMatrixClientFactory.getBaseClientBuilder(
+                    sessionPath = sessionPath,
+                    passphrase = pendingPassphrase,
+                    slidingSyncProxy = AuthenticationConfig.SLIDING_SYNC_PROXY_URL,
+                )
                     .buildWithQrCode(
                         qrCodeData = (qrCodeData as SdkQrCodeLoginData).rustQrCodeData,
                         oidcConfiguration = oidcConfigurationProvider.get(),
@@ -242,7 +247,11 @@ class RustMatrixAuthenticationService @Inject constructor(
     }
 
     private fun getBaseClientBuilder() = rustMatrixClientFactory
-        .getBaseClientBuilder(sessionPath, pendingPassphrase)
+        .getBaseClientBuilder(
+            sessionPath = sessionPath,
+            passphrase = pendingPassphrase,
+            slidingSyncProxy = AuthenticationConfig.SLIDING_SYNC_PROXY_URL,
+        )
         .requiresSlidingSync()
 
     private fun clear() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
When app is launched in airplane mode, the user is presented with login screen. 
Using `ClientBuilder.serverNameOrhomeserverUrl` is launching some network requests, which failed.

Also made some changes so we don't configure slidingSyncProxy when restoring a session.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
