### PR TITLE
Run `SyncService.start()` and `stop()` with a non-UI dispatcher

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -137,7 +137,11 @@ class RustMatrixClient(
 
     private val innerRoomListService = innerSyncService.roomListService()
 
-    private val rustSyncService = RustSyncService(innerSyncService, sessionCoroutineScope)
+    private val rustSyncService = RustSyncService(
+        innerSyncService = innerSyncService,
+        sessionCoroutineScope = sessionCoroutineScope,
+        syncServiceDispatcher = sessionDispatcher
+    )
     private val pushersService = RustPushersService(
         client = innerClient,
         dispatchers = dispatchers,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/sync/RustSyncService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/sync/RustSyncService.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.matrix.impl.sync
 
 import io.element.android.libraries.matrix.api.sync.SyncService
 import io.element.android.libraries.matrix.api.sync.SyncState
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,7 +26,8 @@ import org.matrix.rustcomponents.sdk.SyncService as InnerSyncService
 
 class RustSyncService(
     private val innerSyncService: InnerSyncService,
-    sessionCoroutineScope: CoroutineScope
+    sessionCoroutineScope: CoroutineScope,
+    private val syncServiceDispatcher: CoroutineDispatcher,
 ) : SyncService {
     private val isServiceReady = AtomicBoolean(true)
 
@@ -35,7 +37,9 @@ class RustSyncService(
             return@runCatching
         }
         Timber.i("Start sync")
-        innerSyncService.start()
+        withContext(syncServiceDispatcher) {
+            innerSyncService.start()
+        }
     }.onFailure {
         Timber.d("Start sync failed: $it")
     }
@@ -46,7 +50,9 @@ class RustSyncService(
             return@runCatching
         }
         Timber.i("Stop sync")
-        innerSyncService.stop()
+        withContext(syncServiceDispatcher) {
+            innerSyncService.stop()
+        }
     }.onFailure {
         Timber.d("Stop sync failed: $it")
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Run `SyncService.start()` and `SyncService.stop()` using a background dispatcher.

## Motivation and context

The Rust code doesn't seem to handle coroutine cancellation in a nice way, so sometimes when the sync service too a bit longer than expected to run and several syncs tried to start at the same time a deadlock happened which blocked the main thread in Android.

## Tests

To make testing easier, since I wasn't able to reproduce this issue on my test devices I built [this branch](https://github.com/matrix-org/matrix-rust-sdk/compare/test/android-anr-with-start-sync) of the SDK to make deadlocks more probable.

Then I opened the app and kept backgrounding it, then opening it back non-stop in short amounts of time: without this patch, I'd have an ANR at 5-6s max. With the patch I couldn't trigger it.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
