### PR TITLE
Remove all GPS metadata from images uploaded as media

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -207,12 +207,44 @@ class AndroidMediaPreProcessor @Inject constructor(
 
     private fun removeSensitiveImageMetadata(file: File) {
         // Remove GPS info, user comments and subject location tags
-        val exifInterface = ExifInterface(file)
-        // See ExifInterface.TAG_GPS_INFO_IFD_POINTER
-        exifInterface.setAttribute("GPSInfoIFDPointer", null)
-        exifInterface.setAttribute(ExifInterface.TAG_USER_COMMENT, null)
-        exifInterface.setAttribute(ExifInterface.TAG_SUBJECT_LOCATION, null)
-        tryOrNull { exifInterface.saveAttributes() }
+        ExifInterface(file).apply {
+            // See ExifInterface.TAG_GPS_INFO_IFD_POINTER
+            setAttribute("GPSInfoIFDPointer", null)
+            setAttribute(ExifInterface.TAG_USER_COMMENT, null)
+            setAttribute(ExifInterface.TAG_IMAGE_DESCRIPTION, null)
+
+            setAttribute(ExifInterface.TAG_GPS_VERSION_ID, null)
+            setAttribute(ExifInterface.TAG_GPS_ALTITUDE_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_ALTITUDE, null)
+            setAttribute(ExifInterface.TAG_GPS_TIMESTAMP, null)
+            setAttribute(ExifInterface.TAG_GPS_DATESTAMP, null)
+            setAttribute(ExifInterface.TAG_GPS_SATELLITES, null)
+            setAttribute(ExifInterface.TAG_GPS_STATUS, null)
+            setAttribute(ExifInterface.TAG_GPS_MEASURE_MODE, null)
+            setAttribute(ExifInterface.TAG_GPS_DOP, null)
+            setAttribute(ExifInterface.TAG_GPS_SPEED_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_SPEED, null)
+            setAttribute(ExifInterface.TAG_GPS_TRACK_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_TRACK, null)
+            setAttribute(ExifInterface.TAG_GPS_IMG_DIRECTION_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_IMG_DIRECTION, null)
+            setAttribute(ExifInterface.TAG_GPS_MAP_DATUM, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_BEARING_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_BEARING, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_DISTANCE_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_DISTANCE, null)
+            setAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD, null)
+            setAttribute(ExifInterface.TAG_GPS_AREA_INFORMATION, null)
+            setAttribute(ExifInterface.TAG_GPS_DIFFERENTIAL, null)
+            setAttribute(ExifInterface.TAG_GPS_H_POSITIONING_ERROR, null)
+            setAttribute(ExifInterface.TAG_GPS_LATITUDE, null)
+            setAttribute(ExifInterface.TAG_GPS_LATITUDE_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_LONGITUDE, null)
+            setAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_LONGITUDE, null)
+            setAttribute(ExifInterface.TAG_GPS_DEST_LONGITUDE_REF, null)
+            tryOrNull { saveAttributes() }
+        }
     }
 
     private suspend fun createTmpFileWithInput(inputStream: InputStream): File? {


### PR DESCRIPTION
## Content

Removes all GPS related EXIF metadata from images sent as media (images sent as files will be kept as they are).

## Motivation and context

Previously a minimal set of tags were removed, but we should make sure every single one of them is removed.

## Tests

<!-- Explain how you tested your development -->

- Get an image with GPS metadata (you can download one of [these](https://github.com/ianare/exif-samples/tree/master/jpg/gps)).
- Send it as media in a room with 'photo & video library' option.
- Download the file and pass it through an EXIF metadata viewer, it should have no GPS info.

Maybe do the same while taking a picture using the camera.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
