### PR TITLE
Make Maestro run for each PR push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ env:
   CI_GRADLE_ARG_PROPERTIES: --stacktrace -Dsonar.gradle.skipCompile=true --no-configuration-cache
 
 jobs:
-  debug:
+  build:
     name: Build APKs
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -3,10 +3,7 @@ name: Maestro (local)
 # Run this flow only when APK Build workflow completes
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [APK Build]
-    types:
-      - completed
+  pull_request:
 
 # Enrich gradle.properties for CI/CD
 env:
@@ -21,7 +18,6 @@ jobs:
   build-apk:
     name: Build APK
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     # Allow one per PR.
     concurrency:
       group: ${{ format('maestro-{0}', github.ref) }}
@@ -61,8 +57,6 @@ jobs:
     name: Maestro test suite
     runs-on: ubuntu-latest
     needs: [build-apk]
-    # Only if the APKs were built successfully.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     # Allow one per PR.
     concurrency:
       group: ${{ format('maestro-{0}', github.ref) }}
@@ -74,16 +68,8 @@ jobs:
           # Ensure we are building the branch and not the branch after being merged on develop
           # https://github.com/actions/checkout/issues/881
           ref: ${{ github.ref }}
-      - name: Download APK artifact from 'Build APKs' flow
-        uses: actions/download-artifact@v4
-        if: github.event.workflow_run.conclusion == 'success'
-        with:
-          name: elementx-apk-maestro
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download APK artifact from previous job
         uses: actions/download-artifact@v4
-        if: github.event_name == 'workflow_dispatch'
         with:
           name: elementx-apk-maestro
       - name: Enable KVM group perms
@@ -95,6 +81,7 @@ jobs:
         run: curl -fsSL "https://get.maestro.mobile.dev" | bash
       - name: Run Maestro tests in emulator
         uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true
         env:
           MAESTRO_USERNAME: maestroelement
           MAESTRO_PASSWORD: ${{ secrets.MATRIX_MAESTRO_ACCOUNT_PASSWORD }}

--- a/.github/workflows/scripts/maestro/maestro-local-with-screen-recording.sh
+++ b/.github/workflows/scripts/maestro/maestro-local-with-screen-recording.sh
@@ -8,7 +8,6 @@
 #
 
 adb install -r $1
-set -x
 echo "Starting the screen recording..."
 adb push .github/workflows/scripts/maestro/local-recording.sh /data/local/tmp/
 adb shell "chmod +x /data/local/tmp/local-recording.sh"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Follow up of https://github.com/element-hq/element-x-android/pull/4092, since it wasn't working as expected.

- Remove the `workflow_run` configuration for the Maestro job.
- Make the 'build apk' job always run again too.
- Make sure the test results are uploaded when the Maestro job fails too (this broke somehow).

## Motivation and context

Ideally we wanted to run Maestro once the 'Build APK' flow was finished and reuse its output so we don't have to build the APK twice, but this has proven difficult to achieve, since the 2 options GH actions gives us for that are:

- `workflow_run`, which can set up dependencies in a 'when X flow finishes, run flow Y' way, and it's technically what we want, but has the downside that it'll always use the `.yml` contents of the `develop` branch, which makes it difficult to maintain or change (as proven by https://github.com/element-hq/element-x-android/pull/4092 not really working after being merged).
- `workflow_call`,  which allows a flow to explicitly start another: it worked as seen in [this commit](https://github.com/element-hq/element-x-android/pull/4121/commits/a99a0e3eda087b6b610839f5ef5e6e90406866df), but ended up in either the `Maestro` flow being run and displayed as part of the `Build APK` one or viceversa, and in both cases it was quite awkward since you couldn't see the results directly in the 'checks' UI.

So in the end we're just re-building the APK until a better option appears.

## Tests

There should be a working 'Maestro (local)' flow in the list of actions run.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
