### PR TITLE
Discard timed out verification requests

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -77,17 +77,20 @@ import io.element.android.libraries.matrix.api.verification.SessionVerificationS
 import io.element.android.libraries.matrix.api.verification.VerificationRequest
 import io.element.android.services.appnavstate.api.AppNavigationStateService
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
+import java.time.Duration
+import java.time.Instant
 import java.util.Optional
 import java.util.UUID
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toKotlinDuration
 
 @ContributesNode(SessionScope::class)
 class LoggedInFlowNode @AssistedInject constructor(
@@ -134,12 +137,29 @@ class LoggedInFlowNode @AssistedInject constructor(
         override fun onIncomingSessionRequest(verificationRequest: VerificationRequest.Incoming) {
             // Without this launch the rendering and actual state of this Appyx node's children gets out of sync, resulting in a crash.
             // This might be because this method is called back from Rust in a background thread.
-            MainScope().launch {
+            lifecycleScope.launch {
+                val receivedAt = Instant.now()
+
                 // Wait until the app is in foreground to display the incoming verification request
                 appNavigationStateService.appNavigationState.first { it.isInForeground }
 
-                // Wait for the UI to be ready
-                delay(500.milliseconds)
+                // TODO there should also be a timeout for > 10 minutes elapsed since the request was created, but the SDK doesn't expose that info yet
+                val now = Instant.now()
+                val elapsedTimeSinceReceived = Duration.between(receivedAt, now).toKotlinDuration()
+
+                // Discard the incoming verification request if it has timed out
+                if (elapsedTimeSinceReceived > 2.minutes) {
+                    Timber.w("Incoming verification request ${verificationRequest.details.flowId} discarded due to timeout.")
+                    return@launch
+                }
+
+                // Wait for the RoomList UI to be ready so the incoming verification screen can be displayed on top of it
+                // Otherwise, the RoomList UI may be incorrectly displayed on top
+                withTimeout(5.seconds) {
+                    backstack.elements.first { elements ->
+                        elements.any { it.key.navTarget == NavTarget.RoomList }
+                    }
+                }
 
                 backstack.singleTop(NavTarget.IncomingVerificationRequest(verificationRequest))
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add a timeout for incoming verification requests (2 minutes after reception). Also replace `MainScope` coroutine scope with the Node's `lifecycleScope`.

## Motivation and context

Follow up PR to improve the behaviour of incoming verification requests.

## Tests

With 2 devices with different accounts:

- Put one of the apps in background.
- With the other, start a user verification of the counterpart account.
- Wait for 2 minutes (or modify the code so it's lower) and restore the app to foreground in the first device.
- No user verification screen should be displayed and there should be some log mentioning the verification request was discarded.
- If you start the verification request when the other device has the app in foreground or in background but opens back the app in < 2 minutes, the verification flow should work as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
