### PR TITLE
Centralise the DI code generation logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,14 +19,13 @@ import extension.allLibrariesImpl
 import extension.allServicesImpl
 import extension.koverDependencies
 import extension.locales
+import extension.setupAnvil
 import extension.setupKover
 import java.util.Locale
 
 plugins {
     id("io.element.android-compose-application")
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.anvil)
-    alias(libs.plugins.kapt)
     // When using precompiled plugins, we need to apply the firebase plugin like this
     id(libs.plugins.firebaseAppDistribution.get().pluginId)
     alias(libs.plugins.knit)
@@ -233,6 +232,11 @@ knit {
     }
 }
 
+setupAnvil(
+    generateDaggerCode = true,
+    generateDaggerFactoriesUsingAnvil = false,
+)
+
 dependencies {
     allLibrariesImpl()
     allServicesImpl()
@@ -244,11 +248,9 @@ dependencies {
     }
     allFeaturesImpl(rootDir, logger)
     implementation(projects.features.migration.api)
-    implementation(projects.anvilannotations)
     implementation(projects.appnav)
     implementation(projects.appconfig)
     implementation(projects.libraries.uiStrings)
-    anvil(projects.anvilcodegen)
 
     if (ModulesConfig.pushProvidersConfig.includeFirebase) {
         "gplayImplementation"(projects.libraries.pushproviders.firebase)
@@ -273,9 +275,6 @@ dependencies {
     implementation(libs.serialization.json)
 
     implementation(libs.matrix.emojibase.bindings)
-
-    implementation(libs.dagger)
-    kapt(libs.dagger.compiler)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.robolectric)

--- a/appnav/build.gradle.kts
+++ b/appnav/build.gradle.kts
@@ -8,11 +8,10 @@
 @file:Suppress("UnstableApiUsage")
 
 import extension.allFeaturesApi
+import extension.setupAnvil
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
-    alias(libs.plugins.kapt)
     id("kotlin-parcelize")
 }
 
@@ -20,12 +19,9 @@ android {
     namespace = "io.element.android.appnav"
 }
 
-dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
-    implementation(libs.dagger)
-    kapt(libs.dagger.compiler)
+setupAnvil()
 
+dependencies {
     allFeaturesApi(rootDir, logger)
 
     implementation(projects.libraries.core)

--- a/features/analytics/impl/build.gradle.kts
+++ b/features/analytics/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.analytics.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/cachecleaner/impl/build.gradle.kts
+++ b/features/cachecleaner/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,20 +9,15 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.features.cachecleaner.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.cachecleaner.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/call/impl/build.gradle.kts
+++ b/features/call/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
     alias(libs.plugins.kotlin.serialization)
 }
@@ -24,13 +25,10 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(projects.appconfig)
-    implementation(projects.anvilannotations)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.core)
     implementation(projects.libraries.designsystem)

--- a/features/createroom/impl/build.gradle.kts
+++ b/features/createroom/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/deactivation/impl/build.gradle.kts
+++ b/features/deactivation/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/ftue/impl/build.gradle.kts
+++ b/features/ftue/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.ftue.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.ftue.api)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)

--- a/features/invite/impl/build.gradle.kts
+++ b/features/invite/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.invite.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.invite.api)
     implementation(libs.androidx.datastore.preferences)
     implementation(projects.libraries.core)

--- a/features/joinroom/impl/build.gradle.kts
+++ b/features/joinroom/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.joinroom.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/leaveroom/impl/build.gradle.kts
+++ b/features/leaveroom/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,20 +9,15 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.features.leaveroom.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/licenses/impl/build.gradle.kts
+++ b/features/licenses/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -16,13 +18,9 @@ android {
     namespace = "io.element.android.features.licenses.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(libs.serialization.json)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.designsystem)

--- a/features/location/impl/build.gradle.kts
+++ b/features/location/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -19,9 +20,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.features.location.api)
@@ -39,8 +38,6 @@ dependencies {
     implementation(libs.accompanist.permission)
     implementation(projects.libraries.uiStrings)
     implementation(libs.dagger)
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)

--- a/features/lockscreen/impl/build.gradle.kts
+++ b/features/lockscreen/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.lockscreen.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.lockscreen.api)
     implementation(projects.appconfig)
     implementation(projects.libraries.core)

