### PR TITLE
Fix broken direct room member for rooms with old users that left

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
@@ -58,6 +58,7 @@ fun MatrixRoom.getDirectRoomMember(roomMembersState: MatrixRoomMembersState): St
     return remember(roomMembersState) {
         derivedStateOf {
             roomMembers
+                ?.filter { it.membership.isActive() }
                 ?.takeIf { it.size == 2 && isDirect && isEncrypted }
                 ?.find { it.userId != sessionId }
         }


### PR DESCRIPTION
## Content

This pull request fixes `getDirectRoomMember` not respecting direct rooms with more than two members total but only two active. This commonly occurs when users migrate to a new account by adding a new account to rooms and leaving with the old one.

Other parts of the codebase (such as the people room list filter) already respect the active member count of a room instead of the total (historic) number of unique members.

This fixes the room details screen not showing up correctly, for example missing the avatar cluster.

## Motivation and context

The room details screen would not show avatar clusters correctly in DM rooms created before I migrated my account.

## Screenshots / GIFs

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/cd96299c-c5da-4b8e-a2bc-8043c0181525)|![image](https://github.com/user-attachments/assets/49ffc643-cbe3-4d44-add5-cdcf8e412926)|

## Tests

- Create a DM room
- Invite a new user
- Kick the new user
- Observe the room details screen not showing up correctly

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
