### PR TITLE
Enable all notification actions: quick reply, accept/decline invite, mark as read from notification.

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/NotificationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/NotificationConfig.kt
@@ -11,14 +11,20 @@ import android.graphics.Color
 import androidx.annotation.ColorInt
 
 object NotificationConfig {
-    // TODO EAx Implement and set to true at some point
-    const val SUPPORT_MARK_AS_READ_ACTION = false
+    /**
+     * If set to true, the notification will have a "Mark as read" action.
+     */
+    const val SUPPORT_MARK_AS_READ_ACTION = true
 
-    // TODO EAx Implement and set to true at some point
-    const val SUPPORT_JOIN_DECLINE_INVITE = false
+    /**
+     * If set to true, the notification for invitation will have two actions to accept or decline the invite.
+     */
+    const val SUPPORT_JOIN_DECLINE_INVITE = true
 
-    // TODO EAx Implement and set to true at some point
-    const val SUPPORT_QUICK_REPLY_ACTION = false
+    /**
+     * If set to true, the notification will have a "Quick reply" action, allow to compose and send a message to the room.
+     */
+    const val SUPPORT_QUICK_REPLY_ACTION = true
 
     @ColorInt
     val NOTIFICATION_ACCENT_COLOR: Int = Color.parseColor("#FF0DBD8B")

--- a/appconfig/src/main/kotlin/io/element/android/appconfig/NotificationConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/NotificationConfig.kt
@@ -14,17 +14,17 @@ object NotificationConfig {
     /**
      * If set to true, the notification will have a "Mark as read" action.
      */
-    const val SUPPORT_MARK_AS_READ_ACTION = true
+    const val SHOW_MARK_AS_READ_ACTION = true
 
     /**
      * If set to true, the notification for invitation will have two actions to accept or decline the invite.
      */
-    const val SUPPORT_JOIN_DECLINE_INVITE = true
+    const val SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS = true
 
     /**
      * If set to true, the notification will have a "Quick reply" action, allow to compose and send a message to the room.
      */
-    const val SUPPORT_QUICK_REPLY_ACTION = true
+    const val SHOW_QUICK_REPLY_ACTION = true
 
     @ColorInt
     val NOTIFICATION_ACCENT_COLOR: Int = Color.parseColor("#FF0DBD8B")

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -230,7 +230,7 @@ class DefaultNotificationCreator @Inject constructor(
             .setSmallIcon(smallIcon)
             .setColor(accentColor)
             .apply {
-                if (NotificationConfig.SUPPORT_JOIN_DECLINE_INVITE) {
+                if (NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS) {
                     addAction(rejectInvitationActionFactory.create(inviteNotifiableEvent))
                     addAction(acceptInvitationActionFactory.create(inviteNotifiableEvent))
                 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -230,10 +230,8 @@ class DefaultNotificationCreator @Inject constructor(
             .setSmallIcon(smallIcon)
             .setColor(accentColor)
             .apply {
-                if (NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS) {
-                    addAction(rejectInvitationActionFactory.create(inviteNotifiableEvent))
-                    addAction(acceptInvitationActionFactory.create(inviteNotifiableEvent))
-                }
+                addAction(rejectInvitationActionFactory.create(inviteNotifiableEvent))
+                addAction(acceptInvitationActionFactory.create(inviteNotifiableEvent))
                 // Build the pending intent for when the notification is clicked
                 setContentIntent(pendingIntentFactory.createOpenRoomPendingIntent(inviteNotifiableEvent.sessionId, inviteNotifiableEvent.roomId))
 

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/AcceptInvitationActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/AcceptInvitationActionFactory.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.push.impl.R
 import io.element.android.libraries.push.impl.notifications.NotificationActionIds
 import io.element.android.libraries.push.impl.notifications.NotificationBroadcastReceiver
 import io.element.android.libraries.push.impl.notifications.model.InviteNotifiableEvent
+import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.toolbox.api.strings.StringProvider
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import javax.inject.Inject
@@ -27,7 +28,6 @@ class AcceptInvitationActionFactory @Inject constructor(
     private val stringProvider: StringProvider,
     private val clock: SystemClock,
 ) {
-    // offer to type a quick accept button
     fun create(inviteNotifiableEvent: InviteNotifiableEvent): NotificationCompat.Action {
         val sessionId = inviteNotifiableEvent.sessionId.value
         val roomId = inviteNotifiableEvent.roomId.value
@@ -44,7 +44,7 @@ class AcceptInvitationActionFactory @Inject constructor(
         )
         return NotificationCompat.Action.Builder(
             R.drawable.vector_notification_accept_invitation,
-            stringProvider.getString(R.string.notification_invitation_action_join),
+            stringProvider.getString(CommonStrings.action_accept),
             pendingIntent
         ).build()
     }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/AcceptInvitationActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/AcceptInvitationActionFactory.kt
@@ -11,6 +11,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import io.element.android.appconfig.NotificationConfig
 import io.element.android.libraries.androidutils.uri.createIgnoredUri
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.push.impl.R
@@ -28,7 +29,8 @@ class AcceptInvitationActionFactory @Inject constructor(
     private val stringProvider: StringProvider,
     private val clock: SystemClock,
 ) {
-    fun create(inviteNotifiableEvent: InviteNotifiableEvent): NotificationCompat.Action {
+    fun create(inviteNotifiableEvent: InviteNotifiableEvent): NotificationCompat.Action? {
+        if (!NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS) return null
         val sessionId = inviteNotifiableEvent.sessionId.value
         val roomId = inviteNotifiableEvent.roomId.value
         val intent = Intent(context, NotificationBroadcastReceiver::class.java)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/MarkAsReadActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/MarkAsReadActionFactory.kt
@@ -29,7 +29,7 @@ class MarkAsReadActionFactory @Inject constructor(
     private val clock: SystemClock,
 ) {
     fun create(roomInfo: RoomEventGroupInfo): NotificationCompat.Action? {
-        if (!NotificationConfig.SUPPORT_MARK_AS_READ_ACTION) return null
+        if (!NotificationConfig.SHOW_MARK_AS_READ_ACTION) return null
         val sessionId = roomInfo.sessionId.value
         val roomId = roomInfo.roomId.value
         val intent = Intent(context, NotificationBroadcastReceiver::class.java)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/QuickReplyActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/QuickReplyActionFactory.kt
@@ -34,7 +34,7 @@ class QuickReplyActionFactory @Inject constructor(
     private val clock: SystemClock,
 ) {
     fun create(roomInfo: RoomEventGroupInfo, threadId: ThreadId?): NotificationCompat.Action? {
-        if (!NotificationConfig.SUPPORT_QUICK_REPLY_ACTION) return null
+        if (!NotificationConfig.SHOW_QUICK_REPLY_ACTION) return null
         val sessionId = roomInfo.sessionId
         val roomId = roomInfo.roomId
         val replyPendingIntent = buildQuickReplyIntent(sessionId, roomId, threadId)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/RejectInvitationActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/RejectInvitationActionFactory.kt
@@ -11,6 +11,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import io.element.android.appconfig.NotificationConfig
 import io.element.android.libraries.androidutils.uri.createIgnoredUri
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.push.impl.R
@@ -29,6 +30,7 @@ class RejectInvitationActionFactory @Inject constructor(
     private val clock: SystemClock,
 ) {
     fun create(inviteNotifiableEvent: InviteNotifiableEvent): NotificationCompat.Action? {
+        if (!NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS) return null
         val sessionId = inviteNotifiableEvent.sessionId.value
         val roomId = inviteNotifiableEvent.roomId.value
         val intent = Intent(context, NotificationBroadcastReceiver::class.java)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/RejectInvitationActionFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/action/RejectInvitationActionFactory.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.push.impl.R
 import io.element.android.libraries.push.impl.notifications.NotificationActionIds
 import io.element.android.libraries.push.impl.notifications.NotificationBroadcastReceiver
 import io.element.android.libraries.push.impl.notifications.model.InviteNotifiableEvent
+import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.toolbox.api.strings.StringProvider
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import javax.inject.Inject
@@ -41,10 +42,9 @@ class RejectInvitationActionFactory @Inject constructor(
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-
         return NotificationCompat.Action.Builder(
             R.drawable.vector_notification_reject_invitation,
-            stringProvider.getString(R.string.notification_invitation_action_reject),
+            stringProvider.getString(CommonStrings.action_reject),
             pendingIntent
         ).build()
     }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
@@ -162,8 +162,8 @@ class DefaultRoomGroupMessageCreatorTest {
         val actionTitles = result.actions?.map { it.title }
         assertThat(actionTitles).isEqualTo(
             listOfNotNull(
-                markAsReadActionTitle.takeIf { NotificationConfig.SUPPORT_MARK_AS_READ_ACTION },
-                quickReplyActionTitle.takeIf { NotificationConfig.SUPPORT_QUICK_REPLY_ACTION },
+                markAsReadActionTitle.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION },
+                quickReplyActionTitle.takeIf { NotificationConfig.SHOW_QUICK_REPLY_ACTION },
             )
         )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)
@@ -188,7 +188,7 @@ class DefaultRoomGroupMessageCreatorTest {
         val actionTitles = result.actions?.map { it.title }
         assertThat(actionTitles).isEqualTo(
             listOfNotNull(
-                markAsReadActionTitle.takeIf { NotificationConfig.SUPPORT_MARK_AS_READ_ACTION }
+                markAsReadActionTitle.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION }
             )
         )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.google.common.truth.Truth.assertThat
+import io.element.android.appconfig.NotificationConfig
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_TIMESTAMP
@@ -18,6 +19,8 @@ import io.element.android.libraries.matrix.ui.components.aMatrixUser
 import io.element.android.libraries.matrix.ui.media.AVATAR_THUMBNAIL_SIZE_IN_PIXEL
 import io.element.android.libraries.matrix.ui.media.MediaRequestData
 import io.element.android.libraries.push.impl.notifications.factories.createNotificationCreator
+import io.element.android.libraries.push.impl.notifications.factories.markAsReadActionTitle
+import io.element.android.libraries.push.impl.notifications.factories.quickReplyActionTitle
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
 import io.element.android.libraries.push.test.notifications.FakeImageLoader
 import io.element.android.services.toolbox.api.sdk.BuildVersionSdkIntProvider
@@ -156,6 +159,13 @@ class DefaultRoomGroupMessageCreatorTest {
         )
         assertThat(result.number).isEqualTo(2)
         assertThat(result.`when`).isEqualTo(A_TIMESTAMP + 10)
+        val actionTitles = result.actions?.map { it.title }
+        assertThat(actionTitles).isEqualTo(
+            listOfNotNull(
+                markAsReadActionTitle.takeIf { NotificationConfig.SUPPORT_MARK_AS_READ_ACTION },
+                quickReplyActionTitle.takeIf { NotificationConfig.SUPPORT_QUICK_REPLY_ACTION },
+            )
+        )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)
     }
 
@@ -175,7 +185,12 @@ class DefaultRoomGroupMessageCreatorTest {
             imageLoader = fakeImageLoader.getImageLoader(),
             existingNotification = null,
         )
-        assertThat(result.actions).isNull()
+        val actionTitles = result.actions?.map { it.title }
+        assertThat(actionTitles).isEqualTo(
+            listOfNotNull(
+                markAsReadActionTitle.takeIf { NotificationConfig.SUPPORT_MARK_AS_READ_ACTION }
+            )
+        )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultRoomGroupMessageCreatorTest.kt
@@ -18,9 +18,9 @@ import io.element.android.libraries.matrix.test.A_TIMESTAMP
 import io.element.android.libraries.matrix.ui.components.aMatrixUser
 import io.element.android.libraries.matrix.ui.media.AVATAR_THUMBNAIL_SIZE_IN_PIXEL
 import io.element.android.libraries.matrix.ui.media.MediaRequestData
+import io.element.android.libraries.push.impl.notifications.factories.MARK_AS_READ_ACTION_TITLE
+import io.element.android.libraries.push.impl.notifications.factories.QUICK_REPLY_ACTION_TITLE
 import io.element.android.libraries.push.impl.notifications.factories.createNotificationCreator
-import io.element.android.libraries.push.impl.notifications.factories.markAsReadActionTitle
-import io.element.android.libraries.push.impl.notifications.factories.quickReplyActionTitle
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
 import io.element.android.libraries.push.test.notifications.FakeImageLoader
 import io.element.android.services.toolbox.api.sdk.BuildVersionSdkIntProvider
@@ -162,8 +162,8 @@ class DefaultRoomGroupMessageCreatorTest {
         val actionTitles = result.actions?.map { it.title }
         assertThat(actionTitles).isEqualTo(
             listOfNotNull(
-                markAsReadActionTitle.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION },
-                quickReplyActionTitle.takeIf { NotificationConfig.SHOW_QUICK_REPLY_ACTION },
+                MARK_AS_READ_ACTION_TITLE.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION },
+                QUICK_REPLY_ACTION_TITLE.takeIf { NotificationConfig.SHOW_QUICK_REPLY_ACTION },
             )
         )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)
@@ -188,7 +188,7 @@ class DefaultRoomGroupMessageCreatorTest {
         val actionTitles = result.actions?.map { it.title }
         assertThat(actionTitles).isEqualTo(
             listOfNotNull(
-                markAsReadActionTitle.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION }
+                MARK_AS_READ_ACTION_TITLE.takeIf { NotificationConfig.SHOW_MARK_AS_READ_ACTION }
             )
         )
         assertThat(fakeImageLoader.getCoilRequests().size).isEqualTo(0)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.common.truth.Truth.assertThat
+import io.element.android.appconfig.NotificationConfig
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID
@@ -150,6 +151,13 @@ class DefaultNotificationCreatorTest {
         )
         result.commonAssertions(
             expectedCategory = null,
+        )
+        val actionTitles = result.actions?.map { it.title }
+        assertThat(actionTitles).isEqualTo(
+            listOfNotNull(
+                rejectInvitationActionTitle.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
+                acceptInvitationActionTitle.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
+            )
         )
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -155,8 +155,8 @@ class DefaultNotificationCreatorTest {
         val actionTitles = result.actions?.map { it.title }
         assertThat(actionTitles).isEqualTo(
             listOfNotNull(
-                rejectInvitationActionTitle.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
-                acceptInvitationActionTitle.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
+                REJECT_INVITATION_ACTION_TITLE.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
+                ACCEPT_INVITATION_ACTION_TITLE.takeIf { NotificationConfig.SHOW_ACCEPT_AND_DECLINE_INVITE_ACTIONS },
             )
         )
     }
@@ -279,10 +279,10 @@ class DefaultNotificationCreatorTest {
     }
 }
 
-const val markAsReadActionTitle = "MarkAsReadAction"
-const val quickReplyActionTitle = "QuickReplyAction"
-const val acceptInvitationActionTitle = "AcceptInvitationAction"
-const val rejectInvitationActionTitle = "RejectInvitationAction"
+const val MARK_AS_READ_ACTION_TITLE = "MarkAsReadAction"
+const val QUICK_REPLY_ACTION_TITLE = "QuickReplyAction"
+const val ACCEPT_INVITATION_ACTION_TITLE = "AcceptInvitationAction"
+const val REJECT_INVITATION_ACTION_TITLE = "RejectInvitationAction"
 
 fun createNotificationCreator(
     context: Context = RuntimeEnvironment.getApplication(),
@@ -304,26 +304,26 @@ fun createNotificationCreator(
         markAsReadActionFactory = MarkAsReadActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider(markAsReadActionTitle),
+            stringProvider = FakeStringProvider(MARK_AS_READ_ACTION_TITLE),
             clock = FakeSystemClock(),
         ),
         quickReplyActionFactory = QuickReplyActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider(quickReplyActionTitle),
+            stringProvider = FakeStringProvider(QUICK_REPLY_ACTION_TITLE),
             clock = FakeSystemClock(),
         ),
         bitmapLoader = bitmapLoader,
         acceptInvitationActionFactory = AcceptInvitationActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider(acceptInvitationActionTitle),
+            stringProvider = FakeStringProvider(ACCEPT_INVITATION_ACTION_TITLE),
             clock = FakeSystemClock(),
         ),
         rejectInvitationActionFactory = RejectInvitationActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider(rejectInvitationActionTitle),
+            stringProvider = FakeStringProvider(REJECT_INVITATION_ACTION_TITLE),
             clock = FakeSystemClock(),
         ),
     )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -271,6 +271,11 @@ class DefaultNotificationCreatorTest {
     }
 }
 
+const val markAsReadActionTitle = "MarkAsReadAction"
+const val quickReplyActionTitle = "QuickReplyAction"
+const val acceptInvitationActionTitle = "AcceptInvitationAction"
+const val rejectInvitationActionTitle = "RejectInvitationAction"
+
 fun createNotificationCreator(
     context: Context = RuntimeEnvironment.getApplication(),
     buildMeta: BuildMeta = aBuildMeta(),
@@ -291,26 +296,26 @@ fun createNotificationCreator(
         markAsReadActionFactory = MarkAsReadActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider("MarkAsReadActionFactory"),
+            stringProvider = FakeStringProvider(markAsReadActionTitle),
             clock = FakeSystemClock(),
         ),
         quickReplyActionFactory = QuickReplyActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider("QuickReplyActionFactory"),
+            stringProvider = FakeStringProvider(quickReplyActionTitle),
             clock = FakeSystemClock(),
         ),
         bitmapLoader = bitmapLoader,
         acceptInvitationActionFactory = AcceptInvitationActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider("AcceptInvitationActionFactory"),
+            stringProvider = FakeStringProvider(acceptInvitationActionTitle),
             clock = FakeSystemClock(),
         ),
         rejectInvitationActionFactory = RejectInvitationActionFactory(
             context = context,
             actionIds = NotificationActionIds(buildMeta),
-            stringProvider = FakeStringProvider("RejectInvitationActionFactory"),
+            stringProvider = FakeStringProvider(rejectInvitationActionTitle),
             clock = FakeSystemClock(),
         ),
     )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Enable all notification actions: quick reply, accept/decline invite, mark as read from notification.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3908
Closes #1966

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

![Notification action](https://github.com/user-attachments/assets/8e417828-8346-4252-b14d-6c09967472e8)

## Tests

<!-- Explain how you tested your development -->

- Receive notification for message or for room invite and see that they now have actions.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
