### PR TITLE
Add a way to sign out when the user is asked to verify the session.

### DIFF
--- a/features/verifysession/impl/build.gradle.kts
+++ b/features/verifysession/impl/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.preferences.api)
     implementation(projects.libraries.uiStrings)
+    implementation(projects.features.logout.api)
     api(libs.statemachine)
     api(projects.features.verifysession.api)
 
@@ -52,6 +53,7 @@ dependencies {
     testImplementation(libs.test.robolectric)
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
+    testImplementation(projects.features.logout.test)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.libraries.preferences.test)
     testImplementation(projects.tests.testutils)

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionNode.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionNode.kt
@@ -16,8 +16,10 @@
 
 package io.element.android.features.verifysession.impl
 
+import android.app.Activity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
@@ -25,6 +27,8 @@ import com.bumble.appyx.core.plugin.plugins
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.element.android.anvilannotations.ContributesNode
+import io.element.android.compound.theme.ElementTheme
+import io.element.android.features.logout.api.util.onSuccessLogout
 import io.element.android.features.verifysession.api.VerifySessionEntryPoint
 import io.element.android.libraries.di.SessionScope
 
@@ -39,12 +43,15 @@ class VerifySelfSessionNode @AssistedInject constructor(
     @Composable
     override fun View(modifier: Modifier) {
         val state = presenter.present()
+        val activity = LocalContext.current as Activity
+        val isDark = ElementTheme.isLightTheme.not()
         VerifySelfSessionView(
             state = state,
             modifier = modifier,
             onEnterRecoveryKey = callback::onEnterRecoveryKey,
             onResetKey = callback::onResetKey,
             onFinish = callback::onDone,
+            onSuccessLogout = { onSuccessLogout(activity, isDark, it) },
         )
     }
 }

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionState.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionState.kt
@@ -18,12 +18,14 @@ package io.element.android.features.verifysession.impl
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.verification.SessionVerificationData
 
 @Immutable
 data class VerifySelfSessionState(
     val verificationFlowStep: VerificationStep,
+    val signOutAction: AsyncAction<String?>,
     val displaySkipButton: Boolean,
     val eventSink: (VerifySelfSessionViewEvents) -> Unit,
 ) {

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateProvider.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateProvider.kt
@@ -18,6 +18,7 @@ package io.element.android.features.verifysession.impl
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.verifysession.impl.VerifySelfSessionState.VerificationStep
+import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.verification.SessionVerificationData
 import io.element.android.libraries.matrix.api.verification.VerificationEmoji
@@ -54,6 +55,10 @@ open class VerifySelfSessionStateProvider : PreviewParameterProvider<VerifySelfS
                 verificationFlowStep = VerificationStep.Completed,
                 displaySkipButton = true,
             ),
+            aVerifySelfSessionState(
+                signOutAction = AsyncAction.Loading,
+                displaySkipButton = true,
+            ),
             // Add other state here
         )
 }
@@ -72,12 +77,14 @@ private fun aDecimalsSessionVerificationData(
 
 internal fun aVerifySelfSessionState(
     verificationFlowStep: VerificationStep = VerificationStep.Initial(canEnterRecoveryKey = false),
+    signOutAction: AsyncAction<String?> = AsyncAction.Uninitialized,
     displaySkipButton: Boolean = false,
     eventSink: (VerifySelfSessionViewEvents) -> Unit = {},
 ) = VerifySelfSessionState(
     verificationFlowStep = verificationFlowStep,
     displaySkipButton = displaySkipButton,
     eventSink = eventSink,
+    signOutAction = signOutAction,
 )
 
 private fun aVerificationEmojiList() = listOf(

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionView.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionView.kt
@@ -105,13 +105,15 @@ fun VerifySelfSessionView(
             TopAppBar(
                 title = {},
                 actions = {
-                    if (state.verificationFlowStep != FlowStep.Completed) {
-                        if (state.displaySkipButton && LocalInspectionMode.current.not()) {
-                            TextButton(
-                                text = stringResource(CommonStrings.action_skip),
-                                onClick = { state.eventSink(VerifySelfSessionViewEvents.SkipVerification) }
-                            )
-                        }
+                    if (state.verificationFlowStep != FlowStep.Completed &&
+                        state.displaySkipButton &&
+                        LocalInspectionMode.current.not()) {
+                        TextButton(
+                            text = stringResource(CommonStrings.action_skip),
+                            onClick = { state.eventSink(VerifySelfSessionViewEvents.SkipVerification) }
+                        )
+                    }
+                    if (state.verificationFlowStep is FlowStep.Initial) {
                         TextButton(
                             text = stringResource(CommonStrings.action_signout),
                             onClick = { state.eventSink(VerifySelfSessionViewEvents.SignOut) }

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionViewEvents.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionViewEvents.kt
@@ -23,5 +23,6 @@ sealed interface VerifySelfSessionViewEvents {
     data object DeclineVerification : VerifySelfSessionViewEvents
     data object Cancel : VerifySelfSessionViewEvents
     data object Reset : VerifySelfSessionViewEvents
+    data object SignOut : VerifySelfSessionViewEvents
     data object SkipVerification : VerifySelfSessionViewEvents
 }

--- a/features/verifysession/impl/src/main/res/values/localazy.xml
+++ b/features/verifysession/impl/src/main/res/values/localazy.xml
@@ -28,4 +28,5 @@
   <string name="screen_session_verification_they_match">"They match"</string>
   <string name="screen_session_verification_waiting_to_accept_subtitle">"Accept the request to start the verification process in your other session to continue."</string>
   <string name="screen_session_verification_waiting_to_accept_title">"Waiting to accept request"</string>
+  <string name="screen_signout_in_progress_dialog_content">"Signing out…"</string>
 </resources>

--- a/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionViewTest.kt
+++ b/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionViewTest.kt
@@ -20,6 +20,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.tests.testutils.EnsureNeverCalled
@@ -27,6 +28,7 @@ import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
 import io.element.android.tests.testutils.ensureCalledOnce
+import io.element.android.tests.testutils.ensureCalledOnceWithParam
 import io.element.android.tests.testutils.pressBackKey
 import org.junit.Rule
 import org.junit.Test
@@ -213,11 +215,26 @@ class VerifySelfSessionViewTest {
         }
     }
 
+    @Test
+    fun `on success logout - onFinished callback is called immediately`() {
+        val aUrl = "aUrl"
+        ensureCalledOnceWithParam<String?>(aUrl) { callback ->
+            rule.setVerifySelfSessionView(
+                aVerifySelfSessionState(
+                    signOutAction = AsyncAction.Success(aUrl),
+                    eventSink = EnsureNeverCalledWithParam(),
+                ),
+                onSuccessLogout = callback,
+            )
+        }
+    }
+
     private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setVerifySelfSessionView(
         state: VerifySelfSessionState,
         onEnterRecoveryKey: () -> Unit = EnsureNeverCalled(),
         onFinished: () -> Unit = EnsureNeverCalled(),
         onResetKey: () -> Unit = EnsureNeverCalled(),
+        onSuccessLogout: (String?) -> Unit = EnsureNeverCalledWithParam(),
     ) {
         setContent {
             VerifySelfSessionView(
@@ -225,6 +242,7 @@ class VerifySelfSessionViewTest {
                 onEnterRecoveryKey = onEnterRecoveryKey,
                 onFinish = onFinished,
                 onResetKey = onResetKey,
+                onSuccessLogout = onSuccessLogout,
             )
         }
     }

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:711074ce017e2909ae1cb610925bf7be96e182095cb08de5ca1d57b4dd206c92
-size 30834
+oid sha256:205fc4655fed7b11ef133e0df13b8175676ff38d398fde45a2e6a3b140a216e2
+size 31440

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f7797415de4a52095a47dc7beb5b51c7528a90e9c8daf5e4d3eff030b22f3f7
+size 32596

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_7_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c242503ced2d16da2fd8c738e198689b60d00d40d423b52820aa01a622acd39a
-size 29695
+oid sha256:205fc4655fed7b11ef133e0df13b8175676ff38d398fde45a2e6a3b140a216e2
+size 31440

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_8_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_8_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8d6fedd34ea54f9492bdc74f784aac902717328e3eda83f97d06e1eef970424
-size 24201
+oid sha256:2a8350fe244b42863ee1fb60c403aa2c695a5152755f73bf27598e71e033ef0b
+size 25962

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df4be3e3577698e939dc02ebc0819768c04525a6b6cc67386e33501610dff5b2
-size 29959
+oid sha256:4307ad367eb24d8f7590dfadf4e4b728ec4845ba4720b72824f5b2c60175f8fd
+size 30555

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a66446c1dc2ff1e32fd06ee722aaaed578369e6de0a0024d435104bcadc47d49
+size 31012

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_7_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a229523ad1f17f957adaffb47e8a64679bc3636ab94641bc492f98b7f5d3fe3d
-size 28861
+oid sha256:4307ad367eb24d8f7590dfadf4e4b728ec4845ba4720b72824f5b2c60175f8fd
+size 30555

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_8_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_8_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b090b019f8d0a98b9e0ec4e4bd53628af15737eb441f36f40ba4abceb4c75608
-size 23622
+oid sha256:b0da42a76838a54311a5ea6ec54725f3bb9c91c4ff7bc09ff571d6cd7b6796e1
+size 25369

--- a/tools/localazy/config.json
+++ b/tools/localazy/config.json
@@ -55,6 +55,7 @@
       "name" : ":features:verifysession:impl",
       "includeRegex" : [
         "screen_session_verification_.*",
+        "screen_signout_in_progress_dialog_content",
         "screen_identity_.*"
       ]
     },


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add a way to sign out when the user is asked to verify the session.

Note: on debug builds, it's still possible to skip the verification.

Part of #3329 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Avoid the user to be stuck on session verification. Allow for instance to connect using another account. Before that change user where forced to clear the application data, and this is creating a ghost session.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

![SignOut_Verification](https://github.com/user-attachments/assets/62cd81cf-be71-456a-b9cf-c736bfb61e30)


## Tests

<!-- Explain how you tested your development -->

- Login to an account
- When you're asked to verify the session, click on `Sign out`

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
