### PR TITLE
Fix sliding sync proxy login not working after native SS failure

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.Client
+import org.matrix.rustcomponents.sdk.ClientBuildException
 import org.matrix.rustcomponents.sdk.ClientBuilder
 import org.matrix.rustcomponents.sdk.HumanQrLoginException
 import org.matrix.rustcomponents.sdk.OidcConfiguration
@@ -292,7 +293,7 @@ class RustMatrixAuthenticationService @Inject constructor(
                     )
                     .config()
                     .build()
-            } catch (e: HumanQrLoginException.SlidingSyncNotAvailable) {
+            } catch (e: ClientBuildException.SlidingSyncVersion) {
                 Timber.e(e, "Failed to create client with simplified sliding sync, trying with Proxy now")
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Catch right exception for retrying the HS setup with sliding sync proxy after native sliding sync failed.

## Motivation and context

The wrong exception was being caught and the fallback mechanism wasn't properly working.

## Tests

<!-- Explain how you tested your development -->

- Use a HS without native sliding sync, such as `riot.grin.hu`.
- Try to log in with the SSS toggle enabled.
- It should work, but using the sliding sync proxy (you can check this in the logs).

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
