### PR TITLE
Fix proguard config for nightly and release builds

### DIFF
--- a/libraries/pushproviders/firebase/build.gradle.kts
+++ b/libraries/pushproviders/firebase/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     buildTypes {
         getByName("release") {
             consumerProguardFiles("consumer-proguard-rules.pro")
+            proguardFiles("proguard-rules.pro")
             resValue(
                 type = "string",
                 name = "google_app_id",

--- a/libraries/pushproviders/firebase/build.gradle.kts
+++ b/libraries/pushproviders/firebase/build.gradle.kts
@@ -51,6 +51,7 @@ android {
         register("nightly") {
             isMinifyEnabled = true
             consumerProguardFiles("consumer-proguard-rules.pro")
+            proguardFiles("proguard-rules.pro")
             matchingFallbacks += listOf("release")
             resValue(
                 type = "string",

--- a/libraries/pushproviders/firebase/proguard-rules.pro
+++ b/libraries/pushproviders/firebase/proguard-rules.pro
@@ -1,0 +1,5 @@
+# Used for unit tests
+
+-dontwarn java.lang.invoke.StringConcatFactory
+
+-keep class io.element.android.libraries.pushproviders.firebase.** { *; }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add a proguard rules file for the pushprovider firebase module.

## Motivation and context

For some reason it seems like this module needs extra proguard rules.

## Tests

Nightlies are working again.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
