### PR TITLE
Add the `CallWebView` logs to our logging stack

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -9,6 +9,7 @@ package io.element.android.features.call.impl.ui
 
 import android.annotation.SuppressLint
 import android.view.ViewGroup
+import android.webkit.ConsoleMessage
 import android.webkit.PermissionRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -43,6 +44,7 @@ import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.ui.strings.CommonStrings
+import timber.log.Timber
 
 typealias RequestPermissionCallback = (Array<String>) -> Unit
 
@@ -188,6 +190,11 @@ private fun WebView.setup(
     webChromeClient = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {
             onPermissionsRequested(request)
+        }
+
+        override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
+            consoleMessage?.let { Timber.d("[WebView]: ${it.message()}") }
+            return true
         }
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -8,6 +8,7 @@
 package io.element.android.features.call.impl.ui
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.view.ViewGroup
 import android.webkit.ConsoleMessage
 import android.webkit.PermissionRequest
@@ -192,8 +193,22 @@ private fun WebView.setup(
             onPermissionsRequested(request)
         }
 
-        override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-            consoleMessage?.let { Timber.d("[WebView]: ${it.message()}") }
+        override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+            val priority = when (consoleMessage.messageLevel()) {
+                ConsoleMessage.MessageLevel.ERROR -> Log.ERROR
+                ConsoleMessage.MessageLevel.WARNING -> Log.WARN
+                else -> Log.DEBUG
+            }
+            Timber.tag("WebView").log(
+                priority = priority,
+                message = buildString {
+                    append(consoleMessage.sourceId())
+                    append(":")
+                    append(consoleMessage.lineNumber())
+                    append(" ")
+                    append(consoleMessage.message())
+                },
+            )
             return true
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Intercept the logs for the Element Call webview and log them using Timber so they go through our logging system.

## Motivation and context

Element Call logs were lost in nightly and release versions of the app since they're not printed to the logcat or saved to disk, so it's very difficult to debug issues unless it's in a debug version.

## Tests

- Open a call using EXA.
- Check the logcat, send a rageshake or check the logs using the bug report file viewer.
- Check there are `[WebView]` prefixed logs inside.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
