### PR TITLE
Make pinned events required state in SlidingSync

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomSyncSubscriber.kt
@@ -45,6 +45,7 @@ class RoomSyncSubscriber(
             RequiredState(key = EventType.STATE_ROOM_CANONICAL_ALIAS, value = ""),
             RequiredState(key = EventType.STATE_ROOM_JOIN_RULES, value = ""),
             RequiredState(key = EventType.STATE_ROOM_POWER_LEVELS, value = ""),
+            RequiredState(key = EventType.STATE_ROOM_PINNED_EVENT, value = ""),
         ),
         timelineLimit = DEFAULT_TIMELINE_LIMIT,
         // We don't need heroes here as they're already included in the `all_rooms` list


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Make pinned events required state in SlidingSync.

## Motivation and context

This is needed to always have the pinned events of a room as soon as we open it.

## Tests

- Enable pinned events in developer settings.
- Clear cache.
- Open a room with pinned events that hasn't pinned/unpinned a new one in a while.

The pinned events should be loaded.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
