### PR TITLE
Add a custom sliding sync proxy setting in developer options

### DIFF
--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
@@ -21,5 +21,6 @@ import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
 sealed interface DeveloperSettingsEvents {
     data class UpdateEnabledFeature(val feature: FeatureUiModel, val isEnabled: Boolean) : DeveloperSettingsEvents
     data class SetCustomElementCallBaseUrl(val baseUrl: String?) : DeveloperSettingsEvents
+    data class SetCustomSlidingSyncProxy(val proxy: String?) : DeveloperSettingsEvents
     data object ClearCache : DeveloperSettingsEvents
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
@@ -114,7 +114,7 @@ class DeveloperSettingsPresenter @Inject constructor(
                     appPreferencesStore.setCustomElementCallBaseUrl(urlToSave)
                 }
                 is DeveloperSettingsEvents.SetCustomSlidingSyncProxy -> coroutineScope.launch {
-                    appPreferencesStore.setCustomSlidingSyncProxy(event.proxy)
+                    appPreferencesStore.setCustomSlidingSyncProxy(event.proxy?.takeIf { it.isNotBlank() })
                 }
                 DeveloperSettingsEvents.ClearCache -> coroutineScope.clearCache(clearCacheAction)
             }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
@@ -113,6 +113,9 @@ class DeveloperSettingsPresenter @Inject constructor(
                     val urlToSave = event.baseUrl.takeIf { !it.isNullOrEmpty() && it != ElementCallConfig.DEFAULT_BASE_URL }
                     appPreferencesStore.setCustomElementCallBaseUrl(urlToSave)
                 }
+                is DeveloperSettingsEvents.SetCustomSlidingSyncProxy -> coroutineScope.launch {
+                    appPreferencesStore.setCustomSlidingSyncProxy(event.proxy)
+                }
                 DeveloperSettingsEvents.ClearCache -> coroutineScope.clearCache(clearCacheAction)
             }
         }
@@ -127,6 +130,7 @@ class DeveloperSettingsPresenter @Inject constructor(
                 defaultUrl = ElementCallConfig.DEFAULT_BASE_URL,
                 validator = ::customElementCallUrlValidator,
             ),
+            customSlidingSyncProxy = appPreferencesStore.customSlidingSyncProxy().collectAsState(null).value,
             eventSink = ::handleEvents
         )
     }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
