### PR TITLE
When transcoding a video fails, send it as a file

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -188,13 +188,17 @@ class AndroidMediaPreProcessor @Inject constructor(
     }
 
     private suspend fun processVideo(uri: Uri, mimeType: String?, shouldBeCompressed: Boolean): MediaUploadInfo {
-        val resultFile = videoCompressor.compress(uri, shouldBeCompressed)
-            .onEach {
-                // TODO handle progress
-            }
-            .filterIsInstance<VideoTranscodingEvent.Completed>()
-            .first()
-            .file
+        val resultFile = runCatching {
+            videoCompressor.compress(uri, shouldBeCompressed)
+                .onEach {
+                    // TODO handle progress
+                }
+                .filterIsInstance<VideoTranscodingEvent.Completed>()
+                .first()
+                .file
+        }
+            // If the video could not be compressed, just copy use the original one by copying to a temporary file
+            .getOrNull() ?: copyToTmpFile(uri)
         val thumbnailInfo = thumbnailFactory.createVideoThumbnail(resultFile)
         val videoInfo = extractVideoMetadata(resultFile, mimeType, thumbnailInfo)
         return MediaUploadInfo.Video(

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -209,7 +209,7 @@ class AndroidMediaPreProcessor @Inject constructor(
             )
         } else {
             // If the video could not be compressed, just use the original one, but send it as a file
-            return processFile(uri, mimeType ?: MimeTypes.OctetStream)
+            return processFile(uri, MimeTypes.OctetStream)
         }
     }
 

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -197,15 +197,20 @@ class AndroidMediaPreProcessor @Inject constructor(
                 .first()
                 .file
         }
