### PR TITLE
Improve avatar rendering

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatarDataFetcherFactory.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatarDataFetcherFactory.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.libraries.matrix.ui.media
 
-import android.content.Context
 import coil.ImageLoader
 import coil.fetch.Fetcher
 import coil.request.Options
@@ -15,7 +14,6 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.matrix.api.MatrixClient
 
 internal class AvatarDataFetcherFactory(
-    private val context: Context,
     private val client: MatrixClient
 ) : Fetcher.Factory<AvatarData> {
     override fun create(
@@ -24,7 +22,6 @@ internal class AvatarDataFetcherFactory(
         imageLoader: ImageLoader
     ): Fetcher {
         return CoilMediaFetcher(
-            scalingFunction = { context.resources.displayMetrics.density * it },
             mediaLoader = client.mediaLoader,
             mediaData = data.toMediaRequestData(),
             options = options

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatatarDataExt.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/AvatatarDataExt.kt
@@ -9,11 +9,25 @@ package io.element.android.libraries.matrix.ui.media
 
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.matrix.api.media.MediaSource
-import kotlin.math.roundToLong
+
+/**
+ * The size in pixel of the thumbnail to generate for the avatar.
+ * This is not the size of the avatar displayed in the UI but the size to get from the servers.
+ * Servers SHOULD produce thumbnails with the following dimensions and methods:
+ *
+ * 32x32, crop
+ * 96x96, crop
+ * 320x240, scale
+ * 640x480, scale
+ * 800x600, scale
+ *
+ * Let's always use the same size so coil caching works properly.
+ */
+const val AVATAR_THUMBNAIL_SIZE_IN_PIXEL = 240L
 
 internal fun AvatarData.toMediaRequestData(): MediaRequestData {
     return MediaRequestData(
         source = url?.let { MediaSource(it) },
-        kind = MediaRequestData.Kind.Thumbnail(size.dp.value.roundToLong())
+        kind = MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)
     )
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -20,10 +20,8 @@ import okio.Buffer
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
 import java.nio.ByteBuffer
-import kotlin.math.roundToLong
 
 internal class CoilMediaFetcher(
-    private val scalingFunction: (Float) -> Float,
     private val mediaLoader: MatrixMediaLoader,
     private val mediaData: MediaRequestData,
     private val options: Options
@@ -74,8 +72,8 @@ internal class CoilMediaFetcher(
     private suspend fun fetchThumbnail(mediaSource: MediaSource, kind: MediaRequestData.Kind.Thumbnail, options: Options): FetchResult? {
         return mediaLoader.loadMediaThumbnail(
             source = mediaSource,
-            width = scalingFunction(kind.width.toFloat()).roundToLong(),
-            height = scalingFunction(kind.height.toFloat()).roundToLong(),
+            width = kind.width,
+            height = kind.height,
         ).map { byteArray ->
             byteArray.asSourceResult(options)
         }.onFailure {

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/ImageLoaderFactories.kt
@@ -43,8 +43,8 @@ class DefaultLoggedInImageLoaderFactory @Inject constructor(
                 }
                 add(AvatarDataKeyer())
                 add(MediaRequestDataKeyer())
-                add(AvatarDataFetcherFactory(context, matrixClient))
-                add(MediaRequestDataFetcherFactory(context, matrixClient))
+                add(AvatarDataFetcherFactory(matrixClient))
+                add(MediaRequestDataFetcherFactory(matrixClient))
             }
             .build()
     }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataFetcherFactory.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataFetcherFactory.kt
@@ -7,14 +7,12 @@
 
 package io.element.android.libraries.matrix.ui.media
 
-import android.content.Context
 import coil.ImageLoader
 import coil.fetch.Fetcher
 import coil.request.Options
 import io.element.android.libraries.matrix.api.MatrixClient
 
 internal class MediaRequestDataFetcherFactory(
-    private val context: Context,
     private val client: MatrixClient
 ) : Fetcher.Factory<MediaRequestData> {
     override fun create(
@@ -23,7 +21,6 @@ internal class MediaRequestDataFetcherFactory(
         imageLoader: ImageLoader
     ): Fetcher {
         return CoilMediaFetcher(
-            scalingFunction = { context.resources.displayMetrics.density * it },
             mediaLoader = client.mediaLoader,
             mediaData = data,
             options = options

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationBitmapLoader.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationBitmapLoader.kt
@@ -19,6 +19,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.media.MediaSource
+import io.element.android.libraries.matrix.ui.media.AVATAR_THUMBNAIL_SIZE_IN_PIXEL
 import io.element.android.libraries.matrix.ui.media.MediaRequestData
 import io.element.android.libraries.push.api.notifications.NotificationBitmapLoader
 import io.element.android.services.toolbox.api.sdk.BuildVersionSdkIntProvider
@@ -45,7 +46,7 @@ class DefaultNotificationBitmapLoader @Inject constructor(
     private suspend fun loadRoomBitmap(path: String, imageLoader: ImageLoader): Bitmap? {
         return try {
             val imageRequest = ImageRequest.Builder(context)
-                .data(MediaRequestData(MediaSource(path), MediaRequestData.Kind.Thumbnail(1024)))
+                .data(MediaRequestData(MediaSource(path), MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)))
                 .transformations(CircleCropTransformation())
                 .build()
             val result = imageLoader.execute(imageRequest)
@@ -73,7 +74,7 @@ class DefaultNotificationBitmapLoader @Inject constructor(
     private suspend fun loadUserIcon(path: String, imageLoader: ImageLoader): IconCompat? {
         return try {
             val imageRequest = ImageRequest.Builder(context)
-                .data(MediaRequestData(MediaSource(path), MediaRequestData.Kind.Thumbnail(1024)))
+                .data(MediaRequestData(MediaSource(path), MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)))
                 .transformations(CircleCropTransformation())
                 .build()
             val result = imageLoader.execute(imageRequest)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
@@ -15,6 +15,7 @@ import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_TIMESTAMP
 import io.element.android.libraries.matrix.ui.components.aMatrixUser
+import io.element.android.libraries.matrix.ui.media.AVATAR_THUMBNAIL_SIZE_IN_PIXEL
 import io.element.android.libraries.matrix.ui.media.MediaRequestData
 import io.element.android.libraries.push.impl.notifications.factories.createNotificationCreator
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
@@ -84,7 +85,7 @@ class DefaultRoomGroupMessageCreatorTest {
             expectedCoilRequests = listOf(
                 MediaRequestData(
                     source = MediaSource(url = A_ROOM_AVATAR),
-                    kind = MediaRequestData.Kind.Thumbnail(1024)
+                    kind = MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)
                 )
             )
         )
@@ -98,15 +99,15 @@ class DefaultRoomGroupMessageCreatorTest {
             expectedCoilRequests = listOf(
                 MediaRequestData(
                     source = MediaSource(url = A_USER_AVATAR_1),
-                    kind = MediaRequestData.Kind.Thumbnail(1024)
+                    kind = MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)
                 ),
                 MediaRequestData(
                     source = MediaSource(url = A_USER_AVATAR_2),
-                    kind = MediaRequestData.Kind.Thumbnail(1024)
+                    kind = MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)
                 ),
                 MediaRequestData(
                     source = MediaSource(url = A_ROOM_AVATAR),
-                    kind = MediaRequestData.Kind.Thumbnail(1024)
+                    kind = MediaRequestData.Kind.Thumbnail(AVATAR_THUMBNAIL_SIZE_IN_PIXEL)
                 ),
             )
         )


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
This PR takes care of using a single thumbnail request size, so caching works properly.
Indeed, according to the matrix specs : 

> Servers SHOULD produce thumbnails with the following dimensions and methods:
> 32x32, crop
> 96x96, crop
> 320x240, scale
> 640x480, scale
> 800x600, scale

For rendering avatar we could use crop, but it's not available in the rust sdk yet.
So instead, always use the smallest scale function ie. requesting with a size <= 240 pixels would makes sure we do.

This way, we'll be hitting the server only once per mxc url, and not for each size we've defined in our AvatarSize.

<!-- Describe shortly what has been changed -->

## Motivation and context
Improve rendering by removing useless network calls.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
