### PR TITLE
Fix stickers display text on room summary

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -85,7 +85,7 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
                 }
             }
             is StickerContent -> {
-                content.body
+                prefixIfNeeded(sp.getString(CommonStrings.common_sticker) + " (" + content.body + ")", senderDisambiguatedDisplayName, isDmRoom)
             }
             is UnableToDecryptContent -> {
                 val message = sp.getString(CommonStrings.common_waiting_for_decryption_key)

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
@@ -105,11 +105,12 @@ class DefaultRoomLastMessageFormatterTest {
     @Test
     @Config(qualifiers = "en")
     fun `Sticker content`() {
-        val body = "body"
+        val body = "a sticker body"
         val info = ImageInfo(null, null, null, null, null, null, null)
         val message = createRoomEvent(false, null, StickerContent(body, info, aMediaSource(url = "url")))
         val result = formatter.format(message, false)
-        assertThat(result).isEqualTo(body)
+        val expectedBody = someoneElseId.toString() + ": Sticker (a sticker body)"
+        assertThat(result.toString()).isEqualTo(expectedBody)
     }
 
     @Test


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Tweak how stickers are displayed in the room summary

<!-- Describe shortly what has been changed -->

## Motivation and context

After this change https://github.com/matrix-org/matrix-rust-sdk/pull/3715 stickers will show up in the room summary but only displaying the content body, which can be interpreted as a file name or as a sticker description, but in both cases it can look like a normal message (Images appear as 'Image').

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
Before
![image](https://github.com/user-attachments/assets/f452e06a-d711-4f61-897f-ce3aeb5a82bb)
After
![image](https://github.com/user-attachments/assets/ca73d27e-a23a-4936-87c3-3add8be7d44f)

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
