### PR TITLE
Fix building the app using a local SDK.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -275,8 +275,6 @@ dependencies {
     implementation(libs.serialization.json)
 
     implementation(libs.matrix.emojibase.bindings)
-    // Needed for UtdTracker
-    implementation(libs.matrix.sdk)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.test.robolectric)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.impl.util.anonymizedTokens
 import io.element.android.libraries.network.useragent.UserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.libraries.sessionstorage.api.SessionStore
+import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
@@ -44,7 +45,7 @@ class RustMatrixClientFactory @Inject constructor(
     private val userCertificatesProvider: UserCertificatesProvider,
     private val proxyProvider: ProxyProvider,
     private val clock: SystemClock,
-    private val utdTracker: UtdTracker,
+    private val analyticsService: AnalyticsService,
     private val featureFlagService: FeatureFlagService,
     private val timelineEventTypeFilterFactory: TimelineEventTypeFilterFactory,
     private val clientBuilderProvider: ClientBuilderProvider,
@@ -64,7 +65,7 @@ class RustMatrixClientFactory @Inject constructor(
         client.restoreSession(sessionData.toSession())
 
         val syncService = client.syncService()
-            .withUtdHook(utdTracker)
+            .withUtdHook(UtdTracker(analyticsService))
             .finish()
 
         val (anonymizedAccessToken, anonymizedRefreshToken) = sessionData.anonymizedTokens()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
@@ -13,9 +13,8 @@ import org.matrix.rustcomponents.sdk.UnableToDecryptDelegate
 import org.matrix.rustcomponents.sdk.UnableToDecryptInfo
 import timber.log.Timber
 import uniffi.matrix_sdk_crypto.UtdCause
-import javax.inject.Inject
 
-class UtdTracker @Inject constructor(
+class UtdTracker(
     private val analyticsService: AnalyticsService,
 ) : UnableToDecryptDelegate {
     override fun onUtd(info: UnableToDecryptInfo) {

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/MainActivity.kt
@@ -21,7 +21,6 @@ import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.matrix.api.auth.MatrixAuthenticationService
 import io.element.android.libraries.matrix.impl.RustClientBuilderProvider
 import io.element.android.libraries.matrix.impl.RustMatrixClientFactory
-import io.element.android.libraries.matrix.impl.analytics.UtdTracker
 import io.element.android.libraries.matrix.impl.auth.OidcConfigurationProvider
 import io.element.android.libraries.matrix.impl.auth.RustMatrixAuthenticationService
 import io.element.android.libraries.matrix.impl.paths.SessionPathsFactory
@@ -56,7 +55,7 @@ class MainActivity : ComponentActivity() {
                 userCertificatesProvider = userCertificatesProvider,
                 proxyProvider = proxyProvider,
                 clock = DefaultSystemClock(),
-                utdTracker = UtdTracker(NoopAnalyticsService()),
+                analyticsService = NoopAnalyticsService(),
                 featureFlagService = AlwaysEnabledFeatureFlagService(),
                 timelineEventTypeFilterFactory = RustTimelineEventTypeFilterFactory(),
                 clientBuilderProvider = RustClientBuilderProvider(),


### PR DESCRIPTION
Inject `AnalyticsService` instead of `UtdTracker` since `UtdTracker` requires access to `org.matrix.rustcomponents.sdk.UnableToDecryptDelegate`.