### PR TITLE
SyncOrchestrator: restore the initial sync step

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
@@ -92,7 +92,7 @@ class SyncOrchestrator @AssistedInject constructor(
             Timber.tag(tag).d("isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable")
             if (syncState == SyncState.Running && !isAppActive) {
                 SyncStateAction.StopSync
-            } else if (syncState != SyncState.Running && isAppActive && isNetworkAvailable) {
+            } else if (syncState == SyncState.Idle && isAppActive && isNetworkAvailable) {
                 SyncStateAction.StartSync
             } else {
                 SyncStateAction.NoOp

--- a/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.appnav.di
 
+import androidx.annotation.VisibleForTesting
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -21,6 +22,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -51,15 +53,8 @@ class SyncOrchestrator @AssistedInject constructor(
      * Starting observing the app state and network state to start/stop the sync service.
      *
      * Before observing the state, a first attempt at starting the sync service will happen if it's not already running.
-     *
-     * @param performInitialSync If `true`, the initial sync will be performed before starting observing the state. This is the default behaviour.
-     *
-     * **IMPORTANT: this should only be `false` in tests.**
      */
-    @OptIn(FlowPreview::class)
-    fun start(
-        performInitialSync: Boolean = true,
-    ) {
+    fun start() {
         if (!started.compareAndSet(false, true)) {
             Timber.tag(tag).d("already started, exiting early")
             return
@@ -68,53 +63,60 @@ class SyncOrchestrator @AssistedInject constructor(
         coroutineScope.launch {
             // Perform an initial sync if the sync service is not running, to check whether the homeserver is accessible
             // Otherwise, if the device is offline the sync service will never start and the SyncState will be Idle, not Offline
-            if (performInitialSync) {
-                Timber.tag(tag).d("performing initial sync attempt")
-                syncService.startSync()
-            }
+            Timber.tag(tag).d("performing initial sync attempt")
+            syncService.startSync()
 
-            Timber.tag(tag).d("start observing the app and network state")
+            // Wait until the sync service is not idle, either it will be running or in error/offline state
+            syncService.syncState.first { it != SyncState.Idle }
 
-            combine(
-                // small debounce to avoid spamming startSync when the state is changing quickly in case of error.
-                syncService.syncState.debounce(100.milliseconds),
-                networkMonitor.connectivity,
-                appForegroundStateService.isInForeground,
-                appForegroundStateService.isInCall,
-                appForegroundStateService.isSyncingNotificationEvent,
-            ) { syncState, networkState, isInForeground, isInCall, isSyncingNotificationEvent ->
-                val isAppActive = isInForeground || isInCall || isSyncingNotificationEvent
-                val isNetworkAvailable = networkState == NetworkStatus.Connected
-
-                Timber.tag(tag).d("isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable")
-                if (syncState == SyncState.Running && !isAppActive) {
-                    SyncStateAction.StopSync
-                } else if (syncState != SyncState.Running && isAppActive && isNetworkAvailable) {
-                    SyncStateAction.StartSync
-                } else {
-                    SyncStateAction.NoOp
-                }
-            }
-                .distinctUntilChanged()
-                .debounce { action ->
-                    // Don't stop the sync immediately, wait a bit to avoid starting/stopping the sync too often
-                    if (action == SyncStateAction.StopSync) 3.seconds else 0.seconds
-                }
-                .onCompletion {
-                    Timber.tag(tag).d("has been stopped")
-                }
-                .collect { action ->
-                    when (action) {
-                        SyncStateAction.StartSync -> {
-                            syncService.startSync()
-                        }
-                        SyncStateAction.StopSync -> {
-                            syncService.stopSync()
-                        }
-                        SyncStateAction.NoOp -> Unit
-                    }
-                }
+            observeStates()
         }
+    }
+
+    @OptIn(FlowPreview::class)
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun observeStates() = coroutineScope.launch {
+        Timber.tag(tag).d("start observing the app and network state")
+
+        combine(
+            // small debounce to avoid spamming startSync when the state is changing quickly in case of error.
+            syncService.syncState.debounce(100.milliseconds),
+            networkMonitor.connectivity,
+            appForegroundStateService.isInForeground,
+            appForegroundStateService.isInCall,
+            appForegroundStateService.isSyncingNotificationEvent,
+        ) { syncState, networkState, isInForeground, isInCall, isSyncingNotificationEvent ->
+            val isAppActive = isInForeground || isInCall || isSyncingNotificationEvent
+            val isNetworkAvailable = networkState == NetworkStatus.Connected
+
+            Timber.tag(tag).d("isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable")
+            if (syncState == SyncState.Running && !isAppActive) {
+                SyncStateAction.StopSync
+            } else if (syncState != SyncState.Running && isAppActive && isNetworkAvailable) {
+                SyncStateAction.StartSync
+            } else {
+                SyncStateAction.NoOp
+            }
+        }
+            .distinctUntilChanged()
+            .debounce { action ->
+                // Don't stop the sync immediately, wait a bit to avoid starting/stopping the sync too often
+                if (action == SyncStateAction.StopSync) 3.seconds else 0.seconds
+            }
+            .onCompletion {
+                Timber.tag(tag).d("has been stopped")
+            }
+            .collect { action ->
+                when (action) {
+                    SyncStateAction.StartSync -> {
+                        syncService.startSync()
+                    }
+                    SyncStateAction.StopSync -> {
+                        syncService.stopSync()
+                    }
+                    SyncStateAction.NoOp -> Unit
+                }
+            }
     }
 }
 

--- a/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
@@ -44,7 +44,27 @@ class SyncOrchestratorTest {
         )
 
         // We start observing with an initial sync
-        syncOrchestrator.start(performInitialSync = true)
+        syncOrchestrator.start()
+
+        // Advance the time just enough to make sure the initial sync has run
+        advanceTimeBy(1.milliseconds)
+        startSyncRecorder.assertions().isCalledOnce()
+    }
+
+    @Test
+    fun `when the sync wasn't running before, an initial sync will take place`() = runTest {
+        val startSyncRecorder = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val syncService = FakeSyncService(initialSyncState = SyncState.Idle).apply {
+            startSyncLambda = startSyncRecorder
+        }
+        val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
+        val syncOrchestrator = createSyncOrchestrator(
+            syncService = syncService,
+            networkMonitor = networkMonitor,
+        )
+
+        // We start observing with an initial sync
+        syncOrchestrator.start()
 
         // Advance the time just enough to make sure the initial sync has run
         advanceTimeBy(1.milliseconds)
@@ -70,7 +90,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -102,7 +122,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -150,7 +170,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -193,7 +213,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -237,7 +257,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -280,7 +300,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // Advance the time to make sure the orchestrator has had time to start processing the inputs
         advanceTimeBy(100.milliseconds)
@@ -309,7 +329,7 @@ class SyncOrchestratorTest {
         )
 
         // We start observing
-        syncOrchestrator.start(performInitialSync = false)
+        syncOrchestrator.observeStates()
 
         // This should still not trigger a sync, since there is no network
         advanceTimeBy(10.seconds)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Restore the initial sync in the `SyncOrchestrator.start()` method. However, this is now split into a private `observeStates` method, that purely observers the different app states that lead to starting/stopping the sync service, and the `start` one that has the initial sync too. This allows us to test both behaviours separately, as well has writing tests for the transition between them.

## Motivation and context

Without this initial sync, the `SyncState` will be `Idle`, which means 'not started', not 'offline', so some UI didn't react accordingly (the `ConnectivityIndicatorView`, i.e.), giving the false impression of the app having network connectivity when it was started *without* network connectivity. If we do a initial sync, it'll fail and return `SyncState.Offline`, which will be correctly represented in the UI.

## Tests

<!-- Explain how you tested your development -->

- Start the app with no network connectivity.
- The offline indicator should be displayed.
- Everything else should keep working as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
