### PR TITLE
Fix room settings not treating unencrypted DMs as DMs

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembers.kt
@@ -44,7 +44,7 @@ fun MatrixRoom.getDirectRoomMember(roomMembersState: MatrixRoomMembersState): St
         derivedStateOf {
             roomMembers
                 ?.filter { it.membership.isActive() }
-                ?.takeIf { it.size == 2 && isDirect && isEncrypted }
+                ?.takeIf { it.size == 2 && isDirect }
                 ?.find { it.userId != sessionId }
         }
     }

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembersTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomMembersTest.kt
@@ -60,7 +60,7 @@ class MatrixRoomMembersTest {
     }
 
     @Test
-    fun `getDirectRoomMember emit null if the room is not encrypted`() = runTest {
+    fun `getDirectRoomMember emits other member even if the room is not encrypted`() = runTest {
         val matrixRoom = FakeMatrixRoom(
             sessionId = A_USER_ID,
             isEncrypted = false,
@@ -71,7 +71,7 @@ class MatrixRoomMembersTest {
                 MatrixRoomMembersState.Ready(persistentListOf(roomMember1, roomMember2))
             )
         }.test {
-            assertThat(awaitItem().value).isNull()
+            assertThat(awaitItem().value).isEqualTo(roomMember2)
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Removes the `&& isEncrypted` check when trying to retrieve the other user in a DM.

## Motivation and context

This condition was left there by mistake, we already consider unencrypted direct rooms with 2 people DMs.

Fixes https://github.com/element-hq/element-x-android/issues/3071.

## Tests

Open an unencrypted direct room with 2 people in it (you and someone else).

The room settings screen should display the info for the other user (double avatar, no invite button, etc.).

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
