### PR TITLE
Always display encryption badge

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsState.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsState.kt
@@ -48,12 +48,10 @@ data class RoomDetailsState(
     val eventSink: (RoomDetailsEvent) -> Unit
 ) {
     val roomBadges = buildList {
-        if (isEncrypted || isPublic) {
-            if (isEncrypted) {
-                add(RoomBadge.ENCRYPTED)
-            } else {
-                add(RoomBadge.NOT_ENCRYPTED)
-            }
+        if (isEncrypted) {
+            add(RoomBadge.ENCRYPTED)
+        } else {
+            add(RoomBadge.NOT_ENCRYPTED)
         }
         if (isPublic) {
             add(RoomBadge.PUBLIC)

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateTest.kt
@@ -13,12 +13,14 @@ import org.junit.Test
 
 class RoomDetailsStateTest {
     @Test
-    fun `room not public not encrypted should have no badges`() {
+    fun `room not public not encrypted should have not encrypted badge`() {
         val sut = aRoomDetailsState(
             isPublic = false,
             isEncrypted = false,
         )
-        assertThat(sut.roomBadges).isEmpty()
+        assertThat(sut.roomBadges).isEqualTo(
+            persistentListOf(RoomBadge.NOT_ENCRYPTED)
+        )
     }
 
     @Test

--- a/tests/uitests/src/test/snapshots/images/features.roomdetails.impl_RoomDetailsDark_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomdetails.impl_RoomDetailsDark_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1dd220efe1e2b30ebc14e10bb359b97a7be9c9d25c35e339ad74384a18150a2
-size 42675
+oid sha256:6fc7dc287c5da18ee2a7f8fdadf91285f6e9ed7a8328515cbfd6f90b21642794
+size 42190

--- a/tests/uitests/src/test/snapshots/images/features.roomdetails.impl_RoomDetails_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roomdetails.impl_RoomDetails_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c93a5ad4c336ea01f6f17ce17c6c933066c2298c587b3db9bf24eff48c286f4d
-size 44073
+oid sha256:787945a9d09f405aa8ae2efe88b40cf61b07e21b402e6d842723378ff7d0a001
+size 43242


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that the encryption badge are always displayed in the room detail screen, by removing the `isPublic` condition.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Parity with iOS and advertise the encryption status of the room explicitely.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open room detail screen of various room type and see that the encryption badge is always shown.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
