### PR TITLE
deps(rust sdk) : update to 25.03.05

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -174,7 +174,7 @@ jsoup = "org.jsoup:jsoup:1.19.1"
 appyx_core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
 molecule-runtime = "app.cash.molecule:molecule-runtime:2.0.0"
 timber = "com.jakewharton.timber:timber:5.0.1"
-matrix_sdk = "org.matrix.rustcomponents:sdk-android:25.2.26"
+matrix_sdk = "org.matrix.rustcomponents:sdk-android:25.3.5"
 matrix_richtexteditor = { module = "io.element.android:wysiwyg", version.ref = "wysiwyg" }
 matrix_richtexteditor_compose = { module = "io.element.android:wysiwyg-compose", version.ref = "wysiwyg" }
 sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -83,7 +83,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
-import org.matrix.rustcomponents.sdk.AllowedMessageTypes
 import org.matrix.rustcomponents.sdk.DateDividerMode
 import org.matrix.rustcomponents.sdk.IdentityStatusChangeListener
 import org.matrix.rustcomponents.sdk.KnockRequestsListener
@@ -92,6 +91,7 @@ import org.matrix.rustcomponents.sdk.RoomInfoListener
 import org.matrix.rustcomponents.sdk.RoomListItem
 import org.matrix.rustcomponents.sdk.RoomMessageEventMessageType
 import org.matrix.rustcomponents.sdk.TimelineConfiguration
+import org.matrix.rustcomponents.sdk.TimelineFilter
 import org.matrix.rustcomponents.sdk.TimelineFocus
 import org.matrix.rustcomponents.sdk.TypingNotificationsListener
 import org.matrix.rustcomponents.sdk.UserPowerLevelUpdate
@@ -234,9 +234,9 @@ class RustMatrixRoom(
             )
         }
 
-        val allowedMessageTypes = when (createTimelineParams) {
+        val filter = when (createTimelineParams) {
             is CreateTimelineParams.MediaOnly,
-            is CreateTimelineParams.MediaOnlyFocused -> AllowedMessageTypes.Only(
+            is CreateTimelineParams.MediaOnlyFocused -> TimelineFilter.OnlyMessage(
                 types = listOf(
                     RoomMessageEventMessageType.FILE,
                     RoomMessageEventMessageType.IMAGE,
@@ -245,7 +245,7 @@ class RustMatrixRoom(
                 )
             )
             is CreateTimelineParams.Focused,
-            CreateTimelineParams.PinnedOnly -> AllowedMessageTypes.All
+            CreateTimelineParams.PinnedOnly -> TimelineFilter.All
         }
 
         val internalIdPrefix = when (createTimelineParams) {
@@ -268,9 +268,10 @@ class RustMatrixRoom(
             innerRoom.timelineWithConfiguration(
                 configuration = TimelineConfiguration(
                     focus = focus,
-                    allowedMessageTypes = allowedMessageTypes,
+                    filter = filter,
                     internalIdPrefix = internalIdPrefix,
                     dateDividerMode = dateDividerMode,
+                    trackReadReceipts = false,
                 )
             ).let { inner ->
                 val mode = when (createTimelineParams) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RoomTimelineExtensions.kt
@@ -20,11 +20,11 @@ import org.matrix.rustcomponents.sdk.TimelineDiff
 import org.matrix.rustcomponents.sdk.TimelineInterface
 import org.matrix.rustcomponents.sdk.TimelineListener
 import timber.log.Timber
-import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
+import uniffi.matrix_sdk.RoomPaginationStatus
 
-internal fun TimelineInterface.liveBackPaginationStatus(): Flow<LiveBackPaginationStatus> = callbackFlow {
+internal fun TimelineInterface.liveBackPaginationStatus(): Flow<RoomPaginationStatus> = callbackFlow {
     val listener = object : PaginationStatusListener {
-        override fun onUpdate(status: LiveBackPaginationStatus) {
+        override fun onUpdate(status: RoomPaginationStatus) {
             trySend(status)
         }
     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -73,7 +73,7 @@ import org.matrix.rustcomponents.sdk.SendAttachmentJoinHandle
 import org.matrix.rustcomponents.sdk.UploadParameters
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
-import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
+import uniffi.matrix_sdk.RoomPaginationStatus
 import java.io.File
 import org.matrix.rustcomponents.sdk.EventOrTransactionId as RustEventOrTransactionId
 import org.matrix.rustcomponents.sdk.Timeline as InnerTimeline
@@ -148,8 +148,8 @@ class RustTimeline(
             .onEach { backPaginationStatus ->
                 updatePaginationStatus(Timeline.PaginationDirection.BACKWARDS) {
                     when (backPaginationStatus) {
-                        is LiveBackPaginationStatus.Idle -> it.copy(isPaginating = false, hasMoreToLoad = !backPaginationStatus.hitStartOfTimeline)
-                        is LiveBackPaginationStatus.Paginating -> it.copy(isPaginating = true, hasMoreToLoad = true)
+                        is RoomPaginationStatus.Idle -> it.copy(isPaginating = false, hasMoreToLoad = !backPaginationStatus.hitTimelineStart)
+                        is RoomPaginationStatus.Paginating -> it.copy(isPaginating = true, hasMoreToLoad = true)
                     }
                 }
             }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeRustTimeline.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeRustTimeline.kt
@@ -13,7 +13,7 @@ import org.matrix.rustcomponents.sdk.TaskHandle
 import org.matrix.rustcomponents.sdk.Timeline
 import org.matrix.rustcomponents.sdk.TimelineDiff
 import org.matrix.rustcomponents.sdk.TimelineListener
-import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
+import uniffi.matrix_sdk.RoomPaginationStatus
 
 class FakeRustTimeline : Timeline(NoPointer) {
     private var listener: TimelineListener? = null
@@ -32,7 +32,7 @@ class FakeRustTimeline : Timeline(NoPointer) {
         return FakeRustTaskHandle()
     }
 
-    fun emitPaginationStatus(status: LiveBackPaginationStatus) {
+    fun emitPaginationStatus(status: RoomPaginationStatus) {
         paginationStatusListener!!.onUpdate(status)
     }
 

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimelineTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimelineTest.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.matrix.rustcomponents.sdk.TimelineChange
-import uniffi.matrix_sdk_ui.LiveBackPaginationStatus
+import uniffi.matrix_sdk.RoomPaginationStatus
 import org.matrix.rustcomponents.sdk.Timeline as InnerTimeline
 
 class RustTimelineTest {
@@ -78,10 +78,10 @@ class RustTimelineTest {
             // Start pagination
             sut.paginate(Timeline.PaginationDirection.BACKWARDS)
             // Simulate SDK starting pagination
-            inner.emitPaginationStatus(LiveBackPaginationStatus.Paginating)
+            inner.emitPaginationStatus(RoomPaginationStatus.Paginating)
             // No new events received
             // Simulate SDK stopping pagination, more event to load
-            inner.emitPaginationStatus(LiveBackPaginationStatus.Idle(hitStartOfTimeline = false))
+            inner.emitPaginationStatus(RoomPaginationStatus.Idle(hitTimelineStart = false))
             // expect an item to be emitted, with an updated timestamp
             with(awaitItem()) {
                 assertThat(size).isEqualTo(2)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Updated the sdk to 25.03.05 and fixes the breaking changes.
There is also a new `clearCache` api, but this PR doesn't expose it, it'll be done in a separate PR.
## Motivation and context
Have the latest version!
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
