### PR TITLE
Fix linkification not working for `Spanned` strings in text messages

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -17,6 +17,7 @@
 package io.element.android.features.messages.impl.timeline.factories.event
 
 import android.text.Spannable
+import android.text.Spanned
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import androidx.core.text.buildSpannedString
@@ -264,27 +265,27 @@ class TimelineItemContentMessageFactory @Inject constructor(
     }
 
     private fun CharSequence.withFixedURLSpans(): CharSequence {
-        if (this !is Spannable) return this
+        val spannable = this.toSpannable()
         // Get all URL spans, as they will be removed by LinkifyCompat.addLinks
-        val oldURLSpans = getSpans<URLSpan>(0, length).associateWith {
-            val start = getSpanStart(it)
-            val end = getSpanEnd(it)
+        val oldURLSpans = spannable.getSpans<URLSpan>(0, length).associateWith {
+            val start = spannable.getSpanStart(it)
+            val end = spannable.getSpanEnd(it)
             Pair(start, end)
         }
         // Find and set as URLSpans any links present in the text
-        LinkifyCompat.addLinks(this, Linkify.WEB_URLS or Linkify.PHONE_NUMBERS or Linkify.EMAIL_ADDRESSES)
+        LinkifyCompat.addLinks(spannable, Linkify.WEB_URLS or Linkify.PHONE_NUMBERS or Linkify.EMAIL_ADDRESSES)
         // Restore old spans, remove new ones if there is a conflict
         for ((urlSpan, location) in oldURLSpans) {
             val (start, end) = location
-            val addedSpans = getSpans<URLSpan>(start, end).orEmpty()
+            val addedSpans = spannable.getSpans<URLSpan>(start, end).orEmpty()
             if (addedSpans.isNotEmpty()) {
                 for (span in addedSpans) {
-                    removeSpan(span)
+                    spannable.removeSpan(span)
                 }
             }
-            setSpan(urlSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannable.setSpan(urlSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-        return this
+        return spannable
     }
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -17,7 +17,6 @@
 package io.element.android.features.messages.impl.timeline.factories.event
 
 import android.text.Spannable
-import android.text.Spanned
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import androidx.core.text.buildSpannedString

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactoryTest.kt
@@ -20,9 +20,11 @@ import android.net.Uri
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.SpannedString
 import android.text.style.URLSpan
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
+import androidx.core.text.toSpannable
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.location.api.Location
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemAudioContent
@@ -74,6 +76,7 @@ import io.element.android.libraries.mediaviewer.api.util.FileExtensionExtractorW
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -195,7 +198,7 @@ class TimelineItemContentMessageFactoryTest {
             inSpans(URLSpan("https://matrix.org")) {
                 append("and manually added link")
             }
-        }
+        }.toSpannable()
         val sut = createTimelineItemContentMessageFactory(
             htmlConverterTransform = { expected }
         )
@@ -610,7 +613,7 @@ class TimelineItemContentMessageFactoryTest {
             senderDisambiguatedDisplayName = "Bob",
             eventId = AN_EVENT_ID,
         )
-        assertThat((result as TimelineItemNoticeContent).formattedBody).isEqualTo("formatted")
+        (result as TimelineItemNoticeContent).formattedBody.assertSpannedEquals(SpannedString("formatted"))
     }
 
     @Test
@@ -644,7 +647,8 @@ class TimelineItemContentMessageFactoryTest {
             senderDisambiguatedDisplayName = "Bob",
             eventId = AN_EVENT_ID,
         )
-        assertThat((result as TimelineItemEmoteContent).formattedBody).isEqualTo(SpannableString("* Bob formatted"))
+
+        (result as TimelineItemEmoteContent).formattedBody.assertSpannedEquals(SpannableString("* Bob formatted"))
     }
 
     @Test
@@ -654,7 +658,7 @@ class TimelineItemContentMessageFactoryTest {
             inSpans(URLSpan("https://www.example.org")) {
                 append("me@matrix.org")
             }
-        }
+        }.toSpannable()
         val sut = createTimelineItemContentMessageFactory(
             htmlConverterTransform = { expectedSpanned },
             permalinkParser = FakePermalinkParser { PermalinkData.FallbackLink(Uri.EMPTY) }
@@ -669,7 +673,59 @@ class TimelineItemContentMessageFactoryTest {
             senderDisambiguatedDisplayName = "Bob",
             eventId = AN_EVENT_ID,
         )
-        assertThat((result as TimelineItemTextContent).formattedBody).isEqualTo(expectedSpanned)
+        (result as TimelineItemTextContent).formattedBody.assertSpannedEquals(expectedSpanned)
+    }
+
+    @Test
+    fun `a message with plain URL in a formatted body Spanned format gets linkified too`() = runTest {
+        val expectedSpanned = buildSpannedString {
+            append("Test ")
+            inSpansWithFlags(URLSpan("https://www.example.org"), flags = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) {
+                append("https://www.example.org")
+            }
+        }
+        val sut = createTimelineItemContentMessageFactory(
+            htmlConverterTransform = { expectedSpanned },
+            permalinkParser = FakePermalinkParser { PermalinkData.FallbackLink(Uri.EMPTY) }
+        )
+        val result = sut.create(
+            content = createMessageContent(
+                type = TextMessageType(
+                    body = "Test [me@matrix.org](https://www.example.org)",
+                    formatted = FormattedBody(MessageFormat.HTML, "Test https://www.example.org")
+                )
+            ),
+            senderDisambiguatedDisplayName = "Bob",
+            eventId = AN_EVENT_ID,
+        )
+        (result as TimelineItemTextContent).formattedBody.assertSpannedEquals(expectedSpanned)
+    }
+
+    @Test
+    fun `a message with plain URL in a formatted body with plain text format gets linkified too`() = runTest {
+        val resultString = "Test https://www.example.org"
+        val expectedSpanned = buildSpannedString {
+            append("Test ")
+            inSpansWithFlags(URLSpan("https://www.example.org"), flags = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) {
+                append("https://www.example.org")
+            }
+        }.toSpannable()
+        val sut = createTimelineItemContentMessageFactory(
+            htmlConverterTransform = { resultString },
+            permalinkParser = FakePermalinkParser { PermalinkData.FallbackLink(Uri.EMPTY) }
+        )
+        val result = sut.create(
+            content = createMessageContent(
+                type = TextMessageType(
+                    body = "Test [me@matrix.org](https://www.example.org)",
+                    formatted = FormattedBody(MessageFormat.HTML, "Test https://www.example.org")
+                )
+            ),
+            senderDisambiguatedDisplayName = "Bob",
+            eventId = AN_EVENT_ID,
+        )
+
+        (result as TimelineItemTextContent).formattedBody.assertSpannedEquals(expectedSpanned)
     }
 
     private fun createMessageContent(
@@ -717,4 +773,41 @@ class TimelineItemContentMessageFactoryTest {
         fileSizeFormatter = FakeFileSizeFormatter(),
         fileExtensionExtractor = FileExtensionExtractorWithoutValidation()
     )
+}
+
+private inline fun SpannableStringBuilder.inSpansWithFlags(span: Any, flags: Int, action: SpannableStringBuilder.() -> Unit) {
+    val start = this.length
+    action()
+    val end = this.length
+    setSpan(span, start, end, flags)
+}
+
+fun CharSequence?.assertSpannedEquals(other: CharSequence?) {
+    if (this == null && other == null) {
+        return
+    } else if (this is Spanned && other is Spanned) {
+        assertThat(this.toString()).isEqualTo(other.toString())
+        assertThat(this.length).isEqualTo(other.length)
+        val thisSpans = this.getSpans(0, this.length, Any::class.java)
+        val otherSpans = other.getSpans(0, other.length, Any::class.java)
+        if (thisSpans.size != otherSpans.size) {
+            fail("Expected ${thisSpans.size} spans, got ${otherSpans.size}")
+        }
+        thisSpans.forEachIndexed { index, span ->
+            val otherSpan = otherSpans[index]
+            // URLSpans don't have a proper `equals` implementation, so we compare the URL instead
+            if (span is URLSpan && otherSpan is URLSpan) {
+                assertThat(span.url).isEqualTo(otherSpan.url)
+            } else {
+                assertThat(span).isEqualTo(otherSpan)
+            }
+            assertThat(this.getSpanStart(span)).isEqualTo(other.getSpanStart(otherSpan))
+            assertThat(this.getSpanEnd(span)).isEqualTo(other.getSpanEnd(otherSpan))
+            assertThat(this.getSpanFlags(span)).isEqualTo(other.getSpanFlags(otherSpan))
+        }
+    } else {
+        val thisString = this?.toString() ?: "null"
+        val otherString = other?.toString() ?: "null"
+        fail("Expected Spanned, got $thisString and $otherString")
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Make `CharSequence.withFixedURLSpans()` handle any type of CharSequence, not only `Spannable`. If the text wasn't `Spannable`,  a new one will be created from it.

## Motivation and context

Previously, the RTE would always return a `SpannableString` as a result, and as the code checked for `this is Spannable` it worked fine.

Now a `SpannedString` is returned instead (the result of a `buildSpannedString { ... }` block), so the code was skipped.

This issue was found as a regression after upgrading the RTE version to `2.37.7` in https://github.com/element-hq/element-x-android/pull/3218.

## Tests

<!-- Explain how you tested your development -->

- Open a room where a plain link was sent inside a message with `formatted_body`.
- The link should be auto linkified again.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
