### PR TITLE
Ensure sessionPath is not reused for different homeserver. Fixes not loading media issue.

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -60,7 +60,7 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)
 class RustMatrixAuthenticationService @Inject constructor(
-    baseDirectory: File,
+    private val baseDirectory: File,
     private val coroutineDispatchers: CoroutineDispatchers,
     private val sessionStore: SessionStore,
     private val rustMatrixClientFactory: RustMatrixClientFactory,
@@ -70,9 +70,17 @@ class RustMatrixAuthenticationService @Inject constructor(
     // Passphrase which will be used for new sessions. Existing sessions will use the passphrase
     // stored in the SessionData.
     private val pendingPassphrase = getDatabasePassphrase()
-    private val sessionPath = File(baseDirectory, UUID.randomUUID().toString()).absolutePath
+    // Need to keep a copy of the current session path to delete it.
+    // Ideally it would be possible to get the sessionPath from the Client to avoid doing this.
+    private var sessionPath: File? = null
     private var currentClient: Client? = null
     private var currentHomeserver = MutableStateFlow<MatrixHomeServerDetails?>(null)
+
+    private fun rotateSessionPath(): File {
+        sessionPath?.deleteRecursively()
+        return File(baseDirectory, UUID.randomUUID().toString())
+            .also { sessionPath = it }
+    }
 
     override fun loggedInStateFlow(): Flow<LoggedInState> {
         return sessionStore.isLoggedIn()
@@ -117,8 +125,9 @@ class RustMatrixAuthenticationService @Inject constructor(
 
     override suspend fun setHomeserver(homeserver: String): Result<Unit> =
         withContext(coroutineDispatchers.io) {
+            val emptySessionPath = rotateSessionPath()
             runCatching {
-                val client = getBaseClientBuilder()
+                val client = getBaseClientBuilder(emptySessionPath)
                     .serverNameOrHomeserverUrl(homeserver)
                     .build()
                 currentClient = client
@@ -135,13 +144,14 @@ class RustMatrixAuthenticationService @Inject constructor(
         withContext(coroutineDispatchers.io) {
             runCatching {
                 val client = currentClient ?: error("You need to call `setHomeserver()` first")
+                val currentSessionPath = sessionPath ?: error("You need to call `setHomeserver()` first")
                 client.login(username, password, "Element X Android", null)
                 val sessionData = client.session()
                     .toSessionData(
                         isTokenValid = true,
                         loginType = LoginType.PASSWORD,
                         passphrase = pendingPassphrase,
-                        sessionPath = sessionPath,
+                        sessionPath = currentSessionPath.absolutePath,
                     )
                 clear()
                 sessionStore.storeData(sessionData)
@@ -185,13 +195,14 @@ class RustMatrixAuthenticationService @Inject constructor(
         return withContext(coroutineDispatchers.io) {
             runCatching {
                 val client = currentClient ?: error("You need to call `setHomeserver()` first")
+                val currentSessionPath = sessionPath ?: error("You need to call `setHomeserver()` first")
                 val urlForOidcLogin = pendingOidcAuthorizationData ?: error("You need to call `getOidcUrl()` first")
                 client.loginWithOidcCallback(urlForOidcLogin, callbackUrl)
                 val sessionData = client.session().toSessionData(
                     isTokenValid = true,
                     loginType = LoginType.OIDC,
                     passphrase = pendingPassphrase,
-                    sessionPath = sessionPath,
+                    sessionPath = currentSessionPath.absolutePath,
                 )
                 clear()
                 pendingOidcAuthorizationData?.close()
@@ -206,9 +217,10 @@ class RustMatrixAuthenticationService @Inject constructor(
 
     override suspend fun loginWithQrCode(qrCodeData: MatrixQrCodeLoginData, progress: (QrCodeLoginStep) -> Unit) =
         withContext(coroutineDispatchers.io) {
+            val emptySessionPath = rotateSessionPath()
             runCatching {
                 val client = rustMatrixClientFactory.getBaseClientBuilder(
-                    sessionPath = sessionPath,
+                    sessionPath = emptySessionPath.absolutePath,
                     passphrase = pendingPassphrase,
                     slidingSyncProxy = AuthenticationConfig.SLIDING_SYNC_PROXY_URL,
                     slidingSync = ClientBuilderSlidingSync.Discovered,
@@ -229,7 +241,7 @@ class RustMatrixAuthenticationService @Inject constructor(
                             isTokenValid = true,
                             loginType = LoginType.QR,
                             passphrase = pendingPassphrase,
-                            sessionPath = sessionPath,
+                            sessionPath = emptySessionPath.absolutePath,
                         )
                     sessionStore.storeData(sessionData)
                     SessionId(sessionData.userId)
@@ -246,11 +258,13 @@ class RustMatrixAuthenticationService @Inject constructor(
                 }
                 Timber.e(throwable, "Failed to login with QR code")
             }
-    }
+        }
 
-    private fun getBaseClientBuilder() = rustMatrixClientFactory
+    private fun getBaseClientBuilder(
+        sessionPath: File,
+    ) = rustMatrixClientFactory
         .getBaseClientBuilder(
-            sessionPath = sessionPath,
+            sessionPath = sessionPath.absolutePath,
             passphrase = pendingPassphrase,
             slidingSyncProxy = AuthenticationConfig.SLIDING_SYNC_PROXY_URL,
             slidingSync = ClientBuilderSlidingSync.Discovered,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -70,7 +70,8 @@ class RustMatrixAuthenticationService @Inject constructor(
     // Passphrase which will be used for new sessions. Existing sessions will use the passphrase
     // stored in the SessionData.
     private val pendingPassphrase = getDatabasePassphrase()
-    // Need to keep a copy of the current session path to delete it.
+
+    // Need to keep a copy of the current session path to eventually delete it.
     // Ideally it would be possible to get the sessionPath from the Client to avoid doing this.
     private var sessionPath: File? = null
     private var currentClient: Client? = null


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure the folder `sessionPath` is not reused for different homeserver, else some cached data may be wrong.
Rotate the folder and delete the previous one. One side effect is described in #3296 because API to get authentication media may or may not be available and this capability is stored in cache.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3296

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

- No session
- Continue with matrix.org but do not enter credentials.
- Go back
- Change the homeserver with one which does not support authenticated media (for instance element.io)
- Login to this homeserver

Before: media cannot be loaded
After: media can be loaded.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
