### PR TITLE
Fix `build_rust_sdk.sh` script to work on linux

### DIFF
--- a/tools/sdk/build_rust_sdk.sh
+++ b/tools/sdk/build_rust_sdk.sh
@@ -7,7 +7,12 @@ set -e
 read -p "Do you want to build the Rust SDK from local source (yes/no) default to yes? " buildLocal
 buildLocal=${buildLocal:-yes}
 
-date=$(gdate +%Y%m%d%H%M%S)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    date=$(date +%Y%m%d%H%M%S)
+else
+    date=$(gdate +%Y%m%d%H%M%S)
+fi
+
 elementPwd=$(pwd)
 
 # Ask for the Rust SDK local source path


### PR DESCRIPTION
A few linux distributions don't have `gdate`, but I think they should all have `date`.
