### PR TITLE
RTL: ensure sender information are correctly rendered in the timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/MessageEventBubble.kt
@@ -18,7 +18,10 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,7 +32,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.features.messages.impl.timeline.model.TimelineItemGroupPosition
@@ -101,6 +107,8 @@ fun MessageEventBubble(
     val bubbleShape = bubbleShape()
     val radiusPx = (avatarRadius + SENDER_AVATAR_BORDER_WIDTH).toPx()
     val yOffsetPx = -(NEGATIVE_MARGIN_FOR_BUBBLE + avatarRadius).toPx()
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    var contentWidthPx by remember { mutableFloatStateOf(0f) }
     BoxWithConstraints(
         modifier = modifier
             .graphicsLayer {
@@ -112,7 +120,7 @@ fun MessageEventBubble(
                     drawCircle(
                         color = Color.Black,
                         center = Offset(
-                            x = 0f,
+                            x = if (isRtl) contentWidthPx else 0f,
                             y = yOffsetPx,
                         ),
                         radius = radiusPx,
@@ -129,7 +137,9 @@ fun MessageEventBubble(
                 .testTag(TestTags.messageBubble)
                 .widthIn(
                     min = MIN_BUBBLE_WIDTH,
-                    max = (constraints.maxWidth * BUBBLE_WIDTH_RATIO).toInt().toDp()
+                    max = (constraints.maxWidth * BUBBLE_WIDTH_RATIO)
+                        .toInt()
+                        .toDp()
                 )
                 .clip(bubbleShape)
                 .combinedClickable(
@@ -137,7 +147,10 @@ fun MessageEventBubble(
                     onLongClick = onLongClick,
                     indication = ripple(),
                     interactionSource = interactionSource
-                ),
+                )
+                .onGloballyPositioned { coordinates ->
+                    contentWidthPx = coordinates.size.width.toFloat()
+                },
             color = backgroundBubbleColor,
             shape = bubbleShape,
             content = content

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -301,6 +301,8 @@ private fun TimelineItemEventRowContent(
                 Modifier
                     .constrainAs(sender) {
                         top.linkTo(parent.top)
+                        // Required for correct RTL layout
+                        start.linkTo(parent.start)
                     }
                     .padding(horizontal = 16.dp)
                     .zIndex(1f)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Sender information must be rendered at top start of the bubble.

In RTL, the cropping of the bubble was not correct (first commit) and the sender info was not align correctly (second commit)

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Second point of #2865 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|


 -->

From `TimelineItemEventRowTimestampPreview`:

|Before|After|
|-|-|
|<img width="303" alt="image" src="https://github.com/user-attachments/assets/d546e87f-c95c-460d-b63a-854c0023cfb4">|<img width="300" alt="image" src="https://github.com/user-attachments/assets/f9a0acee-2089-4bf9-a9da-525f318e3e17">|

## Tests

<!-- Explain how you tested your development -->

- Set the phone language to a RTL language (such as Persian, which is supported by the app), or force RTL in the developer options of the phone
- Open a timeline and observe that sender informations are rendered correctly.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
