### PR TITLE
Cleanup tests

### DIFF
--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/FakeKnockRoom.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/FakeKnockRoom.kt
@@ -9,9 +9,12 @@ package io.element.android.features.joinroom.impl
 
 import io.element.android.features.joinroom.impl.di.KnockRoom
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.tests.testutils.simulateLongTask
 
 class FakeKnockRoom(
     var lambda: (RoomId) -> Result<Unit> = { Result.success(Unit) }
 ) : KnockRoom {
-    override suspend fun invoke(roomId: RoomId) = lambda(roomId)
+    override suspend fun invoke(roomId: RoomId) = simulateLongTask {
+        lambda(roomId)
+    }
 }

--- a/features/logout/test/src/main/kotlin/io/element/android/features/logout/test/FakeLogoutUseCase.kt
+++ b/features/logout/test/src/main/kotlin/io/element/android/features/logout/test/FakeLogoutUseCase.kt
@@ -9,11 +9,12 @@ package io.element.android.features.logout.test
 
 import io.element.android.features.logout.api.LogoutUseCase
 import io.element.android.tests.testutils.lambda.lambdaError
+import io.element.android.tests.testutils.simulateLongTask
 
 class FakeLogoutUseCase(
     var logoutLambda: (Boolean) -> String? = { lambdaError() }
 ) : LogoutUseCase {
-    override suspend fun logout(ignoreSdkError: Boolean): String? {
-        return logoutLambda(ignoreSdkError)
+    override suspend fun logout(ignoreSdkError: Boolean): String? = simulateLongTask {
+        logoutLambda(ignoreSdkError)
     }
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
@@ -115,7 +115,9 @@ class DeveloperSettingsPresenter @Inject constructor(
                 DeveloperSettingsEvents.ClearCache -> coroutineScope.clearCache(clearCacheAction)
                 is DeveloperSettingsEvents.SetSimplifiedSlidingSyncEnabled -> coroutineScope.launch {
                     appPreferencesStore.setSimplifiedSlidingSyncEnabled(event.isEnabled)
-                    logoutUseCase.logout(ignoreSdkError = true)
+                    runCatching {
+                        logoutUseCase.logout(ignoreSdkError = true)
+                    }
                 }
                 is DeveloperSettingsEvents.SetHideImagesAndVideos -> coroutineScope.launch {
                     appPreferencesStore.setHideImagesAndVideos(event.value)

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.awaitLastSequentialItem
 import io.element.android.tests.testutils.lambda.lambdaRecorder
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -168,11 +169,15 @@ class DeveloperSettingsPresenterTest {
             initialState.eventSink(DeveloperSettingsEvents.SetSimplifiedSlidingSyncEnabled(true))
             assertThat(awaitItem().isSimpleSlidingSyncEnabled).isTrue()
             assertThat(preferences.isSimplifiedSlidingSyncEnabledFlow().first()).isTrue()
+            // Give time for the logout to be called, but for some reason using runCurrent() is not enough
+            delay(2)
             logoutCallRecorder.assertions().isCalledOnce()
 
             initialState.eventSink(DeveloperSettingsEvents.SetSimplifiedSlidingSyncEnabled(false))
             assertThat(awaitItem().isSimpleSlidingSyncEnabled).isFalse()
             assertThat(preferences.isSimplifiedSlidingSyncEnabledFlow().first()).isFalse()
+            // Give time for the logout to be called, but for some reason using runCurrent() is not enough
+            delay(2)
             logoutCallRecorder.assertions().isCalledExactly(times = 2)
         }
     }

--- a/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/lambda/LambdaRecorder.kt
+++ b/tests/testutils/src/main/kotlin/io/element/android/tests/testutils/lambda/LambdaRecorder.kt
@@ -7,8 +7,6 @@
 
 package io.element.android.tests.testutils.lambda
 
-import kotlinx.coroutines.runBlocking
-
 /**
  * A recorder that can be used to record the parameters of lambda invocation.
  */
@@ -95,21 +93,21 @@ inline fun <reified R> lambdaAnyRecorder(
 class LambdaNoParamRecorder<out R>(ensureNeverCalled: Boolean, val block: () -> R) : LambdaRecorder(ensureNeverCalled), () -> R {
     override fun invoke(): R {
         onInvoke()
-        return runBlocking { block() }
+        return block()
     }
 }
 
 class LambdaOneParamRecorder<in T, out R>(ensureNeverCalled: Boolean, val block: (T) -> R) : LambdaRecorder(ensureNeverCalled), (T) -> R {
     override fun invoke(p: T): R {
         onInvoke(p)
-        return runBlocking { block(p) }
+        return block(p)
     }
 }
 
 class LambdaTwoParamsRecorder<in T1, in T2, out R>(ensureNeverCalled: Boolean, val block: (T1, T2) -> R) : LambdaRecorder(ensureNeverCalled), (T1, T2) -> R {
     override fun invoke(p1: T1, p2: T2): R {
         onInvoke(p1, p2)
-        return runBlocking { block(p1, p2) }
+        return block(p1, p2)
     }
 }
 
@@ -118,7 +116,7 @@ class LambdaThreeParamsRecorder<in T1, in T2, in T3, out R>(ensureNeverCalled: B
 ), (T1, T2, T3) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3): R {
         onInvoke(p1, p2, p3)
-        return runBlocking { block(p1, p2, p3) }
+        return block(p1, p2, p3)
     }
 }
 
@@ -127,7 +125,7 @@ class LambdaFourParamsRecorder<in T1, in T2, in T3, in T4, out R>(ensureNeverCal
 ), (T1, T2, T3, T4) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4): R {
         onInvoke(p1, p2, p3, p4)
-        return runBlocking { block(p1, p2, p3, p4) }
+        return block(p1, p2, p3, p4)
     }
 }
 