@@ -27,6 +27,7 @@ data class DeveloperSettingsState(
     val rageshakeState: RageshakePreferencesState,
     val clearCacheAction: AsyncData<Unit>,
     val customElementCallBaseUrlState: CustomElementCallBaseUrlState,
+    val customSlidingSyncProxy: String?,
     val eventSink: (DeveloperSettingsEvents) -> Unit
 )
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
@@ -39,6 +39,7 @@ open class DeveloperSettingsStateProvider : PreviewParameterProvider<DeveloperSe
 fun aDeveloperSettingsState(
     clearCacheAction: AsyncData<Unit> = AsyncData.Uninitialized,
     customElementCallBaseUrlState: CustomElementCallBaseUrlState = aCustomElementCallBaseUrlState(),
+    customSlidingSyncProxy: String? = null,
     eventSink: (DeveloperSettingsEvents) -> Unit = {},
 ) = DeveloperSettingsState(
     features = aFeatureUiModelList(),
@@ -46,6 +47,7 @@ fun aDeveloperSettingsState(
     cacheSize = AsyncData.Success("1.2 MB"),
     clearCacheAction = clearCacheAction,
     customElementCallBaseUrlState = customElementCallBaseUrlState,
+    customSlidingSyncProxy = customSlidingSyncProxy,
     eventSink = eventSink,
 )
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -60,6 +60,14 @@ fun DeveloperSettingsView(
                 title = "Configure tracing",
                 onClick = onOpenConfigureTracing,
             )
+            PreferenceTextField(
+                headline = "Custom sliding sync proxy",
+                supportingText = "You'll need to kill and restart the app for this option to take effect.",
+                value = state.customSlidingSyncProxy,
+                onChange = {
+                    state.eventSink(DeveloperSettingsEvents.SetCustomSlidingSyncProxy(it))
+                }
+            )
         }
         PreferenceCategory(title = "Showkase") {
             PreferenceText(

--- a/libraries/matrix/impl/build.gradle.kts
+++ b/libraries/matrix/impl/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(projects.libraries.di)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.network)
+    implementation(projects.libraries.preferences.api)
     implementation(projects.services.analytics.api)
     implementation(projects.services.toolbox.api)
     implementation(projects.libraries.featureflag.api)

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
@@ -28,5 +28,8 @@ interface AppPreferencesStore {
     suspend fun setTheme(theme: String)
     fun getThemeFlow(): Flow<String?>
 
+    suspend fun setCustomSlidingSyncProxy(string: String?)
+    fun customSlidingSyncProxy(): Flow<String?>
+
     suspend fun reset()
 }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
@@ -38,6 +38,7 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 private val developerModeKey = booleanPreferencesKey("developerMode")
 private val customElementCallBaseUrlKey = stringPreferencesKey("elementCallBaseUrl")
 private val themeKey = stringPreferencesKey("theme")
+private val customSlidingSyncProxyKey = stringPreferencesKey("customSlidingSyncProxy")
 
 @ContributesBinding(AppScope::class)
 class DefaultAppPreferencesStore @Inject constructor(
@@ -86,6 +87,18 @@ class DefaultAppPreferencesStore @Inject constructor(
             prefs[themeKey]
         }
     }
+
+    override suspend fun setCustomSlidingSyncProxy(string: String?) {
+        store.edit { prefs ->
+            if (string == null) {
+                prefs.remove(customSlidingSyncProxyKey)
+            } else {
+                prefs[customSlidingSyncProxyKey] = string
+            }
+        }
+    }
+
+    override fun customSlidingSyncProxy(): Flow<String?> = store.data.map { prefs -> prefs[customSlidingSyncProxyKey] }
 
     override suspend fun reset() {
         store.edit { it.clear() }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
@@ -49,7 +49,7 @@ class DefaultSessionPreferencesStore(
     private val renderReadReceiptsKey = booleanPreferencesKey("renderReadReceipts")
     private val sendTypingNotificationsKey = booleanPreferencesKey("sendTypingNotifications")
     private val renderTypingNotificationsKey = booleanPreferencesKey("renderTypingNotifications")
-    private val skipSessionVerification = booleanPreferencesKey("skipSessionVerification")
+    private val skipSessionVerificationKey = booleanPreferencesKey("skipSessionVerification")
 
     private val dataStoreFile = storeFile(context, sessionId)
     private val store = PreferenceDataStoreFactory.create(
@@ -87,8 +87,8 @@ class DefaultSessionPreferencesStore(
     override suspend fun setRenderTypingNotifications(enabled: Boolean) = update(renderTypingNotificationsKey, enabled)
     override fun isRenderTypingNotificationsEnabled(): Flow<Boolean> = get(renderTypingNotificationsKey) { true }
 
-    override suspend fun setSkipSessionVerification(skip: Boolean) = update(skipSessionVerification, skip)
-    override fun isSessionVerificationSkipped(): Flow<Boolean> = get(skipSessionVerification) { false }
+    override suspend fun setSkipSessionVerification(skip: Boolean) = update(skipSessionVerificationKey, skip)
+    override fun isSessionVerificationSkipped(): Flow<Boolean> = get(skipSessionVerificationKey) { false }
 
     override suspend fun clear() {
         dataStoreFile.safeDelete()

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
@@ -24,10 +24,12 @@ class InMemoryAppPreferencesStore(
     isDeveloperModeEnabled: Boolean = false,
     customElementCallBaseUrl: String? = null,
     theme: String? = null,
+    customSlidingSyncProxy: String? = null,
 ) : AppPreferencesStore {
     private val isDeveloperModeEnabled = MutableStateFlow(isDeveloperModeEnabled)
     private val customElementCallBaseUrl = MutableStateFlow(customElementCallBaseUrl)
     private val theme = MutableStateFlow(theme)
+    private val customSlidingSyncProxy = MutableStateFlow(customSlidingSyncProxy)
 
     override suspend fun setDeveloperModeEnabled(enabled: Boolean) {
         isDeveloperModeEnabled.value = enabled
@@ -51,6 +53,14 @@ class InMemoryAppPreferencesStore(
 
     override fun getThemeFlow(): Flow<String?> {
         return theme
+    }
+
+    override suspend fun setCustomSlidingSyncProxy(string: String?) {
+        customSlidingSyncProxy.tryEmit(string)
+    }
+
+    override fun customSlidingSyncProxy(): Flow<String?> {
+        return customSlidingSyncProxy
     }
 
     override suspend fun reset() {

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(projects.libraries.eventformatter.impl)
     implementation(projects.libraries.fullscreenintent.impl)
     implementation(projects.libraries.preferences.impl)
+    implementation(projects.libraries.preferences.test)
     implementation(projects.libraries.indicator.impl)
     implementation(projects.features.invite.impl)
     implementation(projects.features.roomlist.impl)

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
@@ -33,6 +33,7 @@ import io.element.android.libraries.matrix.impl.analytics.UtdTracker
 import io.element.android.libraries.matrix.impl.auth.OidcConfigurationProvider
 import io.element.android.libraries.matrix.impl.auth.RustMatrixAuthenticationService
 import io.element.android.libraries.network.useragent.SimpleUserAgentProvider
+import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
 import io.element.android.libraries.sessionstorage.api.LoggedInState
 import io.element.android.libraries.sessionstorage.impl.memory.InMemorySessionStore
 import io.element.android.services.analytics.noop.NoopAnalyticsService
@@ -47,6 +48,7 @@ class MainActivity : ComponentActivity() {
         val sessionStore = InMemorySessionStore()
         val userCertificatesProvider = NoOpUserCertificatesProvider()
         val proxyProvider = NoOpProxyProvider()
+        val appPreferencesStore = InMemoryAppPreferencesStore()
         RustMatrixAuthenticationService(
             baseDirectory = baseDirectory,
             coroutineDispatchers = Singleton.coroutineDispatchers,
@@ -62,6 +64,7 @@ class MainActivity : ComponentActivity() {
                 proxyProvider = proxyProvider,
                 clock = DefaultSystemClock(),
                 utdTracker = UtdTracker(NoopAnalyticsService()),
+                appPreferencesStore = appPreferencesStore,
             ),
             passphraseGenerator = NullPassphraseGenerator(),
             oidcConfigurationProvider = OidcConfigurationProvider(baseDirectory),

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db1631ff53075b31c674cde4bf25cc2876cda8053ffcb593bf6c497c5c41d0c4
-size 49825
+oid sha256:788dcb390bac4bf7d2d15288794ced13ba7914e48fd235dc4729bc35861e1484
+size 55363

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db1631ff53075b31c674cde4bf25cc2876cda8053ffcb593bf6c497c5c41d0c4
-size 49825
+oid sha256:788dcb390bac4bf7d2d15288794ced13ba7914e48fd235dc4729bc35861e1484
+size 55363

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Day_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7f5ea92f8413f6b6dc92d074038727036912ef1828210d0c4d6e36fb0f7e5d3
-size 48352
+oid sha256:4ea7c6b8e7e64cb76e4a7e27066b86e91089246ecede795f0e33affbaa5532f6
+size 53948

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ead9e1fe98bc9ffd33d3768e6983964768edbf3bb4c75cd78a82da5ec0eae03b
-size 48275
+oid sha256:5c8c9fe482a9d13ab4f4961a0cc885da51620787d304cf785d075f8728bbd3ef
+size 53645

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ead9e1fe98bc9ffd33d3768e6983964768edbf3bb4c75cd78a82da5ec0eae03b
-size 48275
+oid sha256:5c8c9fe482a9d13ab4f4961a0cc885da51620787d304cf785d075f8728bbd3ef
+size 53645

--- a/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.preferences.impl.developer_DeveloperSettingsView_Night_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee30083ec3b87ba84a34bdee7b10d50939f31c596c3358bdca9b914ba001d198
-size 46843
+oid sha256:0eda38dd74abbbf02c67bb4c5df709601c36b6bc602aae9726429d2b949b995c
+size 52316


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

## Content

Added a new `customSlidingSyncProxy` preference in `AppPreferencesStore` that will be loaded when restoring the session so it can be used to test a different proxy.

## Motivation and context

Implements the Android part of https://github.com/element-hq/element-meta/issues/2468

## Tests

<!-- Explain how you tested your development -->

- Go to developer options, Rust SDK section.
- Select `custom sliding sync proxy`.
- Set a custom value.
- Kill and restart the app, the new proxy should be used.
- Undo what you did by deleting the custom proxy text and restarting the app.
- The default proxy should be used.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
