### PR TITLE
Fix crash when getting the system ringtone for ringing calls

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
@@ -116,7 +116,8 @@ class RingingCallNotificationCreator @Inject constructor(
             false
         )
 
-        val ringtoneUri = RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE)
+        // TODO use a fallback ringtone if the default ringtone is not available
+        val ringtoneUri = runCatching { RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE) }.getOrNull()
         return NotificationCompat.Builder(context, notificationChannelId)
             .setSmallIcon(CommonDrawables.ic_notification_small)
             .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -127,7 +128,11 @@ class RingingCallNotificationCreator @Inject constructor(
             .setWhen(timestamp)
             .setOngoing(true)
             .setShowWhen(false)
-            .setSound(ringtoneUri, AudioManager.STREAM_RING)
+            .apply {
+                if (ringtoneUri != null) {
+                    setSound(ringtoneUri, AudioManager.STREAM_RING)
+                }
+            }
             .setTimeoutAfter(ElementCallConfig.RINGING_CALL_DURATION_SECONDS.seconds.inWholeMilliseconds)
             .setContentIntent(answerIntent)
             .setDeleteIntent(declineIntent)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
@@ -162,7 +162,8 @@ class DefaultNotificationChannels @Inject constructor(
         )
 
         // Register a channel for incoming call notifications which will ring the device when received
-        val ringtoneUri = RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE)
+        // TODO use a fallback ringtone if the default ringtone is not available
+        val ringtoneUri = runCatching { RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE) }.getOrNull()
         notificationManager.createNotificationChannel(
             NotificationChannelCompat.Builder(
                 RINGING_CALL_NOTIFICATION_CHANNEL_ID,
@@ -170,14 +171,18 @@ class DefaultNotificationChannels @Inject constructor(
             )
                 .setName(stringProvider.getString(R.string.notification_channel_ringing_calls).ifEmpty { "Ringing calls" })
                 .setVibrationEnabled(true)
-                .setSound(
-                    ringtoneUri,
-                    AudioAttributes.Builder()
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .setLegacyStreamType(AudioManager.STREAM_RING)
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                        .build()
-                )
+                .apply {
+                    if (ringtoneUri != null) {
+                        setSound(
+                            ringtoneUri,
+                            AudioAttributes.Builder()
+                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                                .setLegacyStreamType(AudioManager.STREAM_RING)
+                                .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                                .build()
+                        )
+                    }
+                }
                 .setDescription(stringProvider.getString(R.string.notification_channel_ringing_calls))
                 .setLightsEnabled(true)
                 .setLightColor(accentColor)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Wrap the call to get the system ringtone in a `runCatching` so we can recover if it fails. The app will use the default notification sound in that case, we should add a fallback one in the future.

## Motivation and context

Fixes #3121.

## Tests

This seems to depend on your OS/vendor version, so there's no easy way to test it.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
