### PR TITLE
Fix login navigation getting stuck when the app was compiled with no-op analytics provider

### DIFF
--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/state/DefaultFtueService.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/state/DefaultFtueService.kt
@@ -98,7 +98,10 @@ class DefaultFtueService @Inject constructor(
             } else {
                 getNextStep(FtueStep.AnalyticsOptIn)
             }
-            FtueStep.AnalyticsOptIn -> null
+            FtueStep.AnalyticsOptIn -> {
+                updateState()
+                null
+            }
         }
 
     private suspend fun isAnyStepIncomplete(): Boolean {


### PR DESCRIPTION
Currently, the FTUE flow requires the `analyticsService.didAskUserConsent()` flow to update in order to evaluate `isAnyStepIncomplete()` and thus to dismiss the onboarding flow. With the no-op analytics provider, `didAskUserConsent()` is always true, such that no `updateState()` call is triggered after accepting or denying notification permission, leaving the user stuck at that screen until re-opening the app.

## Tests

[Compile with no-op analytics provider](https://github.com/SchildiChat/schildichat-android-next/commit/f8a36f2b5ecfa456afefee571e6c1f1cbefc0104) and do a fresh login.

## Tested devices

- [x] Physical / only tested with SchildiChat fork so far
- [ ] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR

## Sign-off

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>