### PR TITLE
Consider that the topic of a room has been removed when it's blank.

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/StateContentFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/StateContentFormatter.kt
@@ -63,7 +63,7 @@ class StateContentFormatter @Inject constructor(
                 }
             }
             is OtherState.RoomTopic -> {
-                val hasRoomTopic = content.topic != null
+                val hasRoomTopic = content.topic?.isNotBlank() == true
                 when {
                     senderIsYou && hasRoomTopic -> sp.getString(R.string.state_event_room_topic_changed_by_you, content.topic)
                     senderIsYou && !hasRoomTopic -> sp.getString(R.string.state_event_room_topic_removed_by_you)

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLastMessageFormatterTest.kt
@@ -662,6 +662,7 @@ class DefaultRoomLastMessageFormatterTest {
         val roomTopic = "New topic"
         val changedContent = StateContent("", OtherState.RoomTopic(roomTopic))
         val removedContent = StateContent("", OtherState.RoomTopic(null))
+        val blankContent = StateContent("", OtherState.RoomTopic(""))
 
         val youChangedRoomTopicEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = changedContent)
         val youChangedRoomTopic = formatter.format(youChangedRoomTopicEvent, false)
@@ -678,6 +679,14 @@ class DefaultRoomLastMessageFormatterTest {
         val someoneRemovedRoomTopicEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = removedContent)
         val someoneRemovedRoomTopic = formatter.format(someoneRemovedRoomTopicEvent, false)
         assertThat(someoneRemovedRoomTopic).isEqualTo("$otherName removed the room topic")
+
+        val youSetBlankRoomTopicEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = blankContent)
+        val youSetBlankRoomTopic = formatter.format(youSetBlankRoomTopicEvent, false)
+        assertThat(youSetBlankRoomTopic).isEqualTo("You removed the room topic")
+
+        val someoneSetBlankRoomTopicEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = blankContent)
+        val someoneSetBlankRoomTopic = formatter.format(someoneSetBlankRoomTopicEvent, false)
+        assertThat(someoneSetBlankRoomTopic).isEqualTo("$otherName removed the room topic")
     }
 
     @Test


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4206

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

<img width="379" alt="image" src="https://github.com/user-attachments/assets/6869cf63-e035-429b-9c2b-26f12ca2a8c6" />

## Tests

<!-- Explain how you tested your development -->

- In a room, set the topic to ""
- observe the rendering on the timeline.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
