### PR TITLE
Improve the text for mentions and replies in notifications

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -104,11 +104,6 @@ class DefaultNotifiableEventResolver @Inject constructor(
             is NotificationContent.MessageLike.RoomMessage -> {
                 val senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId)
                 val messageBody = descriptionFromMessageContent(content, senderDisambiguatedDisplayName)
-                val notificationBody = if (hasMention) {
-                    stringProvider.getString(R.string.notification_mentioned_you_body, messageBody)
-                } else {
-                    messageBody
-                }
                 buildNotifiableMessageEvent(
                     sessionId = userId,
                     senderId = content.senderId,
@@ -117,12 +112,13 @@ class DefaultNotifiableEventResolver @Inject constructor(
                     noisy = isNoisy,
                     timestamp = this.timestamp,
                     senderDisambiguatedDisplayName = senderDisambiguatedDisplayName,
-                    body = notificationBody,
+                    body = messageBody,
                     imageUriString = fetchImageIfPresent(client)?.toString(),
                     roomName = roomDisplayName,
                     roomIsDm = isDm,
                     roomAvatarPath = roomAvatarUrl,
                     senderAvatarPath = senderAvatarUrl,
+                    hasMentionOrReply = hasMention,
                 )
             }
             is NotificationContent.StateEvent.RoomMemberContent -> {
@@ -340,6 +336,7 @@ internal fun buildNotifiableMessageEvent(
     isRedacted: Boolean = false,
     isUpdated: Boolean = false,
     type: String = EventType.MESSAGE,
+    hasMentionOrReply: Boolean = false,
 ) = NotifiableMessageEvent(
     sessionId = sessionId,
     senderId = senderId,
@@ -363,4 +360,5 @@ internal fun buildNotifiableMessageEvent(
     isRedacted = isRedacted,
     isUpdated = isUpdated,
     type = type,
+    hasMentionOrReply = hasMentionOrReply,
 )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -397,10 +397,22 @@ class DefaultNotificationCreator @Inject constructor(
             val senderPerson = if (event.outGoingMessage) {
                 null
             } else {
+                val senderName = event.senderDisambiguatedDisplayName.orEmpty()
+                // If the notification is for a mention or reply, we create a fake `Person` with a custom name and key
+                val displayName = if (event.hasMentionOrReply) {
+                    stringProvider.getString(R.string.notification_sender_mention_reply, senderName)
+                } else {
+                    senderName
+                }
+                val key = if (event.hasMentionOrReply) {
+                    "mention-or-reply:${event.eventId.value}"
+                } else {
+                    event.senderId.value
+                }
                 Person.Builder()
-                    .setName(event.senderDisambiguatedDisplayName?.annotateForDebug(70))
+                    .setName(displayName.annotateForDebug(70))
                     .setIcon(bitmapLoader.getUserIcon(event.senderAvatarPath, imageLoader))
-                    .setKey(event.senderId.value)
+                    .setKey(key)
                     .build()
             }
             when {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableMessageEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableMessageEvent.kt
@@ -52,7 +52,8 @@ data class NotifiableMessageEvent(
     val outGoingMessageFailed: Boolean = false,
     override val isRedacted: Boolean = false,
     override val isUpdated: Boolean = false,
-    val type: String = EventType.MESSAGE
+    val type: String = EventType.MESSAGE,
+    val hasMentionOrReply: Boolean = false,
 ) : NotifiableEvent {
     override val description: String = body ?: ""
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -123,7 +123,7 @@ class DefaultNotifiableEventResolverTest {
             )
         )
         val result = sut.resolveEvent(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID)
-        val expectedResult = createNotifiableMessageEvent(body = "Mentioned you: Hello world")
+        val expectedResult = createNotifiableMessageEvent(body = "Hello world", hasMentionOrReply = true)
         assertThat(result).isEqualTo(expectedResult)
     }
 
@@ -687,7 +687,10 @@ class DefaultNotifiableEventResolverTest {
         )
     }
 
-    private fun createNotifiableMessageEvent(body: String): NotifiableMessageEvent {
+    private fun createNotifiableMessageEvent(
+        body: String,
+        hasMentionOrReply: Boolean = false,
+    ): NotifiableMessageEvent {
         return NotifiableMessageEvent(
             sessionId = A_SESSION_ID,
             roomId = A_ROOM_ID,
@@ -708,7 +711,8 @@ class DefaultNotifiableEventResolverTest {
             outGoingMessage = false,
             outGoingMessageFailed = false,
             isRedacted = false,
-            isUpdated = false
+            isUpdated = false,
+            hasMentionOrReply = hasMentionOrReply,
         )
     }
 }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -112,6 +112,7 @@
   <string name="action_tap_for_options">"Tap for options"</string>
   <string name="action_try_again">"Try again"</string>
   <string name="action_unpin">"Unpin"</string>
+  <string name="action_view_in_timeline">"View in timeline"</string>
   <string name="action_view_source">"View source"</string>
   <string name="action_yes">"Yes"</string>
   <string name="common_about">"About"</string>
@@ -177,6 +178,7 @@ Reason: %1$s."</string>
   <string name="common_people">"People"</string>
   <string name="common_permalink">"Permalink"</string>
   <string name="common_permission">"Permission"</string>
+  <string name="common_pinned">"Pinned"</string>
   <string name="common_please_wait">"Please wait…"</string>
   <string name="common_poll_end_confirmation">"Are you sure you want to end this poll?"</string>
   <string name="common_poll_summary">"Poll: %1$s"</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When we receive a notification with a message that either mentions or replies to the current user - since we can't know if it mentioned **or** replied to, it's either both or none - instead of setting its text to `Foo mentioned you: actual message` we'll  create a fake `Person` to display in the `MessagingStyle` for the notification, similar to what WhatsApp does.

Any other messages will be using the normal `Person` as they did until now, so they'll be grouped together.

## Motivation and context

Counterpart of https://github.com/element-hq/element-x-ios/issues/2397 for Android.

## Screenshots / GIFs

![image](https://github.com/user-attachments/assets/155db0ed-ec11-4787-b0c4-cf5e08b1e5c7)

## Tests

- In some room, send a message that mentions or replies to some other account of yours where you have EXA installed.
- The notification should display as in the screenshot.
- If any other non-mention/reply messages are sent they should keep the current style.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
