### PR TITLE
Add test on function name which may start or end with spaces

### DIFF
--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -495,7 +495,7 @@ class RoomListPresenterTest {
     }
 
     @Test
-    fun `present - when room service returns no room, then contentState is Empty `() = runTest {
+    fun `present - when room service returns no room, then contentState is Empty`() = runTest {
         val scope = CoroutineScope(coroutineContext + SupervisorJob())
         val roomListService = FakeRoomListService()
         roomListService.postAllRoomsLoadingState(RoomList.LoadingState.Loaded(0))

--- a/libraries/mediaviewer/api/src/test/kotlin/io/element/android/libraries/mediaviewer/MediaViewerPresenterTest.kt
+++ b/libraries/mediaviewer/api/src/test/kotlin/io/element/android/libraries/mediaviewer/MediaViewerPresenterTest.kt
@@ -70,7 +70,7 @@ class MediaViewerPresenterTest {
     }
 
     @Test
-    fun `present - check all actions `() = runTest {
+    fun `present - check all actions`() = runTest {
         val matrixMediaLoader = FakeMatrixMediaLoader()
         val mediaActions = FakeLocalMediaActions()
         val snackbarDispatcher = SnackbarDispatcher()

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
@@ -306,7 +306,7 @@ class DefaultPushHandlerTest {
     }
 
     @Test
-    fun `when diagnostic PushData is received, the diagnostic push handler is informed `() =
+    fun `when diagnostic PushData is received, the diagnostic push handler is informed`() =
         runTest {
             val aPushData = PushData(
                 eventId = DefaultTestPush.TEST_EVENT_ID,

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistMethodNameTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistMethodNameTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.tests.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistMethodNameTest {
+    @Test
+    fun `Ensure that method name does not start or end with spaces`() {
+        Konsist.scopeFromProject()
+            .functions()
+            .assertTrue {
+                it.name.trim() == it.name
+            }
+    }
+}


### PR DESCRIPTION
Working on https://github.com/element-hq/element-x-android/issues/3310, I have found a small naming issue that cannot be reproduced thanks to a new Konsist test.