### PR TITLE
Performance : improve time to open a room.

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -490,6 +490,9 @@ class RustMatrixClient(
     override fun roomDirectoryService(): RoomDirectoryService = roomDirectoryService
 
     override fun close() {
+        appCoroutineScope.launch {
+            roomFactory.destroy()
+        }
         sessionCoroutineScope.cancel()
         clientDelegateTaskHandle?.cancelAndDestroy()
         notificationSettingsService.destroy()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -196,8 +196,6 @@ class RustMatrixRoom(
     override fun destroy() {
         roomCoroutineScope.cancel()
         liveTimeline.close()
-        innerRoom.destroy()
-        roomListItem.destroy()
     }
 
     override val displayName: String
@@ -627,12 +625,13 @@ class RustMatrixRoom(
         isLive: Boolean,
         onNewSyncedEvent: () -> Unit = {},
     ): Timeline {
+        val timelineCoroutineScope = roomCoroutineScope.childScope(coroutineDispatchers.main, "TimelineScope-$roomId-$timeline")
         return RustTimeline(
             isKeyBackupEnabled = isKeyBackupEnabled,
             isLive = isLive,
             matrixRoom = this,
             systemClock = systemClock,
-            roomCoroutineScope = roomCoroutineScope,
+            coroutineScope = timelineCoroutineScope,
             dispatcher = roomDispatcher,
             lastLoginTimestamp = sessionData.loginTimestamp,
             onNewSyncedEvent = onNewSyncedEvent,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -89,7 +90,7 @@ class RustRoomFactory(
         }
 
     suspend fun destroy() {
-        withContext(dispatcher) {
+        withContext(NonCancellable + dispatcher) {
             mutex.withLock {
                 Timber.d("Destroying room factory")
                 cache.evictAll()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.libraries.matrix.impl.room
 
+import androidx.collection.lruCache
 import io.element.android.appconfig.TimelineConfig
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -41,6 +42,8 @@ import org.matrix.rustcomponents.sdk.TimelineEventTypeFilter
 import timber.log.Timber
 import org.matrix.rustcomponents.sdk.RoomListService as InnerRoomListService
 
+private const val CACHE_SIZE = 16
+
 class RustRoomFactory(
     private val sessionId: SessionId,
     private val notificationSettingsService: NotificationSettingsService,
@@ -55,8 +58,23 @@ class RustRoomFactory(
     private val getSessionData: suspend () -> SessionData,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val createRoomDispatcher = dispatchers.io.limitedParallelism(1)
+    private val dispatcher = dispatchers.io.limitedParallelism(1)
     private val mutex = Mutex()
+    private var isDestroyed: Boolean = false
+
+    private data class RustRoomObjects(
+        val roomListItem: RoomListItem,
+        val fullRoom: Room,
+    )
+
+    private val cache = lruCache<RoomId, RustRoomObjects>(
+        maxSize = CACHE_SIZE,
+        onEntryRemoved = { evicted, roomId, oldRoom, _ ->
+            Timber.d("On room removed from cache: $roomId, evicted: $evicted")
+            oldRoom.roomListItem.close()
+            oldRoom.fullRoom.close()
+        }
+    )
 
     private val matrixRoomInfoMapper = MatrixRoomInfoMapper()
 
@@ -70,30 +88,41 @@ class RustRoomFactory(
             )
         }
 
-    suspend fun create(roomId: RoomId): MatrixRoom? = withContext(createRoomDispatcher) {
-        var cachedPairOfRoom: Pair<RoomListItem, Room>?
-        mutex.withLock {
-            // Check if already in memory...
-            cachedPairOfRoom = pairOfRoom(roomId)
-            if (cachedPairOfRoom == null) {
-                // ... otherwise, lets wait for the SS to load all rooms and check again.
-                roomListService.allRooms.awaitLoaded()
-                cachedPairOfRoom = pairOfRoom(roomId)
+    suspend fun destroy() {
+        withContext(dispatcher) {
+            mutex.withLock {
+                Timber.d("Destroying room factory")
+                cache.evictAll()
+                isDestroyed = true
             }
         }
-        if (cachedPairOfRoom == null) {
-            Timber.d("No room found for $roomId")
-            return@withContext null
-        }
-        cachedPairOfRoom?.let { (roomListItem, fullRoom) ->
+    }
+
+    suspend fun create(roomId: RoomId): MatrixRoom? = withContext(dispatcher) {
+        mutex.withLock {
+            if (isDestroyed) {
+                Timber.d("Room factory is destroyed, returning null for $roomId")
+                return@withContext null
+            }
+            var roomObjects: RustRoomObjects? = getRoomObjects(roomId)
+            if (roomObjects == null) {
+                // ... otherwise, lets wait for the SS to load all rooms and check again.
+                roomListService.allRooms.awaitLoaded()
+                roomObjects = getRoomObjects(roomId)
+            }
+            if (roomObjects == null) {
+                Timber.d("No room found for $roomId, returning null")
+                return@withContext null
+            }
+            val liveTimeline = roomObjects.fullRoom.timeline()
             RustMatrixRoom(
                 sessionId = sessionId,
                 isKeyBackupEnabled = isKeyBackupEnabled(),
-                roomListItem = roomListItem,
-                innerRoom = fullRoom,
-                innerTimeline = fullRoom.timeline(),
-                notificationSettingsService = notificationSettingsService,
+                roomListItem = roomObjects.roomListItem,
+                innerRoom = roomObjects.fullRoom,
+                innerTimeline = liveTimeline,
                 sessionCoroutineScope = sessionCoroutineScope,
+                notificationSettingsService = notificationSettingsService,
                 coroutineDispatchers = dispatchers,
                 systemClock = systemClock,
                 roomContentForwarder = roomContentForwarder,
@@ -104,20 +133,28 @@ class RustRoomFactory(
         }
     }
 
-    private suspend fun pairOfRoom(roomId: RoomId): Pair<RoomListItem, Room>? {
-        val cachedRoomListItem = innerRoomListService.roomOrNull(roomId.value)
+    private suspend fun getRoomObjects(roomId: RoomId): RustRoomObjects? {
+        cache[roomId]?.let {
+            Timber.d("Room found in cache for $roomId")
+            return it
+        }
+        val roomListItem = innerRoomListService.roomOrNull(roomId.value)
+        if (roomListItem == null) {
+            Timber.d("Room not found for $roomId")
+            return null
+        }
         val fullRoom = try {
-            cachedRoomListItem?.fullRoomWithTimeline(filter = eventFilters)
+            roomListItem.fullRoomWithTimeline(filter = eventFilters)
         } catch (e: RoomListException) {
             Timber.e(e, "Failed to get full room with timeline for $roomId")
-            null
+            return null
         }
-        return if (cachedRoomListItem == null || fullRoom == null) {
-            Timber.d("No room cached for $roomId")
-            null
-        } else {
-            Timber.d("Found room cached for $roomId")
-            Pair(cachedRoomListItem, fullRoom)
+        Timber.d("Got full room with timeline for $roomId")
+        return RustRoomObjects(
+            roomListItem = roomListItem,
+            fullRoom = fullRoom,
+        ).also {
+            cache.put(roomId, it)
         }
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineItemMapper.kt
@@ -26,7 +26,7 @@ import org.matrix.rustcomponents.sdk.TimelineItem
 
 class MatrixTimelineItemMapper(
     private val fetchDetailsForEvent: suspend (EventId) -> Result<Unit>,
-    private val roomCoroutineScope: CoroutineScope,
+    private val coroutineScope: CoroutineScope,
     private val virtualTimelineItemMapper: VirtualTimelineItemMapper = VirtualTimelineItemMapper(),
     private val eventTimelineItemMapper: EventTimelineItemMapper = EventTimelineItemMapper(),
 ) {
@@ -49,7 +49,7 @@ class MatrixTimelineItemMapper(
         return MatrixTimelineItem.Other
     }
 
-    private fun fetchEventDetails(eventId: EventId) = roomCoroutineScope.launch {
+    private fun fetchEventDetails(eventId: EventId) = coroutineScope.launch {
         fetchDetailsForEvent(eventId)
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
@@ -25,13 +25,13 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import org.matrix.rustcomponents.sdk.PaginationStatusListener
-import org.matrix.rustcomponents.sdk.Timeline
 import org.matrix.rustcomponents.sdk.TimelineDiff
+import org.matrix.rustcomponents.sdk.TimelineInterface
 import org.matrix.rustcomponents.sdk.TimelineListener
 import timber.log.Timber
 import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
 
-internal fun Timeline.liveBackPaginationStatus(): Flow<LiveBackPaginationStatus> = callbackFlow {
+internal fun TimelineInterface.liveBackPaginationStatus(): Flow<LiveBackPaginationStatus> = callbackFlow {
     val listener = object : PaginationStatusListener {
         override fun onUpdate(status: LiveBackPaginationStatus) {
             trySend(status)
@@ -45,7 +45,7 @@ internal fun Timeline.liveBackPaginationStatus(): Flow<LiveBackPaginationStatus>
     Timber.d(it, "liveBackPaginationStatus() failed")
 }.buffer(Channel.UNLIMITED)
 
-internal fun Timeline.timelineDiffFlow(): Flow<List<TimelineDiff>> =
+internal fun TimelineInterface.timelineDiffFlow(): Flow<List<TimelineDiff>> =
     callbackFlow {
         val listener = object : TimelineListener {
             override fun onUpdate(diff: List<TimelineDiff>) {
@@ -62,7 +62,7 @@ internal fun Timeline.timelineDiffFlow(): Flow<List<TimelineDiff>> =
         Timber.d(it, "timelineDiffFlow() failed")
     }.buffer(Channel.UNLIMITED)
 
-internal suspend fun Timeline.runWithTimelineListenerRegistered(action: suspend () -> Unit) {
+internal suspend fun TimelineInterface.runWithTimelineListenerRegistered(action: suspend () -> Unit) {
     val result = addListener(NoOpTimelineListener)
     try {
         action()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -56,8 +56,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -67,32 +65,28 @@ import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.FormattedBody
 import org.matrix.rustcomponents.sdk.MessageFormat
 import org.matrix.rustcomponents.sdk.RoomMessageEventContentWithoutRelation
 import org.matrix.rustcomponents.sdk.SendAttachmentJoinHandle
-import org.matrix.rustcomponents.sdk.TimelineChange
-import org.matrix.rustcomponents.sdk.TimelineDiff
-import org.matrix.rustcomponents.sdk.TimelineItem
 import org.matrix.rustcomponents.sdk.messageEventContentFromHtml
 import org.matrix.rustcomponents.sdk.messageEventContentFromMarkdown
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
-import uniffi.matrix_sdk_ui.EventItemOrigin
 import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
 import java.io.File
 import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import org.matrix.rustcomponents.sdk.Timeline as InnerTimeline
 
-private const val INITIAL_MAX_SIZE = 50
 private const val PAGINATION_SIZE = 50
 
 class RustTimeline(
     private val inner: InnerTimeline,
-    isLive: Boolean,
+    private val isLive: Boolean,
     systemClock: SystemClock,
     roomCoroutineScope: CoroutineScope,
     isKeyBackupEnabled: Boolean,
@@ -100,7 +94,7 @@ class RustTimeline(
     private val dispatcher: CoroutineDispatcher,
     lastLoginTimestamp: Date?,
     private val roomContentForwarder: RoomContentForwarder,
-    private val onNewSyncedEvent: () -> Unit,
+    onNewSyncedEvent: () -> Unit,
 ) : Timeline {
     private val initLatch = CompletableDeferred<Unit>()
     private val isInit = AtomicBoolean(false)
@@ -108,20 +102,9 @@ class RustTimeline(
     private val _timelineItems: MutableStateFlow<List<MatrixTimelineItem>> =
         MutableStateFlow(emptyList())
 
-    private val encryptedHistoryPostProcessor = TimelineEncryptedHistoryPostProcessor(
-        lastLoginTimestamp = lastLoginTimestamp,
-        isRoomEncrypted = matrixRoom.isEncrypted,
-        isKeyBackupEnabled = isKeyBackupEnabled,
-        dispatcher = dispatcher,
-    )
-
-    private val roomBeginningPostProcessor = RoomBeginningPostProcessor()
-    private val loadingIndicatorsPostProcessor = LoadingIndicatorsPostProcessor(systemClock)
-    private val lastForwardIndicatorsPostProcessor = LastForwardIndicatorsPostProcessor(isLive)
-
     private val timelineEventContentMapper = TimelineEventContentMapper()
     private val inReplyToMapper = InReplyToMapper(timelineEventContentMapper)
-    private val timelineItemFactory = MatrixTimelineItemMapper(
+    private val timelineItemMapper = MatrixTimelineItemMapper(
         fetchDetailsForEvent = this::fetchDetailsForEvent,
         roomCoroutineScope = roomCoroutineScope,
         virtualTimelineItemMapper = VirtualTimelineItemMapper(),
@@ -129,11 +112,29 @@ class RustTimeline(
             contentMapper = timelineEventContentMapper
         )
     )
-
     private val timelineDiffProcessor = MatrixTimelineDiffProcessor(
         timelineItems = _timelineItems,
-        timelineItemFactory = timelineItemFactory,
+        timelineItemFactory = timelineItemMapper,
     )
+    private val encryptedHistoryPostProcessor = TimelineEncryptedHistoryPostProcessor(
+        lastLoginTimestamp = lastLoginTimestamp,
+        isRoomEncrypted = matrixRoom.isEncrypted,
+        isKeyBackupEnabled = isKeyBackupEnabled,
+        dispatcher = dispatcher,
+    )
+    private val timelineItemsSubscriber = TimelineItemsSubscriber(
+        timeline = inner,
+        roomCoroutineScope = roomCoroutineScope,
+        timelineDiffProcessor = timelineDiffProcessor,
+        initLatch = initLatch,
+        isInit = isInit,
+        dispatcher = dispatcher,
+        onNewSyncedEvent = onNewSyncedEvent,
+    )
+
+    private val roomBeginningPostProcessor = RoomBeginningPostProcessor()
+    private val loadingIndicatorsPostProcessor = LoadingIndicatorsPostProcessor(systemClock)
+    private val lastForwardIndicatorsPostProcessor = LastForwardIndicatorsPostProcessor(isLive)
 
     private val backPaginationStatus = MutableStateFlow(
         Timeline.PaginationStatus(isPaginating = false, hasMoreToLoad = true)
@@ -145,34 +146,26 @@ class RustTimeline(
 
     init {
         roomCoroutineScope.launch(dispatcher) {
-            inner.timelineDiffFlow()
-                .onEach { diffs ->
-                    if (diffs.any { diff -> diff.eventOrigin() == EventItemOrigin.SYNC }) {
-                        onNewSyncedEvent()
-                    }
-                    postDiffs(diffs)
-                }
-                .launchIn(this)
-
-            launch {
-                fetchMembers()
-            }
-
+            fetchMembers()
             if (isLive) {
                 // When timeline is live, we need to listen to the back pagination status as
                 // sdk can automatically paginate backwards.
-                inner.liveBackPaginationStatus()
-                    .onEach { backPaginationStatus ->
-                        updatePaginationStatus(Timeline.PaginationDirection.BACKWARDS) {
-                            when (backPaginationStatus) {
-                                is LiveBackPaginationStatus.Idle -> it.copy(isPaginating = false, hasMoreToLoad = !backPaginationStatus.hitStartOfTimeline)
-                                is LiveBackPaginationStatus.Paginating -> it.copy(isPaginating = true, hasMoreToLoad = true)
-                            }
-                        }
-                    }
-                    .launchIn(this)
+                registerBackPaginationStatusListener()
             }
         }
+    }
+
+    private fun CoroutineScope.registerBackPaginationStatusListener() {
+        inner.liveBackPaginationStatus()
+            .onEach { backPaginationStatus ->
+                updatePaginationStatus(Timeline.PaginationDirection.BACKWARDS) {
+                    when (backPaginationStatus) {
+                        is LiveBackPaginationStatus.Idle -> it.copy(isPaginating = false, hasMoreToLoad = !backPaginationStatus.hitStartOfTimeline)
+                        is LiveBackPaginationStatus.Paginating -> it.copy(isPaginating = true, hasMoreToLoad = true)
+                    }
+                }
+            }
+            .launchIn(this)
     }
 
     override val membershipChangeEventReceived: Flow<Unit> = timelineDiffProcessor.membershipChangeEventReceived
@@ -248,44 +241,20 @@ class RustTimeline(
                 // Keep lastForwardIndicatorsPostProcessor last
                 .let { items -> lastForwardIndicatorsPostProcessor.process(items) }
         }
+    }.onStart {
+        timelineItemsSubscriber.subscribeIfNeeded()
     }
 
     override fun close() {
         inner.close()
     }
 
-    private suspend fun fetchMembers() = withContext(dispatcher) {
+    private fun CoroutineScope.fetchMembers() = launch(dispatcher) {
         initLatch.await()
         try {
             inner.fetchMembers()
         } catch (exception: Exception) {
             Timber.e(exception, "Error fetching members for room ${matrixRoom.roomId}")
-        }
-    }
-
-    private suspend fun postItems(items: List<TimelineItem>) = coroutineScope {
-        // Split the initial items in multiple list as there is no pagination in the cached data, so we can post timelineItems asap.
-        items.chunked(INITIAL_MAX_SIZE).reversed().forEach {
-            ensureActive()
-            timelineDiffProcessor.postItems(it)
-        }
-        isInit.set(true)
-        initLatch.complete(Unit)
-    }
-
-    private suspend fun postDiffs(diffs: List<TimelineDiff>) {
-        val diffsToProcess = diffs.toMutableList()
-        if (!isInit.get()) {
-            val resetDiff = diffsToProcess.firstOrNull { it.change() == TimelineChange.RESET }
-            if (resetDiff != null) {
-                // Keep using the postItems logic so we can post the timelineItems asap.
-                postItems(resetDiff.reset() ?: emptyList())
-                diffsToProcess.remove(resetDiff)
-            }
-        }
-        initLatch.await()
-        if (diffsToProcess.isNotEmpty()) {
-            timelineDiffProcessor.postDiffs(diffsToProcess)
         }
     }
 
@@ -550,12 +519,6 @@ class RustTimeline(
         }
     }
 
-    private suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> {
-        return runCatching {
-            inner.fetchDetailsForEvent(eventId.value)
-        }
-    }
-
     override suspend fun loadReplyDetails(eventId: EventId): InReplyTo = withContext(dispatcher) {
         val timelineItem = _timelineItems.value.firstOrNull { timelineItem ->
             timelineItem is MatrixTimelineItem.Event && timelineItem.eventId == eventId
@@ -570,6 +533,12 @@ class RustTimeline(
             )
         } else {
             inner.loadReplyDetails(eventId.value).use(inReplyToMapper::map)
+        }
+    }
+
+    private suspend fun fetchDetailsForEvent(eventId: EventId): Result<Unit> {
+        return runCatching {
+            inner.fetchDetailsForEvent(eventId.value)
         }
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineItemsSubscriber.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineItemsSubscriber.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl.timeline
+
+import io.element.android.libraries.core.coroutine.childScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.matrix.rustcomponents.sdk.Timeline
+import org.matrix.rustcomponents.sdk.TimelineChange
+import org.matrix.rustcomponents.sdk.TimelineDiff
+import org.matrix.rustcomponents.sdk.TimelineItem
+import uniffi.matrix_sdk_ui.EventItemOrigin
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val INITIAL_MAX_SIZE = 50
+
+/**
+ * This class is responsible for subscribing to a timeline and post the items/diffs to the timelineDiffProcessor.
+ * It will also trigger a callback when a new synced event is received.
+ * It will also handle the initial items and make sure they are posted before any diff.
+ * When closing the room subscription, it will also unsubscribe automatically.
+ */
+internal class TimelineItemsSubscriber(
+    roomCoroutineScope: CoroutineScope,
+    dispatcher: CoroutineDispatcher,
+    private val timeline: Timeline,
+    private val timelineDiffProcessor: MatrixTimelineDiffProcessor,
+    private val initLatch: CompletableDeferred<Unit>,
+    private val isInit: AtomicBoolean,
+    private val onNewSyncedEvent: () -> Unit,
+) {
+    private var subscriptionCount = 0
+    private val mutex = Mutex()
+
+    private val coroutineScope = roomCoroutineScope.childScope(dispatcher, "TimelineItemsSubscriber")
+
+    suspend fun subscribeIfNeeded() = mutex.withLock {
+        if (subscriptionCount == 0) {
+            timeline.timelineDiffFlow()
+                .onEach { diffs ->
+                    if (diffs.any { diff -> diff.eventOrigin() == EventItemOrigin.SYNC }) {
+                        onNewSyncedEvent()
+                    }
+                    postDiffs(diffs)
+                }
+                .launchIn(coroutineScope)
+        }
+        subscriptionCount++
+    }
+
+    suspend fun unsubscribeIfNeeded() = mutex.withLock {
+        when (subscriptionCount) {
+            0 -> return@withLock
+            1 -> {
+                coroutineScope.coroutineContext.cancelChildren()
+            }
+        }
+        subscriptionCount--
+    }
+
+    private suspend fun postItems(items: List<TimelineItem>) = coroutineScope {
+        // Split the initial items in multiple list as there is no pagination in the cached data, so we can post timelineItems asap.
+        items.chunked(INITIAL_MAX_SIZE).reversed().forEach {
+            ensureActive()
+            timelineDiffProcessor.postItems(it)
+        }
+        isInit.set(true)
+        initLatch.complete(Unit)
+    }
+
+    private suspend fun postDiffs(diffs: List<TimelineDiff>) {
+        val diffsToProcess = diffs.toMutableList()
+        if (!isInit.get()) {
+            val resetDiff = diffsToProcess.firstOrNull { it.change() == TimelineChange.RESET }
+            if (resetDiff != null) {
+                // Keep using the postItems logic so we can post the timelineItems asap.
+                postItems(resetDiff.reset() ?: emptyList())
+                diffsToProcess.remove(resetDiff)
+            }
+        }
+        initLatch.await()
+        if (diffsToProcess.isNotEmpty()) {
+            timelineDiffProcessor.postDiffs(diffsToProcess)
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

Currently when getting a room through the `client.getRoom(roomId)` method, it also initialises a `MatrixTimeline` and automatically add the timeline listener.
This is not ok for performance as we use the method in different contexts where we don't need to listen to timeline events. 

The timeline will now be subscribed only when needed. It's still hidden by the sdk, so it remains transparent for the client .

Also, rust sdk has removed his timeline cache, getting a `fullRoom` takes some time as we need to initialise the inner timeline. I've now added a small `lruCache` to keep those in memory.

Last point, the app was triggering some back pagination because of some race condition when building UI items.

## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/3179

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room
- Close the room
- Re-open the same room
- Repeat and everything should stay quick and memory low.

## Tested devices

- [X] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
