### PR TITLE
increase ringing timeout from 15 seconds to 90 seconds

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
@@ -16,5 +16,5 @@ object ElementCallConfig {
     /**
      * The default duration of a ringing call in seconds before it's automatically dismissed.
      */
-    const val RINGING_CALL_DURATION_SECONDS = 15
+    const val RINGING_CALL_DURATION_SECONDS = 90
 }


### PR DESCRIPTION
Bugs around ringing have been resolved and it's considered generally reliable now so it's a good time to increase the timeout.