### PR TITLE
Fix not being able to decline an invite from the room list

### DIFF
--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenter.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenter.kt
@@ -112,8 +112,8 @@ class AcceptDeclineInvitePresenter @Inject constructor(
 
     private fun CoroutineScope.declineInvite(roomId: RoomId, declinedAction: MutableState<AsyncAction<RoomId>>) = launch {
         suspend {
-            client.getRoom(roomId)?.use {
-                it.leave().getOrThrow()
+            client.getInvitedRoom(roomId)?.use {
+                it.declineInvite().getOrThrow()
                 notificationCleaner.clearMembershipNotificationForRoom(client.sessionId, roomId)
             }
             roomId

--- a/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenterTest.kt
+++ b/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenterTest.kt
@@ -21,7 +21,7 @@ import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
-import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import io.element.android.libraries.matrix.test.room.FakeInvitedRoom
 import io.element.android.libraries.matrix.test.room.join.FakeJoinRoom
 import io.element.android.libraries.push.api.notifications.NotificationCleaner
 import io.element.android.libraries.push.test.notifications.FakeNotificationCleaner
@@ -83,12 +83,7 @@ class AcceptDeclineInvitePresenterTest {
             Result.failure<Unit>(RuntimeException("Failed to leave room"))
         }
         val client = FakeMatrixClient().apply {
-            givenGetRoomResult(
-                roomId = A_ROOM_ID,
-                result = FakeMatrixRoom(
-                    leaveRoomLambda = declineInviteFailure
-                )
-            )
+            getInvitedRoomResults[A_ROOM_ID] = FakeInvitedRoom(declineInviteResult = declineInviteFailure)
         }
         val presenter = createAcceptDeclineInvitePresenter(client = client)
         presenter.test {
@@ -133,12 +128,7 @@ class AcceptDeclineInvitePresenterTest {
             Result.success(Unit)
         }
         val client = FakeMatrixClient().apply {
-            givenGetRoomResult(
-                roomId = A_ROOM_ID,
-                result = FakeMatrixRoom(
-                    leaveRoomLambda = declineInviteSuccess
-                )
-            )
+            getInvitedRoomResults[A_ROOM_ID] = FakeInvitedRoom(declineInviteResult = declineInviteSuccess)
         }
         val presenter = createAcceptDeclineInvitePresenter(
             client = client,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.notification.NotificationService
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.oidc.AccountManagementAction
 import io.element.android.libraries.matrix.api.pusher.PushersService
+import io.element.android.libraries.matrix.api.room.InvitedRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
@@ -49,6 +50,7 @@ interface MatrixClient : Closeable {
     val sessionCoroutineScope: CoroutineScope
     val ignoredUsersFlow: StateFlow<ImmutableList<UserId>>
     suspend fun getRoom(roomId: RoomId): MatrixRoom?
+    suspend fun getInvitedRoom(roomId: RoomId): InvitedRoom?
     suspend fun findDM(userId: UserId): RoomId?
     suspend fun ignoreUser(userId: UserId): Result<Unit>
     suspend fun unignoreUser(userId: UserId): Result<Unit>

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/InvitedRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/InvitedRoom.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.room
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+
+/** A reference to a room the current user has been invited to, with the ability to decline the invite. */
+interface InvitedRoom : AutoCloseable {
+    val sessionId: SessionId
+    val roomId: RoomId
+
+    /** Decline the invite to this room. */
+    suspend fun declineInvite(): Result<Unit>
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -29,6 +29,7 @@ import io.element.android.libraries.matrix.api.notificationsettings.Notification
 import io.element.android.libraries.matrix.api.oidc.AccountManagementAction
 import io.element.android.libraries.matrix.api.pusher.PushersService
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.InvitedRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
@@ -243,6 +244,10 @@ class RustMatrixClient(
 
     override suspend fun getRoom(roomId: RoomId): MatrixRoom? {
         return roomFactory.create(roomId)
+    }
+
+    override suspend fun getInvitedRoom(roomId: RoomId): InvitedRoom? {
+        return roomFactory.createInvitedRoom(roomId)
     }
 
     /**

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustInvitedRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustInvitedRoom.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.room
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.room.InvitedRoom
+import org.matrix.rustcomponents.sdk.Room
+
+class RustInvitedRoom(
+    override val sessionId: SessionId,
+    private val invitedRoom: Room,
+) : InvitedRoom {
+    override val roomId = RoomId(invitedRoom.id())
+
+    override suspend fun declineInvite(): Result<Unit> = runCatching {
+        invitedRoom.leave()
+    }
+
+    override fun close() {
+        invitedRoom.destroy()
+    }
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -22,6 +22,7 @@ import io.element.android.libraries.matrix.api.notification.NotificationService
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.oidc.AccountManagementAction
 import io.element.android.libraries.matrix.api.pusher.PushersService
+import io.element.android.libraries.matrix.api.room.InvitedRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.MatrixRoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
@@ -99,6 +100,7 @@ class FakeMatrixClient(
     private var createDmResult: Result<RoomId> = Result.success(A_ROOM_ID)
     private var findDmResult: RoomId? = A_ROOM_ID
     private val getRoomResults = mutableMapOf<RoomId, MatrixRoom>()
+    val getInvitedRoomResults = mutableMapOf<RoomId, InvitedRoom>()
     private val searchUserResults = mutableMapOf<String, Result<MatrixSearchUserResults>>()
     private val getProfileResults = mutableMapOf<UserId, Result<MatrixUser>>()
     private var uploadMediaResult: Result<String> = Result.success(AN_AVATAR_URL)
@@ -123,6 +125,10 @@ class FakeMatrixClient(
 
     override suspend fun getRoom(roomId: RoomId): MatrixRoom? {
         return getRoomResults[roomId]
+    }
+
+    override suspend fun getInvitedRoom(roomId: RoomId): InvitedRoom? {
+        return getInvitedRoomResults[roomId]
     }
 
     override suspend fun findDM(userId: UserId): RoomId? {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeInvitedRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeInvitedRoom.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.test.room
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.room.InvitedRoom
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.tests.testutils.lambda.lambdaError
+
+class FakeInvitedRoom(
+    override val sessionId: SessionId = A_SESSION_ID,
+    override val roomId: RoomId = A_ROOM_ID,
+    private val declineInviteResult: () -> Result<Unit> = { lambdaError() }
+) : InvitedRoom {
+    override suspend fun declineInvite(): Result<Unit> {
+        return declineInviteResult()
+    }
+
+    override fun close() = Unit
+}


### PR DESCRIPTION
## Content

- Use the new `RoomListItem.invitedRoom()` API to get a room in an invited membership state that won't need a timeline to work.
- When calling the 'decline invite' APIs using `AcceptDeclineInvitePresenter` get an invited room instead of the full room and decline the invite.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/3407.

Note the implementation is a quick fix and some iteration on this issue is encouraged: ideally, we'd have `JoinedRoom` and `InvitedRoom` abstractions that share a minimum of logic, and maybe both implement a simplified `MatrixRoom`.

## Tests

<!-- Explain how you tested your development -->

- Get an invite in the room list.
- Decline it.
- Get another invite.
- Open its preview by tapping on the item.
- Decline it.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
