### PR TITLE
Open chat links in regular browser tabs

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
@@ -139,6 +139,7 @@ class MessagesNode @AssistedInject constructor(
         darkTheme: Boolean,
         url: String,
         eventSink: (TimelineEvents) -> Unit,
+        customTab: Boolean
     ) {
         when (val permalink = permalinkParser.parse(url)) {
             is PermalinkData.UserLink -> {
@@ -150,7 +151,11 @@ class MessagesNode @AssistedInject constructor(
                 handleRoomLinkClick(activity, permalink, eventSink)
             }
             is PermalinkData.FallbackLink -> {
-                activity.openUrlInExternalApp(url)
+                if (customTab) {
+                    activity.openUrlInChromeCustomTab(null, darkTheme, url)
+                } else {
+                    activity.openUrlInExternalApp(url)
+                }
             }
             is PermalinkData.RoomEmailInviteLink -> {
                 activity.openUrlInChromeCustomTab(null, darkTheme, url)
@@ -236,7 +241,7 @@ class MessagesNode @AssistedInject constructor(
                 onRoomDetailsClick = this::onRoomDetailsClick,
                 onEventContentClick = this::onEventClick,
                 onUserDataClick = this::onUserDataClick,
-                onLinkClick = { url -> onLinkClick(activity, isDark, url, state.timelineState.eventSink) },
+                onLinkClick = { url, customTab -> onLinkClick(activity, isDark, url, state.timelineState.eventSink, customTab) },
                 onSendLocationClick = this::onSendLocationClick,
                 onCreatePollClick = this::onCreatePollClick,
                 onJoinCallClick = this::onJoinCallClick,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
@@ -40,6 +40,7 @@ import io.element.android.features.messages.impl.timeline.di.LocalTimelineItemPr
 import io.element.android.features.messages.impl.timeline.di.TimelineItemPresenterFactories
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.libraries.androidutils.browser.openUrlInChromeCustomTab
+import io.element.android.libraries.androidutils.system.openUrlInExternalApp
 import io.element.android.libraries.androidutils.system.toast
 import io.element.android.libraries.architecture.NodeInputs
 import io.element.android.libraries.architecture.inputs
@@ -148,7 +149,9 @@ class MessagesNode @AssistedInject constructor(
             is PermalinkData.RoomLink -> {
                 handleRoomLinkClick(activity, permalink, eventSink)
             }
-            is PermalinkData.FallbackLink,
+            is PermalinkData.FallbackLink -> {
+                activity.openUrlInExternalApp(url)
+            }
             is PermalinkData.RoomEmailInviteLink -> {
                 activity.openUrlInChromeCustomTab(null, darkTheme, url)
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -111,7 +111,7 @@ fun MessagesView(
     onRoomDetailsClick: () -> Unit,
     onEventContentClick: (event: TimelineItem.Event) -> Boolean,
     onUserDataClick: (UserId) -> Unit,
-    onLinkClick: (String) -> Unit,
+    onLinkClick: (String, Boolean) -> Unit,
     onSendLocationClick: () -> Unit,
     onCreatePollClick: () -> Unit,
     onJoinCallClick: () -> Unit,
@@ -273,7 +273,7 @@ private fun MessagesViewContent(
     state: MessagesState,
     onContentClick: (TimelineItem.Event) -> Unit,
     onUserDataClick: (UserId) -> Unit,
-    onLinkClick: (String) -> Unit,
+    onLinkClick: (String, Boolean) -> Unit,
     onReactionClick: (key: String, TimelineItem.Event) -> Unit,
     onReactionLongClick: (key: String, TimelineItem.Event) -> Unit,
     onMoreReactionsClick: (TimelineItem.Event) -> Unit,
@@ -347,7 +347,7 @@ private fun MessagesViewContent(
                         state = state.timelineState,
                         timelineProtectionState = state.timelineProtectionState,
                         onUserDataClick = onUserDataClick,
-                        onLinkClick = onLinkClick,
+                        onLinkClick = { url -> onLinkClick(url, false) },
                         onContentClick = onContentClick,
                         onMessageLongClick = onMessageLongClick,
                         onSwipeToReply = onSwipeToReply,
@@ -396,7 +396,7 @@ private fun MessagesViewContent(
 private fun MessagesViewComposerBottomSheetContents(
     subcomposing: Boolean,
     state: MessagesState,
-    onLinkClick: (String) -> Unit,
+    onLinkClick: (String, Boolean) -> Unit,
 ) {
     if (state.userEventPermissions.canSendMessage) {
         Column(modifier = Modifier.fillMaxWidth()) {
@@ -537,7 +537,7 @@ internal fun MessagesViewPreview(@PreviewParameter(MessagesStateProvider::class)
         onRoomDetailsClick = {},
         onEventContentClick = { false },
         onUserDataClick = {},
-        onLinkClick = {},
+        onLinkClick = { _, _ -> },
         onSendLocationClick = {},
         onCreatePollClick = {},
         onJoinCallClick = {},

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateView.kt
@@ -26,7 +26,7 @@ import io.element.android.libraries.ui.strings.CommonStrings
 @Composable
 fun IdentityChangeStateView(
     state: IdentityChangeState,
-    onLinkClick: (String) -> Unit,
+    onLinkClick: (String, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Pick the first identity change to PinViolation
@@ -73,7 +73,7 @@ fun IdentityChangeStateView(
                     url = LinkAnnotation.Url(
                         url = LearnMoreConfig.IDENTITY_CHANGE_URL,
                         linkInteractionListener = {
-                            onLinkClick(LearnMoreConfig.IDENTITY_CHANGE_URL)
+                            onLinkClick(LearnMoreConfig.IDENTITY_CHANGE_URL, true)
                         }
                     ),
                     start = learnMoreStartIndex,
@@ -93,6 +93,6 @@ internal fun IdentityChangeStateViewPreview(
 ) = ElementPreview {
     IdentityChangeStateView(
         state = state,
-        onLinkClick = {},
+        onLinkClick = { _, _ -> },
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/MessagesViewWithIdentityChangePreview.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/MessagesViewWithIdentityChangePreview.kt
@@ -35,7 +35,7 @@ internal fun MessagesViewWithIdentityChangePreview(
         onRoomDetailsClick = {},
         onEventContentClick = { false },
         onUserDataClick = {},
-        onLinkClick = {},
+        onLinkClick = { _, _ -> },
         onSendLocationClick = {},
         onCreatePollClick = {},
         onJoinCallClick = {},

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
@@ -58,6 +58,7 @@ import io.element.android.tests.testutils.EnsureCalledOnceWithParam
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.EnsureNeverCalledWithParamAndResult
+import io.element.android.tests.testutils.EnsureNeverCalledWithTwoParams
 import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
 import io.element.android.tests.testutils.ensureCalledOnce
@@ -514,7 +515,7 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setMessa
     onRoomDetailsClick: () -> Unit = EnsureNeverCalled(),
     onEventClick: (event: TimelineItem.Event) -> Boolean = EnsureNeverCalledWithParamAndResult(),
     onUserDataClick: (UserId) -> Unit = EnsureNeverCalledWithParam(),
-    onLinkClick: (String) -> Unit = EnsureNeverCalledWithParam(),
+    onLinkClick: (String, Boolean) -> Unit = EnsureNeverCalledWithTwoParams(),
     onSendLocationClick: () -> Unit = EnsureNeverCalled(),
     onCreatePollClick: () -> Unit = EnsureNeverCalled(),
     onJoinCallClick: () -> Unit = EnsureNeverCalled(),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Open web hyperlinks in chat messages in the user's regular, preferred web browser. Fixes bug introduced in v0.6.5.

Closes #3885

## Motivation and context

In 5baefd479f0045110918b5abbcb7a21fbf28c01e, a link to a "help" web page was added to the `MessagesView`. Since this page is essentially part of the app, it should and does open in an "in-app" [Chrome Custom Tab](https://developer.chrome.com/docs/android/custom-tabs/guide-get-started#opening_a_custom_tab
), where supported.

Unfortunately, this change affects *every* link in the messages view, including links sent in chat messages. As of v0.6.5, links in chat messages now open in a Custom Tab instead of the user's configured "full" web browser. This is a UX nuisance.

Separate "regular" links from "custom tab" links with a new parameter `onLinkClick(..., customTab)`. If true, the link opens in a custom tab.

Alternatively, the first patch in this PR removes the Custom Tab behavior from `MessagesView` entirely. This is likely not the preferred end result, however.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs


|Before|After|
|-|-|
| ![Screenshot_20250125-211827_Fennec](https://github.com/user-attachments/assets/c0b3d707-b7fa-4732-9b89-cb54d4efc3c3) |![Screenshot_20250125-211852_Fennec](https://github.com/user-attachments/assets/91fd691b-2126-465b-b8f4-5d1792f4238f) |

## Tests

<!-- Explain how you tested your development -->

1. Build F-Droid version with
   ```
   export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64/
   export GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx9g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -Dkotlin.daemon.jvm.options=-Xmx4g"
   ./gradlew app:assembleFDroidDebug
   ```

2. Install on device.

3. Sign in to Element.

4. Open a chat room. Find a message which includes an `https://` web link.

5. Tap on the link.

6. Observe that the link is opened in the "full" web browser with the full browser UI and other tabs. (See screenshots.)

I have not tried to force an identity change to test that the identity change help still loads in a Chrome Custom Tab. I'm not sure what the best way to test that is.

This PR should not introduce any new Android APIs. If API 24 emulator testing is required, can the project recommend an emulator?

## Tested devices

- [x] Physical: Android 14 / LineageOS 21, with f-droid build and the Fennec F-Droid web browser
- [ ] Emulator

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes (N/A, but tested anyway)
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
