### PR TITLE
Use MSC2530 filename when loading media

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
@@ -324,7 +324,7 @@ class MessagesFlowNode @AssistedInject constructor(
             is TimelineItemImageContent -> {
                 val navTarget = NavTarget.MediaViewer(
                     mediaInfo = MediaInfo(
-                        name = event.content.body,
+                        name = event.content.filename ?: event.content.body,
                         mimeType = event.content.mimeType,
                         formattedFileSize = event.content.formattedFileSize,
                         fileExtension = event.content.fileExtension
@@ -358,7 +358,7 @@ class MessagesFlowNode @AssistedInject constructor(
             is TimelineItemVideoContent -> {
                 val navTarget = NavTarget.MediaViewer(
                     mediaInfo = MediaInfo(
-                        name = event.content.body,
+                        name = event.content.filename ?: event.content.body,
                         mimeType = event.content.mimeType,
                         formattedFileSize = event.content.formattedFileSize,
                         fileExtension = event.content.fileExtension

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemImageView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemImageView.kt
@@ -81,7 +81,13 @@ fun TimelineItemImageView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .then(if (isLoaded) Modifier.background(Color.White) else Modifier),
-                model = MediaRequestData(content.preferredMediaSource, MediaRequestData.Kind.File(content.body, content.mimeType)),
+                model = MediaRequestData(
+                    source = content.preferredMediaSource,
+                    kind = MediaRequestData.Kind.File(
+                        body = content.filename ?: content.body,
+                        mimeType = content.mimeType,
+                    ),
+                ),
                 contentScale = ContentScale.Fit,
                 alignment = Alignment.Center,
                 contentDescription = description,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVideoView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemVideoView.kt
@@ -88,7 +88,13 @@ fun TimelineItemVideoView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .then(if (isLoaded) Modifier.background(Color.White) else Modifier),
-                model = MediaRequestData(content.thumbnailSource, MediaRequestData.Kind.File(content.body, content.mimeType)),
+                model = MediaRequestData(
+                    source = content.thumbnailSource,
+                    kind = MediaRequestData.Kind.File(
+                        body = content.filename ?: content.body,
+                        mimeType = content.mimeType
+                    )
+                ),
                 contentScale = ContentScale.Fit,
                 alignment = Alignment.Center,
                 contentDescription = description,


### PR DESCRIPTION
## Content

In the case of captioned images, the `body` of the event is the caption, and is ill suited to be a filename. Often the caption can be prohibitively long, causing the media to fail to load in some cases.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/2882

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1: Try to open an image- receive `An error has occurred` as per https://github.com/element-hq/element-x-android/issues/2882#issuecomment-2384009582
- Step 2: Add this patch and note that the media now loads with no errors

To reproduce: Send `!xkcd 2992` to https://matrix.to/#/@xkcd:spritsail.io and observe that the media will fail to load

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
