### PR TITLE
Fix Element Call closing automatically on API 34

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -133,13 +133,15 @@ class ElementCallActivity :
 
         val pipEventSink by rememberUpdatedState(pipState.eventSink)
         var onUserLeaveHintListener by remember { mutableStateOf<Runnable?>(null) }
-        DisposableEffect(lifecycleState.isAtLeast(Lifecycle.State.STARTED)) {
+        val isReadyToRegister = lifecycleState.isAtLeast(Lifecycle.State.STARTED)
+        DisposableEffect(isReadyToRegister) {
             val listener = onUserLeaveHintListener
-            if (listener != null) {
+            if (isReadyToRegister && listener == null) {
                 onUserLeaveHintListener = Runnable {
                     pipEventSink(PictureInPictureEvents.EnterPictureInPicture)
+                }.also {
+                    addOnUserLeaveHintListener(it)
                 }
-                addOnUserLeaveHintListener(listener)
             }
             onDispose {
                 if (listener != null) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

The leave hint listener for PiP in the Call screen is now registered once the UI is ready.

## Motivation and context

It seems like registering a user leave hint listener way too early was causing the activity to try to enter PiP erroneously and that led to the activity closing instead.

## Tests

<!-- Explain how you tested your development -->

- Try to start a call in Android 14.
- Most of the time (always, in my case) the screen would previously close automatically. It should now work as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
