### PR TITLE
Kover: include back :libraries:matrix:impl module.

### DIFF
--- a/plugins/src/main/kotlin/extension/KoverExtension.kt
+++ b/plugins/src/main/kotlin/extension/KoverExtension.kt
@@ -35,9 +35,6 @@ val excludedKoverSubProjects = listOf(
     ":anvilannotations",
     ":anvilcodegen",
     ":tests:testutils",
-    // Exclude `:libraries:matrix:impl` module, it contains only wrappers to access the Rust Matrix
-    // SDK api, so it is not really relevant to unit test it: there is no logic to test.
-    ":libraries:matrix:impl",
     // Exclude modules which are not Android libraries
     // See https://github.com/Kotlin/kotlinx-kover/issues/312
     ":appconfig",


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Kover: include back :libraries:matrix:impl module.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
We want to track which code is not tested in this module.

We expect a decrease in the coverage

<img width="326" alt="image" src="https://github.com/user-attachments/assets/d96d625f-6818-4852-b96e-03e992583f2c" />

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

NA

## Tested devices

NA

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
