### PR TITLE
Add feature flag to let the application prints logs to logcat in release builds.

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
@@ -16,6 +16,7 @@ import io.element.android.features.rageshake.api.reporter.BugReporter
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.matrix.api.tracing.TracingService
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.services.analytics.api.AnalyticsService
@@ -39,6 +40,8 @@ interface AppBindings {
     fun analyticsService(): AnalyticsService
 
     fun enterpriseService(): EnterpriseService
+
+    fun featureFlagService(): FeatureFlagService
 
     fun buildMeta(): BuildMeta
 }

--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -12,6 +12,7 @@ import android.system.Os
 import androidx.startup.Initializer
 import io.element.android.features.rageshake.api.reporter.BugReporter
 import io.element.android.libraries.architecture.bindings
+import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.tracing.TracingConfiguration
 import io.element.android.libraries.matrix.api.tracing.WriteToFilesConfiguration
 import io.element.android.x.di.AppBindings
@@ -28,9 +29,10 @@ class TracingInitializer : Initializer<Unit> {
         val bugReporter = appBindings.bugReporter()
         Timber.plant(tracingService.createTimberTree(ELEMENT_X_TARGET))
         val preferencesStore = appBindings.preferencesStore()
+        val featureFlagService = appBindings.featureFlagService()
         val logLevel = runBlocking { preferencesStore.getTracingLogLevelFlow().first() }
         val tracingConfiguration = TracingConfiguration(
-            writesToLogcat = true,
+            writesToLogcat = runBlocking { featureFlagService.isFeatureEnabled(FeatureFlags.PrintLogsToLogcat) },
             writesToFilesConfiguration = defaultWriteToDiskConfiguration(bugReporter),
             logLevel = logLevel,
             extraTargets = listOf(ELEMENT_X_TARGET),

--- a/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/TracingInitializer.kt
@@ -14,7 +14,6 @@ import io.element.android.features.rageshake.api.reporter.BugReporter
 import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.matrix.api.tracing.TracingConfiguration
 import io.element.android.libraries.matrix.api.tracing.WriteToFilesConfiguration
-import io.element.android.x.BuildConfig
 import io.element.android.x.di.AppBindings
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -31,7 +30,7 @@ class TracingInitializer : Initializer<Unit> {
         val preferencesStore = appBindings.preferencesStore()
         val logLevel = runBlocking { preferencesStore.getTracingLogLevelFlow().first() }
         val tracingConfiguration = TracingConfiguration(
-            writesToLogcat = BuildConfig.DEBUG,
+            writesToLogcat = true,
             writesToFilesConfiguration = defaultWriteToDiskConfiguration(bugReporter),
             logLevel = logLevel,
             extraTargets = listOf(ELEMENT_X_TARGET),

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -168,4 +168,14 @@ enum class FeatureFlags(
         defaultValue = { true },
         isFinished = false,
     ),
+    PrintLogsToLogcat(
+        key = "feature.print_logs_to_logcat",
+        title = "Print logs to logcat",
+        description = "Print logs to logcat in addition to log files. Requires an app restart to take effect." +
+            "\n\nWARNING: this will make the logs visible in the device logs and may affect performance. " +
+            "It's not intended for daily usage in release builds.",
+        defaultValue = { buildMeta -> buildMeta.buildType != BuildType.RELEASE },
+        // False so it's displayed in the developer options screen
+        isFinished = false,
+    )
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Logs in logcat are enabled now by default in debug and nightly builds based on a new feature flag that can be toggled in the developer options screen, so they can be temporarily enabled in release builds if necessary, while they're disabled by default on those.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4011.

## Screenshots

<img width="320" alt="image" src="https://github.com/user-attachments/assets/f4a9fa26-05c2-44f7-abf8-41e388cf6420" />

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
