### PR TITLE
Fix long click not working on pinned events timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/list/PinnedMessagesListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/list/PinnedMessagesListView.kt
@@ -231,6 +231,7 @@ private fun PinnedMessagesListLoaded(
                         event = event,
                         timelineProtectionState = state.timelineProtectionState,
                         onContentClick = { onEventClick(event) },
+                        onLongClick = { onMessageLongClick(event) },
                         onLinkClick = onLinkClick,
                         modifier = contentModifier,
                         onContentLayoutChange = onContentLayoutChange
@@ -247,6 +248,7 @@ private fun TimelineItemEventContentViewWrapper(
     timelineProtectionState: TimelineProtectionState,
     onContentClick: () -> Unit,
     onLinkClick: (String) -> Unit,
+    onLongClick: (() -> Unit)?,
     onContentLayoutChange: (ContentAvoidingLayoutData) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -265,7 +267,7 @@ private fun TimelineItemEventContentViewWrapper(
             eventSink = { },
             modifier = modifier,
             onContentClick = onContentClick,
-            onLongClick = null,
+            onLongClick = onLongClick,
             onContentLayoutChange = onContentLayoutChange
         )
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

https://github.com/element-hq/element-x-android/pull/3879 made long click not work on the pinned events timeline by mistake.

## Tests

<!-- Explain how you tested your development -->

- Open the pinned events timeline on a room with pinned events (pin some events first if needed).
- Long click on an item, check the modal bottom sheet is displayed as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
