### PR TITLE
Unified push endpoint: do not fallback to default endpoint in case of failure and add troubleshoot test.

### DIFF
--- a/libraries/permissions/impl/src/main/kotlin/io/element/android/libraries/permissions/impl/troubleshoot/NotificationTroubleshootCheckPermissionTest.kt
+++ b/libraries/permissions/impl/src/main/kotlin/io/element/android/libraries/permissions/impl/troubleshoot/NotificationTroubleshootCheckPermissionTest.kt
@@ -37,7 +37,7 @@ class NotificationTroubleshootCheckPermissionTest @Inject constructor(
     private val permissionStateProvider: PermissionStateProvider,
     private val sdkVersionProvider: BuildVersionSdkIntProvider,
     private val permissionActions: PermissionActions,
-    private val stringProvider: StringProvider,
+    stringProvider: StringProvider,
 ) : NotificationTroubleshootTest {
     override val order: Int = 0
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/DefaultPushServiceTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/DefaultPushServiceTest.kt
@@ -29,6 +29,7 @@ import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.api.PushProvider
 import io.element.android.libraries.pushproviders.test.FakePushProvider
+import io.element.android.libraries.pushproviders.test.aCurrentUserPushConfig
 import io.element.android.libraries.pushstore.api.UserPushStoreFactory
 import io.element.android.libraries.pushstore.test.userpushstore.FakeUserPushStore
 import io.element.android.libraries.pushstore.test.userpushstore.FakeUserPushStoreFactory
@@ -57,10 +58,7 @@ class DefaultPushServiceTest {
 
     @Test
     fun `test push ok`() = runTest {
-        val aConfig = CurrentUserPushConfig(
-            url = "aUrl",
-            pushKey = "aPushKey",
-        )
+        val aConfig = aCurrentUserPushConfig()
         val testPushResult = lambdaRecorder<CurrentUserPushConfig, Unit> { }
         val aPushProvider = FakePushProvider(
             currentUserPushConfig = aConfig

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/test/DefaultTestPushTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/test/DefaultTestPushTest.kt
@@ -18,7 +18,7 @@ package io.element.android.libraries.push.impl.test
 
 import io.element.android.appconfig.PushConfig
 import io.element.android.libraries.push.impl.pushgateway.PushGatewayNotifyRequest
-import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
+import io.element.android.libraries.pushproviders.test.aCurrentUserPushConfig
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.lambda.value
 import kotlinx.coroutines.test.runTest
@@ -33,10 +33,7 @@ class DefaultTestPushTest {
                 executeResult = executeResult,
             )
         )
-        val aConfig = CurrentUserPushConfig(
-            url = "aUrl",
-            pushKey = "aPushKey",
-        )
+        val aConfig = aCurrentUserPushConfig()
         defaultTestPush.execute(aConfig)
         executeResult.assertions()
             .isCalledOnce()

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/CurrentPushProviderTestTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/CurrentPushProviderTestTest.kt
@@ -58,6 +58,8 @@ class CurrentPushProviderTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             val lastItem = awaitItem()
             assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(true))
         }
     }
 }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/NotificationTestTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/NotificationTestTest.kt
@@ -61,6 +61,8 @@ class NotificationTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.WaitingForUser)
             assertThat(awaitItem().status).isInstanceOf(NotificationTroubleshootTestState.Status.Failure::class.java)
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(true))
         }
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushLoopbackTestTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushLoopbackTestTest.kt
@@ -71,6 +71,8 @@ class PushLoopbackTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             val lastItem = awaitItem()
             assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(true))
         }
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTestTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTestTest.kt
@@ -40,6 +40,8 @@ class PushProvidersTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             val lastItem = awaitItem()
             assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(true))
         }
     }
 

--- a/libraries/pushproviders/firebase/src/test/kotlin/io/element/android/libraries/pushproviders/firebase/troubleshoot/FirebaseAvailabilityTestTest.kt
+++ b/libraries/pushproviders/firebase/src/test/kotlin/io/element/android/libraries/pushproviders/firebase/troubleshoot/FirebaseAvailabilityTestTest.kt
@@ -59,6 +59,8 @@ class FirebaseAvailabilityTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             val lastItem = awaitItem()
             assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
         }
     }
 

