### PR TITLE
Remove or replace unnecessary `BackHandler` calls

### DIFF
--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/biometric/SetupBiometricView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/biometric/SetupBiometricView.kt
@@ -31,7 +31,7 @@ fun SetupBiometricView(
     state: SetupBiometricState,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler(true) {
+    BackHandler {
         state.eventSink(SetupBiometricEvents.UsePin)
     }
     HeaderFooterPage(

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.features.login.impl.screens.qrcode.confirmation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -44,6 +45,8 @@ fun QrCodeConfirmationView(
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    BackHandler(onBack = onCancel)
+
     val icon = when (step) {
         is QrCodeConfirmationStep.DisplayCheckCode -> CompoundIcons.Computer()
         is QrCodeConfirmationStep.DisplayVerificationCode -> CompoundIcons.LockSolid()
@@ -61,7 +64,6 @@ fun QrCodeConfirmationView(
         iconStyle = BigIcon.Style.Default(icon),
         title = title,
         subTitle = subtitle,
-        onBackClick = onCancel,
         content = { Content(step = step) },
         buttons = { Buttons(onCancel = onCancel) }
     )

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/confirmation/QrCodeConfirmationView.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.features.login.impl.screens.qrcode.confirmation
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -45,9 +44,6 @@ fun QrCodeConfirmationView(
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler {
-        onCancel()
-    }
     val icon = when (step) {
         is QrCodeConfirmationStep.DisplayCheckCode -> CompoundIcons.Computer()
         is QrCodeConfirmationStep.DisplayVerificationCode -> CompoundIcons.LockSolid()
@@ -65,6 +61,7 @@ fun QrCodeConfirmationView(
         iconStyle = BigIcon.Style.Default(icon),
         title = title,
         subTitle = subtitle,
+        onBackClick = onCancel,
         content = { Content(step = step) },
         buttons = { Buttons(onCancel = onCancel) }
     )

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/error/QrCodeErrorView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/error/QrCodeErrorView.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.features.login.impl.screens.qrcode.error
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -44,6 +45,7 @@ fun QrCodeErrorView(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    BackHandler(onBack = onRetry)
     FlowStepPage(
         modifier = modifier,
         iconStyle = BigIcon.Style.AlertSolid,
@@ -51,7 +53,6 @@ fun QrCodeErrorView(
         subTitle = subtitleText(errorScreenType, appName),
         content = { Content(errorScreenType) },
         buttons = { Buttons(onRetry) },
-        onBackClick = onRetry,
     )
 }
 

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/error/QrCodeErrorView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/error/QrCodeErrorView.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.features.login.impl.screens.qrcode.error
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -45,16 +44,14 @@ fun QrCodeErrorView(
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler {
-        onRetry()
-    }
     FlowStepPage(
         modifier = modifier,
         iconStyle = BigIcon.Style.AlertSolid,
         title = titleText(errorScreenType, appName),
         subTitle = subtitleText(errorScreenType, appName),
         content = { Content(errorScreenType) },
-        buttons = { Buttons(onRetry) }
+        buttons = { Buttons(onRetry) },
+        onBackClick = onRetry,
     )
 }
 

--- a/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileView.kt
+++ b/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileView.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.features.userprofile.shared
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -51,7 +50,6 @@ fun UserProfileView(
     openAvatarPreview: (username: String, url: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    BackHandler { goBack() }
     Scaffold(
         modifier = modifier,
         topBar = {

--- a/features/userprofile/shared/src/test/kotlin/io/element/android/features/userprofile/UserProfileViewTest.kt
+++ b/features/userprofile/shared/src/test/kotlin/io/element/android/features/userprofile/UserProfileViewTest.kt
@@ -34,7 +34,6 @@ import io.element.android.tests.testutils.ensureCalledOnce
 import io.element.android.tests.testutils.ensureCalledOnceWithParam
 import io.element.android.tests.testutils.ensureCalledOnceWithTwoParams
 import io.element.android.tests.testutils.pressBack
-import io.element.android.tests.testutils.pressBackKey
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -45,16 +44,6 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 class UserProfileViewTest {
     @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
-
-    @Test
-    fun `on back key press - the expected callback is called`() = runTest {
-        ensureCalledOnce { callback ->
-            rule.setUserProfileView(
-                goBack = callback,
-            )
-            rule.pressBackKey()
-        }
-    }
 
     @Test
     fun `on back button click - the expected callback is called`() = runTest {


### PR DESCRIPTION
## Content

- For `UserProfileView`, remove the redundant `BackHandler` -> `navigateUp()` call.
- ~~For `QrCodeErrorView` and `QrCodeConfirmationView`, remove the external `BackHandler` and move the callback to `FlowStepPage.onBackClick`~~. Restored, since they were used to prevent the back button arrow icon from appearing in the nav bar.
- For `SetupBiometricView`, remove the `enabled = true` parameter, as this is the default value.

## Motivation and context

I noticed these while investigating some issues about StackOverflowError happening when navigating back from some screens, although I don't think they're related.

## Tests

The back button/gestures should still work the same on the affected screens.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
