### PR TITLE
Add a feature flag to be able to enable the event cache

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContextMenu.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContextMenu.kt
@@ -61,6 +61,10 @@ fun RoomListContextMenu(
             onFavoriteChange = { isFavorite ->
                 eventSink(RoomListEvents.SetRoomIsFavorite(contextMenu.roomId, isFavorite))
             },
+            onClearCacheRoomClick = {
+                eventSink(RoomListEvents.HideContextMenu)
+                eventSink(RoomListEvents.ClearCacheOfRoom(contextMenu.roomId))
+            },
         )
     }
 }
@@ -73,6 +77,7 @@ private fun RoomListModalBottomSheetContent(
     onFavoriteChange: (isFavorite: Boolean) -> Unit,
     onRoomMarkReadClick: () -> Unit,
     onRoomMarkUnreadClick: () -> Unit,
+    onClearCacheRoomClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth()
@@ -177,6 +182,18 @@ private fun RoomListModalBottomSheetContent(
             ),
             style = ListItemStyle.Destructive,
         )
+        if (contextMenu.eventCacheFeatureFlagEnabled) {
+            ListItem(
+                headlineContent = {
+                    Text(text = "Clear cache for this room")
+                },
+                modifier = Modifier.clickable { onClearCacheRoomClick() },
+                leadingContent = ListItemContent.Icon(
+                    iconSource = IconSource.Vector(CompoundIcons.Delete())
+                ),
+                style = ListItemStyle.Primary,
+            )
+        }
     }
 }
 
@@ -195,5 +212,6 @@ internal fun RoomListModalBottomSheetContentPreview(
         onRoomSettingsClick = {},
         onLeaveRoomClick = {},
         onFavoriteChange = {},
+        onClearCacheRoomClick = {},
     )
 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListEvents.kt
@@ -25,4 +25,5 @@ sealed interface RoomListEvents {
     data class MarkAsRead(val roomId: RoomId) : ContextMenuEvents
     data class MarkAsUnread(val roomId: RoomId) : ContextMenuEvents
     data class SetRoomIsFavorite(val roomId: RoomId, val isFavorite: Boolean) : ContextMenuEvents
+    data class ClearCacheOfRoom(val roomId: RoomId) : ContextMenuEvents
 }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -146,6 +146,7 @@ class RoomListPresenter @Inject constructor(
                         AcceptDeclineInviteEvents.DeclineInvite(event.roomListRoomSummary.toInviteData())
                     )
                 }
+                is RoomListEvents.ClearCacheOfRoom -> coroutineScope.clearCacheOfRoom(event.roomId)
             }
         }
 
@@ -255,7 +256,8 @@ class RoomListPresenter @Inject constructor(
             isDm = event.roomListRoomSummary.isDm,
             isFavorite = event.roomListRoomSummary.isFavorite,
             markAsUnreadFeatureFlagEnabled = featureFlagService.isFeatureEnabled(FeatureFlags.MarkAsUnread),
-            hasNewContent = event.roomListRoomSummary.hasNewContent
+            hasNewContent = event.roomListRoomSummary.hasNewContent,
+            eventCacheFeatureFlagEnabled = featureFlagService.isFeatureEnabled(FeatureFlags.EventCache),
         )
         contextMenuState.value = initialState
 
@@ -309,6 +311,12 @@ class RoomListPresenter @Inject constructor(
                 .onSuccess {
                     analyticsService.captureInteraction(name = Interaction.Name.MobileRoomListRoomContextMenuUnreadToggle)
                 }
+        }
+    }
+
+    private fun CoroutineScope.clearCacheOfRoom(roomId: RoomId) = launch {
+        client.getRoom(roomId)?.use { room ->
+            room.clearEventCacheStorage()
         }
     }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -46,6 +46,7 @@ data class RoomListState(
             val isDm: Boolean,
             val isFavorite: Boolean,
             val markAsUnreadFeatureFlagEnabled: Boolean,
+            val eventCacheFeatureFlagEnabled: Boolean,
             val hasNewContent: Boolean,
         ) : ContextMenu
     }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateContextMenuShownProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateContextMenuShownProvider.kt
