### PR TITLE
Element Call: display error dialog only when loading the main URL

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
@@ -66,19 +66,34 @@ class WebViewWidgetMessageInterceptor(
             override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
                 // No network for instance, transmit the error
                 Timber.e("onReceivedError error: ${error?.errorCode} ${error?.description}")
-                onError(error?.description?.toString())
+
+                // Only propagate the error if it happens while loading the current page
+                if (view?.url == request?.url.toString()) {
+                    onError(error?.description.toString())
+                }
+
                 super.onReceivedError(view, request, error)
             }
 
             override fun onReceivedHttpError(view: WebView?, request: WebResourceRequest?, errorResponse: WebResourceResponse?) {
                 Timber.e("onReceivedHttpError error: ${errorResponse?.statusCode} ${errorResponse?.reasonPhrase}")
-                onError(errorResponse?.statusCode.toString())
+
+                // Only propagate the error if it happens while loading the current page
+                if (view?.url == request?.url.toString()) {
+                    onError(errorResponse?.statusCode.toString())
+                }
+
                 super.onReceivedHttpError(view, request, errorResponse)
             }
 
             override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
                 Timber.e("onReceivedSslError error: ${error?.primaryError}")
-                onError(error?.primaryError?.toString())
+
+                // Only propagate the error if it happens while loading the current page
+                if (view?.url == error?.url.toString()) {
+                    onError(error?.toString())
+                }
+
                 super.onReceivedSslError(view, handler, error)
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Only propagate 'webview errors' to display the error dialog when the errors happen while trying to load the webview's main URL. At the moment this happened when trying to load any asset or external URL too.

## Motivation and context

Fix https://github.com/element-hq/element-x-android/issues/3896.

Note this *may* not work properly on URL redirections, although I hope a redirection means the webview's URL has changed and the check is still valid. In any case, it would be a rare corner case.

## Tests

<!-- Explain how you tested your development -->

- Open an Element Call external URL.
- If it load properly, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
