### PR TITLE
fix: import path broken in module template

### DIFF
--- a/tools/templates/files/fileTemplates/Template Module Feature Build Gradle Impl.kts
+++ b/tools/templates/files/fileTemplates/Template Module Feature Build Gradle Impl.kts
@@ -1,4 +1,4 @@
-import extensions.setupAnvil
+import extension.setupAnvil
 
 plugins {
     id("io.element.android-compose-library")
@@ -12,7 +12,7 @@ android {
 setupAnvil()
 
 dependencies {
-    api(projects.features.${ MODULE_NAME }.api)
+    api(projects.features.${MODULE_NAME}.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.matrix.api)


### PR DESCRIPTION
## Content
fix `import extensions.setupAnvil` so that it using correct `extension.setupAnvil` and correct template of feature_module_name in `api()` import

## Motivation and context
Im using the developer onboarding docs and creating a new feature module from the template, but it doesn't generate an error free module because of a bad import and template issue.

## Tests

- Follow onboarding docs for creating a new feature module from a template

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR

Signed-off-by: Torry Brelsford <tb@brehl.dev>