### PR TITLE
fix : use RoomMembershipObserver to close room screen when leaving

### DIFF
--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomNode.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomNode.kt
@@ -43,14 +43,14 @@ class JoinRoomNode @AssistedInject constructor(
             state = state,
             onBackClick = ::navigateUp,
             onJoinSuccess = ::navigateUp,
-            onCancelKnockSuccess = ::navigateUp,
-            onKnockSuccess = { },
+            onCancelKnockSuccess = {},
+            onKnockSuccess = {},
             modifier = modifier
         )
         acceptDeclineInviteView.Render(
             state = state.acceptDeclineInviteState,
             onAcceptInvite = {},
-            onDeclineInvite = { navigateUp() },
+            onDeclineInvite = {},
             modifier = Modifier
         )
     }

--- a/features/leaveroom/impl/src/test/kotlin/io/element/android/features/leaveroom/impl/LeaveRoomPresenterTest.kt
+++ b/features/leaveroom/impl/src/test/kotlin/io/element/android/features/leaveroom/impl/LeaveRoomPresenterTest.kt
@@ -14,15 +14,15 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomState
 import io.element.android.libraries.matrix.api.MatrixClient
-import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
-import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.lambda.assert
+import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.testCoroutineDispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -126,26 +126,27 @@ class LeaveRoomPresenterTest {
 
     @Test
     fun `present - leaving a room leaves the room`() = runTest {
-        val roomMembershipObserver = RoomMembershipObserver()
+        val leaveRoomLambda = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
         val presenter = createLeaveRoomPresenter(
             client = FakeMatrixClient().apply {
                 givenGetRoomResult(
                     roomId = A_ROOM_ID,
                     result = FakeMatrixRoom(
-                        leaveRoomLambda = { Result.success(Unit) }
+                        leaveRoomLambda = leaveRoomLambda
                     ),
                 )
             },
-            roomMembershipObserver = roomMembershipObserver
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
             val initialState = awaitItem()
             initialState.eventSink(LeaveRoomEvent.LeaveRoom(A_ROOM_ID))
-            // Membership observer should receive a 'left room' change
-            assertThat(roomMembershipObserver.updates.first().change).isEqualTo(MembershipChange.LEFT)
+            advanceUntilIdle()
             cancelAndIgnoreRemainingEvents()
+            assert(leaveRoomLambda)
+                .isCalledOnce()
+                .withNoParameter()
         }
     }
 
@@ -227,9 +228,7 @@ class LeaveRoomPresenterTest {
 
 private fun TestScope.createLeaveRoomPresenter(
     client: MatrixClient = FakeMatrixClient(),
-    roomMembershipObserver: RoomMembershipObserver = RoomMembershipObserver(),
 ): LeaveRoomPresenter = LeaveRoomPresenter(
     client = client,
-    roomMembershipObserver = roomMembershipObserver,
     dispatchers = testCoroutineDispatchers(false),
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -178,6 +178,8 @@ class RustMatrixClient(
         sessionCoroutineScope = sessionCoroutineScope,
     )
 
+    private val roomMembershipObserver = RoomMembershipObserver()
+
     private val roomFactory = RustRoomFactory(
         roomListService = roomListService,
         innerRoomListService = innerRoomListService,
@@ -191,6 +193,7 @@ class RustMatrixClient(
         roomSyncSubscriber = roomSyncSubscriber,
         timelineEventTypeFilterFactory = timelineEventTypeFilterFactory,
         featureFlagService = featureFlagService,
+        roomMembershipObserver = roomMembershipObserver,
     )
 
     override val mediaLoader: MatrixMediaLoader = RustMediaLoader(
@@ -198,8 +201,6 @@ class RustMatrixClient(
         dispatchers = dispatchers,
         innerClient = client,
     )
-
-    private val roomMembershipObserver = RoomMembershipObserver()
 
     private var clientDelegateTaskHandle: TaskHandle? = client.setDelegate(sessionDelegate)
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustPendingRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustPendingRoom.kt
@@ -10,15 +10,19 @@ package io.element.android.libraries.matrix.impl.room
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.room.PendingRoom
+import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import org.matrix.rustcomponents.sdk.RoomPreview
 
 class RustPendingRoom(
     override val sessionId: SessionId,
     override val roomId: RoomId,
     private val inner: RoomPreview,
+    private val roomMembershipObserver: RoomMembershipObserver,
 ) : PendingRoom {
     override suspend fun leave(): Result<Unit> = runCatching {
         inner.leave()
+    }.onSuccess {
+        roomMembershipObserver.notifyUserLeftRoom(roomId)
     }
 
     override fun close() {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -17,13 +17,13 @@ import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
 import io.element.android.libraries.matrix.api.room.MatrixRoom
 import io.element.android.libraries.matrix.api.room.PendingRoom
+import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.awaitLoaded
 import io.element.android.libraries.matrix.impl.roomlist.fullRoomWithTimeline
 import io.element.android.libraries.matrix.impl.roomlist.roomOrNull
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -51,8 +51,8 @@ class RustRoomFactory(
     private val roomSyncSubscriber: RoomSyncSubscriber,
     private val timelineEventTypeFilterFactory: TimelineEventTypeFilterFactory,
     private val featureFlagService: FeatureFlagService,
+    private val roomMembershipObserver: RoomMembershipObserver,
 ) {
-    @OptIn(ExperimentalCoroutinesApi::class)
     private val dispatcher = dispatchers.io.limitedParallelism(1)
     private val mutex = Mutex()
     private var isDestroyed: Boolean = false
@@ -120,6 +120,7 @@ class RustRoomFactory(
                 roomSyncSubscriber = roomSyncSubscriber,
                 matrixRoomInfoMapper = matrixRoomInfoMapper,
                 featureFlagService = featureFlagService,
+                roomMembershipObserver = roomMembershipObserver,
             )
         }
     }
@@ -148,6 +149,7 @@ class RustRoomFactory(
             sessionId = sessionId,
             roomId = roomId,
             inner = innerRoom,
+            roomMembershipObserver = roomMembershipObserver,
         )
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
Close the room flow when leaving a room from the client.
If leaving, being banned from another client, the room screen will update but won't navigate up to the room list.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui change.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
