### PR TITLE
Sync Strings - tweaks to identity change messages

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateView.kt
@@ -43,7 +43,7 @@ fun IdentityChangeStateView(
             onLinkClick = onLinkClick,
             textId = CommonStrings.crypto_identity_change_pin_violation_new,
             isCritical = false,
-            submitTextId = CommonStrings.action_ok,
+            submitTextId = CommonStrings.action_dismiss,
             onSubmitClick = { state.eventSink(IdentityChangeEvent.PinIdentity(identityChangeViolation.identityRoomMember.userId)) },
             modifier = modifier,
         )

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/crypto/identity/IdentityChangeStateViewTest.kt
@@ -48,7 +48,7 @@ class IdentityChangeStateViewTest {
         rule.onNodeWithText("@alice:localhost", substring = true).assertExists("should display user mxid")
         rule.onNodeWithText("Alice", substring = true).assertExists("should display user displayname")
 
-        rule.clickOn(res = CommonStrings.action_ok)
+        rule.clickOn(res = CommonStrings.action_dismiss)
         eventsRecorder.assertSingle(IdentityChangeEvent.PinIdentity(UserId("@alice:localhost")))
     }
 

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_IdentityChangeStateView_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_IdentityChangeStateView_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e698ec3ede72636c649e44c656cf67d16b5531629b336f7ed101a9a34f99ec3
-size 22739
+oid sha256:e83fdb82f802f77ed962957c059a027ab6c1aba43a996fda824c188ea26e136a
+size 23662

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_IdentityChangeStateView_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_IdentityChangeStateView_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4b706779cd3294a3bb7e879fad3f0d2c914466408c27f8bb3096123e4201dc4
-size 25730
+oid sha256:2d3c8f5951f9a447f5f35912ca8ed4c7c845bc4f51d628c6238e61bcc0c3c56e
+size 26479

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_MessagesViewWithIdentityChange_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_MessagesViewWithIdentityChange_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31879b7c77e3c72b48a59e8ec00381fdffd3e7a973ac42eb868a860aaf7b17c7
-size 62628
+oid sha256:61fb04355b0984f6a2b2cae6bb415936f9144993d988cea55c4db4f25efddb0c
+size 63502

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_MessagesViewWithIdentityChange_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.crypto.identity_MessagesViewWithIdentityChange_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d67caef0dc744e636f8ee67fa9388ddb6a2f2f4cc53a37c682f831e3c96d5b30
-size 66555
+oid sha256:c82612aeb3d83ea4e619e0fbec4bffcbea4589d4af362028caef23346293beea
+size 67399


### PR DESCRIPTION
## Content

Tweak the strings in the identity change messages as per https://github.com/element-hq/element-meta/issues/2792

## Motivation and context

The existing strings were confusing, and users did not like clicking "Ok" when they did not understand, so this is changed to "Dismiss".

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
