### PR TITLE
feat(crypto): Support for new UtdCause for historical messages

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemEncryptedView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemEncryptedView.kt
@@ -40,8 +40,11 @@ fun TimelineItemEncryptedView(
                 UtdCause.UnknownDevice -> {
                     CommonStrings.common_unable_to_decrypt_insecure_device to CompoundDrawables.ic_compound_block
                 }
-                UtdCause.HistoricalMessage -> {
+                UtdCause.HistoricalMessageAndBackupIsDisabled -> {
                     CommonStrings.timeline_decryption_failure_historical_event_no_key_backup to CompoundDrawables.ic_compound_block
+                }
+                UtdCause.HistoricalMessageAndDeviceIsUnverified -> {
+                    CommonStrings.timeline_decryption_failure_historical_event_unverified_device to CompoundDrawables.ic_compound_block
                 }
                 UtdCause.WithheldUnverifiedOrInsecureDevice -> {
                     CommonStrings.timeline_decryption_failure_withheld_unverified to CompoundDrawables.ic_compound_block

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/UtdCause.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/UtdCause.kt
@@ -15,10 +15,17 @@ enum class UtdCause {
     UnknownDevice,
 
     /**
-     * Expected utd because this is a device-historical message and
-     * key storage is not setup or not configured correctly.
+     * We are missing the keys for this event, but it is a "device-historical" message and
+     * there is no key storage backup on the server, presumably because the user has turned it off.
      */
-    HistoricalMessage,
+    HistoricalMessageAndBackupIsDisabled,
+
+    /**
+     * We are missing the keys for this event, but it is a "device-historical"
+     * message, and even though a key storage backup does exist, we can't use
+     * it because our device is unverified.
+     */
+    HistoricalMessageAndDeviceIsUnverified,
 
     /**
      * The key was withheld on purpose because your device is insecure and/or the

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/analytics/UtdTracker.kt
@@ -27,7 +27,9 @@ class UtdTracker(
             UtdCause.UNKNOWN_DEVICE -> {
                 Error.Name.ExpectedSentByInsecureDevice
             }
-            UtdCause.HISTORICAL_MESSAGE -> Error.Name.HistoricalMessage
+            UtdCause.HISTORICAL_MESSAGE_AND_BACKUP_IS_DISABLED,
+            UtdCause.HISTORICAL_MESSAGE_AND_DEVICE_IS_UNVERIFIED,
+                -> Error.Name.HistoricalMessage
             UtdCause.WITHHELD_FOR_UNVERIFIED_OR_INSECURE_DEVICE -> Error.Name.RoomKeysWithheldForUnverifiedDevice
             UtdCause.WITHHELD_BY_SENDER -> Error.Name.OlmKeysNotSentError
         }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
@@ -145,7 +145,8 @@ private fun RustUtdCause.map(): UtdCause {
         RustUtdCause.VERIFICATION_VIOLATION -> UtdCause.VerificationViolation
         RustUtdCause.UNSIGNED_DEVICE -> UtdCause.UnsignedDevice
         RustUtdCause.UNKNOWN_DEVICE -> UtdCause.UnknownDevice
-        RustUtdCause.HISTORICAL_MESSAGE -> UtdCause.HistoricalMessage
+        RustUtdCause.HISTORICAL_MESSAGE_AND_BACKUP_IS_DISABLED -> UtdCause.HistoricalMessageAndBackupIsDisabled
+        RustUtdCause.HISTORICAL_MESSAGE_AND_DEVICE_IS_UNVERIFIED -> UtdCause.HistoricalMessageAndDeviceIsUnverified
         RustUtdCause.WITHHELD_FOR_UNVERIFIED_OR_INSECURE_DEVICE -> UtdCause.WithheldUnverifiedOrInsecureDevice
         RustUtdCause.WITHHELD_BY_SENDER -> UtdCause.WithheldBySender
     }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -343,6 +343,7 @@ Reason: %1$s."</string>
   <string name="test_language_identifier">"en"</string>
   <string name="test_untranslated_default_language_identifier">"en"</string>
   <string name="timeline_decryption_failure_historical_event_no_key_backup">"Historical messages are not available on this device"</string>
+  <string name="timeline_decryption_failure_historical_event_unverified_device">"You need to verify this device for access to historical messages"</string>
   <string name="timeline_decryption_failure_historical_event_user_not_joined">"You don\'t have access to this message"</string>
   <string name="timeline_decryption_failure_unable_to_decrypt">"Unable to decrypt message"</string>
   <string name="timeline_decryption_failure_withheld_unverified">"This message was blocked either because you did not verify your device or because the sender needs to verify your identity."</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/4384

Adds support for new Historical expected UTDs (posthog and display of errors in timeline)
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
