### PR TITLE
Fix navigation to rooms from notifications

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -472,9 +472,9 @@ class LoggedInFlowNode @AssistedInject constructor(
             navTarget is NavTarget.RoomList
         }
 
-        val isRoomAlreadyDisplayed = backstack.elements.value.any {
-            it.key.navTarget is NavTarget.Room && (it.key.navTarget as NavTarget.Room).roomIdOrAlias == roomIdOrAlias
-        }
+        val isRoomAlreadyDisplayed = backstack.active?.key?.navTarget?.let { target ->
+            target is NavTarget.Room && target.roomIdOrAlias == roomIdOrAlias
+        } == true
 
         if (!isRoomAlreadyDisplayed) {
             attachChild<RoomFlowNode> {

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -471,17 +471,28 @@ class LoggedInFlowNode @AssistedInject constructor(
         waitForNavTargetAttached { navTarget ->
             navTarget is NavTarget.RoomList
         }
-        attachChild<RoomFlowNode> {
-            backstack.push(
-                NavTarget.Room(
-                    roomIdOrAlias = roomIdOrAlias,
-                    serverNames = serverNames,
-                    trigger = trigger,
-                    initialElement = RoomNavigationTarget.Messages(
-                        focusedEventId = eventId
+
+        val isRoomAlreadyDisplayed = backstack.elements.value.any {
+            it.key.navTarget is NavTarget.Room && (it.key.navTarget as NavTarget.Room).roomIdOrAlias == roomIdOrAlias
+        }
+
+        if (!isRoomAlreadyDisplayed) {
+            attachChild<RoomFlowNode> {
+                // Remove existing path from the room list target
+                backstack.singleTop(NavTarget.RoomList)
+
+                // Then push the new room target
+                backstack.push(
+                    NavTarget.Room(
+                        roomIdOrAlias = roomIdOrAlias,
+                        serverNames = serverNames,
+                        trigger = trigger,
+                        initialElement = RoomNavigationTarget.Messages(
+                            focusedEventId = eventId
+                        )
                     )
                 )
-            )
+            }
         }
     }
 

--- a/appnav/src/main/kotlin/io/element/android/appnav/NavigateBackToRoomObserverPlugin.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/NavigateBackToRoomObserverPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
+ */
+
+package io.element.android.appnav
+
+import com.bumble.appyx.core.plugin.Plugin
+import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
+
+/**
+ * Plugin that will be notified when we want to navigate back to a room from a screen that is a descendant of it.
+ */
+class NavigateBackToRoomObserverPlugin : Plugin {
+    private val listeners = mutableListOf<(RoomIdOrAlias) -> Unit>()
+
+    fun addListener(listener: (RoomIdOrAlias) -> Unit) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: (RoomIdOrAlias) -> Unit) {
+        listeners.remove(listener)
+    }
+
+    fun navigateBackToRoom(roomIdOrAlias: RoomIdOrAlias) {
+        listeners.forEach { it(roomIdOrAlias) }
+    }
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -247,6 +248,13 @@ fun MessagesView(
         onUserDataClick = onUserDataClick,
     )
     ReinviteDialog(state = state)
+
+    // Make sure we hide the keyboard when the view is disposed
+    DisposableEffect(Unit) {
+        onDispose {
+            localView.hideKeyboard()
+        }
+    }
 }
 
 @Composable

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -183,8 +182,8 @@ fun MessagesView(
                     roomAvatar = state.roomAvatar.dataOrNull(),
                     heroes = state.heroes,
                     roomCallState = state.roomCallState,
-                    onBackClick = { hidingKeyboard { onBackClick() } },
-                    onRoomDetailsClick = { hidingKeyboard { onRoomDetailsClick() } },
+                    onBackClick = onBackClick,
+                    onRoomDetailsClick = onRoomDetailsClick,
                     onJoinCallClick = onJoinCallClick,
                 )
             }
@@ -197,7 +196,7 @@ fun MessagesView(
                     .consumeWindowInsets(padding),
                 onContentClick = ::onContentClick,
                 onMessageLongClick = ::onMessageLongClick,
-                onUserDataClick = { hidingKeyboard { onUserDataClick(it) } },
+                onUserDataClick = onUserDataClick,
                 onLinkClick = onLinkClick,
                 onReactionClick = ::onEmojiReactionClick,
                 onReactionLongClick = ::onEmojiReactionLongClick,
@@ -248,13 +247,6 @@ fun MessagesView(
         onUserDataClick = onUserDataClick,
     )
     ReinviteDialog(state = state)
-
-    // Make sure we hide the keyboard when the view is disposed
-    DisposableEffect(Unit) {
-        onDispose {
-            localView.hideKeyboard()
-        }
-    }
 }
 
 @Composable

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/BaseFlowNode.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/BaseFlowNode.kt
@@ -12,8 +12,11 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bumble.appyx.core.children.ChildEntry
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.modality.BuildContext
@@ -50,6 +53,7 @@ abstract class BaseFlowNode<NavTarget : Any>(
         super.onBuilt()
         lifecycle.logLifecycle(this::class.java.simpleName)
         whenChildAttached<Node> { _, child ->
+
             // BackstackNode will be logged by their parent.
             if (child !is BaseFlowNode<*>) {
                 child.lifecycle.logLifecycle(child::class.java.simpleName)
@@ -65,6 +69,13 @@ inline fun <reified NavTarget : Any> BaseFlowNode<NavTarget>.BackstackView(
         transitionSpec = { spring(stiffness = Spring.StiffnessMediumLow) },
     ),
 ) {
+    val backstackState = backstack.elements.collectAsStateWithLifecycle()
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(backstackState.value.lastOrNull()) {
+        keyboardController?.hide()
+    }
+
     Children(
         modifier = modifier,
         navModel = backstack,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When opening a room from a notification:

- Makes sure not to add a new room screen to the backstack if the same room is already displayed.
- Reset the navigation to the room list level. This is the behaviour in most IM apps, and it seems more natural (tested this on WhatsApp, Telegram and also EXI).
- Make sure the keyboard is closed when navigating out of the chat screen even if the navigation is triggered externally (should fix https://github.com/element-hq/element-x-android/issues/3572).

## Motivation and context

Fix https://github.com/element-hq/element-x-android/issues/3098 and https://github.com/element-hq/element-x-android/issues/3572.

## Tests

<!-- Explain how you tested your development -->

- Open some chat room (let's call it, 'Chat A'), tap on the composer to open the keyboard.
- Go to the home screen of the device without closing the keyboard in-app.
- Receive a notification from another room (Chat B).
- Open the notification.
- Chat B should be displayed, the keyboard should be dismissed and if you tap on the composer you can type normally.
- Go to the home screen again.
- Receive and open another notification from Chat B.
- The same room screen should be reused, no new chat screen should be pushed to the backstack.
- Tapping on back should take you to the room list, not the previous room.
- Send a message with a link to some room in Chat B.
- Follow the link, a new chat screen for that room should be opened.
- If you go back you're in the previous room, as expected, not to Chat A as it happened before.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
