### PR TITLE
…Ensure the snackbar "No more media to show" is not render when opening the media viewer.

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -164,7 +164,9 @@ class MediaViewerPresenter @AssistedInject constructor(
     ) {
         val isRenderingLoadingBackward by remember {
             derivedStateOf {
-                currentIndex.intValue == data.value.lastIndex && data.value.lastOrNull() is MediaViewerPageData.Loading
+                currentIndex.intValue == data.value.lastIndex &&
+                    data.value.size > 1 &&
+                    data.value.lastOrNull() is MediaViewerPageData.Loading
             }
         }
         if (isRenderingLoadingBackward) {
@@ -186,7 +188,9 @@ class MediaViewerPresenter @AssistedInject constructor(
     ) {
         val isRenderingLoadingForward by remember {
             derivedStateOf {
-                currentIndex.intValue == 0 && data.value.firstOrNull() is MediaViewerPageData.Loading
+                currentIndex.intValue == 0 &&
+                    data.value.size > 1 &&
+                    data.value.firstOrNull() is MediaViewerPageData.Loading
             }
         }
         if (isRenderingLoadingForward) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure the snackbar "No more media to show" is not render after the app is loading the first item. It has to be rendered only when moving the slider from a loading item to a media item.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4345

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room
- Open a media from this room
- Observe that the loader is displayed (it can be fast)
- Observe that the media is displayed
- Observe that no snackbar is displayed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
