### PR TITLE
Update the strings for unsupported calls

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemLegacyCallInviteView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemLegacyCallInviteView.kt
@@ -7,24 +7,21 @@
 
 package io.element.android.features.messages.impl.timeline.components.event
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
+import io.element.android.features.messages.impl.R
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
-import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun TimelineItemLegacyCallInviteView(
@@ -32,20 +29,18 @@ fun TimelineItemLegacyCallInviteView(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = CompoundIcons.VoiceCall(),
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.secondary,
+            tint = ElementTheme.colors.iconSecondary,
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            color = MaterialTheme.colorScheme.secondary,
+            color = ElementTheme.colors.textSecondary,
             style = ElementTheme.typography.fontBodyMdRegular,
-            text = stringResource(CommonStrings.common_call_invite),
-            textAlign = TextAlign.Center,
+            text = stringResource(R.string.screen_room_timeline_legacy_call),
+            textAlign = TextAlign.Start,
         )
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/DefaultMessageSummaryFormatter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/DefaultMessageSummaryFormatter.kt
@@ -56,7 +56,7 @@ class DefaultMessageSummaryFormatter @Inject constructor(
             is TimelineItemVideoContent -> context.getString(CommonStrings.common_video)
             is TimelineItemFileContent -> context.getString(CommonStrings.common_file)
             is TimelineItemAudioContent -> context.getString(CommonStrings.common_audio)
-            is TimelineItemLegacyCallInviteContent -> context.getString(CommonStrings.common_call_invite)
+            is TimelineItemLegacyCallInviteContent -> context.getString(CommonStrings.common_unsupported_call)
             is TimelineItemCallNotifyContent -> context.getString(CommonStrings.common_call_started)
         }.take(MAX_SAFE_LENGTH)
     }

--- a/features/messages/impl/src/main/res/values/localazy.xml
+++ b/features/messages/impl/src/main/res/values/localazy.xml
@@ -31,6 +31,7 @@
   <string name="screen_room_timeline_add_reaction">"Add emoji"</string>
   <string name="screen_room_timeline_beginning_of_room">"This is the beginning of %1$s."</string>
   <string name="screen_room_timeline_beginning_of_room_no_name">"This is the beginning of this conversation."</string>
+  <string name="screen_room_timeline_legacy_call">"Unsupported call. Ask if the caller can use the new Element X app."</string>
   <string name="screen_room_timeline_less_reactions">"Show less"</string>
   <string name="screen_room_timeline_message_copied">"Message copied"</string>
   <string name="screen_room_timeline_no_permission_to_post">"You do not have permission to post to this room"</string>

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatter.kt
@@ -91,7 +91,7 @@ class DefaultRoomLastMessageFormatter @Inject constructor(
                 val message = sp.getString(CommonStrings.common_unsupported_event)
                 message.prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
             }
-            is LegacyCallInviteContent -> sp.getString(CommonStrings.common_call_invite)
+            is LegacyCallInviteContent -> sp.getString(CommonStrings.common_unsupported_call)
             is CallNotifyContent -> sp.getString(CommonStrings.common_call_started)
         }?.take(MAX_SAFE_LENGTH)
     }

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultTimelineEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultTimelineEventFormatter.kt
@@ -52,13 +52,11 @@ class DefaultTimelineEventFormatter @Inject constructor(
             is StateContent -> {
                 stateContentFormatter.format(content, senderDisambiguatedDisplayName, isOutgoing, RenderingMode.Timeline)
             }
-            is LegacyCallInviteContent -> {
-                sp.getString(CommonStrings.common_call_invite)
-            }
             is CallNotifyContent -> {
                 sp.getString(CommonStrings.common_call_started)
             }
             RedactedContent,
+            is LegacyCallInviteContent,
             is StickerContent,
             is PollContent,
             is UnableToDecryptContent,

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -151,7 +151,7 @@ class DefaultNotifiableEventResolver @Inject constructor(
                     noisy = isNoisy,
                     timestamp = this.timestamp,
                     senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId),
-                    body = stringProvider.getString(CommonStrings.common_call_invite),
+                    body = stringProvider.getString(CommonStrings.common_unsupported_call),
                     roomName = roomDisplayName,
                     roomIsDm = isDm,
                     roomAvatarPath = roomAvatarUrl,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -588,7 +588,7 @@ class DefaultNotifiableEventResolverTest {
                 noisy = false,
                 timestamp = A_TIMESTAMP,
                 senderDisambiguatedDisplayName = A_USER_NAME_2,
-                body = "Call in progress (unsupported)",
+                body = "Unsupported call",
                 imageUriString = null,
                 imageMimeType = null,
                 threadId = null,

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -247,6 +247,7 @@ Reason: %1$s."</string>
   <string name="common_unable_to_invite_title">"Unable to send invite(s)"</string>
   <string name="common_unlock">"Unlock"</string>
   <string name="common_unmute">"Unmute"</string>
+  <string name="common_unsupported_call">"Unsupported call"</string>
   <string name="common_unsupported_event">"Unsupported event"</string>
   <string name="common_username">"Username"</string>
   <string name="common_verification_cancelled">"Verification cancelled"</string>

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components.event_TimelineItemLegacyCallInviteView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components.event_TimelineItemLegacyCallInviteView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a18ab0b1b73878ccb52efccbad03cec0a47cd2e48628248b82bd4b6af53bbf21
-size 8665
+oid sha256:d0e53ece51bf03c62b187ae05bc4fdd71d9f30dcc9b4c18a50cfcb4619419091
+size 12673

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components.event_TimelineItemLegacyCallInviteView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components.event_TimelineItemLegacyCallInviteView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45b9560a7e0bca74f9d9e8c308a79943bcd34371e0ee6918bc496cadaadf94d1
-size 8642
+oid sha256:f1bbb9c0beb334a94920f3f9f7f6458fa2ea164661a5d78cebb71470368f98ee
+size 12565

--- a/tools/localazy/checkForbiddenTerms.py
+++ b/tools/localazy/checkForbiddenTerms.py
@@ -23,6 +23,8 @@ forbiddenTerms = {
         "screen_onboarding_welcome_title",
         # Contains "Element Call"
         "screen_incoming_call_subtitle_android",
+        # Contains "Element X"
+        "screen_room_timeline_legacy_call",
     ]
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Iterate on the strings used to renders legacy call in:
- notification
- room list last message
- timeline

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes https://github.com/element-hq/element-x-android/issues/3853

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->


https://github.com/user-attachments/assets/7515b42d-daa3-4be8-ad6c-4a525de9ff14



## Tests

<!-- Explain how you tested your development -->

- Alice uses Element X
- Bob is using Element Web
- Bob starts a **voice** call using Element Web
- Alice should see all the unsupported strings regarding the incoming call as per the video above.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