@@ -31,4 +31,5 @@ internal fun aContextMenuShown(
     markAsUnreadFeatureFlagEnabled = true,
     hasNewContent = hasNewContent,
     isFavorite = isFavorite,
+    eventCacheFeatureFlagEnabled = false,
 )

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -288,6 +288,7 @@ class RoomListPresenterTest {
                             isDm = false,
                             isFavorite = false,
                             markAsUnreadFeatureFlagEnabled = true,
+                            eventCacheFeatureFlagEnabled = false,
                             hasNewContent = false,
                         )
                     )
@@ -305,6 +306,7 @@ class RoomListPresenterTest {
                             isDm = false,
                             isFavorite = true,
                             markAsUnreadFeatureFlagEnabled = true,
+                            eventCacheFeatureFlagEnabled = false,
                             hasNewContent = false,
                         )
                     )
@@ -335,6 +337,7 @@ class RoomListPresenterTest {
                         isDm = false,
                         isFavorite = false,
                         markAsUnreadFeatureFlagEnabled = true,
+                        eventCacheFeatureFlagEnabled = false,
                         hasNewContent = false,
                     )
                 )

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -161,4 +161,11 @@ enum class FeatureFlags(
         defaultValue = { buildMeta -> buildMeta.buildType != BuildType.RELEASE },
         isFinished = false,
     ),
+    EventCache(
+        key = "feature.event_cache",
+        title = "Use SDK Event cache",
+        description = "Warning: you must kill and restart the app for the change to take effect.",
+        defaultValue = { false },
+        isFinished = false,
+    ),
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -233,6 +233,11 @@ interface MatrixRoom : Closeable {
     suspend fun setUnreadFlag(isUnread: Boolean): Result<Unit>
 
     /**
+     * Clear the event cache storage for the current room.
+     */
+    suspend fun clearEventCacheStorage(): Result<Unit>
+
+    /**
      * Share a location message in the room.
      *
      * @param body A human readable textual representation of the location.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -109,9 +109,7 @@ class RustMatrixClientFactory @Inject constructor(
             .addRootCertificates(userCertificatesProvider.provides())
             .autoEnableBackups(true)
             .autoEnableCrossSigning(true)
-            // TODO Add a feature flag to enable persistent storage
-            // See https://github.com/matrix-org/matrix-rust-sdk/pull/4396
-            .useEventCachePersistentStorage(false)
+            .useEventCachePersistentStorage(featureFlagService.isFeatureEnabled(FeatureFlags.EventCache))
             .roomKeyRecipientStrategy(
                 strategy = if (featureFlagService.isFeatureEnabled(FeatureFlags.OnlySignedDeviceIsolationMode)) {
                     CollectStrategy.IdentityBasedStrategy

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -569,6 +569,12 @@ class RustMatrixRoom(
         }
     }
 
+    override suspend fun clearEventCacheStorage(): Result<Unit> = withContext(roomDispatcher) {
+        runCatching {
+            innerRoom.clearEventCacheStorage()
+        }
+    }
+
     override suspend fun kickUser(userId: UserId, reason: String?): Result<Unit> = withContext(roomDispatcher) {
         runCatching {
             innerRoom.kickUser(userId.value, reason)

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -574,6 +574,10 @@ class FakeMatrixRoom(
     fun givenRoomMembersState(state: MatrixRoomMembersState) {
         membersStateFlow.value = state
     }
+
+    override suspend fun clearEventCacheStorage(): Result<Unit> {
+        return Result.success(Unit)
+    }
 }
 
 fun defaultRoomPowerLevels() = MatrixRoomPowerLevels(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add a new FF to be able to use the event cache from the SDK (exposed by https://github.com/matrix-org/matrix-rust-sdk/pull/4396). This feature flag is disabled by default for now. After a change, kill and restart the app.

<img width="341" alt="image" src="https://github.com/user-attachments/assets/a0c738e2-b1bb-44cb-bf7b-8e95d4f09d7c" />

Also add a way to clear the event cache of a specific room using a long click from the room list: 

<img width="351" alt="image" src="https://github.com/user-attachments/assets/966bde36-f306-4535-8da8-9f27cb7c0dc4" />

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Snappy EX!

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the flag
- Restart the app
- Open a room and scroll through history
- Go back to the room list
- open the same room again
- Observe that all the Events are still there.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