--- a/features/login/impl/build.gradle.kts
+++ b/features/login/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
     alias(libs.plugins.kotlin.serialization)
 }
@@ -22,14 +23,10 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
     implementation(projects.appconfig)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)

--- a/features/logout/impl/build.gradle.kts
+++ b/features/logout/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/messages/impl/build.gradle.kts
+++ b/features/messages/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.messages.api)
     implementation(projects.appconfig)
     implementation(projects.features.call.api)

--- a/features/networkmonitor/impl/build.gradle.kts
+++ b/features/networkmonitor/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,12 +9,9 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 android {
     namespace = "io.element.android.features.networkmonitor.impl"

--- a/features/onboarding/impl/build.gradle.kts
+++ b/features/onboarding/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.appconfig)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)

--- a/features/poll/impl/build.gradle.kts
+++ b/features/poll/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.poll.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/preferences/impl/build.gradle.kts
+++ b/features/preferences/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.androidutils)
     implementation(projects.appconfig)
     implementation(projects.libraries.core)

--- a/features/rageshake/impl/build.gradle.kts
+++ b/features/rageshake/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.appconfig)
     implementation(projects.services.toolbox.api)
     implementation(projects.libraries.androidutils)

--- a/features/roomaliasresolver/impl/build.gradle.kts
+++ b/features/roomaliasresolver/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.roomaliasresolver.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/roomdetails/impl/build.gradle.kts
+++ b/features/roomdetails/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,14 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/roomdirectory/impl/build.gradle.kts
+++ b/features/roomdirectory/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -20,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.roomdirectory.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/roomlist/impl/build.gradle.kts
+++ b/features/roomlist/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,13 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.appconfig)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)

--- a/features/securebackup/impl/build.gradle.kts
+++ b/features/securebackup/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,14 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.appconfig)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)

--- a/features/share/impl/build.gradle.kts
+++ b/features/share/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -21,14 +22,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.appconfig)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)

--- a/features/signedout/impl/build.gradle.kts
+++ b/features/signedout/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.signedout.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     api(projects.features.signedout.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/features/userprofile/impl/build.gradle.kts
+++ b/features/userprofile/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,14 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/userprofile/shared/build.gradle.kts
+++ b/features/userprofile/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,14 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/verifysession/impl/build.gradle.kts
+++ b/features/verifysession/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -19,14 +20,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/features/viewfolder/impl/build.gradle.kts
+++ b/features/viewfolder/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.features.viewfolder.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ kover = "0.8.3"
 android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref = "android_gradle_plugin" }
 # https://developer.android.com/studio/write/java8-support#library-desugaring-versions
 android_desugar = "com.android.tools:desugar_jdk_libs:2.1.2"
+anvil_gradle_plugin = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kover_gradle_plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 gms_google_services = "com.google.gms:google-services:4.4.2"

--- a/libraries/androidutils/build.gradle.kts
+++ b/libraries/androidutils/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -17,13 +18,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
     implementation(projects.libraries.di)
 
     implementation(projects.libraries.core)

--- a/libraries/cryptography/impl/build.gradle.kts
+++ b/libraries/cryptography/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,21 +9,16 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.cryptography.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
     implementation(libs.dagger)
-    implementation(projects.anvilannotations)
     implementation(projects.libraries.di)
     api(projects.libraries.cryptography.api)
 

--- a/libraries/dateformatter/impl/build.gradle.kts
+++ b/libraries/dateformatter/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,21 +9,16 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 android {
     namespace = "io.element.android.libraries.dateformatter.impl"
 
     dependencies {
-        anvil(projects.anvilcodegen)
         implementation(libs.dagger)
         implementation(projects.libraries.di)
-        implementation(projects.anvilannotations)
 
         api(projects.libraries.dateformatter.api)
         api(libs.datetime)

--- a/libraries/deeplink/build.gradle.kts
+++ b/libraries/deeplink/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.deeplink"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(projects.libraries.di)

--- a/libraries/eventformatter/impl/build.gradle.kts
+++ b/libraries/eventformatter/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -20,14 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)

--- a/libraries/featureflag/impl/build.gradle.kts
+++ b/libraries/featureflag/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,9 +16,7 @@ android {
     namespace = "io.element.android.libraries.featureflag.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.libraries.featureflag.api)

--- a/libraries/featureflag/ui/build.gradle.kts
+++ b/libraries/featureflag/ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,12 +16,8 @@ android {
     namespace = "io.element.android.libraries.featureflag.ui"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.designsystem)
 }

--- a/libraries/fullscreenintent/impl/build.gradle.kts
+++ b/libraries/fullscreenintent/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,21 +9,16 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.fullscreenintent.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.libraries.fullscreenintent.api)
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.permissions.api)

--- a/libraries/indicator/impl/build.gradle.kts
+++ b/libraries/indicator/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,24 +9,19 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 android {
     namespace = "io.element.android.libraries.indicator.impl"
 }
 
 dependencies {
-    anvil(projects.anvilcodegen)
     implementation(libs.dagger)
     implementation(projects.libraries.di)
     implementation(projects.libraries.featureflag.api)
     implementation(projects.libraries.matrix.api)
-    implementation(projects.anvilannotations)
 
     implementation(libs.coroutines.core)
 

--- a/libraries/matrix/api/build.gradle.kts
+++ b/libraries/matrix/api/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -8,7 +10,6 @@
 plugins {
     id("io.element.android-compose-library")
     id("kotlin-parcelize")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -20,9 +21,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(projects.libraries.di)

--- a/libraries/matrix/impl/build.gradle.kts
+++ b/libraries/matrix/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -15,9 +16,7 @@ android {
     namespace = "io.element.android.libraries.matrix.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     releaseImplementation(libs.matrix.sdk)

--- a/libraries/matrixui/build.gradle.kts
+++ b/libraries/matrixui/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.di)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.androidutils)

--- a/libraries/mediaplayer/api/build.gradle.kts
+++ b/libraries/mediaplayer/api/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.mediaplayer.api"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(projects.libraries.matrix.api)

--- a/libraries/mediaplayer/impl/build.gradle.kts
+++ b/libraries/mediaplayer/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.mediaplayer.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.libraries.mediaplayer.api)

--- a/libraries/mediaupload/api/build.gradle.kts
+++ b/libraries/mediaupload/api/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,34 +9,28 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
+
+setupAnvil()
 
 android {
     namespace = "io.element.android.libraries.mediaupload.api"
+}
 
-    anvil {
-        generateDaggerFactories.set(true)
-    }
+dependencies {
+    implementation(projects.libraries.architecture)
+    implementation(projects.libraries.androidutils)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
+    api(projects.libraries.matrix.api)
+    implementation(libs.inject)
+    implementation(libs.coroutines.core)
 
-    dependencies {
-        implementation(projects.anvilannotations)
-        anvil(projects.anvilcodegen)
-
-        implementation(projects.libraries.architecture)
-        implementation(projects.libraries.androidutils)
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.di)
-        api(projects.libraries.matrix.api)
-        implementation(libs.inject)
-        implementation(libs.coroutines.core)
-
-        testImplementation(projects.libraries.matrix.test)
-        testImplementation(projects.libraries.mediaupload.test)
-        testImplementation(projects.tests.testutils)
-        testImplementation(libs.test.junit)
-        testImplementation(libs.test.truth)
-        testImplementation(libs.coroutines.test)
-        testImplementation(libs.test.robolectric)
-    }
+    testImplementation(projects.libraries.matrix.test)
+    testImplementation(projects.libraries.mediaupload.test)
+    testImplementation(projects.tests.testutils)
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.truth)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.test.robolectric)
 }

--- a/libraries/mediaupload/impl/build.gradle.kts
+++ b/libraries/mediaupload/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,15 +9,11 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.mediaupload.impl"
 
-    anvil {
-        generateDaggerFactories.set(true)
-    }
 
     testOptions {
         unitTests {
@@ -23,28 +21,28 @@ android {
         }
     }
 
-    dependencies {
-        implementation(projects.anvilannotations)
-        anvil(projects.anvilcodegen)
+}
 
-        api(projects.libraries.mediaupload.api)
-        implementation(projects.libraries.architecture)
-        implementation(projects.libraries.androidutils)
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.di)
-        implementation(projects.libraries.matrix.api)
-        implementation(projects.services.toolbox.api)
-        implementation(libs.inject)
-        implementation(libs.androidx.exifinterface)
-        implementation(libs.coroutines.core)
-        implementation(libs.otaliastudios.transcoder)
-        implementation(libs.vanniktech.blurhash)
+setupAnvil()
 
-        testImplementation(libs.test.junit)
-        testImplementation(libs.test.robolectric)
-        testImplementation(libs.coroutines.test)
-        testImplementation(libs.test.truth)
-        testImplementation(projects.tests.testutils)
-        testImplementation(projects.services.toolbox.test)
-    }
+dependencies {
+    api(projects.libraries.mediaupload.api)
+    implementation(projects.libraries.architecture)
+    implementation(projects.libraries.androidutils)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
+    implementation(projects.libraries.matrix.api)
+    implementation(projects.services.toolbox.api)
+    implementation(libs.inject)
+    implementation(libs.androidx.exifinterface)
+    implementation(libs.coroutines.core)
+    implementation(libs.otaliastudios.transcoder)
+    implementation(libs.vanniktech.blurhash)
+
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.robolectric)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.test.truth)
+    testImplementation(projects.tests.testutils)
+    testImplementation(projects.services.toolbox.test)
 }

--- a/libraries/mediaupload/impl/build.gradle.kts
+++ b/libraries/mediaupload/impl/build.gradle.kts
@@ -14,13 +14,11 @@ plugins {
 android {
     namespace = "io.element.android.libraries.mediaupload.impl"
 
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
         }
     }
-
 }
 
 setupAnvil()

--- a/libraries/mediaviewer/api/build.gradle.kts
+++ b/libraries/mediaviewer/api/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -19,14 +20,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(libs.coil.compose)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.ui)

--- a/libraries/mediaviewer/impl/build.gradle.kts
+++ b/libraries/mediaviewer/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -14,14 +15,9 @@ android {
     namespace = "io.element.android.libraries.mediaviewer.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(libs.coroutines.core)
     implementation(libs.dagger)
 

--- a/libraries/network/build.gradle.kts
+++ b/libraries/network/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -19,9 +20,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/oidc/impl/build.gradle.kts
+++ b/libraries/oidc/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
     alias(libs.plugins.kotlin.serialization)
 }
@@ -22,14 +23,10 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
     implementation(projects.appconfig)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)

--- a/libraries/permissions/impl/build.gradle.kts
+++ b/libraries/permissions/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -20,14 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-    implementation(projects.anvilannotations)
-
     implementation(libs.accompanist.permission)
     implementation(libs.androidx.datastore.preferences)
 

--- a/libraries/preferences/impl/build.gradle.kts
+++ b/libraries/preferences/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,16 +9,13 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.preferences.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.libraries.preferences.api)

--- a/libraries/push/impl/build.gradle.kts
+++ b/libraries/push/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -20,9 +21,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/pushproviders/firebase/build.gradle.kts
+++ b/libraries/pushproviders/firebase/build.gradle.kts
@@ -7,9 +7,10 @@
 
 @file:Suppress("UnstableApiUsage")
 
+import extension.setupAnvil
+
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -55,9 +56,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/pushproviders/unifiedpush/build.gradle.kts
+++ b/libraries/pushproviders/unifiedpush/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -14,9 +15,7 @@ android {
     namespace = "io.element.android.libraries.pushproviders.unifiedpush"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/pushstore/impl/build.gradle.kts
+++ b/libraries/pushstore/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
@@ -18,9 +19,7 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/roomselect/impl/build.gradle.kts
+++ b/libraries/roomselect/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.libraries.roomselect.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(projects.libraries.core)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)

--- a/libraries/session-storage/impl/build.gradle.kts
+++ b/libraries/session-storage/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.sqldelight)
 }
 
@@ -14,9 +15,7 @@ android {
     namespace = "io.element.android.libraries.sessionstorage.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/libraries/textcomposer/impl/build.gradle.kts
+++ b/libraries/textcomposer/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -18,12 +19,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.uiStrings)
     implementation(projects.libraries.androidutils)

