### PR TITLE
Rely on the SDK to decide if a caption is editable or not

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenter.kt
@@ -32,7 +32,6 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemPollContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemRedactedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemStateContent
-import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVoiceContent
 import io.element.android.features.messages.impl.timeline.model.event.canBeCopied
 import io.element.android.features.messages.impl.timeline.model.event.canBeForwarded
 import io.element.android.features.messages.impl.timeline.model.event.canReact
@@ -155,18 +154,16 @@ class DefaultActionListPresenter @AssistedInject constructor(
                 add(TimelineItemAction.Forward)
             }
             if (timelineItem.isEditable) {
-                add(TimelineItemAction.Edit)
-            } else {
-                // Caption
-                if (timelineItem.isMine &&
-                    timelineItem.content is TimelineItemEventContentWithAttachment &&
-                    timelineItem.content !is TimelineItemVoiceContent) {
+                if (timelineItem.content is TimelineItemEventContentWithAttachment) {
+                    // Caption
                     if (timelineItem.content.caption == null) {
                         add(TimelineItemAction.AddCaption)
                     } else {
                         add(TimelineItemAction.EditCaption)
                         add(TimelineItemAction.RemoveCaption)
                     }
+                } else {
+                    add(TimelineItemAction.Edit)
                 }
             }
             if (canRedact && timelineItem.content is TimelineItemPollContent && !timelineItem.content.isEnded) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
@@ -521,7 +521,7 @@ class ActionListPresenterTest {
             val initialState = awaitItem()
             val messageEvent = aMessageEvent(
                 isMine = true,
-                isEditable = false,
+                isEditable = true,
                 content = aTimelineItemImageContent(),
             )
             initialState.eventSink.invoke(
@@ -567,7 +567,7 @@ class ActionListPresenterTest {
             val initialState = awaitItem()
             val messageEvent = aMessageEvent(
                 isMine = true,
-                isEditable = false,
+                isEditable = true,
                 content = aTimelineItemImageContent(
                     caption = A_CAPTION,
                 ),


### PR DESCRIPTION
Need https://github.com/matrix-org/matrix-rust-sdk/pull/4303 to work but not to compile.

Complement for #3902, let read the value from the SDK instead of computing it again in the application code.

Note: the Rust PR has been merged but we will need a SDK release to have the new behavior. Merging this PR before will temporarily disable edition of caption.