### PR TITLE
Fix incorrect 'device verified' screen when app was opened with no network connection

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
@@ -61,7 +61,7 @@ class RustSessionVerificationService(
     private val verificationStateListenerTaskHandle = encryptionService.verificationStateListener(object : VerificationStateListener {
         override fun onUpdate(status: VerificationState) {
             Timber.d("New verification state: $status")
-            updateVerificationStatus(status)
+            sessionCoroutineScope.launch { updateVerificationStatus() }
         }
     })
 
@@ -70,7 +70,7 @@ class RustSessionVerificationService(
         override fun onUpdate(status: RecoveryState) {
             Timber.d("New recovery state: $status")
             // We could check the `RecoveryState`, but it's easier to just use the verification state directly
-            updateVerificationStatus(encryptionService.verificationState())
+            sessionCoroutineScope.launch { updateVerificationStatus() }
         }
     })
 
@@ -92,15 +92,16 @@ class RustSessionVerificationService(
 
     init {
         // Update initial state in case sliding sync isn't ready
-        updateVerificationStatus(encryptionService.verificationState())
+        sessionCoroutineScope.launch { updateVerificationStatus() }
 
         isReady.onEach { isReady ->
             if (isReady) {
                 Timber.d("Starting verification service")
                 // Immediate status update
-                updateVerificationStatus(encryptionService.verificationState())
+                updateVerificationStatus()
             } else {
                 Timber.d("Stopping verification service")
+                updateVerificationStatus()
             }
         }
         .launchIn(sessionCoroutineScope)
@@ -161,8 +162,9 @@ class RustSessionVerificationService(
                 }
             }
                 .onSuccess {
-                    updateVerificationStatus(VerificationState.VERIFIED)
+                    // Order here is important, first set the flow state as finished, then update the verification status
                     _verificationFlowState.value = VerificationFlowState.Finished
+                    updateVerificationStatus()
                 }
                 .onFailure {
                     Timber.e(it, "Verification finished, but the Rust SDK still reports the session as unverified.")
@@ -200,11 +202,36 @@ class RustSessionVerificationService(
         }
     }
 
-    private fun updateVerificationStatus(verificationState: VerificationState) {
-        _sessionVerifiedStatus.value = when (verificationState) {
-            VerificationState.UNKNOWN -> SessionVerifiedStatus.Unknown
-            VerificationState.VERIFIED -> SessionVerifiedStatus.Verified
-            VerificationState.UNVERIFIED -> SessionVerifiedStatus.NotVerified
+    private suspend fun updateVerificationStatus() {
+        if (verificationFlowState.value == VerificationFlowState.Finished) {
+            // Calling `encryptionService.verificationState()` performs a network call and it will deadlock if there is no network
+            // So we need to check that *only* if we know there is network connection, which is the case when the verification flow just finished
+            Timber.d("Updating verification status: flow just finished")
+            runCatching {
+                encryptionService.waitForE2eeInitializationTasks()
+            }.onSuccess {
+                _sessionVerifiedStatus.value = when (encryptionService.verificationState()) {
+                    VerificationState.UNKNOWN -> SessionVerifiedStatus.Unknown
+                    VerificationState.VERIFIED -> SessionVerifiedStatus.Verified
+                    VerificationState.UNVERIFIED -> SessionVerifiedStatus.NotVerified
+                }
+                Timber.d("New verification status: ${_sessionVerifiedStatus.value}")
+            }
+        } else {
+            // Otherwise, just check the current verification status from the session verification controller instead
+            Timber.d("Updating verification status: flow is pending or was finished some time ago")
+            runCatching {
+                if (!this@RustSessionVerificationService::verificationController.isInitialized) {
+                    verificationController = client.getSessionVerificationController()
+                    verificationController.setDelegate(this@RustSessionVerificationService)
+                }
+                _sessionVerifiedStatus.value = if (verificationController.isVerified()) {
+                    SessionVerifiedStatus.Verified
+                } else {
+                    SessionVerifiedStatus.NotVerified
+                }
+                Timber.d("New verification status: ${_sessionVerifiedStatus.value}")
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Fix checking for session verification status after session restoration, a different check is needed.
- Fix deadlock when reading the `skipVerification` preference. I'd rather just remove it, but it's needed as a workaround on `AppMigration02`.

## Motivation and context

It turns out `encryptionService.verificationState()` runs a network request that will cause a deadlock when it fails and that will trigger a timeout that will assume your session needs to be verified.

Also fixed another deadlock that caused the screen to remain blank sometimes after logging in, because DataStore got stuck when checking the `skipVerification` state for some reason I don't fully understand. We'll have to keep an eye on similar behaviours through the app.

## Tests

<!-- Explain how you tested your development -->

- Open your app with no network connection, it should load just fine.
- Restore network connection, then log out.
- Log in again.
- You should see the session verification screen again.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
