### PR TITLE
Use `Settings.System.DEFAULT_RINGTONE_URI` for ringing notifications

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
@@ -11,7 +11,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
-import android.media.RingtoneManager
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.app.Person
@@ -109,8 +109,6 @@ class RingingCallNotificationCreator @Inject constructor(
             false
         )
 
-        // TODO use a fallback ringtone if the default ringtone is not available
-        val ringtoneUri = runCatching { RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE) }.getOrNull()
         return NotificationCompat.Builder(context, notificationChannelId)
             .setSmallIcon(CommonDrawables.ic_notification_small)
             .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -126,9 +124,7 @@ class RingingCallNotificationCreator @Inject constructor(
                     setContentText(textContent)
                     // Else the content text is set by the style (will be "Incoming call")
                 }
-                if (ringtoneUri != null) {
-                    setSound(ringtoneUri, AudioManager.STREAM_RING)
-                }
+                setSound(Settings.System.DEFAULT_RINGTONE_URI, AudioManager.STREAM_RING)
             }
             .setTimeoutAfter(ElementCallConfig.RINGING_CALL_DURATION_SECONDS.seconds.inWholeMilliseconds)
             .setContentIntent(answerIntent)

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/notifications/RingingCallNotificationCreator.kt
@@ -124,8 +124,8 @@ class RingingCallNotificationCreator @Inject constructor(
                     setContentText(textContent)
                     // Else the content text is set by the style (will be "Incoming call")
                 }
-                setSound(Settings.System.DEFAULT_RINGTONE_URI, AudioManager.STREAM_RING)
             }
+            .setSound(Settings.System.DEFAULT_RINGTONE_URI, AudioManager.STREAM_RING)
             .setTimeoutAfter(ElementCallConfig.RINGING_CALL_DURATION_SECONDS.seconds.inWholeMilliseconds)
             .setContentIntent(answerIntent)
             .setDeleteIntent(declineIntent)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
@@ -157,16 +157,14 @@ class DefaultNotificationChannels @Inject constructor(
             )
                 .setName(stringProvider.getString(R.string.notification_channel_ringing_calls).ifEmpty { "Ringing calls" })
                 .setVibrationEnabled(true)
-                .apply {
-                    setSound(
-                        Settings.System.DEFAULT_RINGTONE_URI,
-                        AudioAttributes.Builder()
-                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                            .setLegacyStreamType(AudioManager.STREAM_RING)
-                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                            .build()
-                    )
-                }
+                .setSound(
+                    Settings.System.DEFAULT_RINGTONE_URI,
+                    AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .setLegacyStreamType(AudioManager.STREAM_RING)
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                        .build()
+                )
                 .setDescription(stringProvider.getString(R.string.notification_channel_ringing_calls))
                 .setLightsEnabled(true)
                 .setLightColor(accentColor)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.libraries.push.impl.notifications.channels
 
-import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioManager
 import android.os.Build
@@ -18,7 +17,6 @@ import androidx.core.app.NotificationManagerCompat
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.appconfig.NotificationConfig
 import io.element.android.libraries.di.AppScope
-import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.push.impl.R
 import io.element.android.services.toolbox.api.strings.StringProvider
@@ -60,7 +58,6 @@ private fun supportNotificationChannels() = Build.VERSION.SDK_INT >= Build.VERSI
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class DefaultNotificationChannels @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val notificationManager: NotificationManagerCompat,
     private val stringProvider: StringProvider,
 ) : NotificationChannels {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
@@ -10,8 +10,8 @@ package io.element.android.libraries.push.impl.notifications.channels
 import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioManager
-import android.media.RingtoneManager
 import android.os.Build
+import android.provider.Settings
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationManagerCompat
@@ -153,8 +153,6 @@ class DefaultNotificationChannels @Inject constructor(
         )
 
         // Register a channel for incoming call notifications which will ring the device when received
-        // TODO use a fallback ringtone if the default ringtone is not available
-        val ringtoneUri = runCatching { RingtoneManager.getActualDefaultRingtoneUri(context, RingtoneManager.TYPE_RINGTONE) }.getOrNull()
         notificationManager.createNotificationChannel(
             NotificationChannelCompat.Builder(
                 RINGING_CALL_NOTIFICATION_CHANNEL_ID,
@@ -163,16 +161,14 @@ class DefaultNotificationChannels @Inject constructor(
                 .setName(stringProvider.getString(R.string.notification_channel_ringing_calls).ifEmpty { "Ringing calls" })
                 .setVibrationEnabled(true)
                 .apply {
-                    if (ringtoneUri != null) {
-                        setSound(
-                            ringtoneUri,
-                            AudioAttributes.Builder()
-                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                                .setLegacyStreamType(AudioManager.STREAM_RING)
-                                .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                                .build()
-                        )
-                    }
+                    setSound(
+                        Settings.System.DEFAULT_RINGTONE_URI,
+                        AudioAttributes.Builder()
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .setLegacyStreamType(AudioManager.STREAM_RING)
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                            .build()
+                    )
                 }
                 .setDescription(stringProvider.getString(R.string.notification_channel_ringing_calls))
                 .setLightsEnabled(true)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannelsTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannelsTest.kt
@@ -10,7 +10,6 @@ package io.element.android.libraries.push.impl.notifications.channels
 import android.os.Build
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import io.element.android.services.toolbox.test.strings.FakeStringProvider
 import io.mockk.every
@@ -65,7 +64,6 @@ class NotificationChannelsTest {
     private fun createNotificationChannels(
         notificationManager: NotificationManagerCompat = mockk(relaxed = true),
     ) = DefaultNotificationChannels(
-        context = InstrumentationRegistry.getInstrumentation().targetContext,
         notificationManager = notificationManager,
         stringProvider = FakeStringProvider(),
     )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -331,5 +331,5 @@ fun createNotificationCreator(
 
 fun createNotificationChannels(): NotificationChannels {
     val context = RuntimeEnvironment.getApplication()
-    return DefaultNotificationChannels(context, NotificationManagerCompat.from(context), FakeStringProvider(""))
+    return DefaultNotificationChannels(NotificationManagerCompat.from(context), FakeStringProvider(""))
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This replaces `RingtoneManager.getActualDefaultRingtoneUri`, it should get the same audio file and avoid some reported issues about not having permission to load the audio file.

## Motivation and context

Fix crashes seen in rageshakes.

## Tests

- Uninstall the app.
- Set a custom ringtone audio picked from your device's storage.
- Install the app and enable notifications, no crash should happen.
- Receive a ringing call notification (start a call with another account in a DM), the custom audio should be used.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
