### PR TITLE
Draft : also clear draft when composer is blank

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/draft/ComposerDraftService.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/draft/ComposerDraftService.kt
@@ -21,5 +21,5 @@ import io.element.android.libraries.matrix.api.room.draft.ComposerDraft
 
 interface ComposerDraftService {
     suspend fun loadDraft(roomId: RoomId): ComposerDraft?
-    suspend fun saveDraft(roomId: RoomId, draft: ComposerDraft)
+    suspend fun updateDraft(roomId: RoomId, draft: ComposerDraft?)
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/draft/DefaultComposerDraftService.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/draft/DefaultComposerDraftService.kt
@@ -42,14 +42,19 @@ class DefaultComposerDraftService @Inject constructor(
         }
     }
 
-    override suspend fun saveDraft(roomId: RoomId, draft: ComposerDraft) {
+    override suspend fun updateDraft(roomId: RoomId, draft: ComposerDraft?) {
         client.getRoom(roomId)?.use { room ->
-            room.saveComposerDraft(draft)
+            val updateDraftResult = if (draft == null) {
+                room.clearComposerDraft()
+            } else {
+                room.saveComposerDraft(draft)
+            }
+            updateDraftResult
                 .onFailure {
-                    Timber.e(it, "Failed to save composer draft for room $roomId")
+                    Timber.e(it, "Failed to update composer draft for room $roomId")
                 }
                 .onSuccess {
-                    Timber.d("Saved composer draft for room $roomId")
+                    Timber.d("Updated composer draft for room $roomId")
                 }
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -582,16 +582,16 @@ class MessageComposerPresenter @Inject constructor(
             }
             is MessageComposerMode.Reply -> ComposerDraftType.Reply(mode.eventId)
         }
-        if (draftType == null || markdown.isBlank()) {
-            return@launch
+        val composerDraft = if (draftType == null || markdown.isBlank()) {
+            null
         } else {
-            val composerDraft = ComposerDraft(
+            ComposerDraft(
                 draftType = draftType,
                 htmlText = html,
                 plainText = markdown,
             )
-            draftService.saveDraft(room.roomId, composerDraft)
         }
+        draftService.updateDraft(room.roomId, composerDraft)
     }
 
     private fun CoroutineScope.toggleTextFormatting(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/draft/FakeComposerDraftService.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/draft/FakeComposerDraftService.kt
@@ -23,6 +23,6 @@ class FakeComposerDraftService : ComposerDraftService {
     var loadDraftLambda: (RoomId) -> ComposerDraft? = { null }
     override suspend fun loadDraft(roomId: RoomId) = loadDraftLambda(roomId)
 
-    var saveDraftLambda: (RoomId, ComposerDraft) -> Unit = { _, _ -> }
-    override suspend fun saveDraft(roomId: RoomId, draft: ComposerDraft) = saveDraftLambda(roomId, draft)
+    var saveDraftLambda: (RoomId, ComposerDraft?) -> Unit = { _, _ -> }
+    override suspend fun updateDraft(roomId: RoomId, draft: ComposerDraft?) = saveDraftLambda(roomId, draft)
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/textcomposer/MessageComposerPresenterTest.kt
@@ -1176,8 +1176,8 @@ class MessageComposerPresenterTest {
     }
 
     @Test
-    fun `present - when save draft event is invoked and composer is empty then nothing happens`() = runTest {
-        val saveDraftLambda = lambdaRecorder<RoomId, ComposerDraft, Unit> { _, _ -> }
+    fun `present - when save draft event is invoked and composer is empty then service is called with null draft`() = runTest {
+        val saveDraftLambda = lambdaRecorder<RoomId, ComposerDraft?, Unit> { _, _ -> }
         val composerDraftService = FakeComposerDraftService().apply {
             this.saveDraftLambda = saveDraftLambda
         }
@@ -1189,13 +1189,14 @@ class MessageComposerPresenterTest {
             initialState.eventSink.invoke(MessageComposerEvents.SaveDraft)
             advanceUntilIdle()
             assert(saveDraftLambda)
-                .isNeverCalled()
+                .isCalledOnce()
+                .with(value(A_ROOM_ID), value(null))
         }
     }
 
     @Test
     fun `present - when save draft event is invoked and composer is not empty then service is called`() = runTest {
-        val saveDraftLambda = lambdaRecorder<RoomId, ComposerDraft, Unit> { _, _ -> }
+        val saveDraftLambda = lambdaRecorder<RoomId, ComposerDraft?, Unit> { _, _ -> }
         val composerDraftService = FakeComposerDraftService().apply {
             this.saveDraftLambda = saveDraftLambda
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
At the moment, draft was cleared only when getting the draft, which is not enought.
If the app is put in bakground while you have a text in the composer, then the draft will be saved.
If you then send the message, and then close the room, the draft will remain and will reappear when re-opening the room.

So, this will now take care to clear the draft when composer is blank too.
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
