### PR TITLE
feat(crypto): Support new expected UTD causes UX + Analytics

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemEncryptedView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemEncryptedView.kt
@@ -40,6 +40,15 @@ fun TimelineItemEncryptedView(
                 UtdCause.UnknownDevice -> {
                     CommonStrings.common_unable_to_decrypt_insecure_device to CompoundDrawables.ic_compound_block
                 }
+                UtdCause.HistoricalMessage -> {
+                    CommonStrings.timeline_decryption_failure_historical_event_no_key_backup to CompoundDrawables.ic_compound_block
+                }
+                UtdCause.WithheldUnverifiedOrInsecureDevice -> {
+                    CommonStrings.timeline_decryption_failure_withheld_unverified to CompoundDrawables.ic_compound_block
+                }
+                UtdCause.WithheldBySender -> {
+                    CommonStrings.timeline_decryption_failure_unable_to_decrypt to CompoundDrawables.ic_compound_error
+                }
                 else -> {
                     CommonStrings.common_waiting_for_decryption_key to CompoundDrawables.ic_compound_time
                 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEncryptedContentProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEncryptedContentProvider.kt
@@ -36,6 +36,24 @@ open class TimelineItemEncryptedContentProvider : PreviewParameterProvider<Timel
             aTimelineItemEncryptedContent(
                 data = UnableToDecryptContent.Data.MegolmV1AesSha2(
                     sessionId = "sessionId",
+                    utdCause = UtdCause.HistoricalMessage,
+                )
+            ),
+            aTimelineItemEncryptedContent(
+                data = UnableToDecryptContent.Data.MegolmV1AesSha2(
+                    sessionId = "sessionId",
+                    utdCause = UtdCause.WithheldUnverifiedOrInsecureDevice,
+                )
+            ),
+            aTimelineItemEncryptedContent(
+                data = UnableToDecryptContent.Data.MegolmV1AesSha2(
+                    sessionId = "sessionId",
+                    utdCause = UtdCause.WithheldBySender,
+                )
+            ),
+            aTimelineItemEncryptedContent(
+                data = UnableToDecryptContent.Data.MegolmV1AesSha2(
+                    sessionId = "sessionId",
                     utdCause = UtdCause.Unknown,
                 )
             ),

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/UtdCause.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/UtdCause.kt
@@ -12,5 +12,22 @@ enum class UtdCause {
     SentBeforeWeJoined,
     VerificationViolation,
     UnsignedDevice,
-    UnknownDevice
+    UnknownDevice,
+
+    /**
+     * Expected utd because this is a device-historical message and
+     * key storage is not setup or not configured correctly.
+     */
+    HistoricalMessage,
+
+    /**
+     * The key was withheld on purpose because your device is insecure and/or the
+     * sender trust requirement settings are not met for your device
+     */
+    WithheldUnverifiedOrInsecureDevice,
+
+    /**
+     * Key is withheld by sender
+     */
+    WithheldBySender,
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
@@ -27,6 +27,9 @@ class UtdTracker(
             UtdCause.UNKNOWN_DEVICE -> {
                 Error.Name.ExpectedSentByInsecureDevice
             }
+            UtdCause.HISTORICAL_MESSAGE -> Error.Name.HistoricalMessage
+            UtdCause.WITHHELD_FOR_UNVERIFIED_OR_INSECURE_DEVICE -> Error.Name.RoomKeysWithheldForUnverifiedDevice
+            UtdCause.WITHHELD_BY_SENDER -> Error.Name.OlmKeysNotSentError
         }
         val event = Error(
             context = null,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
@@ -145,6 +145,9 @@ private fun RustUtdCause.map(): UtdCause {
         RustUtdCause.VERIFICATION_VIOLATION -> UtdCause.VerificationViolation
         RustUtdCause.UNSIGNED_DEVICE -> UtdCause.UnsignedDevice
         RustUtdCause.UNKNOWN_DEVICE -> UtdCause.UnknownDevice
+        RustUtdCause.HISTORICAL_MESSAGE -> UtdCause.HistoricalMessage
+        RustUtdCause.WITHHELD_FOR_UNVERIFIED_OR_INSECURE_DEVICE -> UtdCause.WithheldUnverifiedOrInsecureDevice
+        RustUtdCause.WITHHELD_BY_SENDER -> UtdCause.WithheldBySender
     }
 }
 

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -365,4 +365,7 @@ Reason: %1$s."</string>
   <string name="settings_version_number">"Version: %1$s (%2$s)"</string>
   <string name="test_language_identifier">"en"</string>
   <string name="test_untranslated_default_language_identifier">"en"</string>
+  <string name="timeline_decryption_failure_historical_event_no_key_backup">"Historical messages are not available on this device"</string>
+  <string name="timeline_decryption_failure_unable_to_decrypt">"Unable to decrypt message"</string>
+  <string name="timeline_decryption_failure_withheld_unverified">"This message was blocked either because your device is unverified or because the sender needs to verify your identity."</string>
 </resources>

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -367,5 +367,5 @@ Reason: %1$s."</string>
   <string name="test_untranslated_default_language_identifier">"en"</string>
   <string name="timeline_decryption_failure_historical_event_no_key_backup">"Historical messages are not available on this device"</string>
   <string name="timeline_decryption_failure_unable_to_decrypt">"Unable to decrypt message"</string>
-  <string name="timeline_decryption_failure_withheld_unverified">"This message was blocked either because your device is unverified or because the sender needs to verify your identity."</string>
+  <string name="timeline_decryption_failure_withheld_unverified">"This message was blocked either because you did not verify your device or because the sender needs to verify your identity."</string>
 </resources>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

Adds support for the new expected unabled to decrypt causes, introduced by:
- https://github.com/matrix-org/matrix-rust-sdk/pull/4275
- https://github.com/matrix-org/matrix-rust-sdk/pull/4305

Needs an updated from the rust-sdk so won't compile until update is done 


## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
