### PR TITLE
CalVer: use 2 digits for the year and 2 digits for the month.

### DIFF
--- a/plugins/src/main/kotlin/Versions.kt
+++ b/plugins/src/main/kotlin/Versions.kt
@@ -18,21 +18,26 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
  * output.versionCode.set((output.versionCode.get() ?: 0) * 10 + abiCode))
  * ```
  * We are using a CalVer-like approach to version the application. The version code is calculated as follows:
- * - 4 digits for the year
+ * - 2 digits for the year
  * - 2 digits for the month
- * - 2 digits for the release number
- * So for instance, the first release of Jan 2025 will have the version code: 20250100 (20_250_100)
+ * - 1 (or 2) digits for the release number
+ * Note that the version codes need to be greater than the ones calculated for the previous releases, so we use
+ * year on 4 digits for this internal value.
+ * So for instance, the first release of Jan 2025 will have:
+ * - the version name: 25.01.0
+ * - the version code: 20250100a (202_501_00a) where `a` stands for the architecture code
  */
 
-private const val versionYear = 2025
+private const val versionYear = 25
 private const val versionMonth = 1
 
 // Note: must be in [0,99]
 private const val versionReleaseNumber = 0
 
 object Versions {
-    const val VERSION_CODE = versionYear * 10_000 + versionMonth * 100 + versionReleaseNumber
-    const val VERSION_NAME = "$versionYear.$versionMonth.$versionReleaseNumber"
+    const val VERSION_CODE = (2000 + versionYear) * 10_000 + versionMonth * 100 + versionReleaseNumber
+    val VERSION_NAME = "$versionYear.${versionMonth.toString().padStart(2, '0')}.$versionReleaseNumber"
+
     const val COMPILE_SDK = 35
     const val TARGET_SDK = 35
 


### PR DESCRIPTION
Complement for #4187, following requirements from https://github.com/element-hq/element-meta/issues/2664

This is how it will appear in the app:

<img width="305" alt="image" src="https://github.com/user-attachments/assets/3db81441-91ec-4788-b270-3f5db1fe021e" />
