### PR TITLE
runQualityChecks task shouldn't fail fast

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build Fdroid Debug
         run: ./gradlew :app:compileFdroidDebugKotlin $CI_GRADLE_ARG_PROPERTIES
       - name: Run lint
-        run: ./gradlew :app:lintGplayDebug :app:lintFdroidDebug $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew :app:lintGplayDebug :app:lintFdroidDebug lintDebug $CI_GRADLE_ARG_PROPERTIES --continue
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,9 +166,9 @@ allprojects {
 // Register quality check tasks.
 tasks.register("runQualityChecks") {
     dependsOn(":tests:konsist:testDebugUnitTest")
+    dependsOn(":app:lintGplayDebug")
     project.subprojects {
-        // For some reason `findByName("lint")` doesn't work
-        tasks.findByPath("$path:lint")?.let { dependsOn(it) }
+        tasks.findByPath("$path:lintDebug")?.let { dependsOn(it) }
         tasks.findByName("detekt")?.let { dependsOn(it) }
         tasks.findByName("ktlintCheck")?.let { dependsOn(it) }
         // tasks.findByName("buildHealth")?.let { dependsOn(it) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,9 @@ tasks.register("runQualityChecks") {
         // tasks.findByName("buildHealth")?.let { dependsOn(it) }
     }
     dependsOn(":app:knitCheck")
+
+    // Make sure all checks run even if some fail
+    gradle.startParameter.isContinueOnFailure = true
 }
 
 // Make sure to delete old screenshots before recording new ones

--- a/libraries/ui-strings/src/main/res/values-nb/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-nb/translations.xml
@@ -9,6 +9,7 @@
   <string name="a11y_pause">"Setter på pause"</string>
   <string name="a11y_pin_field">"PIN-felt"</string>
   <string name="a11y_play">"Spill av"</string>
+  <string name="a11y_poll">"Avstemning"</string>
   <string name="a11y_poll_end">"Avsluttet avstemning"</string>
   <string name="a11y_react_with">"Reager med %1$s"</string>
   <string name="a11y_react_with_other_emojis">"Reager med andre emojier"</string>
@@ -143,14 +144,17 @@
   <string name="common_encryption_enabled">"Kryptering aktivert"</string>
   <string name="common_enter_your_pin">"Skriv inn PIN-koden din"</string>
   <string name="common_error">"Feil"</string>
+  <string name="common_everyone">"Alle"</string>
   <string name="common_failed">"Mislyktes"</string>
   <string name="common_favourite">"Favoritt"</string>
   <string name="common_file">"Fil"</string>
   <string name="common_file_saved_on_disk_android">"Fil lagret i Nedlastinger"</string>
+  <string name="common_forward_message">"Videresend melding"</string>
   <string name="common_gif">"GIF"</string>
   <string name="common_image">"Bilde"</string>
   <string name="common_in_reply_to">"Som svar på %1$s"</string>
   <string name="common_install_apk_android">"Installer APK"</string>
+  <string name="common_invite_unknown_profile">"Finner ikke denne Matrix-IDen, så invitasjonen blir kanskje ikke mottatt."</string>
   <string name="common_leaving_room">"Forlater rommet"</string>
   <string name="common_light">"Lys"</string>
   <string name="common_link_copied_to_clipboard">"Lenke kopiert til utklippstavlen"</string>
@@ -220,6 +224,7 @@
   <string name="common_syncing">"Synkroniserer"</string>
   <string name="common_system">"System"</string>
   <string name="common_text">"Tekst"</string>
+  <string name="common_third_party_notices">"Varsler fra tredjeparter"</string>
   <string name="common_thread">"Tråd"</string>
   <string name="common_topic">"Emne"</string>
   <string name="common_topic_placeholder">"Hva er dette rommet for?"</string>
@@ -250,7 +255,11 @@
   <string name="dialog_unsaved_changes_description_android">"Endringene dine er ikke lagret. Er du sikker på at du vil gå tilbake?"</string>
   <string name="dialog_unsaved_changes_title">"Lagre endringer?"</string>
   <string name="error_failed_creating_the_permalink">"Opprettelse av permalenken mislyktes"</string>
+  <string name="error_failed_loading_map">"%1$s kunne ikke laste inn kartet. Prøv igjen senere."</string>
   <string name="error_failed_loading_messages">"Kunne ikke laste inn meldinger"</string>
+  <string name="error_failed_locating_user">"%1$s fikk ikke tilgang til lokasjonen din. Vennligst prøv igjen senere."</string>
+  <string name="error_missing_location_auth_android">"%1$s har ikke tilgang til lokasjonen din. Du kan aktivere tilgang i Innstillinger."</string>
+  <string name="error_missing_location_rationale_android">"%1$s har ikke tilgang til lokasjonen din. Aktiver tilgang nedenfor."</string>
   <string name="error_some_messages_have_not_been_sent">"Noen meldinger er ikke sendt"</string>
   <string name="error_unknown">"Beklager, det oppstod en feil"</string>
   <string name="event_shield_reason_sent_in_clear">"Ikke kryptert."</string>
@@ -258,13 +267,18 @@
   <string name="invite_friends_text">"Hei, snakk med meg på %1$s: %2$s"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="screen_media_picker_error_failed_selection">"Kunne ikke velge medium, prøv igjen."</string>
-  <string name="screen_media_upload_preview_error_failed_processing">"Kunne ikke behandle media for opplasting, vennligst prøv igjen."</string>
-  <string name="screen_media_upload_preview_error_failed_sending">"Opplasting av media mislyktes, vennligst prøv igjen."</string>
-  <string name="screen_room_error_failed_processing_media">"Kunne ikke behandle media for opplasting, vennligst prøv igjen."</string>
+  <string name="screen_media_upload_preview_error_failed_processing">"Kunne ikke behandle medier for opplasting, vennligst prøv igjen."</string>
+  <string name="screen_media_upload_preview_error_failed_sending">"Opplasting av medier mislyktes, vennligst prøv igjen."</string>
+  <string name="screen_room_error_failed_processing_media">"Kunne ikke behandle medier for opplasting, vennligst prøv igjen."</string>
   <string name="screen_room_error_failed_retrieving_user_details">"Kunne ikke hente brukerdetaljer"</string>
+  <string name="screen_share_location_title">"Del lokasjon"</string>
+  <string name="screen_share_my_location_action">"Del min lokasjon"</string>
   <string name="screen_share_open_apple_maps">"Åpne i Apple Maps"</string>
   <string name="screen_share_open_google_maps">"Åpne i Google Maps"</string>
+  <string name="screen_share_open_osm_maps">"Åpne i OpenStreetMap"</string>
+  <string name="screen_share_this_location_action">"Del denne lokasjonen"</string>
   <string name="screen_timeline_item_menu_send_failure_unsigned_device">"Meldingen ble ikke sendt fordi %1$s ikke har verifisert alle enheter."</string>
+  <string name="screen_view_location_title">"Lokasjon"</string>
   <string name="settings_version_number">"Versjon: %1$s (%2$s)"</string>
   <string name="test_language_identifier">"en"</string>
 </resources>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Changes:

- Make sure we run every task it depends on so we get a list with all the issues instead of having to retry several times.
- Tweak `runQualityChecks` task to make sure all Android lint tasks run.
- Fix the CI flow so it works the same as when we run it locally to make sure the results match.

## Motivation and context

It's a pain to have to run `runQualityChecks` several times just to get the next list of issues once we've fixed the current one.

## Tests

- Add some issue for the `runQualityChecks` task to discover. Check finding the error doesn't stop the rest of the tasks from running too.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