--- a/libraries/troubleshoot/impl/build.gradle.kts
+++ b/libraries/troubleshoot/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,7 +8,6 @@
  */
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     alias(libs.plugins.kotlin.serialization)
 }
 
@@ -20,13 +21,9 @@ android {
     }
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    implementation(projects.anvilannotations)
-    anvil(projects.anvilcodegen)
     implementation(libs.dagger)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.designsystem)

--- a/libraries/usersearch/impl/build.gradle.kts
+++ b/libraries/usersearch/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,16 +9,13 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.usersearch.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(projects.libraries.core)

--- a/libraries/voicerecorder/api/build.gradle.kts
+++ b/libraries/voicerecorder/api/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.voicerecorder.api"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.androidx.annotationjvm)

--- a/libraries/voicerecorder/impl/build.gradle.kts
+++ b/libraries/voicerecorder/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.libraries.voicerecorder.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     api(projects.libraries.voicerecorder.api)

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
     implementation(libs.firebase.appdistribution.gradle)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(libs.autonomousapps.dependencyanalysis.plugin)
+    implementation(libs.anvil.gradle.plugin)
 }

--- a/plugins/src/main/kotlin/extension/AnvilExtensions.kt
+++ b/plugins/src/main/kotlin/extension/AnvilExtensions.kt
@@ -9,24 +9,48 @@ package extension
 
 import org.gradle.api.Project
 import com.squareup.anvil.plugin.AnvilExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.kotlin.dsl.the
 
 /**
  * Setup Anvil plugin with the given configuration.
- * @param generateDaggerFactories whether to generate Dagger factories using Anvil
+ * @param generateDaggerCode whether to enable general Dagger code generation using Kapt
+ * @param generateDaggerFactoriesUsingAnvil whether to generate Dagger factories using Anvil instead of Kapt
  */
