### PR TITLE
Handle no network error when starting Element Call.

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenEvents.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenEvents.kt
@@ -11,6 +11,6 @@ import io.element.android.features.call.impl.utils.WidgetMessageInterceptor
 
 sealed interface CallScreenEvents {
     data object Hangup : CallScreenEvents
-    data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) :
-        CallScreenEvents
+    data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) : CallScreenEvents
+    data class OnWebViewError(val description: String?) : CallScreenEvents
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -38,6 +39,7 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.network.useragent.UserAgentProvider
+import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.analytics.api.ScreenTracker
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
@@ -78,8 +80,10 @@ class CallScreenPresenter @AssistedInject constructor(
         val callWidgetDriver = remember { mutableStateOf<MatrixWidgetDriver?>(null) }
         val messageInterceptor = remember { mutableStateOf<WidgetMessageInterceptor?>(null) }
         var isJoinedCall by rememberSaveable { mutableStateOf(false) }
+        var canRenderWebViewInCaseOfError by rememberSaveable { mutableStateOf(false) }
         val languageTag = languageTagProvider.provideLanguageTag()
         val theme = if (ElementTheme.isLightTheme) "light" else "dark"
+        val errorMessage = stringResource(id = CommonStrings.error_unknown)
         DisposableEffect(Unit) {
             coroutineScope.launch {
                 // Sets the call as joined
@@ -125,6 +129,8 @@ class CallScreenPresenter @AssistedInject constructor(
             LaunchedEffect(Unit) {
                 interceptor.interceptedMessages
                     .onEach {
+                        // We are receiving messages from the WebView, consider that the application is loaded
+                        canRenderWebViewInCaseOfError = true
                         // Relay message to Widget Driver
                         callWidgetDriver.value?.send(it)
 
@@ -163,11 +169,25 @@ class CallScreenPresenter @AssistedInject constructor(
                 is CallScreenEvents.SetupMessageChannels -> {
                     messageInterceptor.value = event.widgetMessageInterceptor
                 }
+                is CallScreenEvents.OnWebViewError -> {
+                    if (!canRenderWebViewInCaseOfError) {
+                        urlState.value = AsyncData.Failure(
+                            Exception(
+                                buildString {
+                                    append(errorMessage)
+                                    event.description?.let { append("\n\n").append(it) }
+                                }
+                            )
+                        )
+                    }
+                    // Else ignore the error, give a chance the Element Call to recover by itself.
+                }
             }
         }
 
         return CallScreenState(
             urlState = urlState.value,
+            canRenderWebViewInCaseOfError = canRenderWebViewInCaseOfError,
             userAgent = userAgent,
             isInWidgetMode = isInWidgetMode,
             eventSink = { handleEvents(it) },

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenState.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenState.kt
@@ -11,6 +11,7 @@ import io.element.android.libraries.architecture.AsyncData
 
 data class CallScreenState(
     val urlState: AsyncData<String>,
+    val canRenderWebViewInCaseOfError: Boolean,
     val userAgent: String,
     val isInWidgetMode: Boolean,
     val eventSink: (CallScreenEvents) -> Unit,

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
@@ -21,12 +21,14 @@ open class CallScreenStateProvider : PreviewParameterProvider<CallScreenState> {
 
 internal fun aCallScreenState(
     urlState: AsyncData<String> = AsyncData.Success("https://call.element.io/some-actual-call?with=parameters"),
+    canRenderWebViewInCaseOfError: Boolean = true,
     userAgent: String = "",
     isInWidgetMode: Boolean = false,
     eventSink: (CallScreenEvents) -> Unit = {},
 ): CallScreenState {
     return CallScreenState(
         urlState = urlState,
+        canRenderWebViewInCaseOfError = canRenderWebViewInCaseOfError,
         userAgent = userAgent,
         isInWidgetMode = isInWidgetMode,
         eventSink = eventSink,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that Element Call is not rendering an error webpage when it cannot be loaded.

If Element Call does not start and the WebView emit an error, display a dialog, hide the webview. When the dialog is close, hangup, so finish the Activity.

If Element Call starts (the app receive a message from it), we ignore further error, because Element Call can recover by itself (when netword is back from instance).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3506 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

|Before|After|
|-|-|
|<img width="302" alt="image" src="https://github.com/user-attachments/assets/628fe695-6c4b-4eb6-ba88-5cd86213a691">|(coming)|

## Tests

<!-- Explain how you tested your development -->

- Enter airplane mode
- Start a Call
- Observe the error dialog. It's not possible to enter PiP mode from this state.
- Exit airplane mode
- start a call
- the call starts
- enter airplane mode
- the call freezes
- exit airplane mode
- the call recovers, no error dialog have been displayed

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
