### PR TITLE
Fix 'unverified session' flow displayed when creating account

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/createaccount/CreateAccountPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/createaccount/CreateAccountPresenter.kt
@@ -19,16 +19,23 @@ import dagger.assisted.AssistedInject
 import io.element.android.features.login.impl.DefaultLoginUserStory
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.core.data.tryOrNull
 import io.element.android.libraries.core.extensions.flatMap
 import io.element.android.libraries.core.meta.BuildMeta
+import io.element.android.libraries.matrix.api.MatrixClientProvider
 import io.element.android.libraries.matrix.api.auth.MatrixAuthenticationService
 import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 
 class CreateAccountPresenter @AssistedInject constructor(
     @Assisted private val url: String,
     private val authenticationService: MatrixAuthenticationService,
+    private val clientProvider: MatrixClientProvider,
     private val defaultLoginUserStory: DefaultLoginUserStory,
     private val messageParser: MessageParser,
     private val buildMeta: BuildMeta,
@@ -73,6 +80,12 @@ class CreateAccountPresenter @AssistedInject constructor(
         }.flatMap { externalSession ->
             authenticationService.importCreatedSession(externalSession)
         }.onSuccess { sessionId ->
+            tryOrNull {
+                // Wait until the session is verified
+                val client = clientProvider.getOrRestore(sessionId).getOrThrow()
+                val sessionVerificationService = client.sessionVerificationService()
+                withTimeout(10.seconds) { sessionVerificationService.sessionVerifiedStatus.first { it.isVerified() } }
+            }
             // We will not navigate to the WaitList screen, so the login user story is done
             defaultLoginUserStory.setLoginFlowIsDone(true)
             loggedInState.value = AsyncAction.Success(sessionId)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When creating an account, wait until the session is verified before marking the authentication flow as completed.

## Motivation and context

We had a regression at some point on this that went unnoticed.

## Tests

<!-- Explain how you tested your development -->

- Create a new account in some HS (m.org maybe).
- Once the account is created you can progress into using the app as usual, no session verification flow is displayed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
