### PR TITLE
Fix nightly reports

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressPresenter.kt
@@ -99,7 +99,7 @@ class EditRoomAddressPresenter @AssistedInject constructor(
         suspend {
             val savedCanonicalAlias = room.canonicalAlias
             val savedAliasFromHomeserver = room.firstAliasMatching(serverName)
-            val newRoomAlias = client.roomAliasFromName(newRoomAddress).getOrThrow()
+            val newRoomAlias = client.roomAliasFromName(newRoomAddress) ?: throw IllegalArgumentException("Invalid room address")
 
             // First publish the new alias in the room directory
             room.publishRoomAliasInRoomDirectory(newRoomAlias).getOrThrow()

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/MatrixRoomFixture.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/MatrixRoomFixture.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails
+package io.element.android.features.roomdetails.impl
 
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.UserId

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
@@ -18,7 +18,6 @@ import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomState
 import io.element.android.features.leaveroom.api.aLeaveRoomState
 import io.element.android.features.roomcall.api.aStandByCallState
-import io.element.android.features.roomdetails.aMatrixRoom
 import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.features.userprofile.shared.aUserProfileState

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditPresenterTest.kt
@@ -5,14 +5,12 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.edit
+package io.element.android.features.roomdetails.impl.edit
 
 import android.net.Uri
 import app.cash.turbine.ReceiveTurbine
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.aMatrixRoom
-import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditEvents
-import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditPresenter
+import io.element.android.features.roomdetails.impl.aMatrixRoom
 import io.element.android.libraries.androidutils.file.TemporaryUriDeleter
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.mimetype.MimeTypes

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/edit/RoomDetailsEditViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.edit
+package io.element.android.features.roomdetails.impl.edit
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.StringRes
@@ -18,10 +18,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditEvents
-import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditState
-import io.element.android.features.roomdetails.impl.edit.RoomDetailsEditView
-import io.element.android.features.roomdetails.impl.edit.aRoomDetailsEditState
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.ui.media.AvatarAction
 import io.element.android.libraries.testtags.TestTags

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/invite/RoomInviteMembersPresenterTest.kt
@@ -11,7 +11,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.aMatrixRoom
+import io.element.android.features.roomdetails.impl.aMatrixRoom
 import io.element.android.features.roomdetails.impl.members.RoomMemberListDataSource
 import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.features.roomdetails.impl.members.aRoomMemberList

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/PowerLevelRoomMemberComparatorTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/PowerLevelRoomMemberComparatorTest.kt
@@ -5,10 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.members
+package io.element.android.features.roomdetails.impl.members
 
-import io.element.android.features.roomdetails.impl.members.PowerLevelRoomMemberComparator
-import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.A_USER_ID_2

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListPresenterTest.kt
@@ -5,19 +5,12 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.members
+package io.element.android.features.roomdetails.impl.members
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.impl.members.RoomMemberListDataSource
-import io.element.android.features.roomdetails.impl.members.RoomMemberListEvents
-import io.element.android.features.roomdetails.impl.members.RoomMemberListNavigator
-import io.element.android.features.roomdetails.impl.members.RoomMemberListPresenter
-import io.element.android.features.roomdetails.impl.members.aRoomMemberList
-import io.element.android.features.roomdetails.impl.members.aVictor
-import io.element.android.features.roomdetails.impl.members.aWalter
 import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationEvents
 import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationState
 import io.element.android.features.roomdetails.impl.members.moderation.aRoomMembersModerationState

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/details/RoomMemberDetailsPresenterTest.kt
@@ -5,15 +5,14 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.members.details
+package io.element.android.features.roomdetails.impl.members.details
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.aMatrixRoom
+import io.element.android.features.roomdetails.impl.aMatrixRoom
 import io.element.android.features.roomdetails.impl.members.aRoomMember
-import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.features.userprofile.api.UserProfilePresenterFactory
 import io.element.android.features.userprofile.shared.aUserProfileState
 import io.element.android.libraries.architecture.Presenter

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationPresenterTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.members.moderation
+package io.element.android.features.roomdetails.impl.members.moderation
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
@@ -14,10 +14,6 @@ import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
 import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.features.roomdetails.impl.members.aVictor
-import io.element.android.features.roomdetails.impl.members.moderation.ConfirmingRoomMemberAction
-import io.element.android.features.roomdetails.impl.members.moderation.ModerationAction
-import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationEvents
-import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationPresenter
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.room.MatrixRoomMembersState

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/members/moderation/RoomMembersModerationViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.members.moderation
+package io.element.android.features.roomdetails.impl.members.moderation
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -13,12 +13,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.roomdetails.impl.R
 import io.element.android.features.roomdetails.impl.members.anAlice
-import io.element.android.features.roomdetails.impl.members.moderation.ConfirmingRoomMemberAction
-import io.element.android.features.roomdetails.impl.members.moderation.ModerationAction
-import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationEvents
-import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationState
-import io.element.android.features.roomdetails.impl.members.moderation.RoomMembersModerationView
-import io.element.android.features.roomdetails.impl.members.moderation.aRoomMembersModerationState
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.ui.strings.CommonStrings

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsPresenterTest.kt
@@ -5,15 +5,13 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.notificationsettings
+package io.element.android.features.roomdetails.impl.notificationsettings
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.aMatrixRoom
-import io.element.android.features.roomdetails.impl.notificationsettings.RoomNotificationSettingsEvents
-import io.element.android.features.roomdetails.impl.notificationsettings.RoomNotificationSettingsPresenter
+import io.element.android.features.roomdetails.impl.aMatrixRoom
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_THROWABLE

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionPresenterTest.kt
@@ -5,15 +5,13 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions
+package io.element.android.features.roomdetails.impl.rolesandpermissions
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsEvents
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsPresenter
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.room.RoomMember

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsViewTest.kt
@@ -5,18 +5,13 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions
+package io.element.android.features.roomdetails.impl.rolesandpermissions
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.roomdetails.impl.R
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsEvents
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsNavigator
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsState
-import io.element.android.features.roomdetails.impl.rolesandpermissions.RolesAndPermissionsView
-import io.element.android.features.roomdetails.impl.rolesandpermissions.aRolesAndPermissionsState
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.ui.strings.CommonStrings

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenterTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions.changeroles
+package io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
@@ -13,8 +13,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
 import io.element.android.features.roomdetails.impl.members.aRoomMemberList
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.ChangeRolesEvent
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.ChangeRolesPresenter
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions.changeroles
+package io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -16,11 +16,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.ChangeRolesEvent
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.ChangeRolesState
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.ChangeRolesView
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.aChangeRolesState
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.aChangeRolesStateWithSelectedUsers
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.room.RoomMember
@@ -39,7 +34,6 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.lang.IllegalStateException
 
 @RunWith(AndroidJUnit4::class)
 class ChangeRolesViewTest {

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/MembersByRoleTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/MembersByRoleTest.kt
@@ -5,10 +5,9 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions.changeroles
+package io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.impl.rolesandpermissions.changeroles.MembersByRole
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.A_USER_ID_2

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsPresenterTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions.permissions
+package io.element.android.features.roomdetails.impl.rolesandpermissions.permissions
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
@@ -14,11 +14,6 @@ import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsEvent
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsPresenter
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsSection
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsState
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.RoomPermissionType
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.room.RoomMember.Role.ADMIN
 import io.element.android.libraries.matrix.api.room.RoomMember.Role.MODERATOR

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.rolesandpermissions.permissions
+package io.element.android.features.roomdetails.impl.rolesandpermissions.permissions
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -15,12 +15,6 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.roomdetails.impl.R
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsEvent
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsSection
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsState
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.ChangeRoomPermissionsView
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.RoomPermissionType
-import io.element.android.features.roomdetails.impl.rolesandpermissions.permissions.aChangeRoomPermissionsState
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.ui.strings.CommonStrings

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/FakeSecurityAndPrivacyNavigator.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/FakeSecurityAndPrivacyNavigator.kt
@@ -5,9 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.securityandprivacy
+package io.element.android.features.roomdetails.impl.securityandprivacy
 
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyNavigator
 import io.element.android.tests.testutils.lambda.lambdaError
 
 class FakeSecurityAndPrivacyNavigator(

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/SecurityAndPrivacyPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/SecurityAndPrivacyPresenterTest.kt
@@ -5,14 +5,9 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.securityandprivacy
+package io.element.android.features.roomdetails.impl.securityandprivacy
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyEvents
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyHistoryVisibility
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyNavigator
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyPresenter
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyRoomAccess
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.room.MatrixRoom

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/SecurityAndPrivacyViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/SecurityAndPrivacyViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.securityandprivacy
+package io.element.android.features.roomdetails.impl.securityandprivacy
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -14,13 +14,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.roomdetails.impl.R
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyEvents
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyHistoryVisibility
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyRoomAccess
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyState
-import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyView
-import io.element.android.features.roomdetails.impl.securityandprivacy.aSecurityAndPrivacySettings
-import io.element.android.features.roomdetails.impl.securityandprivacy.aSecurityAndPrivacyState
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.tests.testutils.EnsureNeverCalled

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressPresenterTest.kt
@@ -5,13 +5,11 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.securityandprivacy.editroomaddress
+package io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress
 
 import com.google.common.truth.Truth.assertThat
+import io.element.android.features.roomdetails.impl.securityandprivacy.FakeSecurityAndPrivacyNavigator
 import io.element.android.features.roomdetails.impl.securityandprivacy.SecurityAndPrivacyNavigator
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.EditRoomAddressEvents
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.EditRoomAddressPresenter
-import io.element.android.features.roomdetails.securityandprivacy.FakeSecurityAndPrivacyNavigator
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.room.MatrixRoom

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/securityandprivacy/editroomaddress/EditRoomAddressViewTest.kt
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-package io.element.android.features.roomdetails.securityandprivacy.editroomaddress
+package io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -13,10 +13,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.EditRoomAddressEvents
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.EditRoomAddressState
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.EditRoomAddressView
-import io.element.android.features.roomdetails.impl.securityandprivacy.editroomaddress.anEditRoomAddressState
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.ui.room.address.RoomAddressValidity
 import io.element.android.libraries.testtags.TestTags

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -7,7 +7,9 @@
 
 package io.element.android.libraries.matrix.api
 
+import io.element.android.libraries.core.data.tryOrNull
 import io.element.android.libraries.matrix.api.core.DeviceId
+import io.element.android.libraries.matrix.api.core.MatrixPatterns
 import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -172,11 +174,12 @@ fun MatrixClient.getRoomInfoFlow(roomIdOrAlias: RoomIdOrAlias): Flow<Optional<Ma
 }
 
 /**
- * Returns a room alias from a room alias name.
+ * Returns a room alias from a room alias name, or null if the name is not valid.
  * @param name the room alias name ie. the local part of the room alias.
  */
-fun MatrixClient.roomAliasFromName(name: String): Result<RoomAlias> {
-    return runCatching {
-        RoomAlias("#$name:${userIdServerName()}")
-    }
+fun MatrixClient.roomAliasFromName(name: String): RoomAlias? {
+    return name.takeIf { it.isNotEmpty() }
+        ?.let { "#$it:${userIdServerName()}" }
+        ?.takeIf { MatrixPatterns.isRoomAlias(it) }
+        ?.let { tryOrNull { RoomAlias(it) } }
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/address/RoomAddressValidityEffect.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/address/RoomAddressValidityEffect.kt
@@ -32,7 +32,7 @@ fun RoomAddressValidityEffect(
         }
         // debounce the room address validation
         delay(300)
-        val roomAlias = client.roomAliasFromName(newRoomAddress).getOrNull()
+        val roomAlias = client.roomAliasFromName(newRoomAddress)
         if (roomAlias == null || !roomAliasHelper.isRoomAliasValid(roomAlias)) {
             onChange(RoomAddressValidity.InvalidSymbols)
         } else {


### PR DESCRIPTION
First commit is just moving test classes to the correct package.

Second commit fix the test in release mode: `./gradlew :features:roomdetails:impl:testReleaseUnitTest` was failing before this change because RoomAlias does not fail in release mode when the room alias is invalid.