### PR TITLE
Hide "unencrypted" lock for redacted messages

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
@@ -25,6 +25,7 @@ import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.isEdited
+import io.element.android.features.messages.impl.timeline.model.event.isRedacted
 import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -44,7 +45,8 @@ fun TimelineEventTimestampView(
     val hasError = event.localSendState is LocalEventSendState.Failed
     val hasEncryptionCritical = event.messageShield?.isCritical.orFalse()
     val isMessageEdited = event.content.isEdited()
-    val tint = if (hasError || hasEncryptionCritical) ElementTheme.colors.textCriticalPrimary else ElementTheme.colors.textSecondary
+    val isMessageRedacted = event.content.isRedacted()
+    val tint = if (hasError || hasEncryptionCritical && !isMessageRedacted) ElementTheme.colors.textCriticalPrimary else ElementTheme.colors.textSecondary
     Row(
         modifier = Modifier
                 .padding(PaddingValues(start = TimelineEventTimestampViewDefaults.spacing))
@@ -78,19 +80,22 @@ fun TimelineEventTimestampView(
                         },
             )
         }
-        event.messageShield?.let { shield ->
-            Spacer(modifier = Modifier.width(2.dp))
-            Icon(
-                imageVector = shield.toIcon(),
-                contentDescription = shield.toText(),
-                modifier = Modifier
+
+        if (!isMessageRedacted) {
+            event.messageShield?.let { shield ->
+                Spacer(modifier = Modifier.width(2.dp))
+                Icon(
+                    imageVector = shield.toIcon(),
+                    contentDescription = shield.toText(),
+                    modifier = Modifier
                         .size(15.dp)
                         .clickable {
                             eventSink(TimelineEvents.ShowShieldDialog(shield))
                         },
-                tint = shield.toIconColor(),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
+                    tint = shield.toIconColor(),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
         }
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -10,7 +10,6 @@ package io.element.android.features.messages.impl.timeline.components
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
-import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemRedactedContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageShield

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -34,9 +34,9 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
             aTimelineItemEvent(
                 messageShield = MessageShield.UnknownDevice(isCritical = true),
             ),
-            aTimelineItemEvent(
-                content = aTimelineItemRedactedContent(),
-                messageShield = MessageShield.SentInClear(isCritical = true),
-            ),
+            // aTimelineItemEvent(
+            //    content = aTimelineItemRedactedContent(),
+            //    messageShield = MessageShield.SentInClear(isCritical = true),
+            //),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -10,6 +10,7 @@ package io.element.android.features.messages.impl.timeline.components
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemRedactedContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageShield
@@ -32,6 +33,10 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
             ),
             aTimelineItemEvent(
                 messageShield = MessageShield.UnknownDevice(isCritical = true),
+            ),
+            aTimelineItemEvent(
+                content = aTimelineItemRedactedContent(),
+                messageShield = MessageShield.SentInClear(isCritical = true),
             ),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
@@ -92,6 +92,11 @@ fun TimelineItemEventContent.isEdited(): Boolean = when (this) {
     else -> false
 }
 
+/**
+ * Whether the event content has been redacted.
+ */
+fun TimelineItemEventContent.isRedacted(): Boolean = this is TimelineItemRedactedContent
+
 fun TimelineItemEventContentWithAttachment.duration(): Duration? {
     return when (this) {
         is TimelineItemAudioContent -> duration


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Hides the "unencrypted" icon for redacted (deleted) messages.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #3352. On iOS this seems to be already implemented.


## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|
![image](https://github.com/user-attachments/assets/754a9769-f176-4783-9d33-01e8b89c1d3e)
|
![image](https://github.com/user-attachments/assets/6c8fca5d-4dea-4424-9b60-3191ee14255b)
|
 -->

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/754a9769-f176-4783-9d33-01e8b89c1d3e) | ![image](https://github.com/user-attachments/assets/6c8fca5d-4dea-4424-9b60-3191ee14255b) |



## Tests

<!-- Explain how you tested your development -->

- Write a message in a E2E encrypted room
- Delete that message

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): API 24, API 34

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes have been tested on an Android device or Android emulator with API 24
- [X] UI change has been tested on both light and dark themes
- [X] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request title will be used in the release note, it clearly define what will change for the user
- [X] Pull request includes screenshots or videos if containing UI changes
- [X] You've made a self review of your PR
