### PR TITLE
Build SDK for the local hardware

### DIFF
--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -132,7 +132,7 @@ Prerequisites:
   ```
 * Install the Android Rust toolchain for your machine's hardware:
   ```
-  rustup target add `uname -m`-linux-android
+  rustup target add aarch64-linux-android x86_64-linux-android
   ```
 * Depending on the location of the Android SDK, you may need to set
   `ANDROID_HOME`:

--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -130,9 +130,9 @@ Prerequisites:
   ```
   cargo install cargo-ndk
   ```
-* Install the Android Rust toolchain:
+* Install the Android Rust toolchain for your machine's hardware:
   ```
-  rustup target add aarch64-linux-android
+  rustup target add `uname -m`-linux-android
   ```
 * Depending on the location of the Android SDK, you may need to set
   `ANDROID_HOME`:

--- a/tools/sdk/build_rust_sdk.sh
+++ b/tools/sdk/build_rust_sdk.sh
@@ -59,6 +59,10 @@ buildApp=${buildApp:-no}
 
 cd "${elementPwd}"
 
+default_arch="$(uname -m)-linux-android"
+read -p "Enter the architecture you want to build for (default '$default_arch'): " target_arch
+target_arch="${target_arch:-${default_arch}}"
+
 # If folder ../matrix-rust-components-kotlin does not exist, clone the repo
 if [ ! -d "../matrix-rust-components-kotlin" ]; then
     printf "\nFolder ../matrix-rust-components-kotlin does not exist. Cloning the repository into ../matrix-rust-components-kotlin.\n\n"
@@ -71,8 +75,8 @@ git reset --hard
 git checkout main
 git pull
 
-printf "\nBuilding the SDK for aarch64-linux-android...\n\n"
-./scripts/build.sh -p "${rustSdkPath}" -m sdk -t aarch64-linux-android -o "${elementPwd}/libraries/rustsdk"
+printf "\nBuilding the SDK for ${target_arch}...\n\n"
+./scripts/build.sh -p "${rustSdkPath}" -m sdk -t "${target_arch}" -o "${elementPwd}/libraries/rustsdk"
 
 cd "${elementPwd}"
 mv ./libraries/rustsdk/sdk-android-debug.aar ./libraries/rustsdk/matrix-rust-sdk.aar

--- a/tools/sdk/build_rust_sdk.sh
+++ b/tools/sdk/build_rust_sdk.sh
@@ -60,6 +60,9 @@ buildApp=${buildApp:-no}
 cd "${elementPwd}"
 
 default_arch="$(uname -m)-linux-android"
+# On ARM MacOS, `uname -m` returns arm64, but the toolchain is called aarch64
+default_arch="${default_arch/arm64/aarch64}"
+
 read -p "Enter the architecture you want to build for (default '$default_arch'): " target_arch
 target_arch="${target_arch:-${default_arch}}"
 


### PR DESCRIPTION
It's likely that you want to build the SDK to run on the emulator on your
machine, so let's default to that, rather than aarch64.

Signed-off-by: Richard van der Hoff \<richardv@element.io>

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR