### PR TITLE
Fix avatar sometimes not loading

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatarDataFetcherFactory.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatarDataFetcherFactory.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.ui.media
+
+import android.content.Context
+import coil.ImageLoader
+import coil.fetch.Fetcher
+import coil.request.Options
+import io.element.android.libraries.designsystem.components.avatar.AvatarData
+import io.element.android.libraries.matrix.api.MatrixClient
+
+internal class AvatarDataFetcherFactory(
+    private val context: Context,
+    private val client: MatrixClient
+) : Fetcher.Factory<AvatarData> {
+    override fun create(
+        data: AvatarData,
+        options: Options,
+        imageLoader: ImageLoader
+    ): Fetcher {
+        return CoilMediaFetcher(
+            scalingFunction = { context.resources.displayMetrics.density * it },
+            mediaLoader = client.mediaLoader,
+            mediaData = data.toMediaRequestData(),
+            options = options
+        )
+    }
+}

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatatarDataExt.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatatarDataExt.kt
@@ -20,7 +20,7 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.matrix.api.media.MediaSource
 import kotlin.math.roundToLong
 
-fun AvatarData.toMediaRequestData(): MediaRequestData {
+internal fun AvatarData.toMediaRequestData(): MediaRequestData {
     return MediaRequestData(
         source = url?.let { MediaSource(it) },
         kind = MediaRequestData.Kind.Thumbnail(size.dp.value.roundToLong())

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -34,12 +34,13 @@ import kotlin.math.roundToLong
 internal class CoilMediaFetcher(
     private val scalingFunction: (Float) -> Float,
     private val mediaLoader: MatrixMediaLoader,
-    private val mediaData: MediaRequestData?,
+    private val mediaData: MediaRequestData,
     private val options: Options
 ) : Fetcher {
     override suspend fun fetch(): FetchResult? {
-        if (mediaData?.source == null) return null.also {
+        if (mediaData.source == null) {
             Timber.e("MediaData source is null")
+            return null
         }
         return when (mediaData.kind) {
             is MediaRequestData.Kind.Content -> fetchContent(mediaData.source, options)

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -16,16 +16,12 @@
 
 package io.element.android.libraries.matrix.ui.media
 
-import android.content.Context
-import coil.ImageLoader
 import coil.decode.DataSource
 import coil.decode.ImageSource
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.fetch.SourceResult
 import coil.request.Options
-import io.element.android.libraries.designsystem.components.avatar.AvatarData
-import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.media.toFile
@@ -101,42 +97,5 @@ internal class CoilMediaFetcher(
             mimeType = null,
             dataSource = DataSource.MEMORY
         )
-    }
-
-    class MediaRequestDataFactory(
-        private val context: Context,
-        private val client: MatrixClient
-    ) :
-        Fetcher.Factory<MediaRequestData> {
-        override fun create(
-            data: MediaRequestData,
-            options: Options,
-            imageLoader: ImageLoader
-        ): Fetcher {
-            return CoilMediaFetcher(
-                scalingFunction = { context.resources.displayMetrics.density * it },
-                mediaLoader = client.mediaLoader,
-                mediaData = data,
-                options = options
-            )
-        }
-    }
-
-    class AvatarFactory(
-        private val context: Context,
-        private val client: MatrixClient
-    ) : Fetcher.Factory<AvatarData> {
-        override fun create(
-            data: AvatarData,
-            options: Options,
-            imageLoader: ImageLoader
-        ): Fetcher {
-            return CoilMediaFetcher(
-                scalingFunction = { context.resources.displayMetrics.density * it },
-                mediaLoader = client.mediaLoader,
-                mediaData = data.toMediaRequestData(),
-                options = options
-            )
-        }
     }
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -38,7 +38,9 @@ internal class CoilMediaFetcher(
     private val options: Options
 ) : Fetcher {
     override suspend fun fetch(): FetchResult? {
-        if (mediaData?.source == null) return null
+        if (mediaData?.source == null) return null.also {
+            Timber.e("MediaData source is null")
+        }
         return when (mediaData.kind) {
             is MediaRequestData.Kind.Content -> fetchContent(mediaData.source, options)
             is MediaRequestData.Kind.Thumbnail -> fetchThumbnail(mediaData.source, mediaData.kind, options)
@@ -72,6 +74,8 @@ internal class CoilMediaFetcher(
             source = mediaSource,
         ).map { byteArray ->
             byteArray.asSourceResult(options)
+        }.onFailure {
+            Timber.e(it)
         }.getOrNull()
     }
 
@@ -82,6 +86,8 @@ internal class CoilMediaFetcher(
             height = scalingFunction(kind.height.toFloat()).roundToLong(),
         ).map { byteArray ->
             byteArray.asSourceResult(options)
+        }.onFailure {
+            Timber.e(it)
         }.getOrNull()
     }
 

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
@@ -52,8 +52,8 @@ class DefaultLoggedInImageLoaderFactory @Inject constructor(
                 }
                 add(AvatarDataKeyer())
                 add(MediaRequestDataKeyer())
-                add(CoilMediaFetcher.AvatarFactory(context, matrixClient))
-                add(CoilMediaFetcher.MediaRequestDataFactory(context, matrixClient))
+                add(AvatarDataFetcherFactory(context, matrixClient))
+                add(MediaRequestDataFetcherFactory(context, matrixClient))
             }
             .build()
     }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataFetcherFactory.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataFetcherFactory.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.ui.media
+
+import android.content.Context
+import coil.ImageLoader
+import coil.fetch.Fetcher
+import coil.request.Options
+import io.element.android.libraries.matrix.api.MatrixClient
+
+internal class MediaRequestDataFetcherFactory(
+    private val context: Context,
+    private val client: MatrixClient
+) : Fetcher.Factory<MediaRequestData> {
+    override fun create(
+        data: MediaRequestData,
+        options: Options,
+        imageLoader: ImageLoader
+    ): Fetcher {
+        return CoilMediaFetcher(
+            scalingFunction = { context.resources.displayMetrics.density * it },
+            mediaLoader = client.mediaLoader,
+            mediaData = data,
+            options = options
+        )
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
It seems that since the last SDK release, `Client.getMediaThumbnail` cannot be run in multiple thread, else the SDK report a locked database error. The last commit of this PR add a mutex.

First commit are just rework, name change, and adding log to help investigating such issues.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3354 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

Using an account with many rooms:

- kill the app
- start the app
- filter the room list on `People`
- observe that with this change, all the avatar are loaded.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
