### PR TITLE
Refresh room summaries when date or time changes in the device

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -51,7 +51,6 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
 import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.api.roomlist.RoomList
-import io.element.android.libraries.matrix.api.sync.SyncService
 import io.element.android.libraries.matrix.api.timeline.ReceiptType
 import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.push.api.notifications.NotificationCleaner
@@ -93,7 +92,6 @@ class RoomListPresenter @Inject constructor(
     private val logoutPresenter: Presenter<DirectLogoutState>,
 ) : Presenter<RoomListState> {
     private val encryptionService: EncryptionService = client.encryptionService()
-    private val syncService: SyncService = client.syncService()
 
     @Composable
     override fun present(): RoomListState {

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSource.kt
@@ -7,13 +7,11 @@
 
 package io.element.android.features.roomlist.impl.datasource
 
-import android.content.Context
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.androidutils.system.DateTimeObserver
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
@@ -34,7 +32,6 @@ import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
 class RoomListDataSource @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val roomListService: RoomListService,
     private val roomListRoomSummaryFactory: RoomListRoomSummaryFactory,
     private val coroutineDispatchers: CoroutineDispatchers,

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -22,7 +22,7 @@ import io.element.android.features.logout.api.direct.aDirectLogoutState
 import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.test.FakeNetworkMonitor
 import io.element.android.features.roomlist.impl.datasource.RoomListDataSource
-import io.element.android.features.roomlist.impl.datasource.RoomListRoomSummaryFactory
+import io.element.android.features.roomlist.impl.datasource.aRoomListRoomSummaryFactory
 import io.element.android.features.roomlist.impl.filters.RoomListFiltersState
 import io.element.android.features.roomlist.impl.filters.aRoomListFiltersState
 import io.element.android.features.roomlist.impl.model.createRoomListRoomSummary
@@ -651,7 +651,7 @@ class RoomListPresenterTest {
         leaveRoomPresenter = { leaveRoomState },
         roomListDataSource = RoomListDataSource(
             roomListService = client.roomListService,
-            roomListRoomSummaryFactory = RoomListRoomSummaryFactory(
+            roomListRoomSummaryFactory = aRoomListRoomSummaryFactory(
                 lastMessageTimestampFormatter = lastMessageTimestampFormatter,
                 roomLastMessageFormatter = roomLastMessageFormatter,
             ),

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -29,6 +29,7 @@ import io.element.android.features.roomlist.impl.model.createRoomListRoomSummary
 import io.element.android.features.roomlist.impl.search.RoomListSearchEvents
 import io.element.android.features.roomlist.impl.search.RoomListSearchState
 import io.element.android.features.roomlist.impl.search.aRoomListSearchState
+import io.element.android.libraries.androidutils.system.DateTimeObserver
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.dateformatter.api.LastMessageTimestampFormatter
 import io.element.android.libraries.dateformatter.test.A_FORMATTED_DATE
@@ -83,6 +84,7 @@ import io.element.android.tests.testutils.lambda.value
 import io.element.android.tests.testutils.test
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -655,7 +657,8 @@ class RoomListPresenterTest {
             ),
             coroutineDispatchers = testCoroutineDispatchers(),
             notificationSettingsService = client.notificationSettingsService(),
-            appScope = backgroundScope
+            appScope = backgroundScope,
+            dateTimeObserver = FakeDateTimeObserver(),
         ),
         featureFlagService = featureFlagService,
         indicatorService = DefaultIndicatorService(
@@ -671,4 +674,12 @@ class RoomListPresenterTest {
         notificationCleaner = notificationCleaner,
         logoutPresenter = { aDirectLogoutState() },
     )
+}
+
+class FakeDateTimeObserver : DateTimeObserver {
+    override val changes = MutableSharedFlow<DateTimeObserver.Event>()
+
+    fun given(event: DateTimeObserver.Event) {
+        changes.tryEmit(event)
+    }
 }

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -677,7 +677,7 @@ class RoomListPresenterTest {
 }
 
 class FakeDateTimeObserver : DateTimeObserver {
-    override val changes = MutableSharedFlow<DateTimeObserver.Event>()
+    override val changes = MutableSharedFlow<DateTimeObserver.Event>(extraBufferCapacity = 1)
 
     fun given(event: DateTimeObserver.Event) {
         changes.tryEmit(event)

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
@@ -11,6 +11,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.roomlist.impl.FakeDateTimeObserver
 import io.element.android.libraries.androidutils.system.DateTimeObserver
+import io.element.android.libraries.dateformatter.test.FakeLastMessageTimestampFormatter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.room.aRoomSummary
@@ -29,22 +30,30 @@ class RoomListDataSourceTest {
             postAllRooms(listOf(aRoomSummary()))
         }
         val dateTimeObserver = FakeDateTimeObserver()
-        val roomListDataSource = createRoomListDataSource(roomListService = roomListService, dateTimeObserver = dateTimeObserver)
+        val lastMessageTimestampFormatter = FakeLastMessageTimestampFormatter()
+        lastMessageTimestampFormatter.givenFormat("Today")
+        val roomListDataSource = createRoomListDataSource(
+            roomListService = roomListService,
+            roomListRoomSummaryFactory = aRoomListRoomSummaryFactory(
+                lastMessageTimestampFormatter = lastMessageTimestampFormatter,
+            ),
+            dateTimeObserver = dateTimeObserver,
+        )
 
         roomListDataSource.allRooms.test {
             // Observe room list items changes
             roomListDataSource.launchIn(backgroundScope)
-
             // Get the initial room list
             val initialRoomList = awaitItem()
             assertThat(initialRoomList).isNotEmpty()
-
+            assertThat(initialRoomList.first().timestamp).isEqualTo("Today")
+            lastMessageTimestampFormatter.givenFormat("Yesterday")
             // Trigger a date change
             dateTimeObserver.given(DateTimeObserver.Event.DateChanged(Instant.MIN, Instant.now()))
-
-            // Check there is a new list and it's not the same as the previous one (although it has the same content)
+            // Check there is a new list and it's not the same as the previous one
             val newRoomList = awaitItem()
             assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
+            assertThat(newRoomList.first().timestamp).isEqualTo("Yesterday")
         }
     }
 
@@ -55,22 +64,29 @@ class RoomListDataSourceTest {
             postAllRooms(listOf(aRoomSummary()))
         }
         val dateTimeObserver = FakeDateTimeObserver()
-        val roomListDataSource = createRoomListDataSource(roomListService = roomListService, dateTimeObserver = dateTimeObserver)
-
+        val lastMessageTimestampFormatter = FakeLastMessageTimestampFormatter()
+        lastMessageTimestampFormatter.givenFormat("Today")
+        val roomListDataSource = createRoomListDataSource(
+            roomListService = roomListService,
+            roomListRoomSummaryFactory = aRoomListRoomSummaryFactory(
+                lastMessageTimestampFormatter = lastMessageTimestampFormatter,
+            ),
+            dateTimeObserver = dateTimeObserver,
+        )
         roomListDataSource.allRooms.test {
             // Observe room list items changes
             roomListDataSource.launchIn(backgroundScope)
-
             // Get the initial room list
             val initialRoomList = awaitItem()
             assertThat(initialRoomList).isNotEmpty()
-
+            assertThat(initialRoomList.first().timestamp).isEqualTo("Today")
+            lastMessageTimestampFormatter.givenFormat("Yesterday")
             // Trigger a timezone change
             dateTimeObserver.given(DateTimeObserver.Event.TimeZoneChanged)
-
-            // Check there is a new list and it's not the same as the previous one (although it has the same content)
+            // Check there is a new list and it's not the same as the previous one
             val newRoomList = awaitItem()
             assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
+            assertThat(newRoomList.first().timestamp).isEqualTo("Yesterday")
         }
     }
 

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
@@ -76,10 +76,7 @@ class RoomListDataSourceTest {
 
     private fun TestScope.createRoomListDataSource(
         roomListService: FakeRoomListService = FakeRoomListService(),
-        roomListRoomSummaryFactory: RoomListRoomSummaryFactory = RoomListRoomSummaryFactory(
-            lastMessageTimestampFormatter = { _ -> "Yesterday" },
-            roomLastMessageFormatter = { _, _ -> "Hey" }
-        ),
+        roomListRoomSummaryFactory: RoomListRoomSummaryFactory = aRoomListRoomSummaryFactory(),
         notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
         dateTimeObserver: FakeDateTimeObserver = FakeDateTimeObserver(),
     ) = RoomListDataSource(

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
@@ -11,15 +11,11 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.roomlist.impl.FakeDateTimeObserver
 import io.element.android.libraries.androidutils.system.DateTimeObserver
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.dateformatter.api.LastMessageTimestampFormatter
-import io.element.android.libraries.eventformatter.api.RoomLastMessageFormatter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.room.aRoomSummary
 import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
 import io.element.android.tests.testutils.testCoroutineDispatchers
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -49,8 +45,6 @@ class RoomListDataSourceTest {
             // Check there is a new list and it's not the same as the previous one (although it has the same content)
             val newRoomList = awaitItem()
             assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
-
-            cancelAndIgnoreRemainingEvents()
         }
     }
 
@@ -77,28 +71,23 @@ class RoomListDataSourceTest {
             // Check there is a new list and it's not the same as the previous one (although it has the same content)
             val newRoomList = awaitItem()
             assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
-
-            cancelAndIgnoreRemainingEvents()
         }
     }
 
     private fun TestScope.createRoomListDataSource(
         roomListService: FakeRoomListService = FakeRoomListService(),
-        roomListRoomSummaryFactory: RoomListRoomSummaryFactory =
-        RoomListRoomSummaryFactory(
-            lastMessageTimestampFormatter = LastMessageTimestampFormatter { _ -> "Yesterday" },
-            roomLastMessageFormatter = RoomLastMessageFormatter { _, _ -> "Hey" }
+        roomListRoomSummaryFactory: RoomListRoomSummaryFactory = RoomListRoomSummaryFactory(
+            lastMessageTimestampFormatter = { _ -> "Yesterday" },
+            roomLastMessageFormatter = { _, _ -> "Hey" }
         ),
-        dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
         notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
-        appScope: CoroutineScope = backgroundScope,
         dateTimeObserver: FakeDateTimeObserver = FakeDateTimeObserver(),
     ) = RoomListDataSource(
         roomListService = roomListService,
         roomListRoomSummaryFactory = roomListRoomSummaryFactory,
-        coroutineDispatchers = dispatchers,
+        coroutineDispatchers = testCoroutineDispatchers(),
         notificationSettingsService = notificationSettingsService,
-        appScope = appScope,
+        appScope = backgroundScope,
         dateTimeObserver = dateTimeObserver,
     )
 }

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListDataSourceTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.features.roomlist.impl.datasource
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.roomlist.impl.FakeDateTimeObserver
+import io.element.android.libraries.androidutils.system.DateTimeObserver
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.dateformatter.api.LastMessageTimestampFormatter
+import io.element.android.libraries.eventformatter.api.RoomLastMessageFormatter
+import io.element.android.libraries.matrix.api.roomlist.RoomListService
+import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
+import io.element.android.libraries.matrix.test.room.aRoomSummary
+import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
+import io.element.android.tests.testutils.testCoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.Instant
+
+class RoomListDataSourceTest {
+    @Test
+    fun `when DateTimeObserver gets a date change, the room summaries are refreshed`() = runTest {
+        val roomListService = FakeRoomListService().apply {
+            postState(RoomListService.State.Running)
+            postAllRooms(listOf(aRoomSummary()))
+        }
+        val dateTimeObserver = FakeDateTimeObserver()
+        val roomListDataSource = createRoomListDataSource(roomListService = roomListService, dateTimeObserver = dateTimeObserver)
+
+        roomListDataSource.allRooms.test {
+            // Observe room list items changes
+            roomListDataSource.launchIn(backgroundScope)
+
+            // Get the initial room list
+            val initialRoomList = awaitItem()
+            assertThat(initialRoomList).isNotEmpty()
+
+            // Trigger a date change
+            dateTimeObserver.given(DateTimeObserver.Event.DateChanged(Instant.MIN, Instant.now()))
+
+            // Check there is a new list and it's not the same as the previous one (although it has the same content)
+            val newRoomList = awaitItem()
+            assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when DateTimeObserver gets a time zone change, the room summaries are refreshed`() = runTest {
+        val roomListService = FakeRoomListService().apply {
+            postState(RoomListService.State.Running)
+            postAllRooms(listOf(aRoomSummary()))
+        }
+        val dateTimeObserver = FakeDateTimeObserver()
+        val roomListDataSource = createRoomListDataSource(roomListService = roomListService, dateTimeObserver = dateTimeObserver)
+
+        roomListDataSource.allRooms.test {
+            // Observe room list items changes
+            roomListDataSource.launchIn(backgroundScope)
+
+            // Get the initial room list
+            val initialRoomList = awaitItem()
+            assertThat(initialRoomList).isNotEmpty()
+
+            // Trigger a timezone change
+            dateTimeObserver.given(DateTimeObserver.Event.TimeZoneChanged)
+
+            // Check there is a new list and it's not the same as the previous one (although it has the same content)
+            val newRoomList = awaitItem()
+            assertThat(newRoomList).isNotSameInstanceAs(initialRoomList)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun TestScope.createRoomListDataSource(
+        roomListService: FakeRoomListService = FakeRoomListService(),
+        roomListRoomSummaryFactory: RoomListRoomSummaryFactory =
+        RoomListRoomSummaryFactory(
+            lastMessageTimestampFormatter = LastMessageTimestampFormatter { _ -> "Yesterday" },
+            roomLastMessageFormatter = RoomLastMessageFormatter { _, _ -> "Hey" }
+        ),
+        dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
+        notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
+        appScope: CoroutineScope = backgroundScope,
+        dateTimeObserver: FakeDateTimeObserver = FakeDateTimeObserver(),
+    ) = RoomListDataSource(
+        roomListService = roomListService,
+        roomListRoomSummaryFactory = roomListRoomSummaryFactory,
+        coroutineDispatchers = dispatchers,
+        notificationSettingsService = notificationSettingsService,
+        appScope = appScope,
+        dateTimeObserver = dateTimeObserver,
+    )
+}

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListRoomSummaryFactoryTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/datasource/RoomListRoomSummaryFactoryTest.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.features.roomlist.impl.datasource
+
+import io.element.android.libraries.dateformatter.api.LastMessageTimestampFormatter
+import io.element.android.libraries.eventformatter.api.RoomLastMessageFormatter
+
+fun aRoomListRoomSummaryFactory(
+    lastMessageTimestampFormatter: LastMessageTimestampFormatter = LastMessageTimestampFormatter { _ -> "Today" },
+    roomLastMessageFormatter: RoomLastMessageFormatter = RoomLastMessageFormatter { _, _ -> "Hey" }
+) = RoomListRoomSummaryFactory(
+    lastMessageTimestampFormatter = lastMessageTimestampFormatter,
+    roomLastMessageFormatter = roomLastMessageFormatter
+)

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchPresenterTest.kt
@@ -11,7 +11,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomlist.impl.datasource.RoomListRoomSummaryFactory
+import io.element.android.features.roomlist.impl.datasource.aRoomListRoomSummaryFactory
 import io.element.android.libraries.dateformatter.test.FakeLastMessageTimestampFormatter
 import io.element.android.libraries.eventformatter.test.FakeRoomLastMessageFormatter
 import io.element.android.libraries.featureflag.api.FeatureFlagService
@@ -142,7 +142,7 @@ fun TestScope.createRoomListSearchPresenter(
     return RoomListSearchPresenter(
         dataSource = RoomListSearchDataSource(
             roomListService = roomListService,
-            roomSummaryFactory = RoomListRoomSummaryFactory(
+            roomSummaryFactory = aRoomListRoomSummaryFactory(
                 lastMessageTimestampFormatter = FakeLastMessageTimestampFormatter(),
                 roomLastMessageFormatter = FakeRoomLastMessageFormatter(),
             ),

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCache.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCache.kt
@@ -24,7 +24,6 @@ interface MutableDiffCache<E> : DiffCache<E> {
     fun removeAt(index: Int): E?
     fun add(index: Int, element: E?)
     operator fun set(index: Int, element: E?)
-    fun clear()
 }
 
 /**
@@ -54,9 +53,5 @@ class MutableListDiffCache<E>(private val mutableList: MutableList<E?> = ArrayLi
 
     override fun add(index: Int, element: E?) {
         mutableList.add(index, element)
-    }
-
-    override fun clear() {
-        mutableList.clear()
     }
 }

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCache.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/diff/DiffCache.kt
@@ -24,6 +24,7 @@ interface MutableDiffCache<E> : DiffCache<E> {
     fun removeAt(index: Int): E?
     fun add(index: Int, element: E?)
     operator fun set(index: Int, element: E?)
+    fun clear()
 }
 
 /**
@@ -53,5 +54,9 @@ class MutableListDiffCache<E>(private val mutableList: MutableList<E?> = ArrayLi
 
     override fun add(index: Int, element: E?) {
         mutableList.add(index, element)
+    }
+
+    override fun clear() {
+        mutableList.clear()
     }
 }

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
@@ -15,6 +15,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.androidutils.system.DateTimeObserver.Event
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.di.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import java.time.Instant
@@ -30,6 +31,7 @@ interface DateTimeObserver {
 }
 
 @ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
 class DefaultDateTimeObserver @Inject constructor(
     @ApplicationContext context: Context
 ) : DateTimeObserver {

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
@@ -28,6 +28,7 @@ class DateTimeObserver @Inject constructor(
             when (intent.action) {
                 Intent.ACTION_TIMEZONE_CHANGED -> _changes.tryEmit(Event.TimeZoneChanged)
                 Intent.ACTION_DATE_CHANGED -> _changes.tryEmit(Event.DateChanged(lastTime, newDate))
+                Intent.ACTION_TIME_CHANGED -> _changes.tryEmit(Event.DateChanged(lastTime, newDate))
             }
             lastTime = newDate
         }
@@ -40,6 +41,7 @@ class DateTimeObserver @Inject constructor(
         context.registerReceiver(dateTimeReceiver, IntentFilter().apply {
             addAction(Intent.ACTION_TIMEZONE_CHANGED)
             addAction(Intent.ACTION_DATE_CHANGED)
+            addAction(Intent.ACTION_TIME_CHANGED)
         })
     }
 

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/DateTimeObserver.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.libraries.androidutils.system
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import io.element.android.libraries.di.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.time.Instant
+import javax.inject.Inject
+
+class DateTimeObserver @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val dateTimeReceiver = object : BroadcastReceiver() {
+        private var lastTime = Instant.now()
+
+        override fun onReceive(context: Context, intent: Intent) {
+            val newDate = Instant.now()
+            when (intent.action) {
+                Intent.ACTION_TIMEZONE_CHANGED -> _changes.tryEmit(Event.TimeZoneChanged)
+                Intent.ACTION_DATE_CHANGED -> _changes.tryEmit(Event.DateChanged(lastTime, newDate))
+            }
+            lastTime = newDate
+        }
+    }
+
+    private val _changes = MutableSharedFlow<Event>(extraBufferCapacity = 10)
+    val changes: Flow<Event> = _changes
+
+    init {
+        context.registerReceiver(dateTimeReceiver, IntentFilter().apply {
+            addAction(Intent.ACTION_TIMEZONE_CHANGED)
+            addAction(Intent.ACTION_DATE_CHANGED)
+        })
+    }
+
+    sealed interface Event {
+        data object TimeZoneChanged : Event
+        data class DateChanged(val previous: Instant, val new: Instant) : Event
+    }
+}

--- a/libraries/dateformatter/api/src/main/kotlin/io/element/android/libraries/dateformatter/api/LastMessageTimestampFormatter.kt
+++ b/libraries/dateformatter/api/src/main/kotlin/io/element/android/libraries/dateformatter/api/LastMessageTimestampFormatter.kt
@@ -7,6 +7,6 @@
 
 package io.element.android.libraries.dateformatter.api
 
-interface LastMessageTimestampFormatter {
+fun interface LastMessageTimestampFormatter {
     fun format(timestamp: Long?): String
 }

--- a/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/DateFormatters.kt
+++ b/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/DateFormatters.kt
@@ -11,7 +11,6 @@ import android.text.format.DateFormat
 import android.text.format.DateUtils
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toJavaLocalDateTime
@@ -25,7 +24,7 @@ import kotlin.math.absoluteValue
 class DateFormatters @Inject constructor(
     private val locale: Locale,
     private val clock: Clock,
-    private val timeZone: TimeZone,
+    private val timeZoneProvider: TimezoneProvider,
 ) {
     private val onlyTimeFormatter: DateTimeFormatter by lazy {
         DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(locale)
@@ -70,7 +69,7 @@ class DateFormatters @Inject constructor(
         return if (period.years.absoluteValue >= 1) {
             formatDateWithYear(dateToFormat)
         } else if (useRelative && period.days.absoluteValue < 2 && period.months.absoluteValue < 1) {
-            getRelativeDay(dateToFormat.toInstant(timeZone).toEpochMilliseconds())
+            getRelativeDay(dateToFormat.toInstant(timeZoneProvider.provide()).toEpochMilliseconds())
         } else {
             formatDateWithMonth(dateToFormat)
         }

--- a/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/LocalDateTimeProvider.kt
+++ b/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/LocalDateTimeProvider.kt
@@ -10,21 +10,20 @@ package io.element.android.libraries.dateformatter.impl
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import javax.inject.Inject
 
 class LocalDateTimeProvider @Inject constructor(
     private val clock: Clock,
-    private val timezone: TimeZone,
+    private val timezoneProvider: TimezoneProvider,
 ) {
     fun providesNow(): LocalDateTime {
         val now: Instant = clock.now()
-        return now.toLocalDateTime(timezone)
+        return now.toLocalDateTime(timezoneProvider.provide())
     }
 
     fun providesFromTimestamp(timestamp: Long): LocalDateTime {
         val tsInstant = Instant.fromEpochMilliseconds(timestamp)
-        return tsInstant.toLocalDateTime(timezone)
+        return tsInstant.toLocalDateTime(timezoneProvider.provide())
     }
 }

--- a/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/TimezoneProvider.kt
+++ b/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/TimezoneProvider.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.libraries.dateformatter.impl
+
+import kotlinx.datetime.TimeZone
+
+fun interface TimezoneProvider {
+    fun provide(): TimeZone
+}

--- a/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/di/DateFormatterModule.kt
+++ b/libraries/dateformatter/impl/src/main/kotlin/io/element/android/libraries/dateformatter/impl/di/DateFormatterModule.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.dateformatter.impl.di
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
+import io.element.android.libraries.dateformatter.impl.TimezoneProvider
 import io.element.android.libraries.di.AppScope
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
@@ -25,5 +26,5 @@ object DateFormatterModule {
     fun providesLocale(): Locale = Locale.getDefault()
 
     @Provides
-    fun providesTimezone(): TimeZone = TimeZone.currentSystemDefault()
+    fun providesTimezone(): TimezoneProvider = TimezoneProvider { TimeZone.currentSystemDefault() }
 }

--- a/libraries/dateformatter/impl/src/test/kotlin/io/element/android/libraries/dateformatter/impl/DefaultLastMessageTimestampFormatterTest.kt
+++ b/libraries/dateformatter/impl/src/test/kotlin/io/element/android/libraries/dateformatter/impl/DefaultLastMessageTimestampFormatterTest.kt
@@ -93,7 +93,7 @@ class DefaultLastMessageTimestampFormatterTest {
         val now = "1980-04-06T18:35:24.00Z"
         val dat = "1979-04-06T18:35:24.00Z"
         val clock = FakeClock().apply { givenInstant(Instant.parse(now)) }
-        val dateFormatters = DateFormatters(Locale.US, clock, TimeZone.UTC)
+        val dateFormatters = DateFormatters(Locale.US, clock) { TimeZone.UTC }
         assertThat(dateFormatters.formatDateWithFullFormat(Instant.parse(dat).toLocalDateTime(TimeZone.UTC))).isEqualTo("Friday, April 6, 1979")
     }
 
@@ -102,8 +102,8 @@ class DefaultLastMessageTimestampFormatterTest {
      */
     private fun createFormatter(@Suppress("SameParameterValue") currentDate: String): LastMessageTimestampFormatter {
         val clock = FakeClock().apply { givenInstant(Instant.parse(currentDate)) }
-        val localDateTimeProvider = LocalDateTimeProvider(clock, TimeZone.UTC)
-        val dateFormatters = DateFormatters(Locale.US, clock, TimeZone.UTC)
+        val localDateTimeProvider = LocalDateTimeProvider(clock) { TimeZone.UTC }
+        val dateFormatters = DateFormatters(Locale.US, clock) { TimeZone.UTC }
         return DefaultLastMessageTimestampFormatter(localDateTimeProvider, dateFormatters)
     }
 }

--- a/libraries/eventformatter/api/src/main/kotlin/io/element/android/libraries/eventformatter/api/RoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/api/src/main/kotlin/io/element/android/libraries/eventformatter/api/RoomLastMessageFormatter.kt
@@ -9,6 +9,6 @@ package io.element.android.libraries.eventformatter.api
 
 import io.element.android.libraries.matrix.api.timeline.item.event.EventTimelineItem
 
-interface RoomLastMessageFormatter {
+fun interface RoomLastMessageFormatter {
     fun format(event: EventTimelineItem, isDmRoom: Boolean): CharSequence?
 }

--- a/samples/minimal/build.gradle.kts
+++ b/samples/minimal/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(projects.libraries.permissions.noop)
     implementation(projects.libraries.sessionStorage.implMemory)
     implementation(projects.libraries.designsystem)
+    implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.core)
     implementation(projects.libraries.network)

--- a/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
+++ b/samples/minimal/src/main/kotlin/io/element/android/samples/minimal/RoomListScreen.kt
@@ -24,6 +24,7 @@ import io.element.android.features.roomlist.impl.filters.RoomListFiltersPresente
 import io.element.android.features.roomlist.impl.filters.selection.DefaultFilterSelectionStrategy
 import io.element.android.features.roomlist.impl.search.RoomListSearchDataSource
 import io.element.android.features.roomlist.impl.search.RoomListSearchPresenter
+import io.element.android.libraries.androidutils.system.DefaultDateTimeObserver
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.dateformatter.impl.DateFormatters
 import io.element.android.libraries.dateformatter.impl.DefaultLastMessageTimestampFormatter
@@ -59,9 +60,8 @@ class RoomListScreen(
 ) {
     private val clock = Clock.System
     private val locale = Locale.getDefault()
-    private val timeZone = TimeZone.currentSystemDefault()
-    private val dateTimeProvider = LocalDateTimeProvider(clock, timeZone)
-    private val dateFormatters = DateFormatters(locale, clock, timeZone)
+    private val dateTimeProvider = LocalDateTimeProvider(clock) { TimeZone.currentSystemDefault() }
+    private val dateFormatters = DateFormatters(locale, clock) { TimeZone.currentSystemDefault() }
     private val sessionVerificationService = matrixClient.sessionVerificationService()
     private val encryptionService = matrixClient.encryptionService()
     private val stringProvider = AndroidStringProvider(context.resources)
@@ -92,7 +92,8 @@ class RoomListScreen(
             roomListRoomSummaryFactory = roomListRoomSummaryFactory,
             coroutineDispatchers = coroutineDispatchers,
             notificationSettingsService = matrixClient.notificationSettingsService(),
-            appScope = Singleton.appScope
+            appScope = Singleton.appScope,
+            dateTimeObserver = DefaultDateTimeObserver(context),
         ),
         indicatorService = DefaultIndicatorService(
             sessionVerificationService = sessionVerificationService,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Create `DateTimeObserver`, which will register a receiver for date and time changes in the devices and emit updates.
- Have `RoomListDataSource` listen to those updates.
- Refresh the summary timestamps when an update is received.
- Modify the DI so we have a `TimezoneProvider` instead of injecting the `Timezone` used when the app was opened.

Alternative to https://github.com/element-hq/element-x-android/pull/3650.

## Motivation and context

There is a bug where in the room list you might be able to see rooms whose state hasn't changed since yesterday still displaying the time at which some event happened instead of 'Yesterday', making you think they happened at some time today and they're out of order.

If you open one of these rooms, the room list item is also refreshed and the right 'Yesterday' formatted timestamp is used.

The same happens with the time if you change the timezone of your device.

## Screenshots / GIFs

They should be the same.

## Tests

<!-- Explain how you tested your development -->

- Open the app and let the room list load completely until it doesn't receive new updates.
- Go to system settings -> change the day. Check the timestamps change in the room list.
- Restore the current value, check it changes back to what's expected.
- Now change the timezone and check the time also changes in the room list.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
