### PR TITLE
navigation : clear backstack when opening room from outer node

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -20,11 +20,20 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.bumble.appyx.core.composable.PermanentChild
 import com.bumble.appyx.core.lifecycle.subscribe
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.NavElements
+import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.core.plugin.plugins
 import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.navmodel.backstack.BackStack.State.ACTIVE
+import com.bumble.appyx.navmodel.backstack.BackStack.State.CREATED
+import com.bumble.appyx.navmodel.backstack.BackStack.State.STASHED
+import com.bumble.appyx.navmodel.backstack.BackStackElement
+import com.bumble.appyx.navmodel.backstack.BackStackElements
+import com.bumble.appyx.navmodel.backstack.operation.BackStackOperation
+import com.bumble.appyx.navmodel.backstack.operation.Push
 import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.operation.replace
@@ -312,7 +321,7 @@ class LoggedInFlowNode @AssistedInject constructor(
                     }
 
                     override fun onForwardedToSingleRoom(roomId: RoomId) {
-                        coroutineScope.launch { attachRoom(roomId.toRoomIdOrAlias()) }
+                        coroutineScope.launch { attachRoom(roomId.toRoomIdOrAlias(), clearBackstack = false) }
                     }
 
                     override fun onPermalinkClick(data: PermalinkData, pushToBackstack: Boolean) {
@@ -472,21 +481,21 @@ class LoggedInFlowNode @AssistedInject constructor(
         serverNames: List<String> = emptyList(),
         trigger: JoinedRoom.Trigger? = null,
         eventId: EventId? = null,
+        clearBackstack: Boolean,
     ) {
         waitForNavTargetAttached { navTarget ->
             navTarget is NavTarget.RoomList
         }
         attachChild<RoomFlowNode> {
-            backstack.push(
-                NavTarget.Room(
-                    roomIdOrAlias = roomIdOrAlias,
-                    serverNames = serverNames,
-                    trigger = trigger,
-                    initialElement = RoomNavigationTarget.Messages(
-                        focusedEventId = eventId
-                    )
+            val roomNavTarget = NavTarget.Room(
+                roomIdOrAlias = roomIdOrAlias,
+                serverNames = serverNames,
+                trigger = trigger,
+                initialElement = RoomNavigationTarget.Messages(
+                    focusedEventId = eventId
                 )
             )
+            backstack.accept(AttachRoomOperation(roomNavTarget, clearBackstack))
         }
     }
 
@@ -530,4 +539,32 @@ class LoggedInFlowNode @AssistedInject constructor(
         @Assisted buildContext: BuildContext,
         @Assisted plugins: List<Plugin>,
     ) : Node(buildContext, plugins = plugins)
+}
+
+@Parcelize
+private class AttachRoomOperation(
+    val roomTarget: LoggedInFlowNode.NavTarget.Room,
+    val clearBackstack: Boolean,
+) : BackStackOperation<LoggedInFlowNode.NavTarget> {
+    override fun isApplicable(elements: NavElements<LoggedInFlowNode.NavTarget, BackStack.State>) = true
+
+    override fun invoke(elements: BackStackElements<LoggedInFlowNode.NavTarget>): BackStackElements<LoggedInFlowNode.NavTarget> {
+        return if (clearBackstack) {
+            // Makes sure the room list target is alone in the backstack and stashed
+            elements.mapNotNull { element ->
+                if (element.key.navTarget == LoggedInFlowNode.NavTarget.RoomList) {
+                    element.transitionTo(STASHED, this)
+                } else {
+                    null
+                }
+            } + BackStackElement(
+                key = NavKey(roomTarget),
+                fromState = CREATED,
+                targetState = ACTIVE,
+                operation = this
+            )
+        } else {
+            Push<LoggedInFlowNode.NavTarget>(roomTarget).invoke(elements)
+        }
+    }
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -303,6 +303,7 @@ class RootFlowNode @AssistedInject constructor(
                             trigger = JoinedRoom.Trigger.MobilePermalink,
                             serverNames = permalinkData.viaParameters,
                             eventId = permalinkData.eventId,
+                            clearBackstack = true
                         )
                     }
                     is PermalinkData.UserLink -> {
@@ -318,7 +319,7 @@ class RootFlowNode @AssistedInject constructor(
             .apply {
                 when (deeplinkData) {
                     is DeeplinkData.Root -> Unit // The room list will always be shown, observing FtueState
-                    is DeeplinkData.Room -> attachRoom(deeplinkData.roomId.toRoomIdOrAlias())
+                    is DeeplinkData.Room -> attachRoom(deeplinkData.roomId.toRoomIdOrAlias(), clearBackstack = true)
                 }
             }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
Take over https://github.com/element-hq/element-x-android/pull/3968

Reset the navigation to the room list level. This is the behaviour in most IM apps, and it seems more natural (tested this on WhatsApp, Telegram and also EXI).
The room is always added to the backstack, even if already stashed or active.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes https://github.com/element-hq/element-x-android/issues/3098
## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
