### PR TITLE
Make the room filter use normalized strings.

### DIFF
--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/extensions/BasicExtensions.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/extensions/BasicExtensions.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.core.extensions
 
+import java.text.Normalizer
 import java.util.Locale
 
 fun Boolean.toOnOff() = if (this) "ON" else "OFF"
@@ -82,4 +83,9 @@ fun String.safeCapitalize(): String {
             it.toString()
         }
     }
+}
+
+fun String.withoutAccents(): String {
+    return Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace("\\p{Mn}+".toRegex(), "")
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
@@ -7,6 +7,8 @@
 
 package io.element.android.libraries.matrix.api.roomlist
 
+import io.element.android.libraries.core.extensions.withoutAccents
+
 sealed interface RoomListFilter {
     companion object {
         /**
@@ -73,5 +75,7 @@ sealed interface RoomListFilter {
      */
     data class NormalizedMatchRoomName(
         val pattern: String
-    ) : RoomListFilter
+    ) : RoomListFilter {
+        val normalizedPattern: String = pattern.withoutAccents()
+    }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilter.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilter.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.impl.roomlist
 
+import io.element.android.libraries.core.extensions.withoutAccents
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.isDm
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
@@ -30,7 +31,7 @@ val RoomListFilter.predicate
             !roomSummary.isInvited() && (roomSummary.info.numUnreadNotifications > 0 || roomSummary.info.isMarkedUnread)
         }
         is RoomListFilter.NormalizedMatchRoomName -> { roomSummary: RoomSummary ->
-            roomSummary.info.name.orEmpty().contains(pattern, ignoreCase = true)
+            roomSummary.info.name?.withoutAccents().orEmpty().contains(normalizedPattern, ignoreCase = true)
         }
         RoomListFilter.Invite -> { roomSummary: RoomSummary ->
             roomSummary.isInvited()

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTest.kt
@@ -34,6 +34,9 @@ class RoomListFilterTest {
     private val roomToSearch = aRoomSummary(
         name = "Room to search"
     )
+    private val roomWithAccent = aRoomSummary(
+        name = "Frédéric"
+    )
     private val invitedRoom = aRoomSummary(
         currentUserMembership = CurrentUserMembership.INVITED
     )
@@ -45,6 +48,7 @@ class RoomListFilterTest {
         markedAsUnreadRoom,
         unreadNotificationRoom,
         roomToSearch,
+        roomWithAccent,
         invitedRoom
     )
 
@@ -69,7 +73,9 @@ class RoomListFilterTest {
     @Test
     fun `Room list filter group`() = runTest {
         val filter = RoomListFilter.Category.Group
-        assertThat(roomSummaries.filter(filter)).containsExactly(regularRoom, favoriteRoom, markedAsUnreadRoom, unreadNotificationRoom, roomToSearch)
+        assertThat(roomSummaries.filter(filter)).containsExactly(
+            regularRoom, favoriteRoom, markedAsUnreadRoom, unreadNotificationRoom, roomToSearch, roomWithAccent
+        )
     }
 
     @Test
@@ -94,6 +100,18 @@ class RoomListFilterTest {
     fun `Room list filter normalized match room name`() = runTest {
         val filter = RoomListFilter.NormalizedMatchRoomName("search")
         assertThat(roomSummaries.filter(filter)).containsExactly(roomToSearch)
+    }
+
+    @Test
+    fun `Room list filter normalized match room name with accent`() = runTest {
+        val filter = RoomListFilter.NormalizedMatchRoomName("Fred")
+        assertThat(roomSummaries.filter(filter)).containsExactly(roomWithAccent)
+    }
+
+    @Test
+    fun `Room list filter normalized match room name with accent when searching with accent`() = runTest {
+        val filter = RoomListFilter.NormalizedMatchRoomName("Fréd")
+        assertThat(roomSummaries.filter(filter)).containsExactly(roomWithAccent)
     }
 
     @Test

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterTest.kt
@@ -74,7 +74,12 @@ class RoomListFilterTest {
     fun `Room list filter group`() = runTest {
         val filter = RoomListFilter.Category.Group
         assertThat(roomSummaries.filter(filter)).containsExactly(
-            regularRoom, favoriteRoom, markedAsUnreadRoom, unreadNotificationRoom, roomToSearch, roomWithAccent
+            regularRoom,
+            favoriteRoom,
+            markedAsUnreadRoom,
+            unreadNotificationRoom,
+            roomToSearch,
+            roomWithAccent,
         )
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Searching for a room with name containing accent should now work even if the entered filter does not contain accent.

We do not use the filter facility offered by the Rust SDK because of performance issue.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Ease search of rooms.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 23
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
