### PR TITLE
Fix photo / video name

### DIFF
--- a/libraries/mediapickers/impl/src/main/kotlin/io/element/android/libraries/mediapickers/impl/DefaultPickerProvider.kt
+++ b/libraries/mediapickers/impl/src/main/kotlin/io/element/android/libraries/mediapickers/impl/DefaultPickerProvider.kt
@@ -24,7 +24,6 @@ import io.element.android.libraries.mediapickers.api.PickerLauncher
 import io.element.android.libraries.mediapickers.api.PickerProvider
 import io.element.android.libraries.mediapickers.api.PickerType
 import java.io.File
-import java.util.UUID
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -111,7 +110,7 @@ class DefaultPickerProvider(private val isInTest: Boolean) : PickerProvider {
             NoOpPickerLauncher { onResult(null) }
         } else {
             val context = LocalContext.current
-            val tmpFile = remember { getTemporaryFile(context) }
+            val tmpFile = remember { getTemporaryFile(context, "photo.jpg") }
             val tmpFileUri = remember(tmpFile) { getTemporaryUri(context, tmpFile) }
             rememberPickerLauncher(type = PickerType.Camera.Photo(tmpFileUri)) { success ->
                 // Execute callback
@@ -131,7 +130,7 @@ class DefaultPickerProvider(private val isInTest: Boolean) : PickerProvider {
             NoOpPickerLauncher { onResult(null) }
         } else {
             val context = LocalContext.current
-            val tmpFile = remember { getTemporaryFile(context) }
+            val tmpFile = remember { getTemporaryFile(context, "video.mp4") }
             val tmpFileUri = remember(tmpFile) { getTemporaryUri(context, tmpFile) }
             rememberPickerLauncher(type = PickerType.Camera.Video(tmpFileUri)) { success ->
                 // Execute callback
@@ -142,8 +141,8 @@ class DefaultPickerProvider(private val isInTest: Boolean) : PickerProvider {
 
     private fun getTemporaryFile(
         context: Context,
+        filename: String,
         baseFolder: File = context.cacheDir,
-        filename: String = UUID.randomUUID().toString(),
     ): File {
         return File(baseFolder, filename)
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure taken photos and video has human readable name and a correct extension.
It seems that Element Web  need the extension to render the media correctly.

Second commit is just cleanup.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3894 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- In a room take a photo and send it to a room
- Observe that Element Web now is able to render the photo and that the photo filename is `photo.jpg` instead of a UUID

Repeat by recording the video. The filename will be `video.mp4`.

## Tested devices

- [ ] Physical
- [x] Emulator + latest Element Web.
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
