### PR TITLE
Use the frame at 1us pos in videos for generating a thumbnail

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ThumbnailFactory.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ThumbnailFactory.kt
@@ -47,8 +47,9 @@ private const val THUMB_MAX_HEIGHT = 600
 
 /**
  * Frame of the video to be used for generating a thumbnail.
+ * It should be at least 1µs to avoid issues with some video files
  */
-private const val VIDEO_THUMB_FRAME = 0L
+private const val VIDEO_THUMB_FRAME = 1L
 
 class ThumbnailFactory @Inject constructor(
     @ApplicationContext private val context: Context,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Using the 1us mark should help  fix this issue.

## Motivation and context

Using '0' apparently caused the feature to fail with some specific videos with:

> IllegalStateException: Timestamps must be monotonically increasing: 0, 0

## Tests

I'm not sure which video formats cause this to be honest, I saw some mentions of MP4 files but those were working fine for me, maybe it's some codec that causes the issue.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
