### PR TITLE
Fixed presentation of checked / unchecked state for checkboxes and switches and selected state for radio buttons when used with a screen reader

### DIFF
--- a/features/analytics/api/src/main/kotlin/io/element/android/features/analytics/api/preferences/AnalyticsPreferencesView.kt
+++ b/features/analytics/api/src/main/kotlin/io/element/android/features/analytics/api/preferences/AnalyticsPreferencesView.kt
@@ -8,9 +8,11 @@
 package io.element.android.features.analytics.api.preferences
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.features.analytics.api.AnalyticsOptInEvents
 import io.element.android.features.analytics.api.R
@@ -43,6 +45,13 @@ fun AnalyticsPreferencesView(
     )
     Column(modifier) {
         ListItem(
+            modifier = Modifier
+                .toggleable(
+                    value = state.isEnabled,
+                    role = Role.Checkbox,
+                    enabled = true,
+                    onValueChange = { onEnabledChanged(!state.isEnabled) }
+                ),
             headlineContent = {
                 Text(stringResource(id = R.string.screen_analytics_settings_share_data))
             },
@@ -52,10 +61,7 @@ fun AnalyticsPreferencesView(
             leadingContent = null,
             trailingContent = ListItemContent.Switch(
                 checked = state.isEnabled,
-            ),
-            onClick = {
-                onEnabledChanged(!state.isEnabled)
-            }
+            )
         )
         ListSupportingText(annotatedString = linkText)
     }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -31,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -281,6 +283,13 @@ private fun RoomVisibilityOptions(
         RoomVisibilityItem.entries.forEach { item ->
             val isSelected = item == selected
             ListItem(
+                modifier = Modifier
+                .selectable(
+                    selected = isSelected,
+                    role = Role.RadioButton,
+                    enabled = true,
+                    onClick = { onOptionClick(item) }
+                ),
                 leadingContent = ListItemContent.Custom {
                     RoundedIconAtom(
                         size = RoundedIconAtomSize.Big,
@@ -291,7 +300,6 @@ private fun RoomVisibilityOptions(
                 headlineContent = { Text(text = stringResource(item.title)) },
                 supportingContent = { Text(text = stringResource(item.description)) },
                 trailingContent = ListItemContent.RadioButton(selected = isSelected),
-                onClick = { onOptionClick(item) },
             )
         }
     }
@@ -308,11 +316,18 @@ private fun RoomAccessOptions(
         modifier = modifier,
     ) {
         RoomAccessItem.entries.forEach { item ->
+            val isSelected = item == selected
             ListItem(
+                modifier = Modifier
+                .selectable(
+                    selected = isSelected,
+                    role = Role.RadioButton,
+                    enabled = true,
+                                onClick = { onOptionClick(item) }
+                ),
                 headlineContent = { Text(text = stringResource(item.title)) },
                 supportingContent = { Text(text = stringResource(item.description)) },
-                trailingContent = ListItemContent.RadioButton(selected = item == selected),
-                onClick = { onOptionClick(item) },
+                trailingContent = ListItemContent.RadioButton(selected = isSelected),
             )
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/report/ReportMessageView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/report/ReportMessageView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
@@ -102,6 +104,12 @@ fun ReportMessageView(
 
             Row(
                 modifier = Modifier
+                    .toggleable(
+                        value = state.blockUser,
+                        role = Role.Checkbox,
+                        enabled = !isSending,
+                        onValueChange = { state.eventSink(ReportMessageEvents.ToggleBlockUser) }
+                    )
                     .fillMaxWidth()
                     .padding(vertical = 12.dp)
             ) {
@@ -119,7 +127,7 @@ fun ReportMessageView(
                 Switch(
                     enabled = !isSending,
                     checked = state.blockUser,
-                    onCheckedChange = { state.eventSink(ReportMessageEvents.ToggleBlockUser) },
+                    onCheckedChange = null,
                 )
             }
 

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/CreatePollView.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/create/CreatePollView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -145,7 +147,7 @@ fun CreatePollView(
                     trailingContent = ListItemContent.Custom {
                         Icon(
                             imageVector = CompoundIcons.Delete(),
-                            contentDescription = null,
+                            contentDescription = stringResource(id = R.string.screen_create_poll_remove_option_btn),
                             modifier = Modifier.clickable(answer.canDelete) {
                                 state.eventSink(CreatePollEvents.RemoveAnswer(index))
                             },
@@ -176,11 +178,18 @@ fun CreatePollView(
                 Column {
                     HorizontalDivider()
                     ListItem(
+                        modifier = Modifier
+                        .toggleable(
+                            value = state.pollKind == PollKind.Undisclosed,
+                            role = Role.Checkbox,
+                            enabled = true,
+                            onValueChange = { state.eventSink(CreatePollEvents.SetPollKind(if (it) PollKind.Undisclosed else PollKind.Disclosed)) }
+                        ),
                         headlineContent = { Text(text = stringResource(id = R.string.screen_create_poll_anonymous_headline)) },
                         supportingContent = { Text(text = stringResource(id = R.string.screen_create_poll_anonymous_desc)) },
                         trailingContent = ListItemContent.Switch(
                             checked = state.pollKind == PollKind.Undisclosed,
-                            onChange = { state.eventSink(CreatePollEvents.SetPollKind(if (it) PollKind.Undisclosed else PollKind.Disclosed)) },
+                            onChange = null,
                         ),
                     )
                     if (state.canDelete) {

--- a/features/poll/impl/src/main/res/values/localazy.xml
+++ b/features/poll/impl/src/main/res/values/localazy.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_create_poll_add_option_btn">"Add option"</string>
+  <string name="screen_create_poll_remove_option_btn">"Remove option"</string>
   <string name="screen_create_poll_anonymous_desc">"Show results only after poll ends"</string>
   <string name="screen_create_poll_anonymous_headline">"Hide votes"</string>
   <string name="screen_create_poll_answer_hint">"Option %1$d"</string>

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -7,9 +7,11 @@
 
 package io.element.android.features.preferences.impl.advanced
 
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import im.vector.app.features.analytics.plan.Interaction
 import io.element.android.compound.theme.Theme
@@ -53,6 +55,13 @@ fun AdvancedSettingsView(
             }
         )
         ListItem(
+            modifier = Modifier
+            .toggleable(
+                value = state.isDeveloperModeEnabled,
+                role = Role.Checkbox,
+                enabled = true,
+                            onValueChange = { state.eventSink(AdvancedSettingsEvents.SetDeveloperModeEnabled(!state.isDeveloperModeEnabled)) }
+            ),
             headlineContent = {
                 Text(text = stringResource(id = CommonStrings.action_view_source))
             },
@@ -61,10 +70,16 @@ fun AdvancedSettingsView(
             },
             trailingContent = ListItemContent.Switch(
                 checked = state.isDeveloperModeEnabled,
-            ),
-            onClick = { state.eventSink(AdvancedSettingsEvents.SetDeveloperModeEnabled(!state.isDeveloperModeEnabled)) }
+            )
         )
         ListItem(
+            modifier = Modifier
+            .toggleable(
+                value = state.isSharePresenceEnabled,
+                role = Role.Checkbox,
+                enabled = true,
+                            onValueChange = { state.eventSink(AdvancedSettingsEvents.SetSharePresenceEnabled(!state.isSharePresenceEnabled)) }
+            ),
             headlineContent = {
                 Text(text = stringResource(id = R.string.screen_advanced_settings_share_presence))
             },
@@ -73,10 +88,26 @@ fun AdvancedSettingsView(
             },
             trailingContent = ListItemContent.Switch(
                 checked = state.isSharePresenceEnabled,
-            ),
-            onClick = { state.eventSink(AdvancedSettingsEvents.SetSharePresenceEnabled(!state.isSharePresenceEnabled)) }
+            )
         )
         ListItem(
+            modifier = Modifier
+            .toggleable(
+                value = state.doesCompressMedia,
+                role = Role.Checkbox,
+                enabled = true,
+                            onValueChange = {
+                                val newValue = !state.doesCompressMedia
+                                analyticsService.captureInteraction(
+                                    if (newValue) {
+                                        Interaction.Name.MobileSettingsOptimizeMediaUploadsEnabled
+                                    } else {
+                                        Interaction.Name.MobileSettingsOptimizeMediaUploadsDisabled
+                                    }
+                                )
+                                state.eventSink(AdvancedSettingsEvents.SetCompressMedia(newValue))
+                            }
+            ),
             headlineContent = {
                 Text(text = stringResource(id = R.string.screen_advanced_settings_media_compression_title))
             },
@@ -86,17 +117,6 @@ fun AdvancedSettingsView(
             trailingContent = ListItemContent.Switch(
                 checked = state.doesCompressMedia,
             ),
-            onClick = {
-                val newValue = !state.doesCompressMedia
-                analyticsService.captureInteraction(
-                    if (newValue) {
-                        Interaction.Name.MobileSettingsOptimizeMediaUploadsEnabled
-                    } else {
-                        Interaction.Name.MobileSettingsOptimizeMediaUploadsDisabled
-                    }
-                )
-                state.eventSink(AdvancedSettingsEvents.SetCompressMedia(newValue))
-            }
         )
     }
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/edit/DefaultNotificationSettingOption.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/notifications/edit/DefaultNotificationSettingOption.kt
@@ -7,9 +7,11 @@
 
 package io.element.android.features.preferences.impl.notifications.edit
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import io.element.android.features.preferences.impl.R
 import io.element.android.libraries.designsystem.components.list.ListItemContent
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -38,11 +40,16 @@ fun DefaultNotificationSettingOption(
         else -> null
     }
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+        .selectable(
+            selected = isSelected,
+            role = Role.RadioButton,
+            enabled = true,
+                        onClick = { onSelectOption(mode) }
+        ),
         headlineContent = { Text(title) },
         supportingContent = subtitle?.let { { Text(it) } },
         trailingContent = ListItemContent.RadioButton(selected = isSelected),
-        onClick = { onSelectOption(mode) },
     )
 }
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsOption.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsOption.kt
@@ -8,9 +8,11 @@
 package io.element.android.features.roomdetails.impl.notificationsettings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import io.element.android.features.roomdetails.impl.R
 import io.element.android.libraries.designsystem.components.list.ListItemContent
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -37,12 +39,17 @@ fun RoomNotificationSettingsOption(
         else -> null
     }
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+            .selectable(
+                selected = isSelected,
+                role = Role.RadioButton,
+                enabled = enabled,
+                            onClick = { onSelectOption(roomNotificationSettingsItem) }
+            ),
         enabled = enabled,
         headlineContent = { Text(title) },
         supportingContent = subtitle?.let { { Text(it) } },
         trailingContent = ListItemContent.RadioButton(selected = isSelected),
-        onClick = { onSelectOption(roomNotificationSettingsItem) },
     )
 }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContextMenu.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListContextMenu.kt
@@ -10,11 +10,13 @@ package io.element.android.features.roomlist.impl
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.element.android.compound.theme.ElementTheme
@@ -123,6 +125,13 @@ private fun RoomListModalBottomSheetContent(
             }
         }
         ListItem(
+            modifier = Modifier
+                .toggleable(
+                    value = contextMenu.isFavorite,
+                    role = Role.Checkbox,
+                    enabled = true,
+                    onValueChange = { onFavoriteChange(!contextMenu.isFavorite) }
+                ),
             headlineContent = {
                 Text(
                     text = stringResource(id = CommonStrings.common_favourite),
@@ -137,13 +146,8 @@ private fun RoomListModalBottomSheetContent(
             ),
             trailingContent = ListItemContent.Switch(
                 checked = contextMenu.isFavorite,
-                onChange = { isFavorite ->
-                    onFavoriteChange(isFavorite)
-                },
+                onChange = null,
             ),
-            onClick = {
-                onFavoriteChange(!contextMenu.isFavorite)
-            },
             style = ListItemStyle.Primary,
         )
         ListItem(

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
@@ -9,9 +9,11 @@ package io.element.android.features.securebackup.impl.root
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.progressSemantics
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
@@ -74,7 +76,35 @@ fun SecureBackupRootView(
         )
 
         // Disable / Enable key storage
+        val keyStorageToggleModifier = when (state.backupState) {
+            BackupState.UNKNOWN -> {
+                when (state.doesBackupExistOnServer) {
+                    is AsyncData.Success -> {
+                        Modifier
+                            .toggleable(
+                                value = state.doesBackupExistOnServer.data,
+                                role = Role.Checkbox,
+                                enabled = true,
+                                onValueChange = {
+                                    if (state.doesBackupExistOnServer.data) {
+                                        onDisableClick()
+                                    } else {
+                                        state.eventSink.invoke(SecureBackupRootEvents.EnableKeyStorage)
+                                    }
+                                }
+                            )
+                    }
+                    else -> {
+                         Modifier
+                    }
+                }
+            }
+            else -> {
+                Modifier
+            }
+        }
         ListItem(
+            modifier = keyStorageToggleModifier,
             headlineContent = {
                 Text(
                     text = stringResource(id = R.string.screen_chat_backup_key_storage_toggle_title),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/CheckboxListItem.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/CheckboxListItem.kt
@@ -7,8 +7,10 @@
 
 package io.element.android.libraries.designsystem.components.list
 
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.ListItemStyle
 import io.element.android.libraries.designsystem.theme.components.Text
@@ -26,13 +28,18 @@ fun CheckboxListItem(
     compactLayout: Boolean = false,
 ) {
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+            .toggleable(
+                value = checked,
+                role = Role.Checkbox,
+                enabled = enabled,
+                onValueChange = { onChange(!checked) }
+            ),
         headlineContent = { Text(headline) },
         supportingContent = supportingText?.let { @Composable { Text(it) } },
         leadingContent = ListItemContent.Checkbox(checked, null, enabled, compact = compactLayout),
         trailingContent = trailingContent,
         style = style,
         enabled = enabled,
-        onClick = { onChange(!checked) },
     )
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/RadioButtonListItem.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/RadioButtonListItem.kt
@@ -7,8 +7,10 @@
 
 package io.element.android.libraries.designsystem.components.list
 
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.ListItemStyle
 import io.element.android.libraries.designsystem.theme.components.Text
@@ -26,13 +28,18 @@ fun RadioButtonListItem(
     compactLayout: Boolean = false,
 ) {
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+            .selectable(
+                selected = selected,
+                role = Role.RadioButton,
+                enabled = enabled,
+                            onClick = onSelect
+            ),
         headlineContent = { Text(headline) },
         supportingContent = supportingText?.let { @Composable { Text(it) } },
         leadingContent = ListItemContent.RadioButton(selected, null, enabled, compact = compactLayout),
         trailingContent = trailingContent,
         style = style,
         enabled = enabled,
-        onClick = onSelect,
     )
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/SwitchListItem.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/list/SwitchListItem.kt
@@ -7,8 +7,10 @@
 
 package io.element.android.libraries.designsystem.components.list
 
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.ListItemStyle
 import io.element.android.libraries.designsystem.theme.components.Text
@@ -25,13 +27,18 @@ fun SwitchListItem(
     style: ListItemStyle = ListItemStyle.Default,
 ) {
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+            .toggleable(
+                value = value,
+                role = Role.Checkbox,
+                enabled = enabled,
+                onValueChange = { onChange(!value) }
+            ),
         headlineContent = { Text(headline) },
         supportingContent = supportingText?.let { @Composable { Text(it) } },
         leadingContent = leadingContent,
         trailingContent = ListItemContent.Switch(value, null, enabled),
         style = style,
         enabled = enabled,
-        onClick = { onChange(!value) },
     )
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceCheckbox.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceCheckbox.kt
@@ -9,9 +9,11 @@ package io.element.android.libraries.designsystem.components.preferences
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.designsystem.components.list.ListItemContent
@@ -37,8 +39,13 @@ fun PreferenceCheckbox(
     showIconAreaIfNoIcon: Boolean = false,
 ) {
     ListItem(
-        modifier = modifier,
-        onClick = onCheckedChange.takeIf { enabled }?.let { { onCheckedChange(!isChecked) } },
+        modifier = modifier
+            .toggleable(
+                value = isChecked,
+                role = Role.Checkbox,
+                enabled = enabled,
+                onValueChange = { onCheckedChange.takeIf { enabled }?.let { { onCheckedChange(!isChecked) } } }
+            ),
         leadingContent = preferenceIcon(
             icon = icon,
             iconResourceId = iconResourceId,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceSwitch.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/preferences/PreferenceSwitch.kt
@@ -9,9 +9,11 @@ package io.element.android.libraries.designsystem.components.preferences
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -35,7 +37,13 @@ fun PreferenceSwitch(
     showIconAreaIfNoIcon: Boolean = false,
 ) {
     ListItem(
-        modifier = modifier,
+        modifier = modifier
+            .toggleable(
+                value = isChecked,
+                role = Role.Checkbox,
+                enabled = enabled,
+                onValueChange = { onCheckedChange.takeIf { enabled }?.let { { onCheckedChange(!isChecked) } } }
+            ),
         enabled = enabled,
         onClick = onCheckedChange.takeIf { enabled }?.let { { onCheckedChange(!isChecked) } },
         leadingContent = preferenceIcon(


### PR DESCRIPTION
## Content

Checkboxes, switches and radio buttons are implemented in a way that icon, title, the interactive control and optional description is encapsulated in a parent composable which receives onClick event. Checkboxes, switches and radio buttons them selves have no click handler. When considering universal user experience it's very nice approach as it increases touch target for these UI controls. However when considering screen reader accessibility screen readers are not receiving role and state information for these controls. Thus when using the app with a screen reader I can't find out if a check box is checked or not, if a switch is turned on or not and which of the radio buttons is selected.
I am trying to address this by adding toggleable and selectable modifiers where appropriate.

## Motivation and context

I am using this app daily, I used to experiment and guess the state of these checkboxes, switches and radio buttons, ask my friends until I have found I can try to improve it.

## Screenshots / GIFs

I believe appearance is unchanged. Also I have opted not to create and work with screenshots at all since I am unable to.

## Tests

Tested on a real device.

* Pressed both the volume buttons simultaneously to enable talkback screen reader
* Opened the app
* Touched any of the rooms on the screen
* Performed the double tap and hold gesture to bring up the context menu
* Used single finger flick gestures to navigate to the favorite the selected room.
* I have repeated the similar procedure in the user settings.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
