### PR TITLE
Run the 'prevent blocked' workflow even if PR has conflicts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: Pull Request
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, edited, labeled, unlabeled, synchronize ]
   workflow_call:
     secrets:


### PR DESCRIPTION
See the description of `pull_request` versus `pull_request_target` documented at https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request.