### PR TITLE
Hide unencrypted lock for redacted msgs

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineEventTimestampView.kt
@@ -25,6 +25,7 @@ import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.timeline.TimelineEvents
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.event.isEdited
+import io.element.android.features.messages.impl.timeline.model.event.isRedacted
 import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -44,7 +45,8 @@ fun TimelineEventTimestampView(
     val hasError = event.localSendState is LocalEventSendState.Failed
     val hasEncryptionCritical = event.messageShield?.isCritical.orFalse()
     val isMessageEdited = event.content.isEdited()
-    val tint = if (hasError || hasEncryptionCritical) ElementTheme.colors.textCriticalPrimary else ElementTheme.colors.textSecondary
+    val isMessageRedacted = event.content.isRedacted()
+    val tint = if (hasError || hasEncryptionCritical && !isMessageRedacted) ElementTheme.colors.textCriticalPrimary else ElementTheme.colors.textSecondary
     Row(
         modifier = Modifier
                 .padding(PaddingValues(start = TimelineEventTimestampViewDefaults.spacing))
@@ -78,19 +80,22 @@ fun TimelineEventTimestampView(
                         },
             )
         }
-        event.messageShield?.let { shield ->
-            Spacer(modifier = Modifier.width(2.dp))
-            Icon(
-                imageVector = shield.toIcon(),
-                contentDescription = shield.toText(),
-                modifier = Modifier
+
+        if (!isMessageRedacted) {
+            event.messageShield?.let { shield ->
+                Spacer(modifier = Modifier.width(2.dp))
+                Icon(
+                    imageVector = shield.toIcon(),
+                    contentDescription = shield.toText(),
+                    modifier = Modifier
                         .size(15.dp)
                         .clickable {
                             eventSink(TimelineEvents.ShowShieldDialog(shield))
                         },
-                tint = shield.toIconColor(),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
+                    tint = shield.toIconColor(),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
         }
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -10,6 +10,7 @@ package io.element.android.features.messages.impl.timeline.components
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.features.messages.impl.timeline.aTimelineItemEvent
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemRedactedContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemTextContent
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageShield
@@ -33,9 +34,9 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
             aTimelineItemEvent(
                 messageShield = MessageShield.UnknownDevice(isCritical = true),
             ),
-            // aTimelineItemEvent(
-            //    content = aTimelineItemRedactedContent(),
-            //    messageShield = MessageShield.SentInClear(isCritical = true),
-            //),
+            aTimelineItemEvent(
+                content = aTimelineItemRedactedContent(),
+                messageShield = MessageShield.SentInClear(isCritical = true),
+            ),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventForTimestampViewProvider.kt
@@ -33,5 +33,9 @@ class TimelineItemEventForTimestampViewProvider : PreviewParameterProvider<Timel
             aTimelineItemEvent(
                 messageShield = MessageShield.UnknownDevice(isCritical = true),
             ),
+            // aTimelineItemEvent(
+            //    content = aTimelineItemRedactedContent(),
+            //    messageShield = MessageShield.SentInClear(isCritical = true),
+            //),
         )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRowTimestampPreview.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRowTimestampPreview.kt
@@ -22,18 +22,25 @@ internal fun TimelineItemEventRowTimestampPreview(
     @PreviewParameter(TimelineItemEventForTimestampViewProvider::class) event: TimelineItem.Event
 ) = ElementPreview {
     Column {
-        val oldContent = event.content as TimelineItemTextContent
-        listOf(
-            "Text",
-            "Text longer, displayed on 1 line",
-            "Text which should be rendered on several lines",
-        ).forEach { str ->
-            ATimelineItemEventRow(
-                event = event.copy(
-                    content = oldContent.copy(
-                        body = str,
-                        pillifiedBody = str,
+        when (event.content) {
+            is TimelineItemTextContent -> listOf(
+                "Text",
+                "Text longer, displayed on 1 line",
+                "Text which should be rendered on several lines",
+            ).forEach { str ->
+                ATimelineItemEventRow(
+                    event = event.copy(
+                        content = event.content.copy(
+                            body = str,
+                            pillifiedBody = str,
+                        ),
+                        reactionsState = aTimelineItemReactions(count = 0),
                     ),
+                )
+            }
+            else -> ATimelineItemEventRow(
+                event = event.copy(
+                    content = event.content,
                     reactionsState = aTimelineItemReactions(count = 0),
                 ),
             )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
@@ -92,6 +92,11 @@ fun TimelineItemEventContent.isEdited(): Boolean = when (this) {
     else -> false
 }
 
+/**
+ * Whether the event content has been redacted.
+ */
+fun TimelineItemEventContent.isRedacted(): Boolean = this is TimelineItemRedactedContent
+
 fun TimelineItemEventContentWithAttachment.duration(): Duration? {
     return when (this) {
         is TimelineItemAudioContent -> duration

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineEventTimestampView_Day_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineEventTimestampView_Day_7_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9876d82b13a220cd296f6117bedf7c1a260d9560978701065ce068e22b1c8b
+size 4485

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineEventTimestampView_Night_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineEventTimestampView_Night_7_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dc95cafaeda3d0cd45ce37408de0858543f1de07a29b18d165cf2c9a438e9c6
+size 4465

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineItemEventRowTimestamp_Day_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineItemEventRowTimestamp_Day_7_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8cf8e9260385fdc03b2bb611a7c79af93190b7f6c9cfbb53d45afebd0590d08
+size 11279

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineItemEventRowTimestamp_Night_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_TimelineItemEventRowTimestamp_Night_7_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf4558bdae3a8f6e04a3390e15194cef3faa7552f5c0fd772eb8b4a7b9954de2
+size 11234


### PR DESCRIPTION
Follow up for #4410, no review needed.

The recording of screenshots has [failed](https://github.com/element-hq/element-x-android/actions/runs/13924422930/job/38965078255). Let's do it again from this PR.