### PR TITLE
Fix events blinking at the beginning of DM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -162,7 +162,7 @@ jsoup = "org.jsoup:jsoup:1.18.1"
 appyx_core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
 molecule-runtime = "app.cash.molecule:molecule-runtime:2.0.0"
 timber = "com.jakewharton.timber:timber:5.0.1"
-matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.2.43"
+matrix_sdk = "org.matrix.rustcomponents:sdk-android:0.2.44"
 matrix_richtexteditor = { module = "io.element.android:wysiwyg", version.ref = "wysiwyg" }
 matrix_richtexteditor_compose = { module = "io.element.android:wysiwyg-compose", version.ref = "wysiwyg" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoomInfo.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoomInfo.kt
@@ -44,5 +44,6 @@ data class MatrixRoomInfo(
     val hasRoomCall: Boolean,
     val activeRoomCallParticipants: ImmutableList<String>,
     val heroes: ImmutableList<MatrixUser>,
-    val pinnedEventIds: ImmutableList<EventId>
+    val pinnedEventIds: ImmutableList<EventId>,
+    val creator: UserId?,
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/MatrixRoomInfoMapper.kt
@@ -28,6 +28,7 @@ class MatrixRoomInfoMapper {
     fun map(rustRoomInfo: RustRoomInfo): MatrixRoomInfo = rustRoomInfo.let {
         return MatrixRoomInfo(
             id = RoomId(it.id),
+            creator = it.creator?.let(::UserId),
             name = it.displayName,
             rawName = it.rawName,
             topic = it.topic,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -207,15 +207,17 @@ class RustTimeline(
         _timelineItems,
         backPaginationStatus.map { it.hasMoreToLoad }.distinctUntilChanged(),
         forwardPaginationStatus.map { it.hasMoreToLoad }.distinctUntilChanged(),
+        matrixRoom.roomInfoFlow.map { it.creator },
         isInit,
-    ) { timelineItems, hasMoreToLoadBackward, hasMoreToLoadForward, isInit ->
+    ) { timelineItems, hasMoreToLoadBackward, hasMoreToLoadForward, roomCreator, isInit ->
         withContext(dispatcher) {
             timelineItems
                 .process { items ->
                     roomBeginningPostProcessor.process(
                         items = items,
                         isDm = matrixRoom.isDm,
-                        hasMoreToLoadBackwards = hasMoreToLoadBackward
+                        roomCreator = roomCreator,
+                        hasMoreToLoadBackwards = hasMoreToLoadBackward,
                     )
                 }
                 .process(predicate = isInit) { items ->

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineItemsSubscriber.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/TimelineItemsSubscriber.kt
@@ -38,7 +38,7 @@ internal class TimelineItemsSubscriber(
     private val timeline: Timeline,
     private val timelineDiffProcessor: MatrixTimelineDiffProcessor,
     private val initLatch: CompletableDeferred<Unit>,
-    private val isInit: MutableStateFlow<Boolean>,
+    private val isTimelineInitialized: MutableStateFlow<Boolean>,
     private val onNewSyncedEvent: () -> Unit,
 ) {
     private var subscriptionCount = 0
@@ -85,13 +85,13 @@ internal class TimelineItemsSubscriber(
             ensureActive()
             timelineDiffProcessor.postItems(it)
         }
-        isInit.value = true
+        isTimelineInitialized.value = true
         initLatch.complete(Unit)
     }
 
     private suspend fun postDiffs(diffs: List<TimelineDiff>) {
         val diffsToProcess = diffs.toMutableList()
-        if (!isInit.value) {
+        if (!isTimelineInitialized.value) {
             val resetDiff = diffsToProcess.firstOrNull { it.change() == TimelineChange.RESET }
             if (resetDiff != null) {
                 // Keep using the postItems logic so we can post the timelineItems asap.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LastForwardIndicatorsPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LastForwardIndicatorsPostProcessor.kt
@@ -22,9 +22,9 @@ class LastForwardIndicatorsPostProcessor(
 
     fun process(
         items: List<MatrixTimelineItem>,
-        isInit: Boolean,
+        isTimelineInitialized: Boolean,
     ): List<MatrixTimelineItem> {
-        if (!isInit) return items
+        if (!isTimelineInitialized) return items
         // We don't need to add the last forward indicator if we are not in the FOCUSED_ON_EVENT mode
         if (mode != Timeline.Mode.FOCUSED_ON_EVENT) {
             return items

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LastForwardIndicatorsPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LastForwardIndicatorsPostProcessor.kt
@@ -22,7 +22,9 @@ class LastForwardIndicatorsPostProcessor(
 
     fun process(
         items: List<MatrixTimelineItem>,
+        isInit: Boolean,
     ): List<MatrixTimelineItem> {
+        if (!isInit) return items
         // We don't need to add the last forward indicator if we are not in the FOCUSED_ON_EVENT mode
         if (mode != Timeline.Mode.FOCUSED_ON_EVENT) {
             return items

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LoadingIndicatorsPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LoadingIndicatorsPostProcessor.kt
@@ -16,9 +16,11 @@ import io.element.android.services.toolbox.api.systemclock.SystemClock
 class LoadingIndicatorsPostProcessor(private val systemClock: SystemClock) {
     fun process(
         items: List<MatrixTimelineItem>,
+        isInit: Boolean,
         hasMoreToLoadBackward: Boolean,
         hasMoreToLoadForward: Boolean,
     ): List<MatrixTimelineItem> {
+        if (!isInit) return items
         val shouldAddForwardLoadingIndicator = hasMoreToLoadForward && items.isNotEmpty()
         val currentTimestamp = systemClock.epochMillis()
         return buildList {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LoadingIndicatorsPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/LoadingIndicatorsPostProcessor.kt
@@ -16,11 +16,11 @@ import io.element.android.services.toolbox.api.systemclock.SystemClock
 class LoadingIndicatorsPostProcessor(private val systemClock: SystemClock) {
     fun process(
         items: List<MatrixTimelineItem>,
-        isInit: Boolean,
+        isTimelineInitialized: Boolean,
         hasMoreToLoadBackward: Boolean,
         hasMoreToLoadForward: Boolean,
     ): List<MatrixTimelineItem> {
-        if (!isInit) return items
+        if (!isTimelineInitialized) return items
         val shouldAddForwardLoadingIndicator = hasMoreToLoadForward && items.isNotEmpty()
         val currentTimestamp = systemClock.epochMillis()
         return buildList {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/RoomBeginningPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/RoomBeginningPostProcessor.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.matrix.impl.timeline.postprocessor
 
 import androidx.annotation.VisibleForTesting
 import io.element.android.libraries.matrix.api.core.UniqueId
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
@@ -25,12 +26,14 @@ class RoomBeginningPostProcessor(private val mode: Timeline.Mode) {
     fun process(
         items: List<MatrixTimelineItem>,
         isDm: Boolean,
-        hasMoreToLoadBackwards: Boolean
+        roomCreator: UserId?,
+        hasMoreToLoadBackwards: Boolean,
     ): List<MatrixTimelineItem> {
         return when {
+            items.isEmpty() -> items
             mode == Timeline.Mode.PINNED_EVENTS -> items
+            isDm -> processForDM(items, roomCreator)
             hasMoreToLoadBackwards -> items
-            isDm -> processForDM(items)
             else -> processForRoom(items)
         }
     }
@@ -40,15 +43,18 @@ class RoomBeginningPostProcessor(private val mode: Timeline.Mode) {
         return listOf(roomBeginningItem) + items
     }
 
-    private fun processForDM(items: List<MatrixTimelineItem>): List<MatrixTimelineItem> {
-        // Find room creation event. This is usually index 0
+    private fun processForDM(items: List<MatrixTimelineItem>, roomCreator: UserId?): List<MatrixTimelineItem> {
+        // Find room creation event.
+        // This is usually the first MatrixTimelineItem.Event (so index 1, index 0 is a date)
         val roomCreationEventIndex = items.indexOfFirst {
             val stateEventContent = (it as? MatrixTimelineItem.Event)?.event?.content as? StateContent
             stateEventContent?.content is OtherState.RoomCreate
         }
 
-        // Find self-join event for room creator. This is usually index 1
-        val roomCreatorUserId = (items.getOrNull(roomCreationEventIndex) as? MatrixTimelineItem.Event)?.event?.sender
+        // If the parameter roomCreator is null, the creator is the sender of the RoomCreate Event.
+        val roomCreatorUserId = roomCreator ?: (items.getOrNull(roomCreationEventIndex) as? MatrixTimelineItem.Event)?.event?.sender
+        // Find self-join event for the room creator.
+        // This is usually the second MatrixTimelineItem.Event (so index 2)
         val selfUserJoinedEventIndex = roomCreatorUserId?.let { creatorUserId ->
             items.indexOfFirst {
                 val stateEventContent = (it as? MatrixTimelineItem.Event)?.event?.content as? RoomMembershipContent
@@ -56,6 +62,9 @@ class RoomBeginningPostProcessor(private val mode: Timeline.Mode) {
             }
         } ?: -1
 
+        if (roomCreationEventIndex == -1 && selfUserJoinedEventIndex == -1) {
+            return items
+        }
         // Remove items at the indices we found
         val newItems = items.toMutableList()
         if (selfUserJoinedEventIndex in newItems.indices) {

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomSummaryListProcessorTest.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.matrix.impl.roomlist
 import com.google.common.truth.Truth.assertThat
 import com.sun.jna.Pointer
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
@@ -215,6 +216,7 @@ private fun aRustRoomInfo(
     numUnreadNotifications: ULong = 0uL,
     numUnreadMentions: ULong = 0uL,
     pinnedEventIds: List<String> = listOf(),
+    roomCreator: UserId? = null,
 ) = RoomInfo(
     id = id,
     displayName = displayName,
@@ -245,6 +247,7 @@ private fun aRustRoomInfo(
     numUnreadNotifications = numUnreadNotifications,
     numUnreadMentions = numUnreadMentions,
     pinnedEventIds = pinnedEventIds,
+    creator = roomCreator?.value,
 )
 
 class FakeRoomListItem(

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/RoomBeginningPostProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/RoomBeginningPostProcessorTest.kt
@@ -22,85 +22,174 @@ import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
 import org.junit.Test
 
 class RoomBeginningPostProcessorTest {
+    private val roomCreateEvent = MatrixTimelineItem.Event(
+        uniqueId = UniqueId("m.room.create"),
+        event = anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))
+    )
+    private val roomCreatorJoinEvent = MatrixTimelineItem.Event(
+        uniqueId = UniqueId("m.room.member"),
+        event = anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))
+    )
+    private val otherMemberJoinEvent = MatrixTimelineItem.Event(
+        uniqueId = UniqueId("m.room.member_other"),
+        event = anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, null, MembershipChange.JOINED))
+    )
+    private val messageEvent = MatrixTimelineItem.Event(
+        uniqueId = UniqueId("m.room.message"),
+        event = anEventTimelineItem(content = aMessageContent("hi"))
+    )
+
+    @Test
+    fun `processor returns empty list when empty list is provided`() {
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
+        val processedItems = processor.process(
+            items = emptyList(),
+            isDm = true,
+            roomCreator = A_USER_ID,
+            hasMoreToLoadBackwards = false,
+        )
+        assertThat(processedItems).isEmpty()
+    }
+
+    @Test
+    fun `processor returns the provided list when it only contains a message`() {
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
+        val processedItems = processor.process(
+            items = listOf(messageEvent),
+            isDm = true,
+            roomCreator = A_USER_ID,
+            hasMoreToLoadBackwards = false,
+        )
+        assertThat(processedItems).isEqualTo(listOf(messageEvent))
+    }
+
+    @Test
+    fun `processor returns the provided list when it only contains a message and the roomCreator is not provided`() {
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
+        val processedItems = processor.process(
+            items = listOf(messageEvent),
+            isDm = true,
+            roomCreator = null,
+            hasMoreToLoadBackwards = false,
+        )
+        assertThat(processedItems).isEqualTo(listOf(messageEvent))
+    }
+
     @Test
     fun `processor removes room creation event and self-join event from DM timeline`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(UniqueId("m.room.create"), anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))),
-            MatrixTimelineItem.Event(UniqueId("m.room.member"), anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))),
+            roomCreateEvent,
+            roomCreatorJoinEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = true, hasMoreToLoadBackwards = false)
+        val processedItems = processor.process(
+            items = timelineItems,
+            isDm = true,
+            roomCreator = A_USER_ID,
+            hasMoreToLoadBackwards = false,
+        )
         assertThat(processedItems).isEmpty()
+    }
+
+    @Test
+    fun `processor does not remove anything with PINNED_EVENTS mode`() {
+        val timelineItems = listOf(
+            roomCreateEvent,
+            roomCreatorJoinEvent,
+        )
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.PINNED_EVENTS)
+        val processedItems = processor.process(
+            items = timelineItems,
+            isDm = true,
+            roomCreator = A_USER_ID,
+            hasMoreToLoadBackwards = false,
+        )
+        assertThat(processedItems).isEqualTo(timelineItems)
     }
 
     @Test
     fun `processor removes room creation event and self-join event from DM timeline even if they're not the first items`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(
-                UniqueId("m.room.member_other"),
-                anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, null, MembershipChange.JOINED))
-            ),
-            MatrixTimelineItem.Event(UniqueId("m.room.create"), anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))),
-            MatrixTimelineItem.Event(UniqueId("m.room.message"), anEventTimelineItem(content = aMessageContent("hi"))),
-            MatrixTimelineItem.Event(UniqueId("m.room.member"), anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))),
+            otherMemberJoinEvent,
+            roomCreateEvent,
+            messageEvent,
+            roomCreatorJoinEvent,
         )
         val expected = listOf(
-            MatrixTimelineItem.Event(
-                UniqueId("m.room.member_other"),
-                anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, null, MembershipChange.JOINED))
-            ),
-            MatrixTimelineItem.Event(UniqueId("m.room.message"), anEventTimelineItem(content = aMessageContent("hi"))),
+            otherMemberJoinEvent,
+            messageEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = true, hasMoreToLoadBackwards = false)
+        val processedItems = processor.process(timelineItems, isDm = true, roomCreator = A_USER_ID, hasMoreToLoadBackwards = false)
         assertThat(processedItems).isEqualTo(expected)
     }
 
     @Test
     fun `processor will add beginning of room item if it's not a DM`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(UniqueId("m.room.create"), anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))),
-            MatrixTimelineItem.Event(UniqueId("m.room.member"), anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))),
+            roomCreateEvent,
+            roomCreatorJoinEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = false, hasMoreToLoadBackwards = false)
+        val processedItems = processor.process(timelineItems, isDm = false, roomCreator = A_USER_ID, hasMoreToLoadBackwards = false)
         assertThat(processedItems).isEqualTo(
             listOf(processor.createRoomBeginningItem()) + timelineItems
         )
     }
 
     @Test
-    fun `processor won't remove items if it's not at the start of the timeline`() {
+    fun `processor will not add beginning of room item if it's not a DM but the room has more to load`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(UniqueId("m.room.create"), anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))),
-            MatrixTimelineItem.Event(UniqueId("m.room.member"), anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))),
+            roomCreateEvent,
+            roomCreatorJoinEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = true, hasMoreToLoadBackwards = true)
+        val processedItems = processor.process(timelineItems, isDm = false, roomCreator = A_USER_ID, hasMoreToLoadBackwards = true)
         assertThat(processedItems).isEqualTo(timelineItems)
     }
 
     @Test
-    fun `processor won't remove the first member join event if it can't find the room creation event`() {
+    fun `processor will add beginning of room item if it's not a DM, when the parameter roomCreator is null`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(UniqueId("m.room.member"), anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))),
+            roomCreateEvent,
+            roomCreatorJoinEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = true, hasMoreToLoadBackwards = true)
-        assertThat(processedItems).isEqualTo(timelineItems)
+        val processedItems = processor.process(timelineItems, isDm = false, roomCreator = null, hasMoreToLoadBackwards = false)
+        assertThat(processedItems).isEqualTo(
+            listOf(processor.createRoomBeginningItem()) + timelineItems
+        )
+    }
+
+    @Test
+    fun `processor removes items event it's not at the start of the timeline`() {
+        val timelineItems = listOf(
+            roomCreateEvent,
+            roomCreatorJoinEvent,
+        )
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
+        val processedItems = processor.process(timelineItems, isDm = true, roomCreator = A_USER_ID, hasMoreToLoadBackwards = true)
+        assertThat(processedItems).isEmpty()
+    }
+
+    @Test
+    fun `processor removes the first member join event if it matches the roomCreator parameter`() {
+        val timelineItems = listOf(
+            roomCreatorJoinEvent,
+        )
+        val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
+        val processedItems = processor.process(timelineItems, isDm = true, roomCreator = A_USER_ID, hasMoreToLoadBackwards = true)
+        assertThat(processedItems).isEmpty()
     }
 
     @Test
     fun `processor won't remove the first member join event if it's not from the room creator`() {
         val timelineItems = listOf(
-            MatrixTimelineItem.Event(UniqueId("m.room.create"), anEventTimelineItem(sender = A_USER_ID, content = StateContent("", OtherState.RoomCreate))),
-            MatrixTimelineItem.Event(
-                UniqueId("m.room.member"),
-                anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, null, MembershipChange.JOINED))
-            ),
+            roomCreateEvent,
+            otherMemberJoinEvent,
         )
         val processor = RoomBeginningPostProcessor(Timeline.Mode.LIVE)
