### PR TITLE
Rename AppBindings to XAppBindings

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainActivity.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainActivity.kt
@@ -34,7 +34,7 @@ import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.designsystem.theme.ElementThemeApp
 import io.element.android.libraries.designsystem.utils.snackbar.LocalSnackbarDispatcher
-import io.element.android.x.di.AppBindings
+import io.element.android.x.di.XAppBindings
 import io.element.android.x.intent.SafeUriHandler
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -43,7 +43,7 @@ private val loggerTag = LoggerTag("MainActivity")
 
 class MainActivity : NodeActivity() {
     private lateinit var mainNode: MainNode
-    private lateinit var appBindings: AppBindings
+    private lateinit var appBindings: XAppBindings
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Timber.tag(loggerTag.value).w("onCreate, with savedInstanceState: ${savedInstanceState != null}")
@@ -58,7 +58,7 @@ class MainActivity : NodeActivity() {
     }
 
     @Composable
-    private fun MainContent(appBindings: AppBindings) {
+    private fun MainContent(appBindings: XAppBindings) {
         val migrationState = appBindings.migrationEntryPoint().present()
         ElementThemeApp(appBindings.preferencesStore()) {
             CompositionLocalProvider(

--- a/app/src/main/kotlin/io/element/android/x/di/XAppBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/XAppBindings.kt
@@ -17,8 +17,9 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.matrix.api.tracing.TracingService
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 
+// Note: AppBindings has been renamed to XAppBindings to attempt to fix reproducible build issue.
 @ContributesTo(AppScope::class)
-interface AppBindings {
+interface XAppBindings {
     fun snackbarDispatcher(): SnackbarDispatcher
 
     fun tracingService(): TracingService

--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -20,12 +20,12 @@ import io.element.android.libraries.matrix.api.tracing.TracingConfiguration
 import io.element.android.libraries.matrix.api.tracing.TracingFilterConfigurations
 import io.element.android.libraries.matrix.api.tracing.WriteToFilesConfiguration
 import io.element.android.x.BuildConfig
-import io.element.android.x.di.AppBindings
+import io.element.android.x.di.XAppBindings
 import timber.log.Timber
 
 class TracingInitializer : Initializer<Unit> {
     override fun create(context: Context) {
-        val appBindings = context.bindings<AppBindings>()
+        val appBindings = context.bindings<XAppBindings>()
         val tracingService = appBindings.tracingService()
         val bugReporter = appBindings.bugReporter()
         Timber.plant(tracingService.createTimberTree())


### PR DESCRIPTION
Rename AppBindings to XAppBindings to attempt to fix reproducible build issue

Attempt to fix difference reported here: https://github.com/element-hq/element-x-android/issues/3420#issuecomment-2349031957

If this does not work, we may want to move `XAppBindings` to a sub package...