### PR TITLE
Make sure to save the tokens the Client might return when its session is restored

### DIFF
--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/DefaultLogoutUseCase.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/DefaultLogoutUseCase.kt
@@ -33,7 +33,7 @@ class DefaultLogoutUseCase @Inject constructor(
         return if (currentSession != null) {
             matrixClientProvider.getOrRestore(currentSession)
                 .getOrThrow()
-                .logout(ignoreSdkError = true, forced = false)
+                .logout(userInitiated = true, ignoreSdkError = true)
         } else {
             error("No session to sign out")
         }

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/DefaultLogoutUseCase.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/DefaultLogoutUseCase.kt
@@ -33,7 +33,7 @@ class DefaultLogoutUseCase @Inject constructor(
         return if (currentSession != null) {
             matrixClientProvider.getOrRestore(currentSession)
                 .getOrThrow()
-                .logout(ignoreSdkError = true)
+                .logout(ignoreSdkError = true, forced = false)
         } else {
             error("No session to sign out")
         }

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutPresenter.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutPresenter.kt
@@ -104,7 +104,7 @@ class LogoutPresenter @Inject constructor(
         ignoreSdkError: Boolean,
     ) = launch {
         suspend {
-            matrixClient.logout(ignoreSdkError, forced = false)
+            matrixClient.logout(userInitiated = true, ignoreSdkError)
         }.runCatchingUpdatingState(logoutAction)
     }
 }

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutPresenter.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutPresenter.kt
@@ -104,7 +104,7 @@ class LogoutPresenter @Inject constructor(
         ignoreSdkError: Boolean,
     ) = launch {
         suspend {
-            matrixClient.logout(ignoreSdkError)
+            matrixClient.logout(ignoreSdkError, forced = false)
         }.runCatchingUpdatingState(logoutAction)
     }
 }

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenter.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenter.kt
@@ -86,7 +86,7 @@ class DefaultDirectLogoutPresenter @Inject constructor(
         ignoreSdkError: Boolean,
     ) = launch {
         suspend {
-            matrixClient.logout(ignoreSdkError)
+            matrixClient.logout(ignoreSdkError, forced = false)
         }.runCatchingUpdatingState(logoutAction)
     }
 }

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenter.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenter.kt
@@ -86,7 +86,7 @@ class DefaultDirectLogoutPresenter @Inject constructor(
         ignoreSdkError: Boolean,
     ) = launch {
         suspend {
-            matrixClient.logout(ignoreSdkError, forced = false)
+            matrixClient.logout(userInitiated = true, ignoreSdkError)
         }.runCatchingUpdatingState(logoutAction)
     }
 }

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutPresenterTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/LogoutPresenterTest.kt
@@ -144,7 +144,7 @@ class LogoutPresenterTest {
     @Test
     fun `present - logout with error then cancel`() = runTest {
         val matrixClient = FakeMatrixClient().apply {
-            logoutLambda = { _ ->
+            logoutLambda = { _, _ ->
                 throw A_THROWABLE
             }
         }
@@ -172,7 +172,7 @@ class LogoutPresenterTest {
     @Test
     fun `present - logout with error then force`() = runTest {
         val matrixClient = FakeMatrixClient().apply {
-            logoutLambda = { ignoreSdkError ->
+            logoutLambda = { ignoreSdkError, _ ->
                 if (!ignoreSdkError) {
                     throw A_THROWABLE
                 } else {

--- a/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenterTest.kt
+++ b/features/logout/impl/src/test/kotlin/io/element/android/features/logout/impl/direct/DefaultDirectLogoutPresenterTest.kt
@@ -125,7 +125,7 @@ class DefaultDirectLogoutPresenterTest {
     @Test
     fun `present - logout with error then cancel`() = runTest {
         val matrixClient = FakeMatrixClient().apply {
-            logoutLambda = { _ ->
+            logoutLambda = { _, _ ->
                 throw A_THROWABLE
             }
         }
@@ -153,7 +153,7 @@ class DefaultDirectLogoutPresenterTest {
     @Test
     fun `present - logout with error then force`() = runTest {
         val matrixClient = FakeMatrixClient().apply {
-            logoutLambda = { ignoreSdkError ->
+            logoutLambda = { ignoreSdkError, _ ->
                 if (!ignoreSdkError) {
                     throw A_THROWABLE
                 } else {

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -88,10 +88,10 @@ interface MatrixClient : Closeable {
      * Logout the user.
      * Returns an optional URL. When the URL is there, it should be presented to the user after logout for
      * Relying Party (RP) initiated logout on their account page.
+     * @param userInitiated if false, the logout came from the HS, no request will be made and the session entry will be kept in the store.
      * @param ignoreSdkError if true, the SDK will ignore any error and delete the session data anyway.
-     * @param forced if true, the logout came from the HS, no request will be made and the data will be kept.
      */
-    suspend fun logout(ignoreSdkError: Boolean, forced: Boolean): String?
+    suspend fun logout(userInitiated: Boolean, ignoreSdkError: Boolean): String?
 
     /**
      * Retrieve the user profile, will also eventually emit a new value to [userProfile].

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -89,8 +89,9 @@ interface MatrixClient : Closeable {
      * Returns an optional URL. When the URL is there, it should be presented to the user after logout for
      * Relying Party (RP) initiated logout on their account page.
      * @param ignoreSdkError if true, the SDK will ignore any error and delete the session data anyway.
+     * @param forced if true, the logout came from the HS, no request will be made and the data will be kept.
      */
-    suspend fun logout(ignoreSdkError: Boolean): String?
+    suspend fun logout(ignoreSdkError: Boolean, forced: Boolean): String?
 
     /**
      * Retrieve the user profile, will also eventually emit a new value to [userProfile].

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.matrix.impl
+
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.matrix.impl.mapper.toSessionData
+import io.element.android.libraries.matrix.impl.paths.getSessionPaths
+import io.element.android.libraries.matrix.impl.util.anonymizedTokens
+import io.element.android.libraries.sessionstorage.api.SessionStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import org.matrix.rustcomponents.sdk.ClientDelegate
+import org.matrix.rustcomponents.sdk.ClientSessionDelegate
+import org.matrix.rustcomponents.sdk.Session
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * This class is responsible for handling the session data for the Rust SDK.
+ *
+ * It implements both [ClientSessionDelegate] and [ClientDelegate] to react to session data updates and auth errors.
+ *
+ * IMPORTANT: you must set the [client] property as soon as possible so [didReceiveAuthError] can work properly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RustClientSessionDelegate(
+    private val sessionStore: SessionStore,
+    private val appCoroutineScope: CoroutineScope,
+    coroutineDispatchers: CoroutineDispatchers,
+) : ClientSessionDelegate, ClientDelegate {
+    private val clientLog = Timber.tag("$this")
+
+    // Used to ensure a single coroutine will be modifying the token data at a time.
+    private val isLoggingOut = AtomicBoolean(false)
+
+    // To make sure only one coroutine affecting the token persistence can run at a time
+    private val updateTokensDispatcher = coroutineDispatchers.io.limitedParallelism(1)
+
+    /** This [RustMatrixClient] needs to be set up as soon as possible so `didReceiveAuthError` can work properly. */
+    var client: RustMatrixClient? = null
+
+    override fun saveSessionInKeychain(session: Session) {
+        appCoroutineScope.launch(updateTokensDispatcher) {
+            val existingData = sessionStore.getSession(session.userId) ?: return@launch
+            val (anonymizedAccessToken, anonymizedRefreshToken) = session.anonymizedTokens()
+            clientLog.d(
+                "Saving new session data with token: access token '$anonymizedAccessToken' and refresh token '$anonymizedRefreshToken'. " +
+                    "Was token valid: ${existingData.isTokenValid}"
+            )
+            val newData = session.toSessionData(
+                isTokenValid = true,
+                loginType = existingData.loginType,
+                passphrase = existingData.passphrase,
+                sessionPaths = existingData.getSessionPaths(),
+            )
+            sessionStore.updateData(newData)
+            clientLog.d("Saved new session data with access token: '$anonymizedAccessToken'.")
+        }.invokeOnCompletion {
+            if (it != null) {
+                clientLog.e(it, "Failed to save new session data.")
+            }
+        }
+    }
+
+    override fun didReceiveAuthError(isSoftLogout: Boolean) {
+        clientLog.w("didReceiveAuthError(isSoftLogout=$isSoftLogout)")
+        if (isLoggingOut.getAndSet(true).not()) {
+            clientLog.v("didReceiveAuthError -> do the cleanup")
+            // TODO handle isSoftLogout parameter.
+            appCoroutineScope.launch(updateTokensDispatcher) {
+                val currentClient = this@RustClientSessionDelegate.client
+                if (currentClient == null) {
+                    clientLog.w("didReceiveAuthError -> no client, exiting")
+                    return@launch
+                }
+                val existingData = sessionStore.getSession(currentClient.sessionId.value)
+                val (anonymizedAccessToken, anonymizedRefreshToken) = existingData.anonymizedTokens()
+                clientLog.d(
+                    "Removing session data with access token '$anonymizedAccessToken' " +
+                        "and refresh token '$anonymizedRefreshToken'."
+                )
+                if (existingData != null) {
+                    // Set isTokenValid to false
+                    val newData = existingData.copy(isTokenValid = false)
+                    sessionStore.updateData(newData)
+                    clientLog.d("Invalidated session data with access token: '$anonymizedAccessToken'.")
+                } else {
+                    clientLog.d("No session data found.")
+                }
+                client?.logout(ignoreSdkError = true, forced = true)
+            }.invokeOnCompletion {
+                if (it != null) {
+                    clientLog.e(it, "Failed to remove session data.")
+                }
+            }
+        } else {
+            clientLog.v("didReceiveAuthError -> already cleaning up")
+        }
+    }
+
+    override fun didRefreshTokens() {
+        // This is done in `saveSessionInKeychain(Session)` instead.
+    }
+
+    override fun retrieveSessionFromKeychain(userId: String): Session {
+        // This should never be called, as it's only used for multi-process setups
+        error("retrieveSessionFromKeychain should never be called for Android")
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
@@ -45,7 +45,7 @@ class RustClientSessionDelegate(
 ) : ClientSessionDelegate, ClientDelegate {
     private val clientLog = Timber.tag("$this")
 
-    // Used to ensure a single coroutine will be modifying the token data at a time.
+    // Used to ensure several calls to `didReceiveAuthError` don't trigger multiple logouts
     private val isLoggingOut = AtomicBoolean(false)
 
     // To make sure only one coroutine affecting the token persistence can run at a time

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -223,6 +223,9 @@ class RustMatrixClient(
         .stateIn(sessionCoroutineScope, started = SharingStarted.Eagerly, initialValue = persistentListOf())
 
     init {
+        // Make sure the session delegate has a reference to the client to be able to logout on auth error
+        client.setDelegate(sessionDelegate)
+
         sessionCoroutineScope.launch {
             // Force a refresh of the profile
             getUserProfile()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -89,9 +89,6 @@ class RustMatrixClientFactory @Inject constructor(
             sessionDelegate = sessionDelegate,
         ).also {
             Timber.tag(it.toString()).d("Creating Client with access token '$anonymizedAccessToken' and refresh token '$anonymizedRefreshToken'")
-
-            // Make sure the session delegate has a reference to the client to be able to logout on auth error
-            sessionDelegate.client = it
         }
     }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -170,8 +170,8 @@ class FakeMatrixClient(
         clearCacheLambda()
     }
 
-    override suspend fun logout(ignoreSdkError: Boolean, forced: Boolean): String? = simulateLongTask {
-        return logoutLambda(ignoreSdkError, forced)
+    override suspend fun logout(userInitiated: Boolean, ignoreSdkError: Boolean): String? = simulateLongTask {
+        return logoutLambda(ignoreSdkError, userInitiated)
     }
 
     override fun close() = Unit

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -122,7 +122,7 @@ class FakeMatrixClient(
     var getRoomInfoFlowLambda = { _: RoomId ->
         flowOf<Optional<MatrixRoomInfo>>(Optional.empty())
     }
-    var logoutLambda: (Boolean) -> String? = {
+    var logoutLambda: (Boolean, Boolean) -> String? = { _, _ ->
         null
     }
 
@@ -170,8 +170,8 @@ class FakeMatrixClient(
         clearCacheLambda()
     }
 
-    override suspend fun logout(ignoreSdkError: Boolean): String? = simulateLongTask {
-        return logoutLambda(ignoreSdkError)
+    override suspend fun logout(ignoreSdkError: Boolean, forced: Boolean): String? = simulateLongTask {
+        return logoutLambda(ignoreSdkError, forced)
     }
 
     override fun close() = Unit


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When we're restoring a Rust `Client` object with some session data, the client might automatically refresh the tokens it uses. Usually, this would get reported by the `ClientDelegate` methods, but since that's only added *after* the session is restored, the update doesn't trigger the delegate callback and the new tokens aren't stored locally. This means next time we restore the session we'd be using discarded credentials and the server will log us out.

I'm creating a new `RustClientSessionDelegate` that implements both:
- `ClientSessionDelegate`: used by iOS mainly up until now, it's passed to the `ClientBuilder` so it will be able to handle token refreshes while the Client is restoring the session, solving the problem above.
- `ClientDelegate`: what we were using for handling token refreshes and refresh errors that should end in a logout. Since the previous delegate is handling token refreshes now, we only need the logout part.

## Motivation and context

Found some promising explanation in [a rageshake](https://github.com/element-hq/element-x-android-rageshakes/issues/2621#issuecomment-2324525182).

This might fix https://github.com/element-hq/element-x-android/issues/3274.

## Tests

<!-- Explain how you tested your development -->

This is quite difficult to test since it depends on the access token expiration time, which is different in each homeserver and also you need some luck (or bad luck) to make it fail, so even if it doesn't fail in some hours or days the fix might not do anything.

I think the best we can do is include it, then check if there haven't been any recent reports of spontaneous logouts.

When I tried to test it, I did the next:

- Set up an OIDC account, log in, verify, etc., and have a room in common that will trigger notifications.
- Wait until a token refresh happens, then kill the app by swiping them from the recents menu (this will kill the app but not prevent notifications from being received).
- Wait until the access token expiry date happens and don't touch the app in the meantime.
- Send a message that will trigger a notification in the OIDC session.
- Check the logs, the restoration of the client and the refresh of the tokens should happen in that order and there should be no issues.

However, I'm not 100% certain this is the right way to reproduce the previous error.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
