### PR TITLE
Subscribe to `RoomListItems` in the visible range

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
@@ -20,6 +20,7 @@ import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.libraries.matrix.api.core.RoomId
 
 sealed interface RoomListEvents {
+    data class UpdateVisibleRange(val range: IntRange) : RoomListEvents
     data object DismissRequestVerificationPrompt : RoomListEvents
     data object DismissRecoveryKeyPrompt : RoomListEvents
     data object ToggleSearchResults : RoomListEvents

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
@@ -30,6 +30,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -165,6 +170,18 @@ private fun RoomsViewList(
     modifier: Modifier = Modifier,
 ) {
     val lazyListState = rememberLazyListState()
+    val visibleRange by remember {
+        derivedStateOf {
+            val layoutInfo = lazyListState.layoutInfo
+            val firstItemIndex = layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: 0
+            val size = layoutInfo.visibleItemsInfo.size
+            firstItemIndex until firstItemIndex + size
+        }
+    }
+    val updatedEventSink by rememberUpdatedState(newValue = eventSink)
+    LaunchedEffect(visibleRange) {
+        updatedEventSink(RoomListEvents.UpdateVisibleRange(visibleRange))
+    }
     LazyColumn(
         state = lazyListState,
         modifier = modifier,
@@ -177,7 +194,7 @@ private fun RoomsViewList(
                     item {
                         ConfirmRecoveryKeyBanner(
                             onContinueClick = onConfirmRecoveryKeyClick,
-                            onDismissClick = { eventSink(RoomListEvents.DismissRecoveryKeyPrompt) }
+                            onDismissClick = { updatedEventSink(RoomListEvents.DismissRecoveryKeyPrompt) }
                         )
                     }
                 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
@@ -20,6 +20,7 @@ import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
@@ -57,6 +58,10 @@ class RoomListDataSource @Inject constructor(
         old?.roomId == new?.roomId
     }
 
+    val allRooms: Flow<ImmutableList<RoomListRoomSummary>> = _allRooms
+
+    val loadingState = roomListService.allRooms.loadingState
+
     fun launchIn(coroutineScope: CoroutineScope) {
         roomListService
             .allRooms
@@ -67,9 +72,9 @@ class RoomListDataSource @Inject constructor(
             .launchIn(coroutineScope)
     }
 
-    val allRooms: Flow<ImmutableList<RoomListRoomSummary>> = _allRooms
-
-    val loadingState = roomListService.allRooms.loadingState
+    suspend fun subscribeToVisibleRooms(roomIds: List<RoomId>) {
+        roomListService.subscribeToVisibleRooms(roomIds)
+    }
 
     @OptIn(FlowPreview::class)
     private fun observeNotificationSettings() {

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListService.kt
@@ -17,6 +17,7 @@
 package io.element.android.libraries.matrix.api.roomlist
 
 import androidx.compose.runtime.Immutable
+import io.element.android.libraries.matrix.api.core.RoomId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -52,6 +53,12 @@ interface RoomListService {
         initialFilter: RoomListFilter,
         source: RoomList.Source,
     ): DynamicRoomList
+
+    /**
+     * Subscribes to sync requests for the visible rooms.
+     * @param roomIds the list of visible room ids to subscribe to.
+     */
+    suspend fun subscribeToVisibleRooms(roomIds: List<RoomId>)
 
     /**
      * Returns a [DynamicRoomList] object of all rooms we want to display.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -55,6 +55,7 @@ import io.element.android.libraries.matrix.impl.notificationsettings.RustNotific
 import io.element.android.libraries.matrix.impl.oidc.toRustAction
 import io.element.android.libraries.matrix.impl.pushers.RustPushersService
 import io.element.android.libraries.matrix.impl.room.RoomContentForwarder
+import io.element.android.libraries.matrix.impl.room.RoomSyncSubscriber
 import io.element.android.libraries.matrix.impl.room.RustRoomFactory
 import io.element.android.libraries.matrix.impl.room.preview.RoomPreviewMapper
 import io.element.android.libraries.matrix.impl.roomdirectory.RustRoomDirectoryService
@@ -213,6 +214,8 @@ class RustMatrixClient(
         }
     }
 
+    private val roomSyncSubscriber: RoomSyncSubscriber = RoomSyncSubscriber(innerRoomListService, dispatchers)
+
     override val roomListService: RoomListService = RustRoomListService(
         innerRoomListService = innerRoomListService,
         sessionCoroutineScope = sessionCoroutineScope,
@@ -221,6 +224,7 @@ class RustMatrixClient(
             innerRoomListService = innerRoomListService,
             sessionCoroutineScope = sessionCoroutineScope,
         ),
+        roomSyncSubscriber = roomSyncSubscriber,
     )
 
     private val verificationService = RustSessionVerificationService(
@@ -238,6 +242,7 @@ class RustMatrixClient(
         dispatchers = dispatchers,
         systemClock = clock,
         roomContentForwarder = RoomContentForwarder(innerRoomListService),
+        roomSyncSubscriber = roomSyncSubscriber,
         isKeyBackupEnabled = { client.encryption().use { it.backupState() == BackupState.ENABLED } },
         getSessionData = { sessionStore.getSession(sessionId.value)!! },
     )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
@@ -19,18 +19,19 @@ package io.element.android.libraries.matrix.impl.room
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.timeline.item.event.EventType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.RequiredState
-import org.matrix.rustcomponents.sdk.RoomListService
+import org.matrix.rustcomponents.sdk.RoomListServiceInterface
 import org.matrix.rustcomponents.sdk.RoomSubscription
 import timber.log.Timber
 
 private const val DEFAULT_TIMELINE_LIMIT = 20u
 
 class RoomSyncSubscriber(
-    private val roomListService: RoomListService,
+    private val roomListService: RoomListServiceInterface,
     private val dispatchers: CoroutineDispatchers,
 ) {
     private val subscriptionCounts = HashMap<RoomId, Int>()
@@ -38,8 +39,10 @@ class RoomSyncSubscriber(
 
     private val settings = RoomSubscription(
         requiredState = listOf(
-            RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
+            RequiredState(key = EventType.STATE_ROOM_NAME, value = ""),
             RequiredState(key = EventType.STATE_ROOM_TOPIC, value = ""),
+            RequiredState(key = EventType.STATE_ROOM_AVATAR, value = ""),
+            RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
             RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
             RequiredState(key = EventType.STATE_ROOM_POWER_LEVELS, value = ""),
         ),
@@ -65,6 +68,27 @@ class RoomSyncSubscriber(
         }
     }
 
+    suspend fun batchSubscribe(roomIds: List<RoomId>) = mutex.withLock {
+        withContext(dispatchers.io) {
+            for (roomId in roomIds) {
+                try {
+                    val currentSubscription = subscriptionCounts.getOrElse(roomId) { 0 }
+                    if (currentSubscription == 0) {
+                        Timber.d("Subscribing to room $roomId}")
+                        roomListService.room(roomId.value).use { roomListItem ->
+                            roomListItem.subscribe(settings)
+                        }
+                    }
+                    subscriptionCounts[roomId] = currentSubscription + 1
+                } catch (cancellationException: CancellationException) {
+                    throw cancellationException
+                } catch (exception: Exception) {
+                    Timber.e("Failed to subscribe to room $roomId")
+                }
+            }
+        }
+    }
+
     suspend fun unsubscribe(roomId: RoomId) = mutex.withLock {
         withContext(dispatchers.io) {
             try {
@@ -83,5 +107,10 @@ class RoomSyncSubscriber(
                 Timber.e("Failed to unsubscribe from room $roomId")
             }
         }
+    }
+
+    fun isSubscribedTo(roomId: RoomId): Boolean {
+        val subscriptionCount = subscriptionCounts[roomId] ?: return false
+        return subscriptionCount > 0
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -50,6 +50,7 @@ class RustRoomFactory(
     private val roomContentForwarder: RoomContentForwarder,
     private val roomListService: RoomListService,
     private val innerRoomListService: InnerRoomListService,
+    private val roomSyncSubscriber: RoomSyncSubscriber,
     private val isKeyBackupEnabled: suspend () -> Boolean,
     private val getSessionData: suspend () -> SessionData,
 ) {
@@ -58,8 +59,6 @@ class RustRoomFactory(
     private val mutex = Mutex()
 
     private val matrixRoomInfoMapper = MatrixRoomInfoMapper()
-
-    private val roomSyncSubscriber: RoomSyncSubscriber = RoomSyncSubscriber(innerRoomListService, dispatchers)
 
     private val eventFilters = TimelineConfig.excludedEvents
         .takeIf { it.isNotEmpty() }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryDetailsFactory.kt
@@ -30,8 +30,8 @@ import org.matrix.rustcomponents.sdk.use
 class RoomSummaryDetailsFactory(private val roomMessageFactory: RoomMessageFactory = RoomMessageFactory()) {
     suspend fun create(roomListItem: RoomListItem): RoomSummary {
         val roomInfo = roomListItem.roomInfo()
-        val latestRoomMessage = roomListItem.latestEvent()?.use {
-            roomMessageFactory.create(it)
+        val latestRoomMessage = roomListItem.latestEvent().use { event ->
+            roomMessageFactory.create(event)
         }
         return RoomSummary(
             roomId = RoomId(roomInfo.id),

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessor.kt
@@ -113,9 +113,7 @@ class RoomSummaryListProcessor(
         val builtRoomSummary = roomListService.roomOrNull(identifier)?.use { roomListItem ->
             buildAndCacheRoomSummaryForRoomListItem(roomListItem)
         }
-        if (builtRoomSummary != null) {
-            roomSummariesByIdentifier[identifier] = builtRoomSummary
-        } else {
+        if (builtRoomSummary == null) {
             roomSummariesByIdentifier.remove(identifier)
         }
         return builtRoomSummary

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTest.kt
@@ -43,6 +43,7 @@ import org.matrix.rustcomponents.sdk.RoomListServiceStateListener
 import org.matrix.rustcomponents.sdk.RoomListServiceSyncIndicatorListener
 import org.matrix.rustcomponents.sdk.RoomMember
 import org.matrix.rustcomponents.sdk.RoomNotificationMode
+import org.matrix.rustcomponents.sdk.RoomSubscription
 import org.matrix.rustcomponents.sdk.TaskHandle
 
 // NOTE: this class is using a fake implementation of a Rust SDK interface which returns actual Rust objects with pointers.
@@ -267,4 +268,6 @@ class FakeRoomListItem(
     override suspend fun latestEvent(): EventTimelineItem? {
         return latestEvent
     }
+
+    override fun subscribe(settings: RoomSubscription?) = Unit
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/roomlist/FakeRoomListService.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.matrix.test.roomlist
 
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.roomlist.DynamicRoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
@@ -24,7 +25,9 @@ import io.element.android.libraries.matrix.api.roomlist.RoomSummary
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class FakeRoomListService : RoomListService {
+class FakeRoomListService(
+    var subscribeToVisibleRoomsLambda: (List<RoomId>) -> Unit = {},
+) : RoomListService {
     private val allRoomSummariesFlow = MutableStateFlow<List<RoomSummary>>(emptyList())
     private val allRoomsLoadingStateFlow = MutableStateFlow<RoomList.LoadingState>(RoomList.LoadingState.NotLoaded)
     private val roomListStateFlow = MutableStateFlow<RoomListService.State>(RoomListService.State.Idle)
@@ -54,6 +57,10 @@ class FakeRoomListService : RoomListService {
         return when (source) {
             RoomList.Source.All -> allRooms
         }
+    }
+
+    override suspend fun subscribeToVisibleRooms(roomIds: List<RoomId>) {
+        subscribeToVisibleRoomsLambda(roomIds)
     }
 
     override val allRooms = SimplePagedRoomList(

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/EventsRecorder.kt
@@ -50,4 +50,8 @@ class EventsRecorder<T>(
     fun assertTrue(index: Int, predicate: (T) -> Boolean) {
         assertThat(predicate(events[index])).isTrue()
     }
+
+    fun clear() {
+        events.clear()
+    }
 }


### PR DESCRIPTION
This ensures the room list items always have updated info.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Subscribe to `RoomListItems` in the visible range so we always have updated info for them. This also helps preload the data rendered when you open one of those rooms.

## Motivation and context

Fixes a limitation introduced by the client side sorting since we no longer use SlidingSync's `visible_rooms` and only fetch the latest event of all the room list items (which, if it's a state event, won't be displayed in the room list).

## Tests

- Clear cache / log out and in with your account.
- Once you're in the room list again you'll see the first few items may have incomplete data.
- Shortly after, the UI should change and reflect the latest info.
- If you scroll, older items will also lazily load this data.
- No rooms should be displayed without a latest event. If there is one, it's probably because its latest message-like event is not in the latest 20 loaded events.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
