### PR TITLE
When an emoji is used as the 'initial' for an avatar, use the whole emoji

### DIFF
--- a/libraries/designsystem/build.gradle.kts
+++ b/libraries/designsystem/build.gradle.kts
@@ -33,6 +33,7 @@ android {
         implementation(libs.vanniktech.blurhash)
         implementation(projects.features.enterprise.api)
         implementation(projects.libraries.architecture)
+        implementation(projects.libraries.core)
         implementation(projects.libraries.preferences.api)
         implementation(projects.libraries.testtags)
         implementation(projects.libraries.uiStrings)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.designsystem.components.avatar
 
 import androidx.compose.runtime.Immutable
+import io.element.android.libraries.core.data.tryOrNull
 import java.text.BreakIterator
 
 @Immutable
@@ -47,7 +48,8 @@ data class AvatarData(
 
                 val fullCharacterIterator = BreakIterator.getCharacterInstance()
                 fullCharacterIterator.setText(dn)
-                val glyphBoundary = runCatching { fullCharacterIterator.following(startIndex).takeIf { it in startIndex until dn.length } }.getOrNull()
+                val glyphBoundary = tryOrNull { fullCharacterIterator.following(startIndex) }
+                    ?.takeIf { it in startIndex until dn.length }
 
                 when {
                     // Use the found boundary

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
@@ -47,9 +47,16 @@ data class AvatarData(
 
                 val fullCharacterIterator = BreakIterator.getCharacterInstance()
                 fullCharacterIterator.setText(dn)
-                val glyphBoundary = fullCharacterIterator.following(startIndex)
+                val glyphBoundary = runCatching { fullCharacterIterator.following(startIndex).takeIf { it in startIndex until dn.length } }.getOrNull()
 
-                dn.substring(startIndex, glyphBoundary)
+                when {
+                    // Use the found boundary
+                    glyphBoundary != null -> dn.substring(startIndex, glyphBoundary)
+                    // If no boundary was found, default to the next char if possible
+                    startIndex + 1 < dn.length -> dn.substring(startIndex, startIndex + 1)
+                    // Return a fallback character otherwise
+                    else -> "#"
+                }
             }
             .uppercase()
     }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
@@ -49,7 +49,7 @@ data class AvatarData(
                 val fullCharacterIterator = BreakIterator.getCharacterInstance()
                 fullCharacterIterator.setText(dn)
                 val glyphBoundary = tryOrNull { fullCharacterIterator.following(startIndex) }
-                    ?.takeIf { it in startIndex until dn.length }
+                    ?.takeIf { it in startIndex..dn.length }
 
                 when {
                     // Use the found boundary

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarData.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.designsystem.components.avatar
 
 import androidx.compose.runtime.Immutable
+import java.text.BreakIterator
 
 @Immutable
 data class AvatarData(
@@ -27,7 +28,6 @@ data class AvatarData(
                     startIndex++
                 }
 
-                var length = 1
                 var next = dn[startIndex]
 
                 // LEFT-TO-RIGHT MARK
@@ -45,17 +45,11 @@ data class AvatarData(
                     }
                 }
 
-                // check if it’s the start of a surrogate pair
-                while (isPartOfEmoji(next) && dn.length > startIndex + length) {
-                    length++
-                    if (dn.length > startIndex + length + 1) {
-                        next = dn[startIndex + length]
-                    } else {
-                        break
-                    }
-                }
+                val fullCharacterIterator = BreakIterator.getCharacterInstance()
+                fullCharacterIterator.setText(dn)
+                val glyphBoundary = fullCharacterIterator.following(startIndex)
 
-                dn.substring(startIndex, startIndex + length)
+                dn.substring(startIndex, glyphBoundary)
             }
             .uppercase()
     }
@@ -63,12 +57,4 @@ data class AvatarData(
 
 fun AvatarData.getBestName(): String {
     return name?.takeIf { it.isNotEmpty() } ?: id
-}
-
-private fun isPartOfEmoji(char: Char): Boolean {
-    val isHighSurrogate = char.code in 0xD800..0xDBFF
-    val isLowSurrogate = char.code in 0xDC00..0xDFFF
-    val isVariantSelector = char.code in 0xFE00..0xFE0F
-    val isZeroWidthJoin = char.code == 0x200D
-    return isHighSurrogate || isLowSurrogate || isVariantSelector || isZeroWidthJoin
 }

--- a/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
+++ b/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
@@ -30,7 +30,7 @@ class AvatarDataTest {
     }
 
     @Test
-    fun `initial with short emoji should get the full emoji`() {
+    fun `initial with short emoji should get the emoji`() {
         val data = AvatarData("id", "✂ Test", null, AvatarSize.InviteSender)
         assertThat(data.initial).isEqualTo("✂")
     }

--- a/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
+++ b/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.designsystem.components.avatar
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AvatarDataTest {
+    @Test
+    fun `initial with text should get the first char, uppercased`() {
+        val data = AvatarData("id", "test", null, AvatarSize.InviteSender)
+        assertThat(data.initial).isEqualTo("T")
+    }
+
+    @Test
+    fun `initial with leading whitespace should get the first non-whitespace char, uppercased`() {
+        val data = AvatarData("id", " test", null, AvatarSize.InviteSender)
+        assertThat(data.initial).isEqualTo("T")
+    }
+
+    @Test
+    fun `initial with long emoji should get the full emoji`() {
+        val data = AvatarData("id", "\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08 Test", null, AvatarSize.InviteSender)
+        assertThat(data.initial).isEqualTo("\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08")
+    }
+
+    @Test
+    fun `initial with short emoji should get the full emoji`() {
+        val data = AvatarData("id", "✂ Test", null, AvatarSize.InviteSender)
+        assertThat(data.initial).isEqualTo("✂")
+    }
+}

--- a/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
+++ b/libraries/designsystem/src/test/kotlin/io/element/android/libraries/designsystem/components/avatar/AvatarDataTest.kt
@@ -34,4 +34,10 @@ class AvatarDataTest {
         val data = AvatarData("id", "✂ Test", null, AvatarSize.InviteSender)
         assertThat(data.initial).isEqualTo("✂")
     }
+
+    @Test
+    fun `initial with a single letter should take that letter`() {
+        val data = AvatarData("id", "T", null, AvatarSize.InviteSender)
+        assertThat(data.initial).isEqualTo("T")
+    }
 }


### PR DESCRIPTION
## Content

When an 'initials avatar' is generated for a user or room based on either its name or id and it begins with an emoji, make sure we retrieve the whole emoji as the char to display in the avatar.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4260.

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="142" alt="image" src="https://github.com/user-attachments/assets/54cea448-29c2-44f0-b0c8-341c3f67971e" />|<img width="136" alt="image" src="https://github.com/user-attachments/assets/8a8adf1a-e0be-4e91-97a9-af00c12ce4db" />|

## Tests

- Create a room with a complex emoji, such as the flag of some country/group, or an emoji with some skin tone or gender, as the first character in its name, and no avatar image.
- Check the generated 'initials' avatar is using the right emoji.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
