### PR TITLE
Ensure that the manual dark theme is rendering correctly regarding -night resource and keyboard

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ElementThemeApp.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ElementThemeApp.kt
@@ -16,7 +16,9 @@
 
 package io.element.android.libraries.designsystem.theme
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -29,6 +31,9 @@ import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 /**
  * Theme to use for all the regular screens of the application.
  * Will manage the light / dark theme based on the user preference.
+ * Will also ensure that the system is applying the correct global theme
+ * to the application, especially when the system is light and the application
+ * is forced to use dark theme.
  */
 @Composable
 fun ElementThemeApp(
@@ -39,6 +44,15 @@ fun ElementThemeApp(
         appPreferencesStore.getThemeFlow().mapToTheme()
     }
         .collectAsState(initial = Theme.System)
+    LaunchedEffect(theme) {
+        AppCompatDelegate.setDefaultNightMode(
+            when (theme) {
+                Theme.System -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                Theme.Light -> AppCompatDelegate.MODE_NIGHT_NO
+                Theme.Dark -> AppCompatDelegate.MODE_NIGHT_YES
+            }
+        )
+    }
     ElementTheme(
         darkTheme = theme.isDark(),
         content = content,


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that the system is aware about "forced" dark theme.
Using `AppCompatDelegate.setDefaultNightMode` is actually working like a charm, I have not found any regression.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Full dark theme when system setting is set to light and application setting is set to dark.

Closes #3168 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|


 -->

|Before|After|
|-|-|
|<img width="260" alt="Screenshot 2024-07-18 at 14 34 45" src="https://github.com/user-attachments/assets/85a3c321-2e54-44db-a685-4b43fe2fbab5">|<img width="260" alt="Screenshot 2024-07-18 at 14 34 51" src="https://github.com/user-attachments/assets/753de011-cb90-4e70-9b2b-d2e0253f06d2">|

## Tests

<!-- Explain how you tested your development -->

- Set system theme to light
- Set application theme to dark
- Before: keyboard was light and some screens were broken (see #3168)
- Clear cache from the application: observe that before the screen was quite broken and is OK now.

Try to change system theme and application theme and observe that the application is always rendering the expected theme.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
