### PR TITLE
Fix crash when session is deleted on another client

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -39,6 +39,7 @@ import io.element.android.features.roomlist.impl.search.RoomListSearchEvents
 import io.element.android.features.roomlist.impl.search.RoomListSearchState
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.snackbar.collectSnackbarMessageAsState
 import io.element.android.libraries.featureflag.api.FeatureFlagService
@@ -218,7 +219,10 @@ class RoomListPresenter @Inject constructor(
             }
         }
         val needsSlidingSyncMigration by produceState(false) {
-            value = client.isNativeSlidingSyncSupported() && !client.isUsingNativeSlidingSync()
+            value = runCatching {
+                // Note: this can fail when the session is destroyed from another client.
+                client.isNativeSlidingSyncSupported() && !client.isUsingNativeSlidingSync()
+            }.getOrNull().orFalse()
         }
         return when {
             showEmpty -> RoomListContentState.Empty

--- a/libraries/network/src/main/kotlin/io/element/android/libraries/network/interceptors/FormattedJsonHttpLogger.kt
+++ b/libraries/network/src/main/kotlin/io/element/android/libraries/network/interceptors/FormattedJsonHttpLogger.kt
@@ -34,6 +34,11 @@ internal class FormattedJsonHttpLogger(
         // It can be only the case if we log the bodies of Http requests.
         if (level != HttpLoggingInterceptor.Level.BODY) return
 
+        if (message.length > 100_000) {
+            Timber.d("Content is too long (${message.length} chars) to be formatted as JSON")
+            return
+        }
+
         if (message.startsWith("{")) {
             // JSON Detected
             try {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Protect call of `isNativeSlidingSyncSupported` and `isUsingNativeSlidingSync`, which can fail if the client is closed due to the session being deleted from another client.

Easier fix than changing the result type of those method to `Result<Boolean>`, also because at some point all those methods will just be removed.

First commit is protecting debug build only.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix several reported rageshake:
- https://github.com/element-hq/element-x-android-rageshakes/issues/2854
- https://github.com/element-hq/element-x-android-rageshakes/issues/2846

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Delete the current session from another client and observe that the app is not crashing anymore.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
