### PR TITLE
Fix navigation issue when entering recovery key after navigating from the banner

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -400,6 +400,11 @@ class LoggedInFlowNode @AssistedInject constructor(
             is NavTarget.SecureBackup -> {
                 secureBackupEntryPoint.nodeBuilder(this, buildContext)
                     .params(SecureBackupEntryPoint.Params(initialElement = navTarget.initialElement))
+                    .callback(object : SecureBackupEntryPoint.Callback {
+                        override fun onDone() {
+                            backstack.pop()
+                        }
+                    })
                     .build()
             }
             NavTarget.Ftue -> {

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/SecureBackupFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/SecureBackupFlowNode.kt
@@ -111,10 +111,15 @@ class SecureBackupFlowNode @AssistedInject constructor(
             NavTarget.EnterRecoveryKey -> {
                 val callback = object : SecureBackupEnterRecoveryKeyNode.Callback {
                     override fun onEnterRecoveryKeySuccess() {
-                        if (callbacks.isNotEmpty()) {
-                            callbacks.forEach { it.onDone() }
-                        } else {
-                            backstack.pop()
+                        when (plugins.filterIsInstance<SecureBackupEntryPoint.Params>().first().initialElement) {
+                            SecureBackupEntryPoint.InitialTarget.EnterRecoveryKey -> {
+                                callbacks.forEach { it.onDone() }
+                            }
+                            SecureBackupEntryPoint.InitialTarget.ResetIdentity,
+                            SecureBackupEntryPoint.InitialTarget.Root,
+                            SecureBackupEntryPoint.InitialTarget.SetUpRecovery -> {
+                                backstack.pop()
+                            }
                         }
                     }
                 }

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/SecureBackupFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/SecureBackupFlowNode.kt
@@ -28,6 +28,7 @@ import io.element.android.features.securebackup.impl.root.SecureBackupRootNode
 import io.element.android.features.securebackup.impl.setup.SecureBackupSetupNode
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
+import io.element.android.libraries.architecture.appyx.canPop
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.di.SessionScope
 import kotlinx.parcelize.Parcelize
@@ -111,15 +112,10 @@ class SecureBackupFlowNode @AssistedInject constructor(
             NavTarget.EnterRecoveryKey -> {
                 val callback = object : SecureBackupEnterRecoveryKeyNode.Callback {
                     override fun onEnterRecoveryKeySuccess() {
-                        when (plugins.filterIsInstance<SecureBackupEntryPoint.Params>().first().initialElement) {
-                            SecureBackupEntryPoint.InitialTarget.EnterRecoveryKey -> {
-                                callbacks.forEach { it.onDone() }
-                            }
-                            SecureBackupEntryPoint.InitialTarget.ResetIdentity,
-                            SecureBackupEntryPoint.InitialTarget.Root,
-                            SecureBackupEntryPoint.InitialTarget.SetUpRecovery -> {
-                                backstack.pop()
-                            }
+                        if (backstack.canPop()) {
+                            backstack.pop()
+                        } else {
+                            callbacks.forEach { it.onDone() }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3278

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

### Before

https://github.com/user-attachments/assets/dfd5f630-b6e4-4174-abe0-317f92a30e44

### After

https://github.com/user-attachments/assets/6327ee08-76c6-441b-9023-32f51794fae2

## Tests

<!-- Explain how you tested your development -->

- Login to an account, but skip the verification step
- Click on the banner to enter the recovery key
- Enter the recovery key

Previous behavior: screen is stuck with a disabled "Continue" button. Need to close the screen manually
Now: navigating back to the room list, the banner is gone

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
