### PR TITLE
Fix crash in the room list after a forced log out in background

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.onEach
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind
 import org.matrix.rustcomponents.sdk.RoomListEntriesListener
 import org.matrix.rustcomponents.sdk.RoomListEntriesUpdate
-import org.matrix.rustcomponents.sdk.RoomListException
 import org.matrix.rustcomponents.sdk.RoomListInterface
 import org.matrix.rustcomponents.sdk.RoomListItem
 import org.matrix.rustcomponents.sdk.RoomListLoadingState
@@ -128,11 +127,10 @@ internal fun RoomListServiceInterface.syncIndicator(): Flow<RoomListServiceSyncI
         }
     }.buffer(Channel.UNLIMITED)
 
-internal suspend fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItem? {
-    return try {
+internal fun RoomListServiceInterface.roomOrNull(roomId: String): RoomListItem? {
+    return tryOrNull(
+        onError = { Timber.e(it, "Failed finding room with id=$roomId.") }
+    ) {
         room(roomId)
-    } catch (exception: RoomListException) {
-        Timber.d(exception, "Failed finding room with id=$roomId.")
-        return null
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Take into account `IllegalStateException` too when trying to retrieve a room from `RoomListService`.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/3173, although it doesn't fix the logout that caused the crash.

## Tests

I don't see an easy way to test this.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
