### PR TITLE
ElementCall: allow user to switch to another call.

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -45,12 +45,13 @@ import io.element.android.features.call.impl.pip.PipView
 import io.element.android.features.call.impl.services.CallForegroundService
 import io.element.android.features.call.impl.utils.CallIntentDataParser
 import io.element.android.libraries.architecture.bindings
+import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.designsystem.theme.ElementThemeApp
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import timber.log.Timber
 import javax.inject.Inject
 
-private const val loggerTag = "ElementCallActivity"
+private val loggerTag = LoggerTag("ElementCallActivity")
 
 class ElementCallActivity :
     AppCompatActivity(),
@@ -135,7 +136,7 @@ class ElementCallActivity :
         DisposableEffect(Unit) {
             val listener = Runnable {
                 if (requestPermissionCallback != null) {
-                    Timber.tag(loggerTag).w("Ignoring onUserLeaveHint event because user is asked to grant permissions")
+                    Timber.tag(loggerTag.value).w("Ignoring onUserLeaveHint event because user is asked to grant permissions")
                 } else {
                     pipEventSink(PictureInPictureEvents.EnterPictureInPicture)
                 }
@@ -149,7 +150,7 @@ class ElementCallActivity :
             val onPictureInPictureModeChangedListener = Consumer { _: PictureInPictureModeChangedInfo ->
                 pipEventSink(PictureInPictureEvents.OnPictureInPictureModeChanged(isInPictureInPictureMode))
                 if (!isInPictureInPictureMode && !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                    Timber.tag(loggerTag).d("Exiting PiP mode: Hangup the call")
+                    Timber.tag(loggerTag.value).d("Exiting PiP mode: Hangup the call")
                     eventSink?.invoke(CallScreenEvents.Hangup)
                 }
             }
@@ -193,18 +194,18 @@ class ElementCallActivity :
         }
         val currentCallType = webViewTarget.value
         if (currentCallType == null && callType == null) {
-            Timber.tag(loggerTag).d("Re-opened the activity but we have no url to load or a cached one, finish the activity")
+            Timber.tag(loggerTag.value).d("Re-opened the activity but we have no url to load or a cached one, finish the activity")
             finish()
         } else if (currentCallType == null) {
-            Timber.tag(loggerTag).d("Set the call type and create the presenter")
+            Timber.tag(loggerTag.value).d("Set the call type and create the presenter")
             webViewTarget.value = callType
             presenter = presenterFactory.create(callType!!, this)
         } else if (callType != currentCallType) {
-            Timber.tag(loggerTag).d("User starts another call, restart the Activity")
+            Timber.tag(loggerTag.value).d("User starts another call, restart the Activity")
             setIntent(intent)
             recreate()
         } else {
-            Timber.tag(loggerTag).d("Coming back from notification, do nothing")
+            Timber.tag(loggerTag.value).d("Coming back from notification, do nothing")
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When the user is in a call, starting (or joining) another call had no effect.

With the change in this PR, if the Activity get a new Intent with other call data, the current call is terminated and the new call starts. Actually the Activity is recreated as it was way simpler than trying to update all the internal state.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Same behavior than on the iOS app.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- In room A start a call
- Enter pip mode
- Navigate to room B
- In room B start a call

Call A should be terminated and Call B should be started

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
