### PR TITLE
"Core Team" is a team of matrix-org. Use team "Vector Core" instead.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,7 +36,7 @@ jobs:
           username: ${{ github.event.pull_request.user.login }}
           organization: element-hq
           team: Vector Core
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN_READ_ORG }}
       - name: Add label
         if: steps.teams.outputs.isTeamMember == 'false'
         uses: actions/github-script@v7

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           username: ${{ github.event.pull_request.user.login }}
           organization: element-hq
-          team: Core Team
+          team: Vector Core
           GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
       - name: Add label
         if: steps.teams.outputs.isTeamMember == 'false'


### PR DESCRIPTION
Fix CI giving label community to PR from us.