### PR TITLE
Remove Showkase processor not found warning from Danger

### DIFF
--- a/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
+++ b/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
@@ -23,18 +23,20 @@ import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreview
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
 
+// Make sure we don't import Compound previews by mistake
+private val PACKAGE_TREES = arrayOf(
+    "io.element.android.features",
+    "io.element.android.libraries",
+    "io.element.android.services",
+    "io.element.android.appicon",
+    "io.element.android.appnav",
+    "io.element.android.x",
+)
+
 object ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
     private val values: List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> by lazy {
         AndroidComposablePreviewScanner()
-            .scanPackageTrees(
-                "io.element.android.features",
-                "io.element.android.libraries",
-                "io.element.android.services",
-                "io.element.android.appicon",
-                "io.element.android.appnav",
-                "io.element.android.x",
-                // Make sure we don't import Compound previews by mistake
-            )
+            .scanPackageTrees(*PACKAGE_TREES)
             .getPreviews()
             .withIndex()
             .toList()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : CI checks cleanup

## Content

Remove Danger check to ensure Showkase is enabled in modules with previews. Instead try to check if the package of the preview is in the list of packages to scan in `ComposablePreviewProvider`.

## Motivation and context

We don't use Showkase anymore for this.

## Tests

The CI failed before when the new rule was broken: https://github.com/element-hq/element-x-android/pull/3148#issuecomment-2210740986

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
