### PR TITLE
change(create room) : use history visibility "invited"

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.createroom.CreateRoomParameters
 import io.element.android.libraries.matrix.api.createroom.RoomPreset
 import io.element.android.libraries.matrix.api.room.alias.RoomAliasHelper
+import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import io.element.android.libraries.matrix.ui.media.AvatarAction
 import io.element.android.libraries.matrix.ui.room.address.RoomAddressValidity
@@ -175,6 +176,7 @@ class ConfigureRoomPresenter @Inject constructor(
                     isEncrypted = config.roomVisibility is RoomVisibilityState.Private,
                     isDirect = false,
                     visibility = RoomVisibility.Private,
+                    historyVisibilityOverride = RoomHistoryVisibility.Invited,
                     preset = RoomPreset.PRIVATE_CHAT,
                     invite = config.invites.map { it.userId },
                     avatar = avatarUrl,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/createroom/CreateRoomParameters.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/createroom/CreateRoomParameters.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.matrix.api.createroom
 
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import java.util.Optional
@@ -22,5 +23,6 @@ data class CreateRoomParameters(
     val invite: List<UserId>? = null,
     val avatar: String? = null,
     val joinRuleOverride: JoinRule? = null,
+    val historyVisibilityOverride: RoomHistoryVisibility? = null,
     val roomAliasName: Optional<String> = Optional.empty(),
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -61,6 +61,7 @@ import io.element.android.libraries.matrix.impl.room.RoomSyncSubscriber
 import io.element.android.libraries.matrix.impl.room.RustRoomFactory
 import io.element.android.libraries.matrix.impl.room.RustRoomPreview
 import io.element.android.libraries.matrix.impl.room.TimelineEventTypeFilterFactory
+import io.element.android.libraries.matrix.impl.room.history.map
 import io.element.android.libraries.matrix.impl.room.join.map
 import io.element.android.libraries.matrix.impl.roomdirectory.RustRoomDirectoryService
 import io.element.android.libraries.matrix.impl.roomdirectory.map
@@ -328,6 +329,7 @@ class RustMatrixClient(
                     }
                 ),
                 joinRuleOverride = createRoomParams.joinRuleOverride?.map(),
+                historyVisibilityOverride = createRoomParams.historyVisibilityOverride?.map(),
                 canonicalAlias = createRoomParams.roomAliasName.getOrNull(),
             )
             val roomId = RoomId(innerClient.createRoom(rustParams))


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Override the room history visibility with `RoomHistoryVisibility.Invited` when creating a private room.
## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/4331
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui changes.

## Tests

<!-- Explain how you tested your development -->

- Click on the "Start room" fab
- Click on new room
- Configure the room as a private one
- Check the history visibility is correctly set to "invited"

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
