### PR TITLE
Fix new logins with Simplified SS using the proxy

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -96,9 +96,10 @@ class RustMatrixClientFactory @Inject constructor(
         restore: Boolean,
     ): ClientBuilder {
         val slidingSync = when {
+            // Always check restore first, since otherwise other values could accidentally override the already persisted config
+            restore -> ClientBuilderSlidingSync.Restored
             AuthenticationConfig.SLIDING_SYNC_PROXY_URL != null -> ClientBuilderSlidingSync.CustomProxy(AuthenticationConfig.SLIDING_SYNC_PROXY_URL!!)
             appPreferencesStore.isSimplifiedSlidingSyncEnabledFlow().first() -> ClientBuilderSlidingSync.Simplified
-            restore -> ClientBuilderSlidingSync.Restored
             else -> ClientBuilderSlidingSync.Discovered
         }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -56,16 +56,11 @@ class RustMatrixClientFactory @Inject constructor(
     private val appPreferencesStore: AppPreferencesStore,
 ) {
     suspend fun create(sessionData: SessionData): RustMatrixClient = withContext(coroutineDispatchers.io) {
-                val sessionDelegate = RustClientSessionDelegate(sessionStore, appCoroutineScope, coroutineDispatchers)
-
+        val sessionDelegate = RustClientSessionDelegate(sessionStore, appCoroutineScope, coroutineDispatchers)
         val client = getBaseClientBuilder(
             sessionPaths = sessionData.getSessionPaths(),
             passphrase = sessionData.passphrase,
-            slidingSync = when {
-                AuthenticationConfig.SLIDING_SYNC_PROXY_URL != null -> ClientBuilderSlidingSync.CustomProxy(AuthenticationConfig.SLIDING_SYNC_PROXY_URL!!)
-                appPreferencesStore.isSimplifiedSlidingSyncEnabledFlow().first() -> ClientBuilderSlidingSync.Simplified
-                else -> ClientBuilderSlidingSync.Restored
-            }
+            restore = true,
         )
             .homeserverUrl(sessionData.homeserverUrl)
             .username(sessionData.userId)
@@ -95,11 +90,18 @@ class RustMatrixClientFactory @Inject constructor(
         }
     }
 
-    internal fun getBaseClientBuilder(
+    internal suspend fun getBaseClientBuilder(
         sessionPaths: SessionPaths,
         passphrase: String?,
-        slidingSync: ClientBuilderSlidingSync,
+        restore: Boolean,
     ): ClientBuilder {
+        val slidingSync = when {
+            AuthenticationConfig.SLIDING_SYNC_PROXY_URL != null -> ClientBuilderSlidingSync.CustomProxy(AuthenticationConfig.SLIDING_SYNC_PROXY_URL!!)
+            appPreferencesStore.isSimplifiedSlidingSyncEnabledFlow().first() -> ClientBuilderSlidingSync.Simplified
+            restore -> ClientBuilderSlidingSync.Restored
+            else -> ClientBuilderSlidingSync.Discovered
+        }
+
         return ClientBuilder()
             .sessionPaths(
                 dataPath = sessionPaths.fileDirectory.absolutePath,
@@ -116,7 +118,8 @@ class RustMatrixClientFactory @Inject constructor(
                     ClientBuilderSlidingSync.Restored -> this
                     is ClientBuilderSlidingSync.CustomProxy -> slidingSyncVersionBuilder(SlidingSyncVersionBuilder.Proxy(slidingSync.url))
                     ClientBuilderSlidingSync.Discovered -> slidingSyncVersionBuilder(SlidingSyncVersionBuilder.DiscoverProxy)
-                    ClientBuilderSlidingSync.Simplified -> slidingSyncVersionBuilder(SlidingSyncVersionBuilder.Native)
+                    ClientBuilderSlidingSync.Simplified -> slidingSyncVersionBuilder(SlidingSyncVersionBuilder.DiscoverNative)
+                    ClientBuilderSlidingSync.ForcedSimplified -> slidingSyncVersionBuilder(SlidingSyncVersionBuilder.Native)
                 }
             }
             .run {
@@ -136,8 +139,12 @@ sealed interface ClientBuilderSlidingSync {
     // A proxy must be discovered whilst building the session.
     data object Discovered : ClientBuilderSlidingSync
 
-    // Use Simplified Sliding Sync (discovery isn't a thing yet).
+    // Use Simplified Sliding Sync.
     data object Simplified : ClientBuilderSlidingSync
+
+    // Force using Simplified Sliding Sync.
+    // TODO allow the user to select between proxy, simplified or force simplified in developer options.
+    data object ForcedSimplified : ClientBuilderSlidingSync
 }
 
 private fun SessionData.toSession() = Session(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -28,7 +28,6 @@ import io.element.android.libraries.matrix.api.auth.OidcDetails
 import io.element.android.libraries.matrix.api.auth.qrlogin.MatrixQrCodeLoginData
 import io.element.android.libraries.matrix.api.auth.qrlogin.QrCodeLoginStep
 import io.element.android.libraries.matrix.api.core.SessionId
-import io.element.android.libraries.matrix.impl.ClientBuilderSlidingSync
 import io.element.android.libraries.matrix.impl.RustMatrixClientFactory
 import io.element.android.libraries.matrix.impl.auth.qrlogin.QrErrorMapper
 import io.element.android.libraries.matrix.impl.auth.qrlogin.SdkQrCodeLoginData
@@ -222,7 +221,7 @@ class RustMatrixAuthenticationService @Inject constructor(
                 val client = rustMatrixClientFactory.getBaseClientBuilder(
                     sessionPaths = emptySessionPaths,
                     passphrase = pendingPassphrase,
-                    slidingSync = ClientBuilderSlidingSync.Discovered,
+                    restore = false,
                 )
                     .buildWithQrCode(
                         qrCodeData = (qrCodeData as SdkQrCodeLoginData).rustQrCodeData,
@@ -259,13 +258,13 @@ class RustMatrixAuthenticationService @Inject constructor(
             }
         }
 
-    private fun getBaseClientBuilder(
+    private suspend fun getBaseClientBuilder(
         sessionPaths: SessionPaths,
     ) = rustMatrixClientFactory
         .getBaseClientBuilder(
             sessionPaths = sessionPaths,
             passphrase = pendingPassphrase,
-            slidingSync = ClientBuilderSlidingSync.Discovered,
+            restore = false,
         )
 
     private fun clear() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Setup whether to use the proxy or native sliding sync at an earlier stage when signing in, so the `SlidingSyncVersion` is properly populated, stored and later restored.

## Motivation and context

With the current code, Simplified Sliding Sync was never used even if it was enabled in developer options.

## Tests

<!-- Explain how you tested your development -->

- Enable SSS.
- Check the logs and ensure the `/sync` requests hit the right endpoint (`_matrix/client/unstable/org.matrix.simplified_msc3575/sync` instead of `_matrix/client/unstable/org.matrix.msc3575/sync`).
- Disable SSS.
- Check again the endpoint for the `/sync` requests.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
