### PR TITLE
Set pin grace period to 2 minutes

### DIFF
--- a/appconfig/build.gradle.kts
+++ b/appconfig/build.gradle.kts
@@ -15,20 +15,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.appconfig"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
-
 dependencies {
     implementation(libs.androidx.annotationjvm)
-    implementation(libs.dagger)
-    implementation(projects.libraries.di)
     implementation(projects.libraries.matrix.api)
 }

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
@@ -23,8 +23,8 @@ object LockScreenConfig {
     /** Whether the PIN is mandatory or not. */
     const val IS_PIN_MANDATORY: Boolean = false
 
-    /** Set of forbidden PIN. */
-    val PIN_BLACKLIST: Set<String> = setOf("0000", "1234")
+    /** Set of forbidden PIN codes. */
+    val FORBIDDEN_PIN_CODES: Set<String> = setOf("0000", "1234")
 
     /** The size of the PIN */
     const val PIN_SIZE: Int = 4

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
@@ -17,7 +17,7 @@
 package io.element.android.appconfig
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 
 object LockScreenConfig {
     /** Whether the PIN is mandatory or not. */
@@ -33,7 +33,7 @@ object LockScreenConfig {
     const val MAX_PIN_CODE_ATTEMPTS_BEFORE_LOGOUT: Int = 3
 
     /** Time period before locking the app once backgrounded. */
-    val GRACE_PERIOD: Duration = 0.seconds
+    val GRACE_PERIOD: Duration = 2.minutes
 
     /** Authentication with strong methods (fingerprint, some face/iris unlock implementations) is supported. */
     const val IS_STRONG_BIOMETRICS_ENABLED: Boolean = true

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
@@ -26,7 +26,7 @@ object LockScreenConfig {
     /** Set of forbidden PIN codes. */
     val FORBIDDEN_PIN_CODES: Set<String> = setOf("0000", "1234")
 
-    /** The size of the PIN */
+    /** The size of the PIN. */
     const val PIN_SIZE: Int = 4
 
     /** Number of attempts before the user is logged out. */

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/LockScreenConfig.kt
@@ -16,44 +16,28 @@
 
 package io.element.android.appconfig
 
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Module
-import dagger.Provides
-import io.element.android.libraries.di.AppScope
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * Configuration for the lock screen feature.
- * @property isPinMandatory Whether the PIN is mandatory or not.
- * @property pinBlacklist Some PINs are forbidden.
- * @property pinSize The size of the PIN.
- * @property maxPinCodeAttemptsBeforeLogout Number of attempts before the user is logged out.
- * @property gracePeriod Time period before locking the app once backgrounded.
- * @property isStrongBiometricsEnabled Authentication with strong methods (fingerprint, some face/iris unlock implementations) is supported.
- * @property isWeakBiometricsEnabled Authentication with weak methods (most face/iris unlock implementations) is supported.
- */
-data class LockScreenConfig(
-    val isPinMandatory: Boolean,
-    val pinBlacklist: Set<String>,
-    val pinSize: Int,
-    val maxPinCodeAttemptsBeforeLogout: Int,
-    val gracePeriod: Duration,
-    val isStrongBiometricsEnabled: Boolean,
-    val isWeakBiometricsEnabled: Boolean,
-)
+object LockScreenConfig {
+    /** Whether the PIN is mandatory or not. */
+    const val IS_PIN_MANDATORY: Boolean = false
 
-@ContributesTo(AppScope::class)
-@Module
-object LockScreenConfigModule {
-    @Provides
-    fun providesLockScreenConfig(): LockScreenConfig = LockScreenConfig(
-        isPinMandatory = false,
-        pinBlacklist = setOf("0000", "1234"),
-        pinSize = 4,
-        maxPinCodeAttemptsBeforeLogout = 3,
-        gracePeriod = 0.seconds,
-        isStrongBiometricsEnabled = true,
-        isWeakBiometricsEnabled = true,
-    )
+    /** Set of forbidden PIN. */
+    val PIN_BLACKLIST: Set<String> = setOf("0000", "1234")
+
+    /** The size of the PIN */
+    const val PIN_SIZE: Int = 4
+
+    /** Number of attempts before the user is logged out. */
+    const val MAX_PIN_CODE_ATTEMPTS_BEFORE_LOGOUT: Int = 3
+
+    /** Time period before locking the app once backgrounded. */
+    val GRACE_PERIOD: Duration = 0.seconds
+
+    /** Authentication with strong methods (fingerprint, some face/iris unlock implementations) is supported. */
+    const val IS_STRONG_BIOMETRICS_ENABLED: Boolean = true
+
+    /** Authentication with weak methods (most face/iris unlock implementations) is supported. */
+    const val IS_WEAK_BIOMETRICS_ENABLED: Boolean = true
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
@@ -17,7 +17,6 @@
 package io.element.android.features.lockscreen.impl
 
 import com.squareup.anvil.annotations.ContributesBinding
-import io.element.android.appconfig.LockScreenConfig
 import io.element.android.features.lockscreen.api.LockScreenLockState
 import io.element.android.features.lockscreen.api.LockScreenService
 import io.element.android.features.lockscreen.impl.biometric.BiometricUnlockManager

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
@@ -54,7 +54,7 @@ class DefaultLockScreenService @Inject constructor(
     private val coroutineScope: CoroutineScope,
     private val sessionObserver: SessionObserver,
     private val appForegroundStateService: AppForegroundStateService,
-    private val biometricUnlockManager: BiometricUnlockManager,
+    biometricUnlockManager: BiometricUnlockManager,
 ) : LockScreenService {
     private val _lockState = MutableStateFlow<LockScreenLockState>(LockScreenLockState.Unlocked)
     override val lockState: StateFlow<LockScreenLockState> = _lockState

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/LockScreenConfig.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/LockScreenConfig.kt
@@ -25,7 +25,7 @@ import io.element.android.appconfig.LockScreenConfig as AppConfigLockScreenConfi
 
 data class LockScreenConfig(
     val isPinMandatory: Boolean,
-    val pinBlacklist: Set<String>,
+    val forbiddenPinCodes: Set<String>,
     val pinSize: Int,
     val maxPinCodeAttemptsBeforeLogout: Int,
     val gracePeriod: Duration,
@@ -39,7 +39,7 @@ object LockScreenConfigModule {
     @Provides
     fun providesLockScreenConfig(): LockScreenConfig = LockScreenConfig(
         isPinMandatory = AppConfigLockScreenConfig.IS_PIN_MANDATORY,
-        pinBlacklist = AppConfigLockScreenConfig.PIN_BLACKLIST,
+        forbiddenPinCodes = AppConfigLockScreenConfig.FORBIDDEN_PIN_CODES,
         pinSize = AppConfigLockScreenConfig.PIN_SIZE,
         maxPinCodeAttemptsBeforeLogout = AppConfigLockScreenConfig.MAX_PIN_CODE_ATTEMPTS_BEFORE_LOGOUT,
         gracePeriod = AppConfigLockScreenConfig.GRACE_PERIOD,

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/LockScreenConfig.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/LockScreenConfig.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.features.lockscreen.impl
+
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import io.element.android.libraries.di.AppScope
+import kotlin.time.Duration
+import io.element.android.appconfig.LockScreenConfig as AppConfigLockScreenConfig
+
+data class LockScreenConfig(
+    val isPinMandatory: Boolean,
+    val pinBlacklist: Set<String>,
+    val pinSize: Int,
+    val maxPinCodeAttemptsBeforeLogout: Int,
+    val gracePeriod: Duration,
+    val isStrongBiometricsEnabled: Boolean,
+    val isWeakBiometricsEnabled: Boolean,
+)
+
+@ContributesTo(AppScope::class)
+@Module
+object LockScreenConfigModule {
+    @Provides
+    fun providesLockScreenConfig(): LockScreenConfig = LockScreenConfig(
+        isPinMandatory = AppConfigLockScreenConfig.IS_PIN_MANDATORY,
+        pinBlacklist = AppConfigLockScreenConfig.PIN_BLACKLIST,
+        pinSize = AppConfigLockScreenConfig.PIN_SIZE,
+        maxPinCodeAttemptsBeforeLogout = AppConfigLockScreenConfig.MAX_PIN_CODE_ATTEMPTS_BEFORE_LOGOUT,
+        gracePeriod = AppConfigLockScreenConfig.GRACE_PERIOD,
+        isStrongBiometricsEnabled = AppConfigLockScreenConfig.IS_STRONG_BIOMETRICS_ENABLED,
+        isWeakBiometricsEnabled = AppConfigLockScreenConfig.IS_WEAK_BIOMETRICS_ENABLED,
+    )
+}

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/biometric/DefaultBiometricUnlockManager.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/biometric/DefaultBiometricUnlockManager.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
 import com.squareup.anvil.annotations.ContributesBinding
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.R
 import io.element.android.features.lockscreen.impl.storage.LockScreenStore
 import io.element.android.libraries.cryptography.api.EncryptionDecryptionService

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.biometric.BiometricUnlockManager
 import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.storage.LockScreenStore

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
@@ -97,7 +97,7 @@ class SetupPinPresenter @Inject constructor(
                             choosePinEntry = choosePinEntry.clear()
                             confirmPinEntry = confirmPinEntry.clear()
                         }
-                        is SetupPinFailure.PinBlacklisted -> {
+                        is SetupPinFailure.ForbiddenPin -> {
                             choosePinEntry = choosePinEntry.clear()
                         }
                         null -> Unit

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
@@ -76,7 +76,7 @@ class SetupPinPresenter @Inject constructor(
                 if (confirmPinEntry == choosePinEntry) {
                     pinCodeManager.createPinCode(confirmPinEntry.toText())
                 } else {
-                    setupPinFailure = SetupPinFailure.PinsDontMatch
+                    setupPinFailure = SetupPinFailure.PinsDoNotMatch
                 }
             }
         }
@@ -93,7 +93,7 @@ class SetupPinPresenter @Inject constructor(
                 }
                 SetupPinEvents.ClearFailure -> {
                     when (setupPinFailure) {
-                        is SetupPinFailure.PinsDontMatch -> {
+                        is SetupPinFailure.PinsDoNotMatch -> {
                             choosePinEntry = choosePinEntry.clear()
                             confirmPinEntry = confirmPinEntry.clear()
                         }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenter.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.pin.model.PinEntry
 import io.element.android.features.lockscreen.impl.setup.pin.validation.PinValidator

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinStateProvider.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinStateProvider.kt
@@ -35,7 +35,7 @@ open class SetupPinStateProvider : PreviewParameterProvider<SetupPinState> {
                 choosePinEntry = PinEntry.createEmpty(4).fillWith("1789"),
                 confirmPinEntry = PinEntry.createEmpty(4).fillWith("1788"),
                 isConfirmationStep = true,
-                creationFailure = SetupPinFailure.PinsDontMatch
+                creationFailure = SetupPinFailure.PinsDoNotMatch
             ),
             aSetupPinState(
                 choosePinEntry = PinEntry.createEmpty(4).fillWith("1111"),

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinStateProvider.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinStateProvider.kt
@@ -39,7 +39,7 @@ open class SetupPinStateProvider : PreviewParameterProvider<SetupPinState> {
             ),
             aSetupPinState(
                 choosePinEntry = PinEntry.createEmpty(4).fillWith("1111"),
-                creationFailure = SetupPinFailure.PinBlacklisted
+                creationFailure = SetupPinFailure.ForbiddenPin
             ),
         )
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
@@ -136,7 +136,7 @@ private fun SetupPinContent(
 private fun SetupPinFailure.content(): String {
     return when (this) {
         SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_content)
-        SetupPinFailure.PinsDontMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_content)
+        SetupPinFailure.PinsDoNotMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_content)
     }
 }
 
@@ -144,7 +144,7 @@ private fun SetupPinFailure.content(): String {
 private fun SetupPinFailure.title(): String {
     return when (this) {
         SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_title)
-        SetupPinFailure.PinsDontMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_title)
+        SetupPinFailure.PinsDoNotMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_title)
     }
 }
 

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
@@ -135,7 +135,7 @@ private fun SetupPinContent(
 @Composable
 private fun SetupPinFailure.content(): String {
     return when (this) {
-        SetupPinFailure.PinBlacklisted -> stringResource(id = R.string.screen_app_lock_setup_pin_blacklisted_dialog_content)
+        SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_content)
         SetupPinFailure.PinsDontMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_content)
     }
 }
@@ -143,7 +143,7 @@ private fun SetupPinFailure.content(): String {
 @Composable
 private fun SetupPinFailure.title(): String {
     return when (this) {
-        SetupPinFailure.PinBlacklisted -> stringResource(id = R.string.screen_app_lock_setup_pin_blacklisted_dialog_title)
+        SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_title)
         SetupPinFailure.PinsDontMatch -> stringResource(id = R.string.screen_app_lock_setup_pin_mismatch_dialog_title)
     }
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/PinValidator.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/PinValidator.kt
@@ -16,7 +16,7 @@
 
 package io.element.android.features.lockscreen.impl.setup.pin.validation
 
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.pin.model.PinEntry
 import javax.inject.Inject
 

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/PinValidator.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/PinValidator.kt
@@ -28,9 +28,9 @@ class PinValidator @Inject constructor(private val lockScreenConfig: LockScreenC
 
     fun isPinValid(pinEntry: PinEntry): Result {
         val pinAsText = pinEntry.toText()
-        val isBlacklisted = lockScreenConfig.pinBlacklist.any { it == pinAsText }
-        return if (isBlacklisted) {
-            Result.Invalid(SetupPinFailure.PinBlacklisted)
+        val isForbidden = lockScreenConfig.forbiddenPinCodes.any { it == pinAsText }
+        return if (isForbidden) {
+            Result.Invalid(SetupPinFailure.ForbiddenPin)
         } else {
             Result.Valid
         }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/SetupPinFailure.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/SetupPinFailure.kt
@@ -18,5 +18,5 @@ package io.element.android.features.lockscreen.impl.setup.pin.validation
 
 sealed interface SetupPinFailure {
     data object ForbiddenPin : SetupPinFailure
-    data object PinsDontMatch : SetupPinFailure
+    data object PinsDoNotMatch : SetupPinFailure
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/SetupPinFailure.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/validation/SetupPinFailure.kt
@@ -17,6 +17,6 @@
 package io.element.android.features.lockscreen.impl.setup.pin.validation
 
 sealed interface SetupPinFailure {
-    data object PinBlacklisted : SetupPinFailure
+    data object ForbiddenPin : SetupPinFailure
     data object PinsDontMatch : SetupPinFailure
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
@@ -25,7 +25,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.squareup.anvil.annotations.ContributesBinding
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.di.SingleIn

--- a/features/lockscreen/impl/src/main/res/values-be/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-be/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Эканомце час і выкарыстоўвайце %1$s для разблакіроўкі праграмы"</string>
   <string name="screen_app_lock_setup_choose_pin">"Выберыце PIN-код"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Пацвярджэнне PIN-кода"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Вы не можаце выбраць гэты PIN-код з меркаванняў бяспекі"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Выберыце іншы PIN-код"</string>
   <string name="screen_app_lock_setup_pin_context">"Заблакіруйце %1$s, каб павялічыць бяспеку вашых чатаў.
 
 Абярыце што-небудзь незабыўнае. Калі вы забудзецеся гэты PIN-код, вы выйдзеце з праграмы."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Вы не можаце выбраць гэты PIN-код з меркаванняў бяспекі"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Выберыце іншы PIN-код"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Увядзіце адзін і той жа PIN двойчы"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN-коды не супадаюць"</string>
   <string name="screen_app_lock_signout_alert_message">"Каб працягнуць, вам неабходна паўторна ўвайсці ў сістэму і стварыць новы PIN-код"</string>

--- a/features/lockscreen/impl/src/main/res/values-bg/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-bg/translations.xml
@@ -9,7 +9,7 @@
   <string name="screen_app_lock_setup_biometric_unlock_skip">"Предпочитам да използвам PIN"</string>
   <string name="screen_app_lock_setup_choose_pin">"Избор на PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Потвърждаване на PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Избор на различен PIN"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Избор на различен PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Моля, въведете един и същ PIN два пъти"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PINs не съвпадат"</string>
   <plurals name="screen_app_lock_subtitle">

--- a/features/lockscreen/impl/src/main/res/values-cs/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-cs/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Ušetřete si čas a použijte pokaždé %1$s pro odemknutí aplikace"</string>
   <string name="screen_app_lock_setup_choose_pin">"Zvolte PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Potvrďte PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Z bezpečnostních důvodů si toto nemůžete zvolit jako svůj PIN kód"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Zvolte jiný PIN"</string>
   <string name="screen_app_lock_setup_pin_context">"Zamkněte %1$s pro zvýšení bezpečnosti vašich konverzací.
 
 Vyberte si něco zapamatovatelného. Pokud tento kód PIN zapomenete, budete z aplikace odhlášeni."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Z bezpečnostních důvodů si toto nemůžete zvolit jako svůj PIN kód"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Zvolte jiný PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Zadejte stejný PIN dvakrát"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN kódy se neshodují."</string>
   <string name="screen_app_lock_signout_alert_message">"Abyste mohli pokračovat, budete se muset znovu přihlásit a vytvořit nový PIN"</string>

--- a/features/lockscreen/impl/src/main/res/values-de/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-de/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Spare dir etwas Zeit und benutze %1$s, um die App zu entsperren"</string>
   <string name="screen_app_lock_setup_choose_pin">"PIN wählen"</string>
   <string name="screen_app_lock_setup_confirm_pin">"PIN bestätigen"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Aus Sicherheitsgründen kann dieser PIN-Code nicht verwendet werden."</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Bitte eine andere PIN verwenden."</string>
   <string name="screen_app_lock_setup_pin_context">"Sperre %1$s mit einem PIN Code, um den Zugriff auf deine Chats zu beschränken.
 
 Wähle etwas Einprägsames. Bei falscher Eingabe wirst du aus der App ausgeloggt."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Aus Sicherheitsgründen kann dieser PIN-Code nicht verwendet werden."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Bitte eine andere PIN verwenden."</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Bitte gib die gleiche PIN wie zuvor ein."</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Die PINs stimmen nicht überein"</string>
   <string name="screen_app_lock_signout_alert_message">"Um fortzufahren, musst du dich erneut anmelden und eine neue PIN erstellen"</string>

--- a/features/lockscreen/impl/src/main/res/values-el/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-el/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Εξοικονόμησε χρόνο και χρησιμοποίησε %1$s για να ξεκλειδώσεις την εφαρμογή κάθε φορά"</string>
   <string name="screen_app_lock_setup_choose_pin">"Επέλεξε PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Επιβεβαίωση PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Δεν μπορείς να το επιλέξεις ως κωδικό PIN για λόγους ασφαλείας"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Επέλεξε διαφορετικό PIN"</string>
   <string name="screen_app_lock_setup_pin_context">"Κλείδωμα του %1$s για να προσθέσεις επιπλέον ασφάλεια στις συνομιλίες σου.
 
 Επέλεξε κάτι αξιομνημόνευτο. Εάν ξεχάσεις αυτό το PIN, θα αποσυνδεθείς από την εφαρμογή."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Δεν μπορείς να το επιλέξεις ως κωδικό PIN για λόγους ασφαλείας"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Επέλεξε διαφορετικό PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Παρακαλώ εισήγαγε το ίδιο PIN δύο φορές"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Τα PIN δεν ταιριάζουν"</string>
   <string name="screen_app_lock_signout_alert_message">"Θα χρειαστεί να συνδεθείς ξανά και να δημιουργήσεις ένα νέο PIN για να προχωρήσεις"</string>

--- a/features/lockscreen/impl/src/main/res/values-es/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-es/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Ahorra algo de tiempo y usa %1$s para desbloquear la aplicación cada vez"</string>
   <string name="screen_app_lock_setup_choose_pin">"Elegir PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Confirmar PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"No puedes usar este código PIN por motivos de seguridad"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Elige un PIN diferente"</string>
   <string name="screen_app_lock_setup_pin_context">"Añade un bloqueo a %1$s para añadir seguridad adicional a tus chats.
 
 Elige algo que puedas recordar. Si olvidas este PIN, se cerrará la sesión de la aplicación."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"No puedes usar este código PIN por motivos de seguridad"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Elige un PIN diferente"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Por favor ingresa el mismo PIN dos veces"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Los PINs no coinciden"</string>
   <string name="screen_app_lock_signout_alert_message">"Tendrás que volver a iniciar sesión y crear un nuevo PIN para continuar"</string>

--- a/features/lockscreen/impl/src/main/res/values-et/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-et/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Säästa aega ja kasuta alati %1$s rakenduse lukustuse eemaldamiseks"</string>
   <string name="screen_app_lock_setup_choose_pin">"Vali PIN-kood"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Korda PIN-koodi"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Turvakaalutlustel sa ei saa sellist PIN-koodi kasutada"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Kasuta mõnda teist PIN-koodi"</string>
   <string name="screen_app_lock_setup_pin_context">"Lisamaks oma %1$s vestlustele turvalisust ja privaatsust, lukusta oma nutiseade.
 
 Vali midagi, mis hästi meelde jääb. Kui unustad selle PIN-koodi, siis turvakaalutlustel logitakse sind rakendusest välja."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Turvakaalutlustel sa ei saa sellist PIN-koodi kasutada"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Kasuta mõnda teist PIN-koodi"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Palun sisesta sama PIN-kood kaks korda"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN-koodid ei klapi omavahel"</string>
   <string name="screen_app_lock_signout_alert_message">"Jätkamaks pead uuesti sisse logima ja looma uue PIN-koodi"</string>

--- a/features/lockscreen/impl/src/main/res/values-fr/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-fr/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Gagnez du temps en utilisant %1$s pour déverrouiller l’application à chaque fois."</string>
   <string name="screen_app_lock_setup_choose_pin">"Choisissez un code PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Confirmer le code PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Vous ne pouvez pas choisir ce code PIN pour des raisons de sécurité"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Choisissez un code PIN différent"</string>
   <string name="screen_app_lock_setup_pin_context">"Verrouillez %1$s pour ajouter une sécurité supplémentaire à vos discussions.
 
 Choisissez un code facile à retenir. Si vous oubliez le code PIN, vous serez déconnecté."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Vous ne pouvez pas choisir ce code PIN pour des raisons de sécurité"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Choisissez un code PIN différent"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Veuillez saisir le même code PIN deux fois"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Les codes PIN ne correspondent pas"</string>
   <string name="screen_app_lock_signout_alert_message">"Pour continuer, vous devrez vous connecter à nouveau et créer un nouveau code PIN."</string>

--- a/features/lockscreen/impl/src/main/res/values-hu/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-hu/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Spóroljon meg némi időt, és használja a %1$st az alkalmazás feloldásához"</string>
   <string name="screen_app_lock_setup_choose_pin">"PIN-kód kiválasztása"</string>
   <string name="screen_app_lock_setup_confirm_pin">"PIN-kód megerősítése"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Ezt biztonsági okokból nem választhatja PIN-kódként"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Válasszon egy másik PIN-kódot"</string>
   <string name="screen_app_lock_setup_pin_context">"Az %1$s zárolása a csevegései nagyobb biztonsága érdekében.
 
 Válasszon valami megjegyezhetőt. Ha elfelejti a PIN-kódot, akkor ki lesz jelentkeztetve az alkalmazásból."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Ezt biztonsági okokból nem választhatja PIN-kódként"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Válasszon egy másik PIN-kódot"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Adja meg a PIN-kódját kétszer"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"A PIN-kódok nem egyeznek"</string>
   <string name="screen_app_lock_signout_alert_message">"A folytatáshoz újra be kell jelentkeznie, és létre kell hoznia egy új PIN-kódot"</string>

--- a/features/lockscreen/impl/src/main/res/values-in/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-in/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Hemat waktu Anda dan gunakan %1$s untuk membuka kunci aplikasi setiap kalinya"</string>
   <string name="screen_app_lock_setup_choose_pin">"Pilih PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Konfirmasi PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Anda tidak dapat memilih PIN ini demi keamanan"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Pilih PIN yang lain"</string>
   <string name="screen_app_lock_setup_pin_context">"Kunci %1$s untuk menambahkan keamanan tambahan pada percakapan Anda.
 
 Pilih sesuatu yang mudah untuk diingat. Jika Anda lupa PIN ini, Anda akan dikeluarkan dari aplikasi."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Anda tidak dapat memilih PIN ini demi keamanan"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Pilih PIN yang lain"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Silakan masukkan PIN yang sama dua kali"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN tidak cocok"</string>
   <string name="screen_app_lock_signout_alert_message">"Anda harus masuk ulang dan membuat PIN baru untuk melanjutkan"</string>

--- a/features/lockscreen/impl/src/main/res/values-it/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-it/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Risparmia un po\' di tempo e usa %1$s per sbloccare l\'app ogni volta"</string>
   <string name="screen_app_lock_setup_choose_pin">"Scegli il PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Conferma il PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Non puoi scegliere questo codice PIN per motivi di sicurezza"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Scegli un PIN diverso"</string>
   <string name="screen_app_lock_setup_pin_context">"Blocca %1$s per aggiungere ulteriore sicurezza alle tue conversazioni.
 
 Scegli qualcosa facile da ricordare. Se dimentichi questo PIN, verrai disconnesso dall\'app."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Non puoi scegliere questo codice PIN per motivi di sicurezza"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Scegli un PIN diverso"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Inserisci lo stesso PIN due volte"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"I PIN non corrispondono"</string>
   <string name="screen_app_lock_signout_alert_message">"Dovrai effettuare nuovamente l\'accesso e creare un nuovo PIN per procedere"</string>

--- a/features/lockscreen/impl/src/main/res/values-pt/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-pt/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Poupa tempo e utiliza %1$s para desbloquear a aplicação"</string>
   <string name="screen_app_lock_setup_choose_pin">"Escolher PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Confirmar PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Não podes escolher este código PIN por razões de segurança"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Escolhe um PIN diferente"</string>
   <string name="screen_app_lock_setup_pin_context">"Bloqueia a %1$s para dar mais segurança às tuas conversas.
 
 Escolhe algo memorável. Se te esqueceres deste PIN, a tua sessão será terminada."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Não podes escolher este código PIN por razões de segurança"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Escolhe um PIN diferente"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Insere o mesmo PIN duas vezes"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Os PINs não coincidem"</string>
   <string name="screen_app_lock_signout_alert_message">"Terás de voltar a iniciar sessão e criar um novo PIN para continuar"</string>

--- a/features/lockscreen/impl/src/main/res/values-ro/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-ro/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Economisiți timp și utilizați %1$s pentru a debloca aplicația de fiecare dată."</string>
   <string name="screen_app_lock_setup_choose_pin">"Alegeți codul PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Confirmare PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Nu puteți alege acest cod PIN din motive de securitate"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Alegeți un alt cod PIN"</string>
   <string name="screen_app_lock_setup_pin_context">"Blocați %1$s pentru a adăuga un plus de securitate la conversațiile dvs.
 
 Alegeți ceva memorabil. Dacă uitați acest PIN, veți fi deconectat din aplicație."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Nu puteți alege acest cod PIN din motive de securitate"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Alegeți un alt cod PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Vă rugăm să introduceți același cod PIN de două ori"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"Codurile PIN nu corespund"</string>
   <string name="screen_app_lock_signout_alert_message">"Va trebui să vă reconectați și să creați un cod PIN nou pentru a continua"</string>

--- a/features/lockscreen/impl/src/main/res/values-ru/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-ru/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Сэкономьте время и используйте %1$s для разблокировки приложения"</string>
   <string name="screen_app_lock_setup_choose_pin">"Выберите PIN-код"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Подтвердите PIN-код"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Из соображений безопасности вы не можешь выбрать это в качестве PIN-кода"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Выберите другой PIN-код"</string>
   <string name="screen_app_lock_setup_pin_context">"Заблокируйте %1$s, чтобы повысить безопасность ваших чатов.
 
 Введите что-нибудь незабываемое. Если вы забудете этот PIN-код, вы выйдете из приложения."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Из соображений безопасности вы не можешь выбрать это в качестве PIN-кода"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Выберите другой PIN-код"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Повторите PIN-код"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN-коды не совпадают"</string>
   <string name="screen_app_lock_signout_alert_message">"Чтобы продолжить, вам необходимо повторно войти в систему и создать новый PIN-код"</string>

--- a/features/lockscreen/impl/src/main/res/values-sk/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-sk/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Ušetrite si čas a použite zakaždým %1$s na odomknutie aplikácie"</string>
   <string name="screen_app_lock_setup_choose_pin">"Vyberte PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Potvrdiť PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Z bezpečnostných dôvodov si nemôžete toto zvoliť ako svoj PIN kód."</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Vyberte iný PIN"</string>
   <string name="screen_app_lock_setup_pin_context">"Uzamknite %1$s, aby ste zvýšili bezpečnosť svojich konverzácií.
 
 Vyberte si niečo zapamätateľné. Ak tento kód PIN zabudnete, budete z aplikácie odhlásení."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Z bezpečnostných dôvodov si nemôžete toto zvoliť ako svoj PIN kód."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Vyberte iný PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Zadajte prosím ten istý PIN dvakrát"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN kódy sa nezhodujú"</string>
   <string name="screen_app_lock_signout_alert_message">"Ak chcete pokračovať, musíte sa znovu prihlásiť a vytvoriť nový PIN kód."</string>

--- a/features/lockscreen/impl/src/main/res/values-sv/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-sv/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Bespara dig själv lite tid och använd %1$s för att låsa upp appen varje gång"</string>
   <string name="screen_app_lock_setup_choose_pin">"Välj PIN-kod"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Bekräfta PIN-kod"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Du kan inte välja detta som din PIN-kod av säkerhetsskäl"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Välj en annan PIN-kod"</string>
   <string name="screen_app_lock_setup_pin_context">"Lås %1$s för att lägga till extra säkerhet i dina chattar.
 
 Välj något minnesvärt. Om du glömmer den här PIN-koden loggas du ut från appen."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Du kan inte välja detta som din PIN-kod av säkerhetsskäl"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Välj en annan PIN-kod"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Ange samma PIN-kod två gånger"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN-koder matchar inte"</string>
   <string name="screen_app_lock_signout_alert_message">"Du måste logga in igen och skapa en ny PIN-kod för att fortsätta"</string>

--- a/features/lockscreen/impl/src/main/res/values-uk/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-uk/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Заощаджуйте час і використовуйте %1$s для розблокування застосунку щоразу"</string>
   <string name="screen_app_lock_setup_choose_pin">"Виберіть PIN-код"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Підтвердити PIN-код"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"Ви не можете вибрати його як свій PIN-код з міркувань безпеки"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Виберіть інший PIN-код"</string>
   <string name="screen_app_lock_setup_pin_context">"Заблокуйте %1$s, щоб додати додаткову безпеку вашим чатам.
 
 Виберіть щось, що запам\'ятовується. Але якщо ви забудете PIN-код, ви вийдете з застосунку."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"Ви не можете вибрати його як свій PIN-код з міркувань безпеки"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Виберіть інший PIN-код"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Будь ласка, введіть один і той самий PIN-код двічі"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN-коди не збігаються"</string>
   <string name="screen_app_lock_signout_alert_message">"Щоб продовжити, вам потрібно буде повторно увійти та створити новий PIN-код"</string>

--- a/features/lockscreen/impl/src/main/res/values-zh-rTW/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-zh-rTW/translations.xml
@@ -13,11 +13,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_skip">"我想使用 PIN 碼"</string>
   <string name="screen_app_lock_setup_choose_pin">"選擇 PIN 碼"</string>
   <string name="screen_app_lock_setup_confirm_pin">"確認 PIN 碼"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"基於安全性的考量，您選的 PIN 碼無法使用"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"選擇不一樣的 PIN 碼"</string>
   <string name="screen_app_lock_setup_pin_context">"將 %1$s 上鎖，為你的聊天室添加一層防護。
 
 請選擇好記憶的數字。如果忘記 PIN 碼，您會被登出。"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"基於安全性的考量，您選的 PIN 碼無法使用"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"選擇不一樣的 PIN 碼"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"請輸入相同的 PIN 碼兩次"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN 碼不一樣"</string>
   <string name="screen_app_lock_signout_alert_message">"您需要重新登入並建立新的 PIN 碼才能繼續"</string>

--- a/features/lockscreen/impl/src/main/res/values-zh/translations.xml
+++ b/features/lockscreen/impl/src/main/res/values-zh/translations.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"节省时间，用 %1$s 来解锁应用程序"</string>
   <string name="screen_app_lock_setup_choose_pin">"选择 PIN 码"</string>
   <string name="screen_app_lock_setup_confirm_pin">"确认 PIN 码"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"出于安全原因，您不能选择这个 PIN 码"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"选择不同的 PIN 码"</string>
   <string name="screen_app_lock_setup_pin_context">"锁定 %1$s 以为聊天增加安全性。
 
 选择好记的 PIN 码。如果忘掉了这个 PIN 码，就不得不登出应用。"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"出于安全原因，您不能选择这个 PIN 码"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"选择不同的 PIN 码"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"请输入两次相同的 PIN 码"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PIN 码不匹配"</string>
   <string name="screen_app_lock_signout_alert_message">"您需要重新登录并创建新的 PIN 才能继续"</string>

--- a/features/lockscreen/impl/src/main/res/values/localazy.xml
+++ b/features/lockscreen/impl/src/main/res/values/localazy.xml
@@ -14,11 +14,11 @@
   <string name="screen_app_lock_setup_biometric_unlock_subtitle">"Save yourself some time and use %1$s to unlock the app each time"</string>
   <string name="screen_app_lock_setup_choose_pin">"Choose PIN"</string>
   <string name="screen_app_lock_setup_confirm_pin">"Confirm PIN"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_content">"You cannot choose this as your PIN code for security reasons"</string>
-  <string name="screen_app_lock_setup_pin_blacklisted_dialog_title">"Choose a different PIN"</string>
   <string name="screen_app_lock_setup_pin_context">"Lock %1$s to add extra security to your chats.
 
 Choose something memorable. If you forget this PIN, you will be logged out of the app."</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_content">"You cannot choose this as your PIN code for security reasons"</string>
+  <string name="screen_app_lock_setup_pin_forbidden_dialog_title">"Choose a different PIN"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_content">"Please enter the same PIN twice"</string>
   <string name="screen_app_lock_setup_pin_mismatch_dialog_title">"PINs don\'t match"</string>
   <string name="screen_app_lock_signout_alert_message">"You’ll need to re-login and create a new PIN to proceed"</string>

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/fixtures/LockScreenConfig.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/fixtures/LockScreenConfig.kt
@@ -16,7 +16,7 @@
 
 package io.element.android.features.lockscreen.impl.fixtures
 
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/fixtures/LockScreenConfig.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/fixtures/LockScreenConfig.kt
@@ -22,7 +22,7 @@ import kotlin.time.Duration.Companion.seconds
 
 internal fun aLockScreenConfig(
     isPinMandatory: Boolean = false,
-    pinBlacklist: Set<String> = emptySet(),
+    forbiddenPinCodes: Set<String> = emptySet(),
     pinSize: Int = 4,
     maxPinCodeAttemptsBeforeLogout: Int = 3,
     gracePeriod: Duration = 3.seconds,
@@ -31,7 +31,7 @@ internal fun aLockScreenConfig(
 ): LockScreenConfig {
     return LockScreenConfig(
         isPinMandatory = isPinMandatory,
-        pinBlacklist = pinBlacklist,
+        forbiddenPinCodes = forbiddenPinCodes,
         pinSize = pinSize,
         maxPinCodeAttemptsBeforeLogout = maxPinCodeAttemptsBeforeLogout,
         gracePeriod = gracePeriod,

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenterTest.kt
@@ -20,7 +20,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.biometric.FakeBiometricUnlockManager
 import io.element.android.features.lockscreen.impl.fixtures.aLockScreenConfig
 import io.element.android.features.lockscreen.impl.fixtures.aPinCodeManager

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
@@ -20,7 +20,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.appconfig.LockScreenConfig
+import io.element.android.features.lockscreen.impl.LockScreenConfig
 import io.element.android.features.lockscreen.impl.fixtures.aLockScreenConfig
 import io.element.android.features.lockscreen.impl.fixtures.aPinCodeManager
 import io.element.android.features.lockscreen.impl.pin.DefaultPinCodeManagerCallback

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class SetupPinPresenterTest {
-    private val blacklistedPin = "1234"
+    private val forbiddenPin = "1234"
     private val halfCompletePin = "12"
     private val completePin = "1235"
     private val mismatchedPin = "1236"
@@ -66,11 +66,11 @@ class SetupPinPresenterTest {
                 state.confirmPinEntry.assertEmpty()
                 assertThat(state.setupPinFailure).isNull()
                 assertThat(state.isConfirmationStep).isFalse()
-                state.onPinEntryChanged(blacklistedPin)
+                state.onPinEntryChanged(forbiddenPin)
             }
             awaitLastSequentialItem().also { state ->
-                state.choosePinEntry.assertText(blacklistedPin)
-                assertThat(state.setupPinFailure).isEqualTo(SetupPinFailure.PinBlacklisted)
+                state.choosePinEntry.assertText(forbiddenPin)
+                assertThat(state.setupPinFailure).isEqualTo(SetupPinFailure.ForbiddenPin)
                 state.eventSink(SetupPinEvents.ClearFailure)
             }
             awaitLastSequentialItem().also { state ->
@@ -122,7 +122,7 @@ class SetupPinPresenterTest {
     private fun createSetupPinPresenter(
         callback: PinCodeManager.Callback,
         lockScreenConfig: LockScreenConfig = aLockScreenConfig(
-            pinBlacklist = setOf(blacklistedPin)
+            forbiddenPinCodes = setOf(forbiddenPin)
         ),
     ): SetupPinPresenter {
         val pinCodeManager = aPinCodeManager()

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinPresenterTest.kt
@@ -89,7 +89,7 @@ class SetupPinPresenterTest {
             awaitLastSequentialItem().also { state ->
                 state.choosePinEntry.assertText(completePin)
                 state.confirmPinEntry.assertText(mismatchedPin)
-                assertThat(state.setupPinFailure).isEqualTo(SetupPinFailure.PinsDontMatch)
+                assertThat(state.setupPinFailure).isEqualTo(SetupPinFailure.PinsDoNotMatch)
                 state.eventSink(SetupPinEvents.ClearFailure)
             }
             awaitLastSequentialItem().also { state ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
https://github.com/element-hq/element-x-android/commit/2efa7fea9629ca434b8a9733c86e8f73772033fe: Change the PIN grace period to 2 minutes. In particular it prevent the user from entering the PIN again when taking a photo or picking a file to share as attachment (if the operation last less than 2 minutes)

For the other changes, this is just cleanup of the codebase.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
More user friendly application.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Configure PIN code
- in a room try to share a îcture from the gallery
- Previously: the PIN code was requested when coming back to the application
- Now: if the operation does not take more than 2 minutes, no need to enter the PIN code.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
