### PR TITLE
Media Viewer: show snackbar when reaching end of timeline.

### DIFF
--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
@@ -56,6 +56,7 @@ private val TESTED_MEDIA_INFO = anApkMediaInfo(
     senderId = A_USER_ID,
 )
 
+@Suppress("LargeClass")
 class MediaViewerPresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Media Viewer: show snackbar when reaching end of timeline.

When the loading page is displayed and there is no more media to load, the loading page vanished (this is handled automatically by the HorizontalPager - without animation (is does not seem to be supported yet by the library) and a Snackbar is displayed. This PR handle the displaying of the snackbar.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Follow design from Figma https://www.figma.com/design/Ni6Ii8YKtmXCKYNE90cC67/Timeline-(new)?node-id=2660-29699&m=dev 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room with at least one media
- navigate to "Media and files" and open the media, then quickly swipe to right to see the loader
- wait for the pagination request to reach the beginning of the room and observe that the media viewer navigate to the previous item and a snckbar is displayed.

## Tested devices

- [ ] Physical
- [x] Emulator using hack code to simulate the scenario above.
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
