### PR TITLE
Merge unit, screenshot tests and coverage in a single CI call

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options=-Xmx2g -XX:+UseG1GC
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -Dsonar.gradle.skipCompile=true
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -Dsonar.gradle.skipCompile=true --no-daemon
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,14 +56,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
-      - name: ⚙️ Run unit tests for debug variant
-        run: ./gradlew testDebugUnitTest $CI_GRADLE_ARG_PROPERTIES
-
-      - name: 📸 Run screenshot tests
-        run: ./gradlew verifyPaparazziDebug $CI_GRADLE_ARG_PROPERTIES
-
-      - name: 📈Generate kover report and verify coverage
-        run: ./gradlew :app:koverXmlReportGplayDebug :app:koverHtmlReportGplayDebug :app:koverVerifyAll $CI_GRADLE_ARG_PROPERTIES
+      - name: ⚙️ Check coverage for debug variant (includes unit & screenshot tests)
+        run: ./gradlew :tests:uitests:verifyPaparazziDebug :app:koverXmlReportGplayDebug :app:koverHtmlReportGplayDebug :app:koverVerifyAll $CI_GRADLE_ARG_PROPERTIES
 
       - name: 🚫 Upload kover failed coverage reports
         if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           name: kover-error-report
           path: |
-            app/build/reports/kover/verifyGplayDebug.err
+            app/build/reports/kover
 
       - name: ✅ Upload kover report (disabled)
         if: always()

--- a/tests/uitests/build.gradle.kts
+++ b/tests/uitests/build.gradle.kts
@@ -19,16 +19,6 @@ android {
     namespace = "ui"
 }
 
-// Workaround: `kover` tasks somehow trigger the screenshot tests with a broken configuration, removing
-// any previous test results and not creating new ones. This is a workaround to disable the screenshot tests
-// when the `kover` tasks are detected.
-tasks.withType<Test> {
-    if (project.gradle.startParameter.taskNames.any { it.contains("kover", ignoreCase = true) }) {
-        println("WARNING: Kover task detected, disabling screenshot test task $name.")
-        isEnabled = false
-    }
-}
-
 dependencies {
     // Paparazzi 1.3.2 workaround (see https://github.com/cashapp/paparazzi/blob/master/CHANGELOG.md#132---2024-01-13)
     constraints.add("testImplementation", "com.google.guava:guava") {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

In the CI, merge the unit tests, screenshot tests and coverage checks in the same Gradle command to avoid having to check for build/config caches between tasks.

## Motivation and context

Reduce test job times in the CI, since they're getting quite high.

## Tests

Check if CI times are lower.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
