### PR TITLE
Skip device verification screen when creating a new account using OIDC

### DIFF
--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/FtueSessionVerificationFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/FtueSessionVerificationFlowNode.kt
@@ -46,7 +46,7 @@ class FtueSessionVerificationFlowNode @AssistedInject constructor(
     private val secureBackupEntryPoint: SecureBackupEntryPoint,
 ) : BaseFlowNode<FtueSessionVerificationFlowNode.NavTarget>(
     backstack = BackStack(
-        initialElement = NavTarget.Root,
+        initialElement = NavTarget.Root(showDeviceVerifiedScreen = false),
         savedStateMap = buildContext.savedStateMap,
     ),
     buildContext = buildContext,
@@ -54,7 +54,7 @@ class FtueSessionVerificationFlowNode @AssistedInject constructor(
 ) {
     sealed interface NavTarget : Parcelable {
         @Parcelize
-        data object Root : NavTarget
+        data class Root(val showDeviceVerifiedScreen: Boolean) : NavTarget
 
         @Parcelize
         data object EnterRecoveryKey : NavTarget
@@ -71,7 +71,7 @@ class FtueSessionVerificationFlowNode @AssistedInject constructor(
         override fun onDone() {
             lifecycleScope.launch {
                 // Move to the completed state view in the verification flow
-                backstack.newRoot(NavTarget.Root)
+                backstack.newRoot(NavTarget.Root(showDeviceVerifiedScreen = true))
             }
         }
     }
@@ -80,6 +80,7 @@ class FtueSessionVerificationFlowNode @AssistedInject constructor(
         return when (navTarget) {
             is NavTarget.Root -> {
                 verifySessionEntryPoint.nodeBuilder(this, buildContext)
+                    .params(VerifySessionEntryPoint.Params(navTarget.showDeviceVerifiedScreen))
                     .callback(object : VerifySessionEntryPoint.Callback {
                         override fun onEnterRecoveryKey() {
                             backstack.push(NavTarget.EnterRecoveryKey)

--- a/features/verifysession/api/src/main/kotlin/io/element/android/features/verifysession/api/VerifySessionEntryPoint.kt
+++ b/features/verifysession/api/src/main/kotlin/io/element/android/features/verifysession/api/VerifySessionEntryPoint.kt
@@ -20,12 +20,16 @@ import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
 import io.element.android.libraries.architecture.FeatureEntryPoint
+import io.element.android.libraries.architecture.NodeInputs
 
 interface VerifySessionEntryPoint : FeatureEntryPoint {
+    data class Params(val showDeviceVerifiedScreen: Boolean) : NodeInputs
+
     fun nodeBuilder(parentNode: Node, buildContext: BuildContext): NodeBuilder
 
     interface NodeBuilder {
         fun callback(callback: Callback): NodeBuilder
+        fun params(params: Params): NodeBuilder
         fun build(): Node
     }
 

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/DefaultVerifySessionEntryPoint.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/DefaultVerifySessionEntryPoint.kt
@@ -36,6 +36,11 @@ class DefaultVerifySessionEntryPoint @Inject constructor() : VerifySessionEntryP
                 return this
             }
 
+            override fun params(params: VerifySessionEntryPoint.Params): VerifySessionEntryPoint.NodeBuilder {
+                plugins += params
+                return this
+            }
+
             override fun build(): Node {
                 return parentNode.createNode<VerifySelfSessionNode>(buildContext, plugins)
             }

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionNode.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionNode.kt
@@ -30,15 +30,20 @@ import io.element.android.anvilannotations.ContributesNode
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.features.logout.api.util.onSuccessLogout
 import io.element.android.features.verifysession.api.VerifySessionEntryPoint
+import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.di.SessionScope
 
 @ContributesNode(SessionScope::class)
 class VerifySelfSessionNode @AssistedInject constructor(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
-    private val presenter: VerifySelfSessionPresenter,
+    presenterFactory: VerifySelfSessionPresenter.Factory,
 ) : Node(buildContext, plugins = plugins) {
     private val callback = plugins<VerifySessionEntryPoint.Callback>().first()
+
+    private val presenter = presenterFactory.create(
+        showDeviceVerifiedScreen = inputs<VerifySessionEntryPoint.Params>().showDeviceVerifiedScreen,
+    )
 
     @Composable
     override fun View(modifier: Modifier) {

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionState.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionState.kt
@@ -31,6 +31,7 @@ data class VerifySelfSessionState(
 ) {
     @Stable
     sealed interface VerificationStep {
+        data object Loading : VerificationStep
         data class Initial(val canEnterRecoveryKey: Boolean, val isLastDevice: Boolean = false) : VerificationStep
         data object Canceled : VerificationStep
         data object AwaitingOtherDeviceResponse : VerificationStep

--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateProvider.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/VerifySelfSessionStateProvider.kt
@@ -59,6 +59,12 @@ open class VerifySelfSessionStateProvider : PreviewParameterProvider<VerifySelfS
                 signOutAction = AsyncAction.Loading,
                 displaySkipButton = true,
             ),
+            aVerifySelfSessionState(
+                verificationFlowStep = VerificationStep.Loading
+            ),
+            aVerifySelfSessionState(
+                verificationFlowStep = VerificationStep.Skipped
+            ),
             // Add other state here
         )
 }

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af3e9514bfa603491a2ba225260c8eceaa2156c255da83c547c59d50388953b
+size 5149

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_12_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Day_12_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af3e9514bfa603491a2ba225260c8eceaa2156c255da83c547c59d50388953b
+size 5149

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fef553ca190fc051f6b03946b4de2f3066600da2b2b8e8443a9c83cd7fbf45a4
+size 5153

--- a/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_12_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.verifysession.impl_VerifySelfSessionView_Night_12_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fef553ca190fc051f6b03946b4de2f3066600da2b2b8e8443a9c83cd7fbf45a4
+size 5153


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
It can happen that the session is automatically verified and in this case the FTUE verification step has to be skipped.

This PR handle this.

Note that some shortcut had been taken to show the confirmation screen when the user enter a recovery key, so I had to add a parameter `showDeviceVerifiedScreen` to handle this case properly.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes #3279

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login using OIDC, creating a new account
- The device verification screen must be skipped. A loader can be displayed for a short moment.

Note that I have seen the "Confirm your identity" for a few millis, it seems that the SDK emit a `SessionVerifiedStatus.NotVerified` between the `SessionVerifiedStatus.Unknown` and `SessionVerifiedStatus.Verified`, but I need to check again befor reporting to the SDK.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
