### PR TITLE
Use Sentry breadcrumbs instead of logging new events

### DIFF
--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
@@ -19,12 +19,16 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.services.analyticsproviders.api.AnalyticsProvider
 import io.element.android.services.analyticsproviders.sentry.log.analyticsTag
+import io.sentry.Breadcrumb
 import io.sentry.Sentry
-import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.android.core.SentryAndroid
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
+import kotlin.collections.orEmpty
 
 @ContributesMultibinding(AppScope::class)
 class SentryAnalyticsProvider @Inject constructor(
@@ -59,11 +63,23 @@ class SentryAnalyticsProvider @Inject constructor(
     }
 
     override fun capture(event: VectorAnalyticsEvent) {
-        Sentry.captureMessage("Event: ${event.getName()}", SentryLevel.INFO)
+        val breadcrumb = Breadcrumb(event.getName()).apply {
+            category = "event"
+            for ((key, value) in event.getProperties().orEmpty()) {
+                setData(key, value.toString())
+            }
+        }
+        Sentry.addBreadcrumb(breadcrumb)
     }
 
     override fun screen(screen: VectorAnalyticsScreen) {
-        Sentry.captureMessage("Screen: ${screen.getName()}", SentryLevel.INFO)
+        val breadcrumb = Breadcrumb(screen.getName()).apply {
+            category = "screen"
+            for ((key, value) in screen.getProperties().orEmpty()) {
+                setData(key, value.toString())
+            }
+        }
+        Sentry.addBreadcrumb(breadcrumb)
     }
 
     override fun updateUserProperties(userProperties: UserProperties) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When the analytics are enabled we are logging events and screens to have some context of the user's activity previous to a crash, use breadcrumbs instead of logging new events.

## Motivation and context

In https://github.com/element-hq/element-x-android/pull/4210 I added some extra event captures to have some useful context info besides stacktraces, but it turns out I used the wrong mechanism for this: breadcrumbs should be used, not messages, as these are logged as issues in Sentry instead, polluting our reports.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
