### PR TITLE
Fix element call crash when resuming from notification

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -44,6 +44,7 @@ import io.element.android.features.call.impl.pip.PictureInPictureState
 import io.element.android.features.call.impl.pip.PipView
 import io.element.android.features.call.impl.services.CallForegroundService
 import io.element.android.features.call.impl.utils.CallIntentDataParser
+import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.designsystem.theme.ElementThemeApp
@@ -62,7 +63,7 @@ class ElementCallActivity :
     @Inject lateinit var appPreferencesStore: AppPreferencesStore
     @Inject lateinit var pictureInPicturePresenter: PictureInPicturePresenter
 
-    private lateinit var presenter: CallScreenPresenter
+    private lateinit var presenter: Presenter<CallScreenState>
 
     private lateinit var audioManager: AudioManager
 
@@ -92,6 +93,10 @@ class ElementCallActivity :
         )
 
         setCallType(intent)
+        // If presenter is not created at this point, it means we have no call to display, the Activity is finishing, so return early
+        if (!::presenter.isInitialized) {
+            return
+        }
 
         if (savedInstanceState == null) {
             updateUiMode(resources.configuration)

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -200,12 +200,14 @@ class ElementCallActivity :
             Timber.tag(loggerTag.value).d("Set the call type and create the presenter")
             webViewTarget.value = callType
             presenter = presenterFactory.create(callType!!, this)
+        } else if (callType == null) {
+            Timber.tag(loggerTag.value).d("Coming back from notification, do nothing")
         } else if (callType != currentCallType) {
             Timber.tag(loggerTag.value).d("User starts another call, restart the Activity")
             setIntent(intent)
             recreate()
         } else {
-            Timber.tag(loggerTag.value).d("Coming back from notification, do nothing")
+            Timber.tag(loggerTag.value).d("Other case, do nothing")
         }
     }
 

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -198,21 +198,26 @@ class ElementCallActivity :
                 ?: intent.dataString?.let(::parseUrl)?.let(::ExternalUrl)
         }
         val currentCallType = webViewTarget.value
-        if (currentCallType == null && callType == null) {
-            Timber.tag(loggerTag.value).d("Re-opened the activity but we have no url to load or a cached one, finish the activity")
-            finish()
-        } else if (currentCallType == null) {
-            Timber.tag(loggerTag.value).d("Set the call type and create the presenter")
-            webViewTarget.value = callType
-            presenter = presenterFactory.create(callType!!, this)
-        } else if (callType == null) {
-            Timber.tag(loggerTag.value).d("Coming back from notification, do nothing")
-        } else if (callType != currentCallType) {
-            Timber.tag(loggerTag.value).d("User starts another call, restart the Activity")
-            setIntent(intent)
-            recreate()
+        if (currentCallType == null) {
+            if (callType == null) {
+                Timber.tag(loggerTag.value).d("Re-opened the activity but we have no url to load or a cached one, finish the activity")
+                finish()
+            } else {
+                Timber.tag(loggerTag.value).d("Set the call type and create the presenter")
+                webViewTarget.value = callType
+                presenter = presenterFactory.create(callType, this)
+            }
         } else {
-            Timber.tag(loggerTag.value).d("Other case, do nothing")
+            if (callType == null) {
+                Timber.tag(loggerTag.value).d("Coming back from notification, do nothing")
+            } else if (callType != currentCallType) {
+                Timber.tag(loggerTag.value).d("User starts another call, restart the Activity")
+                setIntent(intent)
+                recreate()
+            } else {
+                // Starting the same call again, should not happen, the UI is preventing this. But maybe when using external links.
+                Timber.tag(loggerTag.value).d("Starting the same call again, do nothing")
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

Ensure that when the call is resume when clicking on the notification, the app does not crash.

Seems that this is a regression from #3833.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #3905 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
