### PR TITLE
Fix a couple of build-time warnings in Gradle output

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,3 @@ android.experimental.enableTestFixtures=true
 
 # Create BuildConfig files as bytecode to avoid Java compilation phase
 android.enableBuildConfigAsBytecode=true
-
-# By default, the plugin applies itself to all subprojects, but we don't want that as it would cause issues with builds using local AARs
-dependency.analysis.autoapply=false

--- a/plugins/src/main/kotlin/extension/KoverExtension.kt
+++ b/plugins/src/main/kotlin/extension/KoverExtension.kt
@@ -58,7 +58,7 @@ fun Project.setupKover() {
     task("koverVerifyAll") {
         group = "verification"
         description = "Verifies the code coverage of all subprojects."
-        val dependencies = listOf(":app:koverVerifyGplayDebug") + koverVariants.map { ":app:koverVerify${it.capitalized()}" }
+        val dependencies = listOf(":app:koverVerifyGplayDebug") + koverVariants.map { ":app:koverVerify${it.replaceFirstChar(Char::titlecase)}" }
         dependsOn(dependencies)
 
     }


### PR DESCRIPTION
## Content
Fix a couple of warnings. See commit messages for what and why

## Motivation and context
They were easy to fix and annoying me
## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