-        val processedItems = processor.process(timelineItems, isDm = true, hasMoreToLoadBackwards = true)
-        assertThat(processedItems).isEqualTo(timelineItems)
+        val processedItems = processor.process(timelineItems, isDm = true, roomCreator = A_USER_ID, hasMoreToLoadBackwards = true)
+        assertThat(processedItems).isEqualTo(listOf(otherMemberJoinEvent))
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -523,6 +523,7 @@ fun aRoomInfo(
     activeRoomCallParticipants: List<String> = emptyList(),
     heroes: List<MatrixUser> = emptyList(),
     pinnedEventIds: List<EventId> = emptyList(),
+    roomCreator: UserId? = null,
 ) = MatrixRoomInfo(
     id = id,
     name = name,
@@ -549,6 +550,7 @@ fun aRoomInfo(
     activeRoomCallParticipants = activeRoomCallParticipants.toImmutableList(),
     heroes = heroes.toImmutableList(),
     pinnedEventIds = pinnedEventIds.toImmutableList(),
+    creator = roomCreator,
 )
 
 fun defaultRoomPowerLevels() = MatrixRoomPowerLevels(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Do not wait for the `m.room.create` Event to be known, or for the start of the timeline to be fully loaded to filter out Events from the beginning of DM. Use the new added field `RoomInfo.creator`, if available, to filter out the creator join Event.

This way the application is able to filter out the join Event of the creator of the DM even if the timeline is not fully loaded.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Stable UI.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![DM_Event_Before](https://github.com/user-attachments/assets/168f0ace-afdd-4b33-909f-d2e0e0ef05fe)|![DM_Event_After](https://github.com/user-attachments/assets/42515202-461a-4fa0-a7e3-9e241f367c55)|

*Notes*: 
- to be able to see the effect I have set up the network type of the emulator to `Edge`, that's why loading the timeline is so slow.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/271ccc3c-04bc-4053-ae7f-bfe0a5b0d696">

- I have recorded the "After" case before the "Before" case, by checkout a commit before the fix, so please ignore the time displayed on the emulator :)

## Tests

<!-- Explain how you tested your development -->

- Create a DM, or have a DM with no messages sent
- Clear the cache from the app
- Navigate to the room list, let it getting loaded
- Reduce the speed of the network, in order to better see the effect
- Open the DM
- Observe the Events displayed
- Observe that the Events `m.room.create` and the join event of the creator are never displayed, or that the number of collapsed Event are 2 (and not 3 or 4)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
