### PR TITLE
fix : display security banner for room list empty state

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContentStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContentStateProvider.kt
@@ -21,6 +21,7 @@ open class RoomListContentStateProvider : PreviewParameterProvider<RoomListConte
             aRoomsContentState(summaries = persistentListOf()),
             aSkeletonContentState(),
             anEmptyContentState(),
+            anEmptyContentState(securityBannerState = SecurityBannerState.SetUpRecovery),
             aRoomsContentState(securityBannerState = SecurityBannerState.NeedsNativeSlidingSyncMigration),
         )
 }
@@ -37,4 +38,8 @@ internal fun aRoomsContentState(
 
 internal fun aSkeletonContentState() = RoomListContentState.Skeleton(16)
 
-internal fun anEmptyContentState() = RoomListContentState.Empty
+internal fun anEmptyContentState(
+    securityBannerState: SecurityBannerState = SecurityBannerState.None,
+) = RoomListContentState.Empty(
+    securityBannerState = securityBannerState,
+)

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -236,11 +236,11 @@ class RoomListPresenter @Inject constructor(
                 client.isNativeSlidingSyncSupported() && !client.isUsingNativeSlidingSync()
             }.getOrNull().orFalse()
         }
+        val securityBannerState by rememberSecurityBannerState(securityBannerDismissed, needsSlidingSyncMigration)
         return when {
-            showEmpty -> RoomListContentState.Empty
+            showEmpty -> RoomListContentState.Empty(securityBannerState = securityBannerState)
             showSkeleton -> RoomListContentState.Skeleton(count = 16)
             else -> {
-                val securityBannerState by rememberSecurityBannerState(securityBannerDismissed, needsSlidingSyncMigration)
                 RoomListContentState.Rooms(
                     securityBannerState = securityBannerState,
                     fullScreenIntentPermissionsState = fullScreenIntentPermissionsPresenter.present(),

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -61,7 +61,9 @@ enum class SecurityBannerState {
 @Immutable
 sealed interface RoomListContentState {
     data class Skeleton(val count: Int) : RoomListContentState
-    data object Empty : RoomListContentState
+    data class Empty(
+        val securityBannerState: SecurityBannerState,
+    ) : RoomListContentState
     data class Rooms(
         val securityBannerState: SecurityBannerState,
         val fullScreenIntentPermissionsState: FullScreenIntentPermissionsState,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
@@ -76,6 +76,10 @@ fun RoomListContentView(
             }
             is RoomListContentState.Empty -> {
                 EmptyView(
+                    state = contentState,
+                    eventSink = eventSink,
+                    onSetUpRecoveryClick = onSetUpRecoveryClick,
+                    onConfirmRecoveryKeyClick = onConfirmRecoveryKeyClick,
                     onCreateRoomClick = onCreateRoomClick,
                 )
             }
@@ -110,21 +114,44 @@ private fun SkeletonView(count: Int, modifier: Modifier = Modifier) {
 
 @Composable
 private fun EmptyView(
+    state: RoomListContentState.Empty,
+    eventSink: (RoomListEvents) -> Unit,
+    onSetUpRecoveryClick: () -> Unit,
+    onConfirmRecoveryKeyClick: () -> Unit,
     onCreateRoomClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    EmptyScaffold(
-        title = R.string.screen_roomlist_empty_title,
-        subtitle = R.string.screen_roomlist_empty_message,
-        action = {
-            Button(
-                text = stringResource(CommonStrings.action_start_chat),
-                leadingIcon = IconSource.Vector(CompoundIcons.Compose()),
-                onClick = onCreateRoomClick,
-            )
-        },
-        modifier = modifier.fillMaxSize(),
-    )
+    Box(modifier.fillMaxSize()) {
+        EmptyScaffold(
+            title = R.string.screen_roomlist_empty_title,
+            subtitle = R.string.screen_roomlist_empty_message,
+            action = {
+                Button(
+                    text = stringResource(CommonStrings.action_start_chat),
+                    leadingIcon = IconSource.Vector(CompoundIcons.Compose()),
+                    onClick = onCreateRoomClick,
+                )
+            },
+            modifier = Modifier.align(Alignment.Center),
+        )
+        Box {
+            when (state.securityBannerState) {
+                SecurityBannerState.SetUpRecovery -> {
+                    SetUpRecoveryKeyBanner(
+                        onContinueClick = onSetUpRecoveryClick,
+                        onDismissClick = { eventSink(RoomListEvents.DismissBanner) }
+                    )
+                }
+                SecurityBannerState.RecoveryKeyConfirmation -> {
+                    ConfirmRecoveryKeyBanner(
+                        onContinueClick = onConfirmRecoveryKeyClick,
+                        onDismissClick = { eventSink(RoomListEvents.DismissBanner) }
+                    )
+                }
+                else -> Unit
+            }
+        }
+    }
 }
 
 @Composable

--- a/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Day_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Day_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a78abedec8a3aad14bf6368bf73d46621feaf8e6fd6e019d381077ef05856259
-size 72236
+oid sha256:f07e339529fa15809163745520ccd2d187d858f88148a37e59ec9df1d9559cdd
+size 46528

--- a/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Day_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Day_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a78abedec8a3aad14bf6368bf73d46621feaf8e6fd6e019d381077ef05856259
+size 72236

--- a/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Night_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Night_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f60d07c4be6d75142e753dec5071f7a6d5dd15519d87a2eb491b708fa7aeea4b
-size 70917
+oid sha256:44b0af23c318bc8c4e881bca9ad61127d821d4d82f43de2d9e785860bbda2fcf
+size 45038

--- a/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomlist.impl.components_RoomListContentView_Night_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f60d07c4be6d75142e753dec5071f7a6d5dd15519d87a2eb491b708fa7aeea4b
+size 70917


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
Display security banner on room list empty state too.
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
https://github.com/element-hq/customer-success/issues/383
## Screenshots / GIFs
Check recorded screenshots.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
