### PR TITLE
Update Element Call base URL to the new format

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/ElementCallConfig.kt
@@ -11,7 +11,7 @@ object ElementCallConfig {
     /**
      * The default base URL for the Element Call service.
      */
-    const val DEFAULT_BASE_URL = "https://call.element.io"
+    const val DEFAULT_BASE_URL = "https://call.element.io/room"
 
     /**
      * The default duration of a ringing call in seconds before it's automatically dismissed.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/call/DefaultElementCallBaseUrlProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/call/DefaultElementCallBaseUrlProvider.kt
@@ -39,5 +39,11 @@ class DefaultElementCallBaseUrlProvider @Inject constructor(
             }
             ?.call
             ?.widgetUrl
+            ?.let { url ->
+                if (!url.endsWith("/room")) {
+                    Timber.w("The Element Call URL in `element.json` may not have a valid format. It should end with the `/room` path.")
+                }
+                url
+            }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

Also add a warning when the overridden URL in `element.json` may have an invalid format. To be honest, I'm not sure if we should just patch the URL instead.

## Motivation and context

After upgrading the SDK, the generated widget URL needs a new format of base url to work properly, ending with a `/room` path.

## Tests

<!-- Explain how you tested your development -->

- Making sure you don't have a custom base URL for EC, join a room call. It should work as usual.
- If possible, now use a HS with a custom `element.json` file overriding this default base URL in the app. If the overridden value contains the `/room` path it should work fine, otherwise you'd be in a 'lobby' screen when joining the call.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
