### PR TITLE
Get library ComposablePreviewScanner from maven and update to the latest version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -156,7 +156,7 @@ test_truth = "com.google.truth:truth:1.4.4"
 test_parameter_injector = "com.google.testparameterinjector:test-parameter-injector:1.18"
 test_robolectric = "org.robolectric:robolectric:4.14.1"
 test_appyx_junit = { module = "com.bumble.appyx:testing-junit4", version.ref = "appyx" }
-test_composable_preview_scanner = "com.github.sergio-sastre.ComposablePreviewScanner:android:0.1.2"
+test_composable_preview_scanner = "io.github.sergio-sastre.ComposablePreviewScanner:android:0.5.1"
 
 # Others
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,13 +18,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        maven {
-            url = URI("https://jitpack.io")
-            content {
-                includeModule("com.github.sergio-sastre.ComposablePreviewScanner", "android")
-                includeModule("com.github.sergio-sastre.ComposablePreviewScanner", "core")
-            }
-        }
         // Snapshot versions
         maven {
             url = URI("https://s01.oss.sonatype.org/content/repositories/snapshots")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Get library ComposablePreviewScanner from Maven instead of Jitpack and update it to the latest version 0.5.1.

I tried to use the new api (available since [0.1.3](https://github.com/sergio-sastre/ComposablePreviewScanner/releases/tag/0.1.3), so not that new) `includePrivatePreviews` and make our preview methods private. This is working, but Showkase still need the preview to be internal.

Maybe we could get ride of Showkase at some point, not sure it's used lot.

It's worth noting that the library claims that the latest releases are improving the performance 🚀 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix Renovate complaining about not be able to update the library (see #150)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/838855c0-50c9-4137-a631-520f6502b5be" />

With this change, Renovate will now be able to upgrade it when necessary.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No impact hopefully.

## Tests

<!-- Explain how you tested your development -->

- NA

## Tested devices

- NA

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