--- a/libraries/pushproviders/test/src/main/kotlin/io/element/android/libraries/pushproviders/test/Fixtures.kt
+++ b/libraries/pushproviders/test/src/main/kotlin/io/element/android/libraries/pushproviders/test/Fixtures.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2023 New Vector Ltd
+ * Copyright (c) 2024 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package io.element.android.libraries.pushproviders.unifiedpush.network
+package io.element.android.libraries.pushproviders.test
 
-import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
-import retrofit2.http.GET
+import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
 
-interface UnifiedPushApi {
-    @GET(UnifiedPushConfig.PUSH_GATEWAY_PATH)
-    suspend fun discover(): DiscoveryResponse
-}
+fun aCurrentUserPushConfig(
+    url: String = "aUrl",
+    pushKey: String = "aPushKey",
+) = CurrentUserPushConfig(
+    url = url,
+    pushKey = pushKey,
+)

--- a/libraries/pushproviders/unifiedpush/build.gradle.kts
+++ b/libraries/pushproviders/unifiedpush/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.libraries.push.test)
+    testImplementation(projects.libraries.pushproviders.test)
     testImplementation(projects.libraries.pushstore.test)
     testImplementation(projects.tests.testutils)
     testImplementation(projects.services.toolbox.test)

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushConfig.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushConfig.kt
@@ -17,13 +17,11 @@
 package io.element.android.libraries.pushproviders.unifiedpush
 
 object UnifiedPushConfig {
-    const val PUSH_GATEWAY_PATH: String = "_matrix/push/v1/notify"
-
     /**
      * It is the push gateway for UnifiedPush.
      * Note: default_push_gateway_http_url should have path '/_matrix/push/v1/notify'
      */
-    const val DEFAULT_PUSH_GATEWAY_HTTP_URL: String = "https://matrix.gateway.unifiedpush.org/$PUSH_GATEWAY_PATH"
+    const val DEFAULT_PUSH_GATEWAY_HTTP_URL: String = "https://matrix.gateway.unifiedpush.org/_matrix/push/v1/notify"
 
     const val UNIFIED_PUSH_DISTRIBUTORS_URL = "https://unifiedpush.org/users/distributors/"
 

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushConfig.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushConfig.kt
@@ -17,11 +17,13 @@
 package io.element.android.libraries.pushproviders.unifiedpush
 
 object UnifiedPushConfig {
+    const val PUSH_GATEWAY_PATH: String = "_matrix/push/v1/notify"
+
     /**
      * It is the push gateway for UnifiedPush.
      * Note: default_push_gateway_http_url should have path '/_matrix/push/v1/notify'
      */
-    const val DEFAULT_PUSH_GATEWAY_HTTP_URL: String = "https://matrix.gateway.unifiedpush.org/_matrix/push/v1/notify"
+    const val DEFAULT_PUSH_GATEWAY_HTTP_URL: String = "https://matrix.gateway.unifiedpush.org/$PUSH_GATEWAY_PATH"
 
     const val UNIFIED_PUSH_DISTRIBUTORS_URL = "https://unifiedpush.org/users/distributors/"
 

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushCurrentUserPushConfigProvider.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushCurrentUserPushConfigProvider.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushproviders.unifiedpush
+
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
+import io.element.android.libraries.pushstore.api.clientsecret.PushClientSecret
+import io.element.android.services.appnavstate.api.AppNavigationStateService
+import io.element.android.services.appnavstate.api.currentSessionId
+import javax.inject.Inject
+
+interface UnifiedPushCurrentUserPushConfigProvider {
+    suspend fun provide(): CurrentUserPushConfig?
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultUnifiedPushCurrentUserPushConfigProvider @Inject constructor(
+    private val pushClientSecret: PushClientSecret,
+    private val unifiedPushStore: UnifiedPushStore,
+    private val appNavigationStateService: AppNavigationStateService,
+) : UnifiedPushCurrentUserPushConfigProvider {
+    override suspend fun provide(): CurrentUserPushConfig? {
+        val currentSession = appNavigationStateService.appNavigationState.value.navigationState.currentSessionId() ?: return null
+        val clientSecret = pushClientSecret.getSecretForUser(currentSession)
+        val url = unifiedPushStore.getPushGateway(clientSecret) ?: return null
+        val pushKey = unifiedPushStore.getEndpoint(clientSecret) ?: return null
+        return CurrentUserPushConfig(
+            url = url,
+            pushKey = pushKey,
+        )
+    }
+}

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
@@ -46,7 +46,7 @@ class DefaultUnifiedPushGatewayResolver @Inject constructor(
         } else {
             val port = if (url.port != -1) ":${url.port}" else ""
             val customBase = "${url.protocol}://${url.host}$port"
-            val customUrl = "$customBase/${UnifiedPushConfig.PUSH_GATEWAY_PATH}"
+            val customUrl = "$customBase/_matrix/push/v1/notify"
             Timber.i("Testing $customUrl")
             return withContext(coroutineDispatchers.io) {
                 val api = unifiedPushApiFactory.create(customBase)

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
@@ -34,29 +34,33 @@ class DefaultUnifiedPushGatewayResolver @Inject constructor(
     private val unifiedPushApiFactory: UnifiedPushApiFactory,
     private val coroutineDispatchers: CoroutineDispatchers,
 ) : UnifiedPushGatewayResolver {
+    private val logger = Timber.tag("DefaultUnifiedPushGatewayResolver")
+
     override suspend fun getGateway(endpoint: String): String {
         val url = tryOrNull(
-            onError = { Timber.d(it, "Cannot parse endpoint as an URL") }
+            onError = { logger.d(it, "Cannot parse endpoint as an URL") }
         ) {
             URL(endpoint)
         }
         return if (url == null) {
-            Timber.d("Using default gateway")
+            logger.d("Using default gateway")
             UnifiedPushConfig.DEFAULT_PUSH_GATEWAY_HTTP_URL
         } else {
             val port = if (url.port != -1) ":${url.port}" else ""
             val customBase = "${url.protocol}://${url.host}$port"
             val customUrl = "$customBase/_matrix/push/v1/notify"
-            Timber.i("Testing $customUrl")
+            logger.i("Testing $customUrl")
             return withContext(coroutineDispatchers.io) {
                 val api = unifiedPushApiFactory.create(customBase)
                 try {
                     val discoveryResponse = api.discover()
                     if (discoveryResponse.unifiedpush.gateway == "matrix") {
-                        Timber.d("Using custom gateway")
+                        logger.d("The endpoint seems to be a valid UnifiedPush gateway")
+                    } else {
+                        logger.e("The endpoint does not seem to be a valid UnifiedPush gateway")
                     }
                 } catch (throwable: Throwable) {
-                    Timber.tag("UnifiedPushHelper").e(throwable)
+                    logger.e(throwable, "Error checking for UnifiedPush endpoint")
                 }
                 // Always return the custom url.
                 customUrl

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
@@ -23,8 +23,6 @@ import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.api.PushProvider
 import io.element.android.libraries.pushstore.api.clientsecret.PushClientSecret
-import io.element.android.services.appnavstate.api.AppNavigationStateService
-import io.element.android.services.appnavstate.api.currentSessionId
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
@@ -34,7 +32,7 @@ class UnifiedPushProvider @Inject constructor(
     private val unRegisterUnifiedPushUseCase: UnregisterUnifiedPushUseCase,
     private val pushClientSecret: PushClientSecret,
     private val unifiedPushStore: UnifiedPushStore,
-    private val appNavigationStateService: AppNavigationStateService,
+    private val unifiedPushCurrentUserPushConfigProvider: UnifiedPushCurrentUserPushConfigProvider,
 ) : PushProvider {
     override val index = UnifiedPushConfig.INDEX
     override val name = UnifiedPushConfig.NAME
@@ -62,13 +60,6 @@ class UnifiedPushProvider @Inject constructor(
     }
 
     override suspend fun getCurrentUserPushConfig(): CurrentUserPushConfig? {
-        val currentSession = appNavigationStateService.appNavigationState.value.navigationState.currentSessionId() ?: return null
-        val clientSecret = pushClientSecret.getSecretForUser(currentSession)
-        val url = unifiedPushStore.getPushGateway(clientSecret) ?: return null
-        val pushKey = unifiedPushStore.getEndpoint(clientSecret) ?: return null
-        return CurrentUserPushConfig(
-            url = url,
-            pushKey = pushKey,
-        )
+        return unifiedPushCurrentUserPushConfigProvider.provide()
     }
 }

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/network/UnifiedPushApi.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/network/UnifiedPushApi.kt
@@ -16,10 +16,9 @@
 
 package io.element.android.libraries.pushproviders.unifiedpush.network
 
-import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
 import retrofit2.http.GET
 
 interface UnifiedPushApi {
-    @GET(UnifiedPushConfig.PUSH_GATEWAY_PATH)
+    @GET("_matrix/push/v1/notify")
     suspend fun discover(): DiscoveryResponse
 }

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
@@ -19,9 +19,9 @@ package io.element.android.libraries.pushproviders.unifiedpush.troubleshoot
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.di.AppScope
-import io.element.android.libraries.pushproviders.api.PushProvider
 import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushApiFactory
 import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
+import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushCurrentUserPushConfigProvider
 import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTest
 import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTestDelegate
 import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTestState
@@ -35,7 +35,7 @@ import javax.inject.Inject
 class UnifiedPushMatrixGatewayTest @Inject constructor(
     private val unifiedPushApiFactory: UnifiedPushApiFactory,
     private val coroutineDispatchers: CoroutineDispatchers,
-    private val pushProvider: PushProvider,
+    private val unifiedPushCurrentUserPushConfigProvider: UnifiedPushCurrentUserPushConfigProvider,
 ) : NotificationTroubleshootTest {
     override val order = 450
     private val delegate = NotificationTroubleshootTestDelegate(
@@ -52,7 +52,7 @@ class UnifiedPushMatrixGatewayTest @Inject constructor(
 
     override suspend fun run(coroutineScope: CoroutineScope) {
         delegate.start()
-        val config = pushProvider.getCurrentUserPushConfig()
+        val config = unifiedPushCurrentUserPushConfigProvider.provide()
         if (config == null) {
             delegate.updateState(
                 description = "No current push provider",

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushproviders.unifiedpush.troubleshoot
+
+import com.squareup.anvil.annotations.ContributesMultibinding
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.pushproviders.api.PushProvider
+import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushApiFactory
+import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
+import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTest
+import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTestDelegate
+import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTestState
+import io.element.android.libraries.troubleshoot.api.test.TestFilterData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class UnifiedPushMatrixGatewayTest @Inject constructor(
+    private val unifiedPushApiFactory: UnifiedPushApiFactory,
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val pushProvider: PushProvider,
+) : NotificationTroubleshootTest {
+    override val order = 450
+    private val delegate = NotificationTroubleshootTestDelegate(
+        defaultName = "Test push gateway",
+        defaultDescription = "Ensure that the push gateway is valid.",
+        visibleWhenIdle = false,
+        fakeDelay = NotificationTroubleshootTestDelegate.SHORT_DELAY,
+    )
+    override val state: StateFlow<NotificationTroubleshootTestState> = delegate.state
+
+    override fun isRelevant(data: TestFilterData): Boolean {
+        return data.currentPushProviderName == UnifiedPushConfig.NAME
+    }
+
+    override suspend fun run(coroutineScope: CoroutineScope) {
+        delegate.start()
+        val config = pushProvider.getCurrentUserPushConfig()
+        if (config == null) {
+            delegate.updateState(
+                description = "No current push provider",
+                status = NotificationTroubleshootTestState.Status.Failure(false)
+            )
+        } else {
+            val gatewayBaseUrl = config.url.removeSuffix("/${UnifiedPushConfig.PUSH_GATEWAY_PATH}")
+            // Checking if the gateway is a Matrix gateway
+            coroutineScope.launch(coroutineDispatchers.io) {
+                val api = unifiedPushApiFactory.create(gatewayBaseUrl)
+                try {
+                    val discoveryResponse = api.discover()
+                    if (discoveryResponse.unifiedpush.gateway == "matrix") {
+                        delegate.updateState(
+                            description = "${config.url} is a Matrix gateway.",
+                            status = NotificationTroubleshootTestState.Status.Success
+                        )
+                    } else {
+                        delegate.updateState(
+                            description = "${config.url} is not a Matrix gateway.",
+                            status = NotificationTroubleshootTestState.Status.Failure(false)
+                        )
+                    }
+                } catch (throwable: Throwable) {
+                    delegate.updateState(
+                        description = "Fail to check the gateway ${config.url}: ${throwable.localizedMessage}",
+                        status = NotificationTroubleshootTestState.Status.Failure(false)
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun reset() = delegate.reset()
+}

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTest.kt
@@ -59,7 +59,7 @@ class UnifiedPushMatrixGatewayTest @Inject constructor(
                 status = NotificationTroubleshootTestState.Status.Failure(false)
             )
         } else {
-            val gatewayBaseUrl = config.url.removeSuffix("/${UnifiedPushConfig.PUSH_GATEWAY_PATH}")
+            val gatewayBaseUrl = config.url.removeSuffix("/_matrix/push/v1/notify")
             // Checking if the gateway is a Matrix gateway
             coroutineScope.launch(coroutineDispatchers.io) {
                 val api = unifiedPushApiFactory.create(gatewayBaseUrl)

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushCurrentUserPushConfigProviderTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushCurrentUserPushConfigProviderTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushproviders.unifiedpush
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.A_SECRET
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
+import io.element.android.libraries.pushstore.api.clientsecret.PushClientSecret
+import io.element.android.libraries.pushstore.test.userpushstore.clientsecret.FakePushClientSecret
+import io.element.android.services.appnavstate.api.AppNavigationState
+import io.element.android.services.appnavstate.api.AppNavigationStateService
+import io.element.android.services.appnavstate.api.NavigationState
+import io.element.android.services.appnavstate.test.FakeAppNavigationStateService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultUnifiedPushCurrentUserPushConfigProviderTest {
+    @Test
+    fun `getCurrentUserPushConfig no session`() = runTest {
+        val sut = createDefaultUnifiedPushCurrentUserPushConfigProvider()
+        val result = sut.provide()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getCurrentUserPushConfig no push gateway`() = runTest {
+        val sut = createDefaultUnifiedPushCurrentUserPushConfigProvider(
+            appNavigationStateService = FakeAppNavigationStateService(
+                appNavigationState = MutableStateFlow(
+                    AppNavigationState(
+                        navigationState = NavigationState.Session(owner = "owner", sessionId = A_SESSION_ID),
+                        isInForeground = true
+                    )
+                )
+            ),
+            pushClientSecret = FakePushClientSecret(
+                getSecretForUserResult = { A_SECRET }
+            ),
+            unifiedPushStore = FakeUnifiedPushStore(
+                getPushGatewayResult = { null }
+            ),
+        )
+        val result = sut.provide()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getCurrentUserPushConfig no push key`() = runTest {
+        val sut = createDefaultUnifiedPushCurrentUserPushConfigProvider(
+            appNavigationStateService = FakeAppNavigationStateService(
+                appNavigationState = MutableStateFlow(
+                    AppNavigationState(
+                        navigationState = NavigationState.Session(owner = "owner", sessionId = A_SESSION_ID),
+                        isInForeground = true
+                    )
+                )
+            ),
+            pushClientSecret = FakePushClientSecret(
+                getSecretForUserResult = { A_SECRET }
+            ),
+            unifiedPushStore = FakeUnifiedPushStore(
+                getPushGatewayResult = { "aPushGateway" },
+                getEndpointResult = { null }
+            ),
+        )
+        val result = sut.provide()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getCurrentUserPushConfig ok`() = runTest {
+        val sut = createDefaultUnifiedPushCurrentUserPushConfigProvider(
+            appNavigationStateService = FakeAppNavigationStateService(
+                appNavigationState = MutableStateFlow(
+                    AppNavigationState(
+                        navigationState = NavigationState.Session(owner = "owner", sessionId = A_SESSION_ID),
+                        isInForeground = true
+                    )
+                )
+            ),
+            pushClientSecret = FakePushClientSecret(
+                getSecretForUserResult = { A_SECRET }
+            ),
+            unifiedPushStore = FakeUnifiedPushStore(
+                getPushGatewayResult = { "aPushGateway" },
+                getEndpointResult = { "aEndpoint" }
+            ),
+        )
+        val result = sut.provide()
+        assertThat(result).isEqualTo(CurrentUserPushConfig("aPushGateway", "aEndpoint"))
+    }
+
+    private fun createDefaultUnifiedPushCurrentUserPushConfigProvider(
+        pushClientSecret: PushClientSecret = FakePushClientSecret(),
+        unifiedPushStore: UnifiedPushStore = FakeUnifiedPushStore(),
+        appNavigationStateService: AppNavigationStateService = FakeAppNavigationStateService(),
+    ): DefaultUnifiedPushCurrentUserPushConfigProvider {
+        return DefaultUnifiedPushCurrentUserPushConfigProvider(
+            pushClientSecret = pushClientSecret,
+            unifiedPushStore = unifiedPushStore,
+            appNavigationStateService = appNavigationStateService,
+        )
+    }
+}

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
@@ -95,7 +95,7 @@ class DefaultUnifiedPushGatewayResolverTest {
     }
 
     @Test
-    fun `when a custom url is not reachable, the default url is returned`() = runTest {
+    fun `when a custom url is not reachable, the custom url is still returned`() = runTest {
         val unifiedPushApiFactory = FakeUnifiedPushApiFactory(
             discoveryResponse = { throw AN_EXCEPTION }
         )
@@ -104,7 +104,7 @@ class DefaultUnifiedPushGatewayResolverTest {
         )
         val result = sut.getGateway("http://custom.url")
         assertThat(unifiedPushApiFactory.baseUrlParameter).isEqualTo("http://custom.url")
-        assertThat(result).isEqualTo(UnifiedPushConfig.DEFAULT_PUSH_GATEWAY_HTTP_URL)
+        assertThat(result).isEqualTo("http://custom.url/_matrix/push/v1/notify")
     }
 
     @Test
@@ -121,7 +121,7 @@ class DefaultUnifiedPushGatewayResolverTest {
     }
 
     @Test
-    fun `when a custom url provides a invalid matrix gateway, the default url is returned`() = runTest {
+    fun `when a custom url provides a invalid matrix gateway, the custom url is still returned`() = runTest {
         val unifiedPushApiFactory = FakeUnifiedPushApiFactory(
             discoveryResponse = invalidDiscoveryResponse
         )
@@ -130,7 +130,7 @@ class DefaultUnifiedPushGatewayResolverTest {
         )
         val result = sut.getGateway("https://custom.url")
         assertThat(unifiedPushApiFactory.baseUrlParameter).isEqualTo("https://custom.url")
-        assertThat(result).isEqualTo(UnifiedPushConfig.DEFAULT_PUSH_GATEWAY_HTTP_URL)
+        assertThat(result).isEqualTo("https://custom.url/_matrix/push/v1/notify")
     }
 
     private fun TestScope.createDefaultUnifiedPushGatewayResolver(

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
@@ -25,23 +25,23 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
+internal val matrixDiscoveryResponse = {
+    DiscoveryResponse(
+        unifiedpush = DiscoveryUnifiedPush(
+            gateway = "matrix"
+        )
+    )
+}
+
+internal val invalidDiscoveryResponse = {
+    DiscoveryResponse(
+        unifiedpush = DiscoveryUnifiedPush(
+            gateway = ""
+        )
+    )
+}
+
 class DefaultUnifiedPushGatewayResolverTest {
-    private val matrixDiscoveryResponse = {
-        DiscoveryResponse(
-            unifiedpush = DiscoveryUnifiedPush(
-                gateway = "matrix"
-            )
-        )
-    }
-
-    private val invalidDiscoveryResponse = {
-        DiscoveryResponse(
-            unifiedpush = DiscoveryUnifiedPush(
-                gateway = ""
-            )
-        )
-    }
-
     @Test
     fun `when a custom url provide a correct matrix gateway, the custom url is returned`() = runTest {
         val unifiedPushApiFactory = FakeUnifiedPushApiFactory(

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/FakeUnifiedPushCurrentUserPushConfigProvider.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/FakeUnifiedPushCurrentUserPushConfigProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushproviders.unifiedpush.troubleshoot
+
+import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
+import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushCurrentUserPushConfigProvider
+import io.element.android.tests.testutils.lambda.lambdaError
+
+class FakeUnifiedPushCurrentUserPushConfigProvider(
+    private val currentUserPushConfig: () -> CurrentUserPushConfig? = { lambdaError() },
+) : UnifiedPushCurrentUserPushConfigProvider {
+    override suspend fun provide(): CurrentUserPushConfig? {
+        return currentUserPushConfig()
+    }
+}

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.element.android.libraries.pushproviders.unifiedpush.troubleshoot
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
+import io.element.android.libraries.pushproviders.test.FakePushProvider
+import io.element.android.libraries.pushproviders.test.aCurrentUserPushConfig
+import io.element.android.libraries.pushproviders.unifiedpush.FakeUnifiedPushApiFactory
+import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
+import io.element.android.libraries.pushproviders.unifiedpush.invalidDiscoveryResponse
+import io.element.android.libraries.pushproviders.unifiedpush.matrixDiscoveryResponse
+import io.element.android.libraries.pushproviders.unifiedpush.network.DiscoveryResponse
+import io.element.android.libraries.troubleshoot.api.test.NotificationTroubleshootTestState
+import io.element.android.libraries.troubleshoot.api.test.TestFilterData
+import io.element.android.tests.testutils.testCoroutineDispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class UnifiedPushMatrixGatewayTestTest {
+    @Test
+    fun `test UnifiedPushMatrixGatewayTest success`() = runTest {
+        val sut = createUnifiedPushMatrixGatewayTest(
+            currentUserPushConfig = aCurrentUserPushConfig(),
+            discoveryResponse = matrixDiscoveryResponse,
+        )
+        launch {
+            sut.run(this)
+        }
+        sut.state.test {
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
+            val lastItem = awaitItem()
+            assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Success)
+        }
+    }
+
+    @Test
+    fun `test UnifiedPushMatrixGatewayTest no config found`() = runTest {
+        val sut = createUnifiedPushMatrixGatewayTest(
+            currentUserPushConfig = null,
+            discoveryResponse = matrixDiscoveryResponse,
+        )
+        launch {
+            sut.run(this)
+        }
+        sut.state.test {
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
+            val lastItem = awaitItem()
+            assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+        }
+    }
+
+    @Test
+    fun `test UnifiedPushMatrixGatewayTest not valid gateway`() = runTest {
+        val sut = createUnifiedPushMatrixGatewayTest(
+            currentUserPushConfig = aCurrentUserPushConfig(),
+            discoveryResponse = invalidDiscoveryResponse,
+        )
+        launch {
+            sut.run(this)
+        }
+        sut.state.test {
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
+            val lastItem = awaitItem()
+            assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+            // Reset the error
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+        }
+    }
+
+    @Test
+    fun `test UnifiedPushMatrixGatewayTest network error`() = runTest {
+        val sut = createUnifiedPushMatrixGatewayTest(
+            currentUserPushConfig = aCurrentUserPushConfig(),
+            discoveryResponse = { throw RuntimeException("Network error") },
+        )
+        launch {
+            sut.run(this)
+        }
+        sut.state.test {
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
+            val lastItem = awaitItem()
+            assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(false))
+        }
+    }
+
+    @Test
+    fun `test isRelevant`() = runTest {
+        val sut = createUnifiedPushMatrixGatewayTest()
+        assertThat(sut.isRelevant(TestFilterData(currentPushProviderName = UnifiedPushConfig.NAME))).isTrue()
+        assertThat(sut.isRelevant(TestFilterData(currentPushProviderName = "other"))).isFalse()
+    }
+
+    private fun TestScope.createUnifiedPushMatrixGatewayTest(
+        currentUserPushConfig: CurrentUserPushConfig? = null,
+        discoveryResponse: () -> DiscoveryResponse = matrixDiscoveryResponse,
+    ): UnifiedPushMatrixGatewayTest {
+        return UnifiedPushMatrixGatewayTest(
+            unifiedPushApiFactory = FakeUnifiedPushApiFactory(discoveryResponse),
+            coroutineDispatchers = testCoroutineDispatchers(),
+            pushProvider = FakePushProvider(currentUserPushConfig = currentUserPushConfig),
+        )
+    }
+}

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
@@ -19,7 +19,6 @@ package io.element.android.libraries.pushproviders.unifiedpush.troubleshoot
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.pushproviders.api.CurrentUserPushConfig
-import io.element.android.libraries.pushproviders.test.FakePushProvider
 import io.element.android.libraries.pushproviders.test.aCurrentUserPushConfig
 import io.element.android.libraries.pushproviders.unifiedpush.FakeUnifiedPushApiFactory
 import io.element.android.libraries.pushproviders.unifiedpush.UnifiedPushConfig
@@ -120,7 +119,9 @@ class UnifiedPushMatrixGatewayTestTest {
         return UnifiedPushMatrixGatewayTest(
             unifiedPushApiFactory = FakeUnifiedPushApiFactory(discoveryResponse),
             coroutineDispatchers = testCoroutineDispatchers(),
-            pushProvider = FakePushProvider(currentUserPushConfig = currentUserPushConfig),
+            unifiedPushCurrentUserPushConfigProvider = FakeUnifiedPushCurrentUserPushConfigProvider(
+                currentUserPushConfig = { currentUserPushConfig }
+            ),
         )
     }
 }

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushMatrixGatewayTestTest.kt
@@ -93,7 +93,7 @@ class UnifiedPushMatrixGatewayTestTest {
     fun `test UnifiedPushMatrixGatewayTest network error`() = runTest {
         val sut = createUnifiedPushMatrixGatewayTest(
             currentUserPushConfig = aCurrentUserPushConfig(),
-            discoveryResponse = { throw RuntimeException("Network error") },
+            discoveryResponse = { error("Network error") },
         )
         launch {
             sut.run(this)

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushTestTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/troubleshoot/UnifiedPushTestTest.kt
@@ -85,6 +85,35 @@ class UnifiedPushTestTest {
     }
 
     @Test
+    fun `test UnifiedPushTest error and reset`() = runTest {
+        val providers = FakeUnifiedPushDistributorProvider()
+        val sut = UnifiedPushTest(
+            unifiedPushDistributorProvider = providers,
+            openDistributorWebPageAction = FakeOpenDistributorWebPageAction(
+                executeAction = {
+                    providers.setDistributorsResult(
+                        listOf(
+                            Distributor("value", "Name"),
+                        )
+                    )
+                }
+            ),
+            stringProvider = FakeStringProvider(),
+        )
+        launch {
+            sut.run(this)
+        }
+        sut.state.test {
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
+            val lastItem = awaitItem()
+            assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Failure(true))
+            sut.reset()
+            assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.Idle(false))
+        }
+    }
+
+    @Test
     fun `test isRelevant`() {
         val sut = UnifiedPushTest(
             unifiedPushDistributorProvider = FakeUnifiedPushDistributorProvider(),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When the UnifiedPush endpoint is not detected as a valid Matrix gateway, the application was using a default endpoint.

Now, the endpoint is still checked, but is used even if it is not valid. This allow to use the provided endpoint even if an unexpected error occurs (network error, SSL certificat error, etc.)

A test is added to the troubleshoot test suite to check again the endpoint and alert the user in case of issue. For instance here, the test is failing:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5bb136f1-5ac7-4a2d-adbd-b714e1150d58">

The second commit is adding more unit test on the other troubleshoot tests.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Make UnifiedPush solution work in more cases and environments.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Configure notification to use UnifiedPush
- Run troubleshoot test suite and see the new test.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
