### PR TITLE
Support new properties in posthog UTD reports

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
@@ -39,6 +39,10 @@ class UtdTracker(
             timeToDecryptMillis = info.timeToDecryptMs?.toInt() ?: -1,
             domain = Error.Domain.E2EE,
             name = name,
+            eventLocalAgeMillis = info.eventLocalAgeMillis.toInt(),
+            userTrustsOwnIdentity = info.userTrustsOwnIdentity,
+            isFederated = info.ownHomeserver != info.senderHomeserver,
+            isMatrixDotOrg = info.ownHomeserver == "matrix.org",
         )
         analyticsService.capture(event)
     }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTrackerTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTrackerTest.kt
@@ -25,6 +25,7 @@ class UtdTrackerTest {
                 eventId = AN_EVENT_ID.value,
                 timeToDecryptMs = null,
                 cause = UtdCause.UNKNOWN,
+                eventLocalAgeMillis = 100L,
             )
         )
         assertThat(fakeAnalyticsService.capturedEvents).containsExactly(
@@ -34,7 +35,11 @@ class UtdTrackerTest {
                 cryptoSDK = Error.CryptoSDK.Rust,
                 timeToDecryptMillis = -1,
                 domain = Error.Domain.E2EE,
-                name = Error.Name.OlmKeysNotSentError
+                name = Error.Name.OlmKeysNotSentError,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 100,
             )
         )
         assertThat(fakeAnalyticsService.screenEvents).isEmpty()
@@ -59,7 +64,11 @@ class UtdTrackerTest {
                 cryptoSDK = Error.CryptoSDK.Rust,
                 timeToDecryptMillis = 123,
                 domain = Error.Domain.E2EE,
-                name = Error.Name.OlmKeysNotSentError
+                name = Error.Name.OlmKeysNotSentError,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
             )
         )
         assertThat(fakeAnalyticsService.screenEvents).isEmpty()
@@ -84,7 +93,11 @@ class UtdTrackerTest {
                 cryptoSDK = Error.CryptoSDK.Rust,
                 timeToDecryptMillis = 123,
                 domain = Error.Domain.E2EE,
-                name = Error.Name.ExpectedDueToMembership
+                name = Error.Name.ExpectedDueToMembership,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
             )
         )
         assertThat(fakeAnalyticsService.screenEvents).isEmpty()
@@ -109,7 +122,11 @@ class UtdTrackerTest {
                 cryptoSDK = Error.CryptoSDK.Rust,
                 timeToDecryptMillis = 123,
                 domain = Error.Domain.E2EE,
-                name = Error.Name.ExpectedSentByInsecureDevice
+                name = Error.Name.ExpectedSentByInsecureDevice,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
             )
         )
     }
@@ -132,7 +149,90 @@ class UtdTrackerTest {
                 cryptoSDK = Error.CryptoSDK.Rust,
                 timeToDecryptMillis = 123,
                 domain = Error.Domain.E2EE,
-                name = Error.Name.ExpectedVerificationViolation
+                name = Error.Name.ExpectedVerificationViolation,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
+            )
+        )
+    }
+
+    @Test
+    fun `when onUtd is called with different sender and receiver servers, the expected analytics Event is sent`() {
+        val fakeAnalyticsService = FakeAnalyticsService()
+        val sut = UtdTracker(fakeAnalyticsService)
+        sut.onUtd(
+            aRustUnableToDecryptInfo(
+                eventId = AN_EVENT_ID.value,
+                ownHomeserver = "example.com",
+                senderHomeserver = "matrix.org",
+            )
+        )
+        assertThat(fakeAnalyticsService.capturedEvents).containsExactly(
+            Error(
+                context = null,
+                cryptoModule = Error.CryptoModule.Rust,
+                cryptoSDK = Error.CryptoSDK.Rust,
+                timeToDecryptMillis = -1,
+                domain = Error.Domain.E2EE,
+                name = Error.Name.OlmKeysNotSentError,
+                isFederated = true,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
+            )
+        )
+    }
+
+    @Test
+    fun `when onUtd is called from a matrix-org user, the expected analytics Event is sent`() {
+        val fakeAnalyticsService = FakeAnalyticsService()
+        val sut = UtdTracker(fakeAnalyticsService)
+        sut.onUtd(
+            aRustUnableToDecryptInfo(
+                eventId = AN_EVENT_ID.value,
+                ownHomeserver = "matrix.org",
+            )
+        )
+        assertThat(fakeAnalyticsService.capturedEvents).containsExactly(
+            Error(
+                context = null,
+                cryptoModule = Error.CryptoModule.Rust,
+                cryptoSDK = Error.CryptoSDK.Rust,
+                timeToDecryptMillis = -1,
+                domain = Error.Domain.E2EE,
+                name = Error.Name.OlmKeysNotSentError,
+                isFederated = true,
+                isMatrixDotOrg = true,
+                userTrustsOwnIdentity = false,
+                eventLocalAgeMillis = 0,
+            )
+        )
+    }
+
+    @Test
+    fun `when onUtd is called from a verified device, the expected analytics Event is sent`() {
+        val fakeAnalyticsService = FakeAnalyticsService()
+        val sut = UtdTracker(fakeAnalyticsService)
+        sut.onUtd(
+            aRustUnableToDecryptInfo(
+                eventId = AN_EVENT_ID.value,
+                userTrustsOwnIdentity = true,
+            )
+        )
+        assertThat(fakeAnalyticsService.capturedEvents).containsExactly(
+            Error(
+                context = null,
+                cryptoModule = Error.CryptoModule.Rust,
+                cryptoSDK = Error.CryptoSDK.Rust,
+                timeToDecryptMillis = -1,
+                domain = Error.Domain.E2EE,
+                name = Error.Name.OlmKeysNotSentError,
+                isFederated = false,
+                isMatrixDotOrg = false,
+                userTrustsOwnIdentity = true,
+                eventLocalAgeMillis = 0,
             )
         )
     }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/UnableToDecryptInfo.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/UnableToDecryptInfo.kt
@@ -12,8 +12,8 @@ import uniffi.matrix_sdk_crypto.UtdCause
 
 internal fun aRustUnableToDecryptInfo(
     eventId: String,
-    timeToDecryptMs: ULong?,
-    cause: UtdCause,
+    timeToDecryptMs: ULong? = null,
+    cause: UtdCause = UtdCause.UNKNOWN,
     eventLocalAgeMillis: Long = 0L,
     userTrustsOwnIdentity: Boolean = false,
     senderHomeserver: String = "",


### PR DESCRIPTION
Add a few new properties to the UTD reports we send to Posthog.

Part of https://github.com/element-hq/element-meta/issues/2582

Requires https://github.com/matrix-org/matrix-rust-sdk/pull/4404.

Signed-off-by: Richard van der Hoff \<richardv@element.io>

## Tests

<!-- Explain how you tested your development -->

- Receive a UTD
- check the logging looks plausible

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR