### PR TITLE
Use the right filename for log files so they're sorted in rageshakes

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -71,8 +71,6 @@ class TracingInitializer : Initializer<Unit> {
         return WriteToFilesConfiguration.Enabled(
             directory = bugReporter.logDirectory().absolutePath,
             filenamePrefix = "logs",
-            // DO NOT CHANGE: suffix *MUST* be "log" for the rageshake server to not rename the file to something generic
-            filenameSuffix = "log",
             // Keep a maximum of 1 week of log files.
             numberOfFiles = 7 * 24,
         )

--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -71,8 +71,9 @@ class TracingInitializer : Initializer<Unit> {
         return WriteToFilesConfiguration.Enabled(
             directory = bugReporter.logDirectory().absolutePath,
             filenamePrefix = "logs",
-            filenameSuffix = null,
-            // Keep a minimum of 1 week of log files.
+            // DO NOT CHANGE: suffix *MUST* be "log" for the rageshake server to not rename the file to something generic
+            filenameSuffix = "log",
+            // Keep a maximum of 1 week of log files.
             numberOfFiles = 7 * 24,
         )
     }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/WriteToFilesConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/WriteToFilesConfiguration.kt
@@ -21,7 +21,9 @@ sealed interface WriteToFilesConfiguration {
     data class Enabled(
         val directory: String,
         val filenamePrefix: String,
-        val filenameSuffix: String?,
         val numberOfFiles: Int?,
-    ) : WriteToFilesConfiguration
+    ) : WriteToFilesConfiguration {
+        // DO NOT CHANGE: suffix *MUST* be "log" for the rageshake server to not rename the file to something generic
+        val filenameSuffix = "log"
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Use the `log` suffix when creating log files so the rageshake server recognises its format and doesn't rename them to just `logs-0001.log.gz`, `logs-0002.log.gz`, etc.

## Motivation and context

This way we'll have instead `logs-2024-07-19-11.log.gz`, `logs-2024-07-19-10.log.gz`, etc., stating the hour of logs included inside in their filename.

## Tests

You can upload a test bug report after letting the app run for a while and collect new logs, then check the rageshakes.

https://github.com/element-hq/element-x-android-rageshakes/issues/2410

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
