### PR TITLE
Improve preview provider name consistency

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationStepProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationStepProvider.kt
@@ -9,7 +9,7 @@ package io.element.android.features.login.impl.screens.qrcode.confirmation
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 
-class QrCodeConfirmationStepPreviewProvider : PreviewParameterProvider<QrCodeConfirmationStep> {
+class QrCodeConfirmationStepProvider : PreviewParameterProvider<QrCodeConfirmationStep> {
     override val values: Sequence<QrCodeConfirmationStep>
         get() = sequenceOf(
             QrCodeConfirmationStep.DisplayCheckCode("12"),

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
@@ -148,7 +148,7 @@ private fun Buttons(
 
 @PreviewsDayNight
 @Composable
-internal fun QrCodeConfirmationViewPreview(@PreviewParameter(QrCodeConfirmationStepPreviewProvider::class) step: QrCodeConfirmationStep) {
+internal fun QrCodeConfirmationViewPreview(@PreviewParameter(QrCodeConfirmationStepProvider::class) step: QrCodeConfirmationStep) {
     ElementPreview {
         QrCodeConfirmationView(
             step = step,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersStateProvider.kt
@@ -13,7 +13,7 @@ import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.ui.components.aMatrixUserList
 import kotlinx.collections.immutable.toPersistentList
 
-class BlockedUsersStatePreviewProvider : PreviewParameterProvider<BlockedUsersState> {
+class BlockedUsersStateProvider : PreviewParameterProvider<BlockedUsersState> {
     override val values: Sequence<BlockedUsersState>
         get() = sequenceOf(
             aBlockedUsersState(),

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/blockedusers/BlockedUsersView.kt
@@ -123,7 +123,7 @@ private fun BlockedUserItem(
 
 @PreviewsDayNight
 @Composable
-internal fun BlockedUsersViewPreview(@PreviewParameter(BlockedUsersStatePreviewProvider::class) state: BlockedUsersState) {
+internal fun BlockedUsersViewPreview(@PreviewParameter(BlockedUsersStateProvider::class) state: BlockedUsersState) {
     ElementPreview {
         BlockedUsersView(
             state = state,

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationStateProvider.kt
@@ -13,7 +13,7 @@ import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.room.RoomMember
 import kotlinx.collections.immutable.toPersistentList
 
-class RoomMembersModerationStatePreviewProvider : PreviewParameterProvider<RoomMembersModerationState> {
+class RoomMembersModerationStateProvider : PreviewParameterProvider<RoomMembersModerationState> {
     override val values: Sequence<RoomMembersModerationState>
         get() = sequenceOf(
             aRoomMembersModerationState(

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationView.kt
@@ -284,7 +284,7 @@ private fun RoomMemberActionsBottomSheet(
 
 @PreviewsDayNight
 @Composable
-internal fun RoomMembersModerationViewPreview(@PreviewParameter(RoomMembersModerationStatePreviewProvider::class) state: RoomMembersModerationState) {
+internal fun RoomMembersModerationViewPreview(@PreviewParameter(RoomMembersModerationStateProvider::class) state: RoomMembersModerationState) {
     ElementPreview {
         Box(
             modifier = Modifier

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsStateProvider.kt
@@ -13,7 +13,7 @@ import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.powerlevels.MatrixRoomPowerLevels
 import kotlinx.collections.immutable.toPersistentList
 
-class ChangeRoomPermissionsStatePreviewProvider : PreviewParameterProvider<ChangeRoomPermissionsState> {
+class ChangeRoomPermissionsStateProvider : PreviewParameterProvider<ChangeRoomPermissionsState> {
     override val values: Sequence<ChangeRoomPermissionsState>
         get() = sequenceOf(
             aChangeRoomPermissionsState(section = ChangeRoomPermissionsSection.RoomDetails),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsView.kt
@@ -180,7 +180,7 @@ private fun titleForSection(item: RoomPermissionType): String = when (item) {
 
 @PreviewsDayNight
 @Composable
-internal fun ChangeRoomPermissionsViewPreview(@PreviewParameter(ChangeRoomPermissionsStatePreviewProvider::class) state: ChangeRoomPermissionsState) {
+internal fun ChangeRoomPermissionsViewPreview(@PreviewParameter(ChangeRoomPermissionsStateProvider::class) state: ChangeRoomPermissionsState) {
     ElementPreview {
         ChangeRoomPermissionsView(
             state = state,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BigIcon.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/BigIcon.kt
@@ -126,7 +126,7 @@ object BigIcon {
 internal fun BigIconPreview() {
     ElementPreview {
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.padding(10.dp)) {
-            val provider = BigIconStylePreviewProvider()
+            val provider = BigIconStyleProvider()
             for (style in provider.values) {
                 BigIcon(style = style)
             }
@@ -134,7 +134,7 @@ internal fun BigIconPreview() {
     }
 }
 
-internal class BigIconStylePreviewProvider : PreviewParameterProvider<BigIcon.Style> {
+internal class BigIconStyleProvider : PreviewParameterProvider<BigIcon.Style> {
     override val values: Sequence<BigIcon.Style>
         get() = sequenceOf(
             BigIcon.Style.Default(Icons.Filled.CatchingPokemon),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/PageTitle.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/PageTitle.kt
@@ -99,7 +99,7 @@ fun PageTitle(
 
 @PreviewsDayNight
 @Composable
-internal fun PageTitleWithIconFullPreview(@PreviewParameter(BigIconStylePreviewProvider::class) style: BigIcon.Style) {
+internal fun PageTitleWithIconFullPreview(@PreviewParameter(BigIconStyleProvider::class) style: BigIcon.Style) {
     ElementPreview {
         PageTitle(
             modifier = Modifier.padding(top = 24.dp),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/icons/IconsPreview.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/icons/IconsPreview.kt
@@ -30,7 +30,7 @@ import io.element.android.libraries.designsystem.theme.components.Text
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
-internal class CompoundIconListPreviewProvider : PreviewParameterProvider<IconChunk> {
+internal class CompoundIconChunkProvider : PreviewParameterProvider<IconChunk> {
     override val values: Sequence<IconChunk>
         get() {
             val chunks = CompoundIcons.allResIds.chunked(36)
@@ -41,7 +41,7 @@ internal class CompoundIconListPreviewProvider : PreviewParameterProvider<IconCh
         }
 }
 
-internal class OtherIconListPreviewProvider : PreviewParameterProvider<IconChunk> {
+internal class OtherIconChunkProvider : PreviewParameterProvider<IconChunk> {
     override val values: Sequence<IconChunk>
         get() {
             val chunks = iconsOther.chunked(36)
@@ -60,7 +60,7 @@ internal data class IconChunk(
 
 @PreviewsDayNight
 @Composable
-internal fun IconsCompoundPreview(@PreviewParameter(CompoundIconListPreviewProvider::class) chunk: IconChunk) = ElementPreview {
+internal fun IconsCompoundPreview(@PreviewParameter(CompoundIconChunkProvider::class) chunk: IconChunk) = ElementPreview {
     IconsPreview(
         title = "R.drawable.ic_compound_* ${chunk.index}/${chunk.total}",
         iconsList = chunk.icons,
@@ -73,7 +73,7 @@ internal fun IconsCompoundPreview(@PreviewParameter(CompoundIconListPreviewProvi
 
 @PreviewsDayNight
 @Composable
-internal fun IconsOtherPreview(@PreviewParameter(OtherIconListPreviewProvider::class) iconChunk: IconChunk) = ElementPreview {
+internal fun IconsOtherPreview(@PreviewParameter(OtherIconChunkProvider::class) iconChunk: IconChunk) = ElementPreview {
     IconsPreview(
         title = "R.drawable.ic_*  ${iconChunk.index}/${iconChunk.total}",
         iconsList = iconChunk.icons,

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistClassNameTest.kt
@@ -9,6 +9,7 @@ package io.element.android.tests.konsist
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.bumble.appyx.core.node.Node
+import com.google.common.truth.Truth.assertThat
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
 import com.lemonappdev.konsist.api.ext.list.withAnnotationNamed
@@ -44,19 +45,26 @@ class KonsistClassNameTest {
 
     @Test
     fun `Classes extending 'PreviewParameterProvider' name MUST end with 'Provider' and MUST contain provided class name`() {
-        Konsist.scopeFromProject()
+        Konsist.scopeFromProduction()
             .classes()
             .withAllParentsOf(PreviewParameterProvider::class)
-            .assertTrue {
+            .also {
+                // Check that classes are actually found
+                assertThat(it.size).isGreaterThan(100)
+            }
+            .assertTrue { klass ->
                 // Cannot find a better way to get the type of the generic
-                val providedType = it.text
+                val providedType = klass.text
+                    .substringAfter("PreviewParameterProvider<")
                     .substringBefore(">")
-                    .substringAfter("<")
                     // Get the substring before the first '<' to remove the generic type
                     .substringBefore("<")
                     .removeSuffix("?")
                     .replace(".", "")
-                it.name.endsWith("Provider") && (it.name.contains("IconList") || it.name.contains(providedType))
+                val name = klass.name
+                name.endsWith("Provider") &&
+                    name.endsWith("PreviewProvider").not() &&
+                    name.contains(providedType)
             }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Rename some classes which implement PreviewParameterProvider according to the new naming convention.

`Provider` suffix is enough and more used than `PreviewProvider`, so let's make the codebase more consistent.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- There should ne no change in the screenshot nor in the application behavior.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