-            // If the video could not be compressed, just copy use the original one by copying to a temporary file
-            .getOrNull() ?: copyToTmpFile(uri)
-        val thumbnailInfo = thumbnailFactory.createVideoThumbnail(resultFile)
-        val videoInfo = extractVideoMetadata(resultFile, mimeType, thumbnailInfo)
-        return MediaUploadInfo.Video(
-            file = resultFile,
-            videoInfo = videoInfo,
-            thumbnailFile = thumbnailInfo?.file
-        )
+            .getOrNull()
+
+        if (resultFile != null) {
+            val thumbnailInfo = thumbnailFactory.createVideoThumbnail(resultFile)
+            val videoInfo = extractVideoMetadata(resultFile, mimeType, thumbnailInfo)
+            return MediaUploadInfo.Video(
+                file = resultFile,
+                videoInfo = videoInfo,
+                thumbnailFile = thumbnailInfo?.file
+            )
+        } else {
+            // If the video could not be compressed, just use the original one, but send it as a file
+            return processFile(uri, mimeType ?: MimeTypes.OctetStream)
+        }
     }
 
     private suspend fun processAudio(uri: Uri, mimeType: String?): MediaUploadInfo {

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
@@ -16,6 +16,8 @@ import com.otaliastudios.transcoder.TranscoderListener
 import com.otaliastudios.transcoder.internal.media.MediaFormatConstants
 import com.otaliastudios.transcoder.resize.AtMostResizer
 import com.otaliastudios.transcoder.strategy.DefaultVideoStrategy
+import com.otaliastudios.transcoder.strategy.PassThroughTrackStrategy
+import com.otaliastudios.transcoder.validator.WriteAlwaysValidator
 import io.element.android.libraries.androidutils.file.createTmpFile
 import io.element.android.libraries.androidutils.file.getMimeType
 import io.element.android.libraries.androidutils.file.safeDelete
@@ -40,7 +42,11 @@ class VideoCompressor @Inject constructor(
     }
 
     fun compress(uri: Uri, shouldBeCompressed: Boolean) = callbackFlow {
-        val (width, height) = getVideoDimensions(uri) ?: (Int.MAX_VALUE to Int.MAX_VALUE)
+        val metadata = getVideoMetadata(uri)
+        val width = metadata?.width ?: Int.MAX_VALUE
+        val height = metadata?.height ?: Int.MAX_VALUE
+        val bitrate = metadata?.bitrate
+        val frameRate = metadata?.frameRate
 
         // We only create a resizer if needed
         val resizer = when {
@@ -53,77 +59,90 @@ class VideoCompressor @Inject constructor(
 
         val tmpFile = context.createTmpFile(extension = MP4_EXTENSION)
 
-        // If there's no transcoding needed for the video file, just copy it to the tmp file and return it
-        val future = if (expectedExtension == MP4_EXTENSION && resizer == null) {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                tmpFile.outputStream().use { output ->
-                    input.copyTo(output)
-                }
-            }
-            trySend(VideoTranscodingEvent.Completed(tmpFile))
-            close()
-            null
+        val videoStrategy = if (resizer == null && expectedExtension == MP4_EXTENSION) {
+            // If there's no transcoding or resizing needed for the video file, just create a new file with the same contents but no metadata
+            PassThroughTrackStrategy()
         } else {
-            Transcoder.into(tmpFile.path)
-                .setVideoTrackStrategy(
-                    DefaultVideoStrategy.Builder()
-                        .apply {
-                            resizer?.let { addResizer(it) }
-                        }
-                        .mimeType(MediaFormatConstants.MIMETYPE_VIDEO_AVC)
-                        .build()
-                )
-                .addDataSource(context, uri)
-                .setListener(object : TranscoderListener {
-                    override fun onTranscodeProgress(progress: Double) {
-                        trySend(VideoTranscodingEvent.Progress(progress.toFloat()))
-                    }
-
-                    override fun onTranscodeCompleted(successCode: Int) {
-                        trySend(VideoTranscodingEvent.Completed(tmpFile))
-                        close()
-                    }
-
-                    override fun onTranscodeCanceled() {
-                        tmpFile.safeDelete()
-                        close()
-                    }
-
-                    override fun onTranscodeFailed(exception: Throwable) {
-                        tmpFile.safeDelete()
-                        close(exception)
-                    }
-                })
-                .transcode()
+            DefaultVideoStrategy.Builder()
+                .apply {
+                    resizer?.let { addResizer(it) }
+                    bitrate?.let { bitRate(it) }
+                    frameRate?.let { frameRate(it) }
+                }
+                .mimeType(MediaFormatConstants.MIMETYPE_VIDEO_AVC)
+                .build()
         }
 
+        val future = Transcoder.into(tmpFile.path)
+            .setVideoTrackStrategy(videoStrategy)
+            .addDataSource(context, uri)
+            // Force the output to be written, even if no transcoding was actually needed
+            .setValidator(WriteAlwaysValidator())
+            .setListener(object : TranscoderListener {
+                override fun onTranscodeProgress(progress: Double) {
+                    trySend(VideoTranscodingEvent.Progress(progress.toFloat()))
+                }
+
+                override fun onTranscodeCompleted(successCode: Int) {
+                    trySend(VideoTranscodingEvent.Completed(tmpFile))
+                    close()
+                }
+
+                override fun onTranscodeCanceled() {
+                    tmpFile.safeDelete()
+                    close()
+                }
+
+                override fun onTranscodeFailed(exception: Throwable) {
+                    tmpFile.safeDelete()
+                    close(exception)
+                }
+            })
+            .transcode()
+
         awaitClose {
-            if (future?.isDone == false) {
+            if (!future.isDone) {
                 future.cancel(true)
             }
         }
     }
 
-    private fun getVideoDimensions(uri: Uri): Pair<Int, Int>? {
+    private fun getVideoMetadata(uri: Uri): VideoFileMetadata? {
         return runCatching {
             MediaMetadataRetriever().use {
                 it.setDataSource(context, uri)
 
                 val width = it.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: -1
                 val height = it.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: -1
+                val bitrate = it.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toLongOrNull() ?: -1
+                val framerate = it.extractMetadata(MediaMetadataRetriever.METADATA_KEY_CAPTURE_FRAMERATE)?.toIntOrNull() ?: -1
 
-                if (width == -1 || height == -1) {
+                val (actualWidth, actualHeight) = if (width == -1 || height == -1) {
                     // Try getting the first frame instead
                     val bitmap = it.getFrameAtTime(0) ?: return null
                     bitmap.width to bitmap.height
                 } else {
                     width to height
                 }
+
+                VideoFileMetadata(
+                    width = actualWidth,
+                    height = actualHeight,
+                    bitrate = bitrate,
+                    frameRate = framerate
+                )
             }
         }.onFailure {
             Timber.e(it, "Failed to get video dimensions")
         }.getOrNull()
     }
+
+    private data class VideoFileMetadata(
+        val width: Int?,
+        val height: Int?,
+        val bitrate: Long?,
+        val frameRate: Int?,
+    )
 }
 
 sealed interface VideoTranscodingEvent {

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
@@ -31,14 +31,21 @@ class VideoCompressor @Inject constructor(
 ) {
     companion object {
         private const val MP4_EXTENSION = "mp4"
+
+        // 720p
+        private const val MAX_COMPRESSED_PIXEL_SIZE = 1280
+
+        // 1080p
+        private const val MAX_PIXEL_SIZE = 1920
     }
 
     fun compress(uri: Uri, shouldBeCompressed: Boolean) = callbackFlow {
         val (width, height) = getVideoDimensions(uri) ?: (Int.MAX_VALUE to Int.MAX_VALUE)
 
+        // We only create a resizer if needed
         val resizer = when {
-            shouldBeCompressed && (width > 720 || height > 720) -> AtMostResizer(720)
-            width > 1080 || height > 1080 -> AtMostResizer(1080)
+            shouldBeCompressed && (width > MAX_COMPRESSED_PIXEL_SIZE || height > MAX_COMPRESSED_PIXEL_SIZE) -> AtMostResizer(MAX_COMPRESSED_PIXEL_SIZE)
+            width > MAX_PIXEL_SIZE || height > MAX_PIXEL_SIZE -> AtMostResizer(MAX_PIXEL_SIZE)
             else -> null
         }
 

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoStrategyFactoryTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoStrategyFactoryTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.mediaupload.impl
+
+import com.otaliastudios.transcoder.strategy.DefaultVideoStrategy
+import com.otaliastudios.transcoder.strategy.PassThroughTrackStrategy
+import com.otaliastudios.transcoder.strategy.TrackStrategy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@Suppress("NOTHING_TO_INLINE")
+@RunWith(RobolectricTestRunner::class)
+class VideoStrategyFactoryTest {
+    @Test
+    fun `if we don't have metadata the video will be transcoded just in case`() {
+        // Given
+        val expectedExtension = "mp4"
+        val metadata = null
+        val shouldBeCompressed = true
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should be compressed and is larger than 720p it will be transcoded`() {
+        // Given
+        val expectedExtension = "mp4"
+        val metadata = VideoFileMetadata(width = 1920, height = 1080, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = true
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should be compressed, has the right format and is smaller or equal to 720p it will not be transcoded`() {
+        // Given
+        val expectedExtension = "mp4"
+        val metadata = VideoFileMetadata(width = 1280, height = 720, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = true
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsNotTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should not be compressed and is larger than 1080p it will be transcoded`() {
+        // Given
+        val expectedExtension = "mp4"
+        val metadata = VideoFileMetadata(width = 2560, height = 1440, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = false
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should not be compressed, has the right format and is smaller or equal than 1080p it will not be transcoded`() {
+        // Given
+        val expectedExtension = "mp4"
+        val metadata = VideoFileMetadata(width = 1920, height = 1080, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = false
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsNotTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should not be compressed but has a wrong format it will be transcoded`() {
+        // Given
+        val expectedExtension = "mkv"
+        val metadata = VideoFileMetadata(width = 320, height = 240, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = false
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsTranscoded(videoStrategy)
+    }
+
+    @Test
+    fun `if the video should be compressed and has a wrong format it will be transcoded`() {
+        // Given
+        val expectedExtension = "mkv"
+        val metadata = VideoFileMetadata(width = 320, height = 240, bitrate = 1_000_000, frameRate = 50)
+        val shouldBeCompressed = true
+
+        // When
+        val videoStrategy = VideoStrategyFactory.create(
+            expectedExtension = expectedExtension,
+            metadata = metadata,
+            shouldBeCompressed = shouldBeCompressed
+        )
+
+        // Then
+        assertIsTranscoded(videoStrategy)
+    }
+
+    private inline fun assertIsTranscoded(videoStrategy: TrackStrategy) {
+        assert(videoStrategy is DefaultVideoStrategy)
+    }
+
+    private inline fun assertIsNotTranscoded(videoStrategy: TrackStrategy) {
+        assert(videoStrategy is PassThroughTrackStrategy)
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Changes:

- Make sure the 'at most' video dimensions are 1080p for non-compressed media and 720p for compressed media, matching iOS.
- Try avoiding transcoding when possible, and when it's not try matching as much properties of the original video as possible.
- If transcoding fails, send the original video as a file.

While reviewing you might want to skip/not thoroughly review commit 64ba34c12355745991a3b04f9398aa2bf8466565 since it's reworked shortly after.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4243, or at least adds a workaround.

## Tests

I was able to make the transcoding fail with [this video](https://drive.google.com/file/d/1cgJ7hVYNQP1AT5pkbQjRRHCVaCYTOCbx/view?usp=sharing) in a Xiaomi Mi 9T with Android 14.

- Try sending the video as an attachment in some room. Processing and transcoding the video will fail.
- Send the video. It will be sent as is, without a thumbnail, but it should still be playable on the other side. For some reason it's send as an `m.video` message instead of a `m.file` one, but it seems like this might need to be changed in the SDK.
- Try some other MP4 video, larger than 1080p if you have disabled media optimisation or 720p if it's enabled, the video will be resized.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
