### PR TITLE
Make sure the logout action doesn't cause a crash

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
@@ -50,7 +50,6 @@ class RustClientSessionDelegate(
      */
     fun bindClient(client: RustMatrixClient) {
         this.client = client
-        client.setDelegate(this)
     }
 
     override fun saveSessionInKeychain(session: Session) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/sync/RustSyncService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/sync/RustSyncService.kt
@@ -16,15 +16,22 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
-import org.matrix.rustcomponents.sdk.SyncServiceInterface
 import org.matrix.rustcomponents.sdk.SyncServiceState
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+import org.matrix.rustcomponents.sdk.SyncService as InnerSyncService
 
 class RustSyncService(
-    private val innerSyncService: SyncServiceInterface,
+    private val innerSyncService: InnerSyncService,
     sessionCoroutineScope: CoroutineScope
 ) : SyncService {
+    private val isServiceReady = AtomicBoolean(true)
+
     override suspend fun startSync() = runCatching {
+        if (!isServiceReady.get()) {
+            Timber.d("Can't start sync: service is not ready")
+            return@runCatching
+        }
         Timber.i("Start sync")
         innerSyncService.start()
     }.onFailure {
@@ -32,10 +39,22 @@ class RustSyncService(
     }
 
     override suspend fun stopSync() = runCatching {
+        if (!isServiceReady.get()) {
+            Timber.d("Can't stop sync: service is not ready")
+            return@runCatching
+        }
         Timber.i("Stop sync")
         innerSyncService.stop()
     }.onFailure {
         Timber.d("Stop sync failed: $it")
+    }
+
+    suspend fun destroy() {
+        // If the service was still running, stop it
+        stopSync()
+        Timber.d("Destroying sync service")
+        isServiceReady.set(false)
+        innerSyncService.destroy()
     }
 
     override val syncState: StateFlow<SyncState> =


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Making sure to unregister the delegate should fix the first part of the issue.

For the other one, adding `RustSyncService.isServiceReady` to check if we should start/stop the service, which is enabled by default and set to false on destroy should help.

We should be extra careful to also include this same behaviour to account deactivation after https://github.com/element-hq/element-x-android/pull/3479 if this PR is merged.

## Motivation and context

Some reasons why this could happen:
1. The `ClientDelegate` could receive a `didReceiveAuthError` callback call on a logout, which could trigger another logout when every Rust object had already been destroyed.
2. Even though we stop the sync before logging out, `LoggedInFlowNode` will try to start it again automatically when it detects we still have internet connection.

## Tests

<!-- Explain how you tested your development -->

- Log in, log out, several times.

If it doesn't create a crash anymore, it's fixed. Also, failures while logging out should restore the client delegate and allow the user to keep refreshing their token and receive auth errors.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