@@ -139,7 +137,7 @@ class LambdaFiveParamsRecorder<in T1, in T2, in T3, in T4, in T5, out R>(
 ), (T1, T2, T3, T4, T5) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5): R {
         onInvoke(p1, p2, p3, p4, p5)
-        return runBlocking { block(p1, p2, p3, p4, p5) }
+        return block(p1, p2, p3, p4, p5)
     }
 }
 
@@ -149,7 +147,7 @@ class LambdaSixParamsRecorder<in T1, in T2, in T3, in T4, in T5, in T6, out R>(
 ) : LambdaRecorder(ensureNeverCalled), (T1, T2, T3, T4, T5, T6) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6): R {
         onInvoke(p1, p2, p3, p4, p5, p6)
-        return runBlocking { block(p1, p2, p3, p4, p5, p6) }
+        return block(p1, p2, p3, p4, p5, p6)
     }
 }
 
@@ -159,7 +157,7 @@ class LambdaSevenParamsRecorder<in T1, in T2, in T3, in T4, in T5, in T6, in T7,
 ) : LambdaRecorder(ensureNeverCalled), (T1, T2, T3, T4, T5, T6, T7) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7): R {
         onInvoke(p1, p2, p3, p4, p5, p6, p7)
-        return runBlocking { block(p1, p2, p3, p4, p5, p6, p7) }
+        return block(p1, p2, p3, p4, p5, p6, p7)
     }
 }
 
@@ -169,7 +167,7 @@ class LambdaEightParamsRecorder<in T1, in T2, in T3, in T4, in T5, in T6, in T7,
 ) : LambdaRecorder(ensureNeverCalled), (T1, T2, T3, T4, T5, T6, T7, T8) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8): R {
         onInvoke(p1, p2, p3, p4, p5, p6, p7, p8)
-        return runBlocking { block(p1, p2, p3, p4, p5, p6, p7, p8) }
+        return block(p1, p2, p3, p4, p5, p6, p7, p8)
     }
 }
 
@@ -179,7 +177,7 @@ class LambdaNineParamsRecorder<in T1, in T2, in T3, in T4, in T5, in T6, in T7, 
 ) : LambdaRecorder(ensureNeverCalled), (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R {
     override fun invoke(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9): R {
         onInvoke(p1, p2, p3, p4, p5, p6, p7, p8, p9)
-        return runBlocking { block(p1, p2, p3, p4, p5, p6, p7, p8, p9) }
+        return block(p1, p2, p3, p4, p5, p6, p7, p8, p9)
     }
 }
 


### PR DESCRIPTION
Remove runBlocking usage in LambdaRecorder.
Protect usage of logoutUseCase.
Let FakeKnockRoom and FakeLogoutUseCase use simulateLongTask, to catch more states.