### PR TITLE
Perform the migration, even if the current version is not known.

### DIFF
--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/MigrationPresenter.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/MigrationPresenter.kt
@@ -45,7 +45,6 @@ class MigrationPresenter @Inject constructor(
         LaunchedEffect(migrationStoreVersion) {
             val migrationValue = migrationStoreVersion ?: return@LaunchedEffect
             if (migrationValue == -1) {
-                // Fresh install, no migration needed
                 Timber.d("Fresh install, or previous installed application did not have the migration mechanism.")
             }
             if (migrationValue == lastMigration) {

--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/MigrationPresenter.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/MigrationPresenter.kt
@@ -46,9 +46,7 @@ class MigrationPresenter @Inject constructor(
             val migrationValue = migrationStoreVersion ?: return@LaunchedEffect
             if (migrationValue == -1) {
                 // Fresh install, no migration needed
-                Timber.d("Fresh install, no migration needed.")
-                migrationStore.setApplicationMigrationVersion(lastMigration)
-                return@LaunchedEffect
+                Timber.d("Fresh install, or previous installed application did not have the migration mechanism.")
             }
             if (migrationValue == lastMigration) {
                 Timber.d("Current app migration version: $migrationValue. No migration needed.")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Perform the migration, even if the current version is not known.

It can happen that user has a very old version with a session, and the mechanism to update the internal data did not exist.
If the user upgrade to a recent version, the migrations were skipped and this can make the existing session not recoverable.

For fresh install, all the existing migrations will be no-op, so that's fine.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3534

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
