### PR TITLE
Add support for Picture In Picture for Element Call

### DIFF
--- a/features/call/impl/build.gradle.kts
+++ b/features/call/impl/build.gradle.kts
@@ -70,4 +70,6 @@ dependencies {
     testImplementation(projects.libraries.push.test)
     testImplementation(projects.services.analytics.test)
     testImplementation(projects.tests.testutils)
+    testImplementation(libs.androidx.compose.ui.test.junit)
+    testReleaseImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/features/call/impl/src/main/AndroidManifest.xml
+++ b/features/call/impl/src/main/AndroidManifest.xml
@@ -38,10 +38,11 @@
     <application>
         <activity
             android:name=".ui.ElementCallActivity"
-            android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"
             android:exported="true"
             android:label="@string/element_call"
             android:launchMode="singleTask"
+            android:supportsPictureInPicture="true"
             android:taskAffinity="io.element.android.features.call">
 
             <intent-filter android:autoVerify="true">

--- a/features/call/impl/src/main/AndroidManifest.xml
+++ b/features/call/impl/src/main/AndroidManifest.xml
@@ -77,10 +77,11 @@
 
         </activity>
 
-        <activity android:name=".ui.IncomingCallActivity"
+        <activity
+            android:name=".ui.IncomingCallActivity"
             android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode"
-            android:exported="false"
             android:excludeFromRecents="true"
+            android:exported="false"
             android:launchMode="singleTask"
             android:taskAffinity="io.element.android.features.call" />
 
@@ -90,9 +91,10 @@
             android:exported="false"
             android:foregroundServiceType="phoneCall" />
 
-        <receiver android:name=".receivers.DeclineCallBroadcastReceiver"
-            android:exported="false"
-            android:enabled="true" />
+        <receiver
+            android:name=".receivers.DeclineCallBroadcastReceiver"
+            android:enabled="true"
+            android:exported="false" />
 
     </application>
 

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureEvents.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureEvents.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+sealed interface PictureInPictureEvents {
+    data object EnterPictureInPicture : PictureInPictureEvents
+}

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenter.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+import android.app.Activity
+import android.app.PictureInPictureParams
+import android.os.Build
+import android.util.Rational
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.core.log.logger.LoggerTag
+import timber.log.Timber
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+
+private val loggerTag = LoggerTag("PiP")
+
+class PictureInPicturePresenter @Inject constructor(
+    pipSupportProvider: PipSupportProvider,
+) : Presenter<PictureInPictureState> {
+    private val isPipSupported = pipSupportProvider.isPipSupported()
+    private var isInPictureInPicture = mutableStateOf(false)
+    private var hostActivity: WeakReference<Activity>? = null
+
+    @Composable
+    override fun present(): PictureInPictureState {
+        fun handleEvent(event: PictureInPictureEvents) {
+            when (event) {
+                PictureInPictureEvents.EnterPictureInPicture -> switchToPip()
+            }
+        }
+
+        return PictureInPictureState(
+            supportPip = isPipSupported,
+            isInPictureInPicture = isInPictureInPicture.value,
+            eventSink = ::handleEvent,
+        )
+    }
+
+    fun onCreate(activity: Activity) {
+        if (isPipSupported) {
+            Timber.tag(loggerTag.value).d("onCreate: Setting PiP params")
+            hostActivity = WeakReference(activity)
+            hostActivity?.get()?.setPictureInPictureParams(getPictureInPictureParams())
+        } else {
+            Timber.tag(loggerTag.value).d("onCreate: PiP is not supported")
+        }
+    }
+
+    fun onDestroy() {
+        Timber.tag(loggerTag.value).d("onDestroy")
+        hostActivity?.clear()
+        hostActivity = null
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getPictureInPictureParams(): PictureInPictureParams {
+        return PictureInPictureParams.Builder()
+            // Portrait for calls seems more appropriate
+            .setAspectRatio(Rational(3, 5))
+            .apply {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    setAutoEnterEnabled(true)
+                }
+            }
+            .build()
+    }
+
+    /**
+     * Enters Picture-in-Picture mode.
+     */
+    private fun switchToPip() {
+        if (isPipSupported) {
+            Timber.tag(loggerTag.value).d("Switch to PiP mode")
+            hostActivity?.get()?.enterPictureInPictureMode(getPictureInPictureParams())
+                ?.also { Timber.tag(loggerTag.value).d("Switch to PiP mode result: $it") }
+        }
+    }
+
+    fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        Timber.tag(loggerTag.value).d("onPictureInPictureModeChanged: $isInPictureInPictureMode")
+        isInPictureInPicture.value = isInPictureInPictureMode
+    }
+
+    fun onUserLeaveHint() {
+        Timber.tag(loggerTag.value).d("onUserLeaveHint")
+        switchToPip()
+    }
+}

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureState.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureState.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+data class PictureInPictureState(
+    val supportPip: Boolean,
+    val isInPictureInPicture: Boolean,
+    val eventSink: (PictureInPictureEvents) -> Unit,
+)

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureStateProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PictureInPictureStateProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+fun aPictureInPictureState(
+    supportPip: Boolean = false,
+    isInPictureInPicture: Boolean = false,
+    eventSink: (PictureInPictureEvents) -> Unit = {},
+): PictureInPictureState {
+    return PictureInPictureState(
+        supportPip = supportPip,
+        isInPictureInPicture = isInPictureInPicture,
+        eventSink = eventSink,
+    )
+}

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PipSupportProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/pip/PipSupportProvider.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.core.bool.orFalse
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
+import javax.inject.Inject
+
+interface PipSupportProvider {
+    @ChecksSdkIntAtLeast(Build.VERSION_CODES.O)
+    fun isPipSupported(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultPipSupportProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : PipSupportProvider {
+    override fun isPipSupported(): Boolean {
+        val hasSystemFeaturePip = context.packageManager?.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE).orFalse()
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && hasSystemFeaturePip
+    }
+}

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
@@ -23,6 +23,7 @@ open class CallScreenStateProvider : PreviewParameterProvider<CallScreenState> {
     override val values: Sequence<CallScreenState>
         get() = sequenceOf(
             aCallScreenState(),
+            aCallScreenState(urlState = AsyncData.Loading()),
             aCallScreenState(urlState = AsyncData.Failure(Exception("An error occurred"))),
         )
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
@@ -28,7 +28,7 @@ open class CallScreenStateProvider : PreviewParameterProvider<CallScreenState> {
         )
 }
 
-private fun aCallScreenState(
+internal fun aCallScreenState(
     urlState: AsyncData<String> = AsyncData.Success("https://call.element.io/some-actual-call?with=parameters"),
     userAgent: String = "",
     isInWidgetMode: Boolean = false,

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -42,6 +42,7 @@ import io.element.android.compound.theme.mapToTheme
 import io.element.android.features.call.api.CallType
 import io.element.android.features.call.impl.DefaultElementCallEntryPoint
 import io.element.android.features.call.impl.di.CallBindings
+import io.element.android.features.call.impl.pip.PictureInPicturePresenter
 import io.element.android.features.call.impl.services.CallForegroundService
 import io.element.android.features.call.impl.utils.CallIntentDataParser
 import io.element.android.libraries.architecture.bindings
@@ -52,6 +53,7 @@ class ElementCallActivity : AppCompatActivity(), CallScreenNavigator {
     @Inject lateinit var callIntentDataParser: CallIntentDataParser
     @Inject lateinit var presenterFactory: CallScreenPresenter.Factory
     @Inject lateinit var appPreferencesStore: AppPreferencesStore
+    @Inject lateinit var pictureInPicturePresenter: PictureInPicturePresenter
 
     private lateinit var presenter: CallScreenPresenter
 
@@ -86,6 +88,8 @@ class ElementCallActivity : AppCompatActivity(), CallScreenNavigator {
             updateUiMode(resources.configuration)
         }
 
+        pictureInPicturePresenter.onCreate(this)
+
         audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
         requestAudioFocus()
 
@@ -95,11 +99,13 @@ class ElementCallActivity : AppCompatActivity(), CallScreenNavigator {
             }
                 .collectAsState(initial = Theme.System)
             val state = presenter.present()
+            val pipState = pictureInPicturePresenter.present()
             ElementTheme(
                 darkTheme = theme.isDark()
             ) {
                 CallScreenView(
                     state = state,
+                    pipState = pipState,
                     requestPermissions = { permissions, callback ->
                         requestPermissionCallback = callback
                         requestPermissionsLauncher.launch(permissions)
@@ -112,6 +118,11 @@ class ElementCallActivity : AppCompatActivity(), CallScreenNavigator {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         updateUiMode(newConfig)
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        pictureInPicturePresenter.onPictureInPictureModeChanged(isInPictureInPictureMode)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -131,10 +142,16 @@ class ElementCallActivity : AppCompatActivity(), CallScreenNavigator {
         }
     }
 
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        pictureInPicturePresenter.onUserLeaveHint()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         releaseAudioFocus()
         CallForegroundService.stop(this)
+        pictureInPicturePresenter.onDestroy()
     }
 
     override fun finish() {

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/FakePipSupportProvider.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/FakePipSupportProvider.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+class FakePipSupportProvider(
+    private val isPipSupported: Boolean
+) : PipSupportProvider {
+    override fun isPipSupported() = isPipSupported
+}

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.pip
+
+import android.os.Build.VERSION_CODES
+import app.cash.molecule.RecompositionMode
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.call.impl.ui.ElementCallActivity
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class PictureInPicturePresenterTest {
+    @Test
+    @Config(sdk = [VERSION_CODES.N, VERSION_CODES.O, VERSION_CODES.S])
+    fun `when pip is not supported, the state value supportPip is false`() = runTest {
+        val presenter = createPictureInPicturePresenter(supportPip = false)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.supportPip).isFalse()
+        }
+        presenter.onDestroy()
+    }
+
+    @Test
+    @Config(sdk = [VERSION_CODES.O, VERSION_CODES.S])
+    fun `when pip is supported, the state value supportPip is true`() = runTest {
+        val presenter = createPictureInPicturePresenter(supportPip = true)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.supportPip).isTrue()
+        }
+        presenter.onDestroy()
+    }
+
+    @Test
+    @Config(sdk = [VERSION_CODES.S])
+    fun `when entering pip is supported, the state value isInPictureInPicture is true`() = runTest {
+        val presenter = createPictureInPicturePresenter(supportPip = true)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.isInPictureInPicture).isFalse()
+            initialState.eventSink(PictureInPictureEvents.EnterPictureInPicture)
+            presenter.onPictureInPictureModeChanged(true)
+            val pipState = awaitItem()
+            assertThat(pipState.isInPictureInPicture).isTrue()
+            // User stops pip
+            presenter.onPictureInPictureModeChanged(false)
+            val finalState = awaitItem()
+            assertThat(finalState.isInPictureInPicture).isFalse()
+        }
+        presenter.onDestroy()
+    }
+
+    @Test
+    @Config(sdk = [VERSION_CODES.S])
+    fun `when onUserLeaveHint is called, the state value isInPictureInPicture becomes true`() = runTest {
+        val presenter = createPictureInPicturePresenter(supportPip = true)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.isInPictureInPicture).isFalse()
+            presenter.onUserLeaveHint()
+            presenter.onPictureInPictureModeChanged(true)
+            val pipState = awaitItem()
+            assertThat(pipState.isInPictureInPicture).isTrue()
+        }
+        presenter.onDestroy()
+    }
+
+    private fun createPictureInPicturePresenter(
+        supportPip: Boolean = true,
+    ): PictureInPicturePresenter {
+        val activity = Robolectric.buildActivity(ElementCallActivity::class.java)
+        return PictureInPicturePresenter(
+            pipSupportProvider = FakePipSupportProvider(supportPip),
+        ).apply {
+            onCreate(activity.get())
+        }
+    }
+}

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
@@ -32,7 +32,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 class PictureInPicturePresenterTest {
     @Test
-    @Config(sdk = [VERSION_CODES.N, VERSION_CODES.O, VERSION_CODES.S])
+    @Config(sdk = [/*VERSION_CODES.N,*/ VERSION_CODES.O, VERSION_CODES.S])
     fun `when pip is not supported, the state value supportPip is false`() = runTest {
         val presenter = createPictureInPicturePresenter(supportPip = false)
         moleculeFlow(RecompositionMode.Immediate) {

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/pip/PictureInPicturePresenterTest.kt
@@ -32,7 +32,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 class PictureInPicturePresenterTest {
     @Test
-    @Config(sdk = [/*VERSION_CODES.N,*/ VERSION_CODES.O, VERSION_CODES.S])
+    @Config(sdk = [VERSION_CODES.O, VERSION_CODES.S])
     fun `when pip is not supported, the state value supportPip is false`() = runTest {
         val presenter = createPictureInPicturePresenter(supportPip = false)
         moleculeFlow(RecompositionMode.Immediate) {

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/impl/ui/CallScreenViewTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.call.impl.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.features.call.impl.pip.PictureInPictureEvents
+import io.element.android.features.call.impl.pip.PictureInPictureState
+import io.element.android.features.call.impl.pip.aPictureInPictureState
+import io.element.android.tests.testutils.EventsRecorder
+import io.element.android.tests.testutils.pressBack
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CallScreenViewTest {
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `clicking on back when pip is not supported hangs up`() {
+        val eventsRecorder = EventsRecorder<CallScreenEvents>()
+        val pipEventsRecorder = EventsRecorder<PictureInPictureEvents>(expectEvents = false)
+        rule.setCallScreenView(
+            aCallScreenState(
+                eventSink = eventsRecorder
+            ),
+            aPictureInPictureState(
+                supportPip = false,
+                eventSink = pipEventsRecorder,
+            ),
+        )
+        rule.pressBack()
+        eventsRecorder.assertSize(2)
+        eventsRecorder.assertTrue(0) { it is CallScreenEvents.SetupMessageChannels }
+        eventsRecorder.assertTrue(1) { it == CallScreenEvents.Hangup }
+    }
+
+    @Test
+    fun `clicking on back when pip is supported enables PiP`() {
+        val eventsRecorder = EventsRecorder<CallScreenEvents>()
+        val pipEventsRecorder = EventsRecorder<PictureInPictureEvents>()
+        rule.setCallScreenView(
+            aCallScreenState(
+                eventSink = eventsRecorder
+            ),
+            aPictureInPictureState(
+                supportPip = true,
+                eventSink = pipEventsRecorder,
+            ),
+        )
+        rule.pressBack()
+        eventsRecorder.assertSize(1)
+        eventsRecorder.assertTrue(0) { it is CallScreenEvents.SetupMessageChannels }
+        pipEventsRecorder.assertSingle(PictureInPictureEvents.EnterPictureInPicture)
+    }
+}
+
+private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setCallScreenView(
+    state: CallScreenState,
+    pipState: PictureInPictureState,
+    requestPermissions: (Array<String>, RequestPermissionCallback) -> Unit = { _, _ -> },
+) {
+    setContent {
+        CallScreenView(
+            state = state,
+            pipState = pipState,
+            requestPermissions = requestPermissions,
+        )
+    }
+}

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUserViewTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUserViewTest.kt
@@ -45,7 +45,7 @@ class BlockedUserViewTest {
     fun `clicking on back invokes back callback`() {
         val eventsRecorder = EventsRecorder<BlockedUsersEvents>(expectEvents = false)
         ensureCalledOnce { callback ->
-            rule.setLogoutView(
+            rule.setBlockedUsersView(
                 aBlockedUsersState(
                     eventSink = eventsRecorder
                 ),
@@ -59,7 +59,7 @@ class BlockedUserViewTest {
     fun `clicking on a user emits the expected Event`() {
         val eventsRecorder = EventsRecorder<BlockedUsersEvents>()
         val userList = aMatrixUserList()
-        rule.setLogoutView(
+        rule.setBlockedUsersView(
             aBlockedUsersState(
                 blockedUsers = userList,
                 eventSink = eventsRecorder
@@ -72,7 +72,7 @@ class BlockedUserViewTest {
     @Test
     fun `clicking on cancel sends a BlockedUsersEvents`() {
         val eventsRecorder = EventsRecorder<BlockedUsersEvents>()
-        rule.setLogoutView(
+        rule.setBlockedUsersView(
             aBlockedUsersState(
                 unblockUserAction = AsyncAction.Confirming,
                 eventSink = eventsRecorder
@@ -85,7 +85,7 @@ class BlockedUserViewTest {
     @Test
     fun `clicking on confirm sends a BlockedUsersEvents`() {
         val eventsRecorder = EventsRecorder<BlockedUsersEvents>()
-        rule.setLogoutView(
+        rule.setBlockedUsersView(
             aBlockedUsersState(
                 unblockUserAction = AsyncAction.Confirming,
                 eventSink = eventsRecorder
@@ -96,7 +96,7 @@ class BlockedUserViewTest {
     }
 }
 
-private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setLogoutView(
+private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setBlockedUsersView(
     state: BlockedUsersState,
     onBackClick: () -> Unit = EnsureNeverCalled(),
 ) {

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
@@ -48,6 +48,6 @@ class EventsRecorder<T>(
     }
 
     fun assertTrue(index: Int, predicate: (T) -> Boolean) {
-        assertThat((predicate(events[index]))).isTrue()
+        assertThat(predicate(events[index])).isTrue()
     }
 }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
@@ -42,4 +42,12 @@ class EventsRecorder<T>(
     fun assertList(expectedEvents: List<T>) {
         assertThat(events).isEqualTo(expectedEvents)
     }
+
+    fun assertSize(size: Int) {
+        assertThat(events.size).isEqualTo(size)
+    }
+
+    fun assertTrue(index: Int, predicate: (T) -> Boolean) {
+        assertThat((predicate(events[index]))).isTrue()
+    }
 }

--- a/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68d9ca60586aac84157c60f126b17b70ca9d52087da80f253b60f47de87d7ff6
-size 13750
+oid sha256:c976f3c1d4809c28cb865b0dfe7ce1eed5fe2c9959a80da8efab5d3594e38e41
+size 14427

--- a/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Day_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Day_2_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68d9ca60586aac84157c60f126b17b70ca9d52087da80f253b60f47de87d7ff6
+size 13750

--- a/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b676c158a1f820d50c9ffd50d048d5c236ee8356279663f257a4882f06c5a1a9
-size 12214
+oid sha256:d6acbdb4ea1e66fa4638fc9b454566968081c511e0dcfde3f1e57fd9725a1edb
+size 13263

--- a/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Night_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.call.impl.ui_CallScreenView_Night_2_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b676c158a1f820d50c9ffd50d048d5c236ee8356279663f257a4882f06c5a1a9
+size 12214


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Add support for picture in picture mode for Element Call Activity

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Allow user to keep seeing a call, while navigating in the Element X application or any application installed on the phone.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start a call on a device > API 26
- Press back, or home button
- observe that the call is not stopped and is now displayed in PiP

Note that nothing is sent to the Element Call instance, and so the rendering of the Element Call application is not always optimal. sometimes it renders the other party video (which is fine), sometimes it render the local video loopback, which is not ideal.

## Tested devices

- [ ] Physical
- [x] Emulator API 33 and 34.
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
