### PR TITLE
Use external app for OIDC fallback instead of webview

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/LoginFlowNode.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/LoginFlowNode.kt
@@ -139,8 +139,9 @@ class LoginFlowNode @AssistedInject constructor(
                                 oidcEntryPoint.openUrlInCustomTab(it, darkTheme, oidcDetails.url)
                             }
                         } else {
-                            // Fallback to WebView mode
-                            backstack.push(NavTarget.OidcView(oidcDetails))
+                            activity?.let {
+                                oidcEntryPoint.openUrlInExternalApp(it, oidcDetails.url)
+                            }
                         }
                     }
 

--- a/libraries/oidc/api/src/main/kotlin/io/element/android/libraries/oidc/api/OidcEntryPoint.kt
+++ b/libraries/oidc/api/src/main/kotlin/io/element/android/libraries/oidc/api/OidcEntryPoint.kt
@@ -14,5 +14,6 @@ import com.bumble.appyx.core.node.Node
 interface OidcEntryPoint {
     fun canUseCustomTab(): Boolean
     fun openUrlInCustomTab(activity: Activity, darkTheme: Boolean, url: String)
+    fun openUrlInExternalApp(activity: Activity, url: String)
     fun createFallbackWebViewNode(parentNode: Node, buildContext: BuildContext, url: String): Node
 }

--- a/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/DefaultOidcEntryPoint.kt
+++ b/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/DefaultOidcEntryPoint.kt
@@ -12,6 +12,7 @@ import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.androidutils.browser.openUrlInChromeCustomTab
+import io.element.android.libraries.androidutils.system.openUrlInExternalApp
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.matrix.api.auth.OidcDetails
@@ -30,6 +31,10 @@ class DefaultOidcEntryPoint @Inject constructor(
     override fun openUrlInCustomTab(activity: Activity, darkTheme: Boolean, url: String) {
         assert(canUseCustomTab()) { "Custom tab is not supported in this device." }
         activity.openUrlInChromeCustomTab(null, darkTheme, url)
+    }
+
+    override fun openUrlInExternalApp(activity: Activity, url: String) {
+        activity.openUrlInExternalApp(url)
     }
 
     override fun createFallbackWebViewNode(parentNode: Node, buildContext: BuildContext, url: String): Node {


### PR DESCRIPTION
 
 

## Motivation and context
if the default browser is not Chrome we are currently using Webview which google no longer supports, and we should open the auth link in an external browser instead

![access blocked](https://github.com/user-attachments/assets/e6e18a04-ecde-4122-9c39-62a82562f8c5)
 
## Tests

- Change the default Browser to other than Chrome
- change the home server
- try login by tapping continue
-  google login URL opened in external browser

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(Android 15):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
