### PR TITLE
Add timeline item prefetching

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -177,9 +177,11 @@ fun TimelineView(
                 onClearFocusRequestState = ::clearFocusRequestState
             )
 
-            val isCloseToStartOfLoadedTimeline by remember { derivedStateOf {
+            val isCloseToStartOfLoadedTimeline by remember {
+                derivedStateOf {
                 lazyListState.firstVisibleItemIndex + lazyListState.layoutInfo.visibleItemsInfo.size >= lazyListState.layoutInfo.totalItemsCount - 10
-            } }
+            }
+            }
             LaunchedEffect(isCloseToStartOfLoadedTimeline) {
                 // Only back paginate when we're close to the start of the loaded timeline items and the user is actively scrolling
                 if (lazyListState.isScrollInProgress && isCloseToStartOfLoadedTimeline) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemVirtualRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemVirtualRow.kt
@@ -28,6 +28,7 @@ import io.element.android.features.messages.impl.timeline.model.virtual.Timeline
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemRoomBeginningModel
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemTypingNotificationModel
 import io.element.android.features.messages.impl.typing.TypingNotificationView
+import timber.log.Timber
 
 @Composable
 fun TimelineItemVirtualRow(
@@ -45,6 +46,7 @@ fun TimelineItemVirtualRow(
                 TimelineLoadingMoreIndicator(virtual.model.direction)
                 val latestEventSink by rememberUpdatedState(eventSink)
                 LaunchedEffect(virtual.model.timestamp) {
+                    Timber.d("Pagination triggered by load more indicator")
                     latestEventSink(TimelineEvents.LoadMore(virtual.model.direction))
                 }
             }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
@@ -41,6 +41,7 @@ import io.element.android.features.messages.impl.pinned.banner.aLoadedPinnedMess
 import io.element.android.features.messages.impl.timeline.FOCUS_ON_PINNED_EVENT_DEBOUNCE_DURATION_IN_MILLIS
 import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
+import io.element.android.features.messages.impl.timeline.aTimelineItemList
 import io.element.android.features.messages.impl.timeline.aTimelineItemReadReceipts
 import io.element.android.features.messages.impl.timeline.aTimelineRoomInfo
 import io.element.android.features.messages.impl.timeline.aTimelineState
@@ -50,6 +51,7 @@ import io.element.android.features.messages.impl.timeline.components.reactionsum
 import io.element.android.features.messages.impl.timeline.components.receipt.aReadReceiptData
 import io.element.android.features.messages.impl.timeline.components.receipt.bottomsheet.ReadReceiptBottomSheetEvents
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.testtags.TestTags
@@ -126,6 +128,9 @@ class MessagesViewTest {
     fun `clicking on an Event invoke expected callback`() {
         val eventsRecorder = EventsRecorder<MessagesEvents>(expectEvents = false)
         val state = aMessagesState(
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+            ),
             eventSink = eventsRecorder
         )
         val timelineItem = state.timelineState.timelineItems.first()
@@ -181,6 +186,9 @@ class MessagesViewTest {
                 canRedactOther = userHasPermissionToRedactOther,
                 canSendReaction = userHasPermissionToSendReaction,
                 canPinUnpin = userCanPinEvent,
+            ),
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
             ),
         )
         val timelineItem = state.timelineState.timelineItems.first() as TimelineItem.Event
@@ -349,7 +357,10 @@ class MessagesViewTest {
     fun `clicking on a reaction emits the expected Event`() {
         val eventsRecorder = EventsRecorder<MessagesEvents>()
         val state = aMessagesState(
-            eventSink = eventsRecorder
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+            ),
+            eventSink = eventsRecorder,
         )
         val timelineItem = state.timelineState.timelineItems.first() as TimelineItem.Event
         rule.setMessagesView(
@@ -363,6 +374,9 @@ class MessagesViewTest {
     fun `long clicking on a reaction emits the expected Event`() {
         val eventsRecorder = EventsRecorder<ReactionSummaryEvents>()
         val state = aMessagesState(
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+            ),
             reactionSummaryState = aReactionSummaryState(
                 target = null,
                 eventSink = eventsRecorder,
@@ -380,6 +394,9 @@ class MessagesViewTest {
     fun `clicking on more reaction emits the expected Event`() {
         val eventsRecorder = EventsRecorder<CustomReactionEvents>()
         val state = aMessagesState(
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+            ),
             customReactionState = aCustomReactionState(
                 eventSink = eventsRecorder,
             ),
@@ -396,7 +413,11 @@ class MessagesViewTest {
     @Test
     fun `clicking on more reaction from action list emits the expected Event`() {
         val eventsRecorder = EventsRecorder<CustomReactionEvents>()
-        val state = aMessagesState()
+        val state = aMessagesState(
+            timelineState = aTimelineState(
+                timelineItems = aTimelineItemList(aTimelineItemTextContent()),
+            ),
+        )
         val timelineItem = state.timelineState.timelineItems.first() as TimelineItem.Event
         val stateWithActionListState = state.copy(
             actionListState = anActionListState(
@@ -538,7 +559,7 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setMessa
                 onCreatePollClick = onCreatePollClick,
                 onJoinCallClick = onJoinCallClick,
                 onViewAllPinnedMessagesClick = onViewAllPinnedMessagesClick,
-                knockRequestsBannerView = {}
+                knockRequestsBannerView = {},
             )
         }
     }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -142,7 +142,7 @@ class TimelineViewTest {
     @Test
     fun `scrolling near to the start of the loaded items triggers a pre-fetch`() {
         val eventsRecorder = EventsRecorder<TimelineEvents>()
-        val items = List<TimelineItem>(20) {
+        val items = List<TimelineItem>(200) {
             aTimelineItemEvent(
                 eventId = EventId("\$event_$it"),
                 content = aTimelineItemUnknownContent(),
@@ -158,7 +158,10 @@ class TimelineViewTest {
             ),
         )
 
-        rule.onNodeWithTag("timeline").performScrollToIndex(10)
+        rule.onNodeWithTag("timeline").performScrollToIndex(180)
+
+        rule.mainClock.advanceTimeBy(1000)
+
         eventsRecorder.assertList(
             listOf(
                 TimelineEvents.OnScrollFinished(firstIndex = 0),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -11,14 +11,18 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.messages.impl.timeline.components.aCriticalShield
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemImageContent
+import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemUnknownContent
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemLoadingIndicatorModel
 import io.element.android.features.messages.impl.timeline.protection.TimelineProtectionState
 import io.element.android.features.messages.impl.timeline.protection.aTimelineProtectionState
+import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UniqueId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.timeline.Timeline
@@ -31,6 +35,7 @@ import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
 import io.element.android.tests.testutils.setSafeContent
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -115,8 +120,6 @@ class TimelineViewTest {
         eventsRecorder.assertList(
             listOf(
                 TimelineEvents.OnScrollFinished(0),
-                TimelineEvents.OnScrollFinished(0),
-                TimelineEvents.OnScrollFinished(0),
                 TimelineEvents.ShowShieldDialog(MessageShield.UnverifiedIdentity(true)),
             )
         )
@@ -134,6 +137,34 @@ class TimelineViewTest {
         )
         rule.clickOn(CommonStrings.action_ok)
         eventsRecorder.assertSingle(TimelineEvents.HideShieldDialog)
+    }
+
+    @Test
+    fun `scrolling near to the start of the loaded items triggers a pre-fetch`() {
+        val eventsRecorder = EventsRecorder<TimelineEvents>()
+        val items = List<TimelineItem>(20) {
+            aTimelineItemEvent(
+                eventId = EventId("\$event_$it"),
+                content = aTimelineItemUnknownContent(),
+            )
+        }.toPersistentList()
+
+        rule.setTimelineView(
+            state = aTimelineState(
+                timelineItems = items,
+                eventSink = eventsRecorder,
+                focusedEventIndex = -1,
+                isLive = false,
+            ),
+        )
+
+        rule.onNodeWithTag("timeline").performScrollToIndex(10)
+        eventsRecorder.assertList(
+            listOf(
+                TimelineEvents.OnScrollFinished(firstIndex = 0),
+                TimelineEvents.LoadMore(Timeline.PaginationDirection.BACKWARDS),
+            )
+        )
     }
 }
 

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -98,6 +98,11 @@ object TestTags {
     val floatingActionButton = TestTag("floating-action-button")
 
     /**
+     * Timeline.
+     */
+    val timeline = TestTag("timeline")
+
+    /**
      * Timeline item.
      */
     val timelineItemSenderInfo = TestTag("timeline_item-sender_info")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This should trigger when getting close the start of the loaded timeline, making scrolling back smoother, specially when combined with the persistent event cache.

## Motivation and context

Try to make scrolling a bit smoother.

Fixes https://github.com/element-hq/element-x-android/issues/4391 (or at least, it should help).

## Tests

Ideally with the persistent event cache enabled, open a room where you've already paginated for a while and start scrolling back.

The scrolling should be smoother than before as we start prefetching the data way sooner. There may still be some 'pauses' as loading new items is not instant.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