-fun Project.setupAnvil(generateDaggerFactories: Boolean = true) {
-    plugins.apply("com.squareup.anvil")
-    project.pluginManager.withPlugin("com.squareup.anvil") {
-        extensions.configure(AnvilExtension::class.java) {
-            this.generateDaggerFactories.set(generateDaggerFactories)
+fun Project.setupAnvil(
+    generateDaggerCode: Boolean = false,
+    generateDaggerFactoriesUsingAnvil: Boolean = true,
+) {
+    val libs = the<LibrariesForLibs>()
+    // Apply plugins and dependencies
+    applyPluginIfNeeded("com.squareup.anvil")
 
-            // These dependencies are only needed for compose libraries
-            if (project.pluginManager.hasPlugin("io.element.android-compose-library")) {
-                // Annotations to generate DI code for Appyx nodes
-                dependencies.add("implementation", project.project(":anvilannotations"))
-                // Code generator for the annotations above
-                dependencies.add("anvil", project.project(":anvilcodegen"))
-            }
+    if (generateDaggerCode) {
+        applyPluginIfNeeded("org.jetbrains.kotlin.kapt")
+        // Needed at the top level since dagger code should be generated at a single point for performance
+        dependencies.add("implementation", libs.dagger)
+        dependencies.add("kapt", libs.dagger.compiler)
+    }
+
+    // These dependencies are only needed for compose library or application modules
+    if (project.pluginManager.hasPlugin("io.element.android-compose-library")
+        || project.pluginManager.hasPlugin("io.element.android-compose-application")) {
+        // Annotations to generate DI code for Appyx nodes
+        dependencies.add("implementation", project.project(":anvilannotations"))
+        // Code generator for the annotations above
+        dependencies.add("anvil", project.project(":anvilcodegen"))
+    }
+
+    project.pluginManager.withPlugin("com.squareup.anvil") {
+        // Setup extension
+        extensions.configure(AnvilExtension::class.java) {
+            this.generateDaggerFactories.set(generateDaggerFactoriesUsingAnvil)
         }
+    }
+}
+
+private fun Project.applyPluginIfNeeded(pluginId: String) {
+    if (!pluginManager.hasPlugin(pluginId)) {
+        pluginManager.apply(pluginId)
     }
 }

--- a/plugins/src/main/kotlin/extension/AnvilExtensions.kt
+++ b/plugins/src/main/kotlin/extension/AnvilExtensions.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package extension
+
+import org.gradle.api.Project
+import com.squareup.anvil.plugin.AnvilExtension
+
+/**
+ * Setup Anvil plugin with the given configuration.
+ * @param generateDaggerFactories whether to generate Dagger factories using Anvil
+ */
+fun Project.setupAnvil(generateDaggerFactories: Boolean = true) {
+    plugins.apply("com.squareup.anvil")
+    project.pluginManager.withPlugin("com.squareup.anvil") {
+        extensions.configure(AnvilExtension::class.java) {
+            this.generateDaggerFactories.set(generateDaggerFactories)
+
+            // These dependencies are only needed for compose libraries
+            if (project.pluginManager.hasPlugin("io.element.android-compose-library")) {
+                // Annotations to generate DI code for Appyx nodes
+                dependencies.add("implementation", project.project(":anvilannotations"))
+                // Code generator for the annotations above
+                dependencies.add("anvil", project.project(":anvilcodegen"))
+            }
+        }
+    }
+}

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -12,6 +12,7 @@ import ModulesConfig
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.logging.Logger
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.closureOf
@@ -19,6 +20,7 @@ import org.gradle.kotlin.dsl.project
 import java.io.File
 
 private fun DependencyHandlerScope.implementation(dependency: Any) = dependencies.add("implementation", dependency)
+internal fun DependencyHandler.implementation(dependency: Any) = add("implementation", dependency)
 
 // Implementation + config block
 private fun DependencyHandlerScope.implementation(

--- a/services/analytics/impl/build.gradle.kts
+++ b/services/analytics/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -7,7 +9,6 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
     id("kotlin-parcelize")
 }
 
@@ -15,13 +16,9 @@ android {
     namespace = "io.element.android.services.analytics.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
-    anvil(projects.anvilcodegen)
-
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)

--- a/services/analytics/noop/build.gradle.kts
+++ b/services/analytics/noop/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.services.analytics.noop"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/services/analyticsproviders/posthog/build.gradle.kts
+++ b/services/analyticsproviders/posthog/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.services.analyticsproviders.posthog"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/services/analyticsproviders/sentry/build.gradle.kts
+++ b/services/analyticsproviders/sentry/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.services.analyticsproviders.sentry"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)

--- a/services/apperror/impl/build.gradle.kts
+++ b/services/apperror/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,19 +9,15 @@
 
 plugins {
     id("io.element.android-compose-library")
-    alias(libs.plugins.anvil)
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 android {
     namespace = "io.element.android.services.apperror.impl"
 }
 
 dependencies {
-    anvil(projects.anvilcodegen)
     implementation(libs.dagger)
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)

--- a/services/appnavstate/impl/build.gradle.kts
+++ b/services/appnavstate/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2022-2024 New Vector Ltd.
  *
@@ -7,24 +9,19 @@
 
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 android {
     namespace = "io.element.android.services.appnavstate.impl"
 }
 
 dependencies {
-    anvil(projects.anvilcodegen)
     implementation(libs.dagger)
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)
     implementation(projects.libraries.matrix.api)
-    implementation(projects.anvilannotations)
 
     implementation(libs.coroutines.core)
     implementation(libs.androidx.corektx)

--- a/services/toolbox/impl/build.gradle.kts
+++ b/services/toolbox/impl/build.gradle.kts
@@ -1,3 +1,5 @@
+import extension.setupAnvil
+
 /*
  * Copyright 2023, 2024 New Vector Ltd.
  *
@@ -6,16 +8,13 @@
  */
 plugins {
     id("io.element.android-library")
-    alias(libs.plugins.anvil)
 }
 
 android {
     namespace = "io.element.android.services.toolbox.impl"
 }
 
-anvil {
-    generateDaggerFactories.set(true)
-}
+setupAnvil()
 
 dependencies {
     implementation(libs.dagger)


### PR DESCRIPTION
## Content

Centralise the DI setup in a single `setupAnvil()` function.

## Motivation and context

- It's easier to maintain.
- It should make the transition to other implementations easier.

## Tests

Build the app & check it runs I guess? 😅 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
