### PR TITLE
Add `WakeLock` to dismiss ringing call screen when call is cancelled

### DIFF
--- a/features/call/api/src/main/kotlin/io/element/android/features/call/api/ElementCallEntryPoint.kt
+++ b/features/call/api/src/main/kotlin/io/element/android/features/call/api/ElementCallEntryPoint.kt
@@ -32,7 +32,7 @@ interface ElementCallEntryPoint {
      * @param notificationChannelId The id of the notification channel to use for the call notification.
      * @param textContent The text content of the notification. If null the default content from the system will be used.
      */
-    fun handleIncomingCall(
+    suspend fun handleIncomingCall(
         callType: CallType.RoomCall,
         eventId: EventId,
         senderId: UserId,

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/DefaultElementCallEntryPoint.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/DefaultElementCallEntryPoint.kt
@@ -18,15 +18,12 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class DefaultElementCallEntryPoint @Inject constructor(
     @ApplicationContext private val context: Context,
     private val activeCallManager: ActiveCallManager,
-    private val coroutineScope: CoroutineScope,
 ) : ElementCallEntryPoint {
     companion object {
         const val EXTRA_CALL_TYPE = "EXTRA_CALL_TYPE"
@@ -37,7 +34,7 @@ class DefaultElementCallEntryPoint @Inject constructor(
         context.startActivity(IntentProvider.createIntent(context, callType))
     }
 
-    override fun handleIncomingCall(
+    override suspend fun handleIncomingCall(
         callType: CallType.RoomCall,
         eventId: EventId,
         senderId: UserId,
@@ -60,8 +57,6 @@ class DefaultElementCallEntryPoint @Inject constructor(
             notificationChannelId = notificationChannelId,
             textContent = textContent,
         )
-        coroutineScope.launch {
-            activeCallManager.registerIncomingCall(notificationData = incomingCallNotificationData)
-        }
+        activeCallManager.registerIncomingCall(notificationData = incomingCallNotificationData)
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/DefaultElementCallEntryPoint.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/DefaultElementCallEntryPoint.kt
@@ -18,12 +18,15 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class DefaultElementCallEntryPoint @Inject constructor(
     @ApplicationContext private val context: Context,
     private val activeCallManager: ActiveCallManager,
+    private val coroutineScope: CoroutineScope,
 ) : ElementCallEntryPoint {
     companion object {
         const val EXTRA_CALL_TYPE = "EXTRA_CALL_TYPE"
@@ -57,6 +60,8 @@ class DefaultElementCallEntryPoint @Inject constructor(
             notificationChannelId = notificationChannelId,
             textContent = textContent,
         )
-        activeCallManager.registerIncomingCall(notificationData = incomingCallNotificationData)
+        coroutineScope.launch {
+            activeCallManager.registerIncomingCall(notificationData = incomingCallNotificationData)
+        }
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/receivers/DeclineCallBroadcastReceiver.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/receivers/DeclineCallBroadcastReceiver.kt
@@ -16,6 +16,8 @@ import io.element.android.features.call.impl.di.CallBindings
 import io.element.android.features.call.impl.notifications.CallNotificationData
 import io.element.android.features.call.impl.utils.ActiveCallManager
 import io.element.android.libraries.architecture.bindings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -27,10 +29,16 @@ class DeclineCallBroadcastReceiver : BroadcastReceiver() {
     }
     @Inject
     lateinit var activeCallManager: ActiveCallManager
+
+    @Inject
+    lateinit var coroutineScope: CoroutineScope
+
     override fun onReceive(context: Context, intent: Intent?) {
         val notificationData = intent?.let { IntentCompat.getParcelableExtra(it, EXTRA_NOTIFICATION_DATA, CallNotificationData::class.java) }
             ?: return
         context.bindings<CallBindings>().inject(this)
-        activeCallManager.hungUpCall(callType = CallType.RoomCall(notificationData.sessionId, notificationData.roomId))
+        coroutineScope.launch {
+            activeCallManager.hungUpCall(callType = CallType.RoomCall(notificationData.sessionId, notificationData.roomId))
+        }
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/receivers/DeclineCallBroadcastReceiver.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/receivers/DeclineCallBroadcastReceiver.kt
@@ -31,13 +31,13 @@ class DeclineCallBroadcastReceiver : BroadcastReceiver() {
     lateinit var activeCallManager: ActiveCallManager
 
     @Inject
-    lateinit var coroutineScope: CoroutineScope
+    lateinit var appCoroutineScope: CoroutineScope
 
     override fun onReceive(context: Context, intent: Intent?) {
         val notificationData = intent?.let { IntentCompat.getParcelableExtra(it, EXTRA_NOTIFICATION_DATA, CallNotificationData::class.java) }
             ?: return
         context.bindings<CallBindings>().inject(this)
-        coroutineScope.launch {
+        appCoroutineScope.launch {
             activeCallManager.hungUpCall(callType = CallType.RoomCall(notificationData.sessionId, notificationData.roomId))
         }
     }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -88,7 +88,7 @@ class CallScreenPresenter @AssistedInject constructor(
             coroutineScope.launch {
                 // Sets the call as joined
                 activeCallManager.joinedCall(callType)
-                getRoomCallUrl(
+                fetchRoomCallUrl(
                     inputs = callType,
                     urlState = urlState,
                     callWidgetDriver = callWidgetDriver,
@@ -188,7 +188,7 @@ class CallScreenPresenter @AssistedInject constructor(
         )
     }
 
-    private suspend fun getRoomCallUrl(
+    private suspend fun fetchRoomCallUrl(
         inputs: CallType,
         urlState: MutableState<AsyncData<String>>,
         callWidgetDriver: MutableState<MatrixWidgetDriver?>,

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -62,6 +62,7 @@ class CallScreenPresenter @AssistedInject constructor(
     private val activeCallManager: ActiveCallManager,
     private val languageTagProvider: LanguageTagProvider,
     private val appForegroundStateService: AppForegroundStateService,
+    private val appCoroutineScope: CoroutineScope,
 ) : Presenter<CallScreenState> {
     @AssistedFactory
     interface Factory {
@@ -87,7 +88,7 @@ class CallScreenPresenter @AssistedInject constructor(
             coroutineScope.launch {
                 // Sets the call as joined
                 activeCallManager.joinedCall(callType)
-                loadUrl(
+                getRoomCallUrl(
                     inputs = callType,
                     urlState = urlState,
                     callWidgetDriver = callWidgetDriver,
@@ -96,7 +97,7 @@ class CallScreenPresenter @AssistedInject constructor(
                 )
             }
             onDispose {
-                activeCallManager.hungUpCall(callType)
+                appCoroutineScope.launch { activeCallManager.hungUpCall(callType) }
             }
         }
 
@@ -187,7 +188,7 @@ class CallScreenPresenter @AssistedInject constructor(
         )
     }
 
-    private suspend fun loadUrl(
+    private suspend fun getRoomCallUrl(
         inputs: CallType,
         urlState: MutableState<AsyncData<String>>,
         callWidgetDriver: MutableState<MatrixWidgetDriver?>,

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/IncomingCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/IncomingCallActivity.kt
@@ -24,9 +24,11 @@ import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.designsystem.theme.ElementThemeApp
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -54,6 +56,9 @@ class IncomingCallActivity : AppCompatActivity() {
 
     @Inject
     lateinit var buildMeta: BuildMeta
+
+    @Inject
+    lateinit var appCoroutineScope: CoroutineScope
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -102,6 +107,8 @@ class IncomingCallActivity : AppCompatActivity() {
 
     private fun onCancel() {
         val activeCall = activeCallManager.activeCall.value ?: return
-        activeCallManager.hungUpCall(callType = activeCall.callType)
+        appCoroutineScope.launch {
+            activeCallManager.hungUpCall(callType = activeCall.callType)
+        }
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
@@ -87,7 +87,9 @@ class DefaultActiveCallManager @Inject constructor(
     private val defaultCurrentCallService: DefaultCurrentCallService,
 ) : ActiveCallManager {
     private var timedOutCallJob: Job? = null
-    private val activeWakeLock: PowerManager.WakeLock? = run {
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val activeWakeLock: PowerManager.WakeLock? = run {
         val powerManager = context.getSystemService<PowerManager>()
 
         if (powerManager?.isWakeLockLevelSupported(PowerManager.PARTIAL_WAKE_LOCK) == true) {

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
@@ -80,7 +80,7 @@ interface ActiveCallManager {
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class DefaultActiveCallManager @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @ApplicationContext context: Context,
     private val coroutineScope: CoroutineScope,
     private val onMissedCallNotificationHandler: OnMissedCallNotificationHandler,
     private val ringingCallNotificationCreator: RingingCallNotificationCreator,
@@ -91,18 +91,9 @@ class DefaultActiveCallManager @Inject constructor(
     private var timedOutCallJob: Job? = null
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val activeWakeLock: PowerManager.WakeLock? = run {
-        val powerManager = context.getSystemService<PowerManager>()
-
-        if (powerManager?.isWakeLockLevelSupported(PowerManager.PARTIAL_WAKE_LOCK) == true) {
-            powerManager.newWakeLock(
-                PowerManager.PARTIAL_WAKE_LOCK,
-                "${context.packageName}:IncomingCallWakeLock",
-            )
-        } else {
-            null
-        }
-    }
+    internal val activeWakeLock: PowerManager.WakeLock? = context.getSystemService<PowerManager>()
+        ?.takeIf { it.isWakeLockLevelSupported(PowerManager.PARTIAL_WAKE_LOCK) }
+        ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "${context.packageName}:IncomingCallWakeLock")
 
     override val activeCall = MutableStateFlow<ActiveCall?>(null)
 

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/DefaultElementCallEntryPointTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/DefaultElementCallEntryPointTest.kt
@@ -73,6 +73,5 @@ class DefaultElementCallEntryPointTest {
     ) = DefaultElementCallEntryPoint(
         context = InstrumentationRegistry.getInstrumentation().targetContext,
         activeCallManager = activeCallManager,
-        coroutineScope = backgroundScope,
     )
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/DefaultElementCallEntryPointTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/DefaultElementCallEntryPointTest.kt
@@ -20,16 +20,21 @@ import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.tests.testutils.lambda.lambdaRecorder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultElementCallEntryPointTest {
     @Test
-    fun `startCall - starts ElementCallActivity setup with the needed extras`() {
+    fun `startCall - starts ElementCallActivity setup with the needed extras`() = runTest {
         val entryPoint = createEntryPoint()
         entryPoint.startCall(CallType.RoomCall(A_SESSION_ID, A_ROOM_ID))
 
@@ -39,8 +44,9 @@ class DefaultElementCallEntryPointTest {
         assertThat(intent.extras?.containsKey("EXTRA_CALL_TYPE")).isTrue()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `handleIncomingCall - registers the incoming call using ActiveCallManager`() {
+    fun `handleIncomingCall - registers the incoming call using ActiveCallManager`() = runTest {
         val registerIncomingCallLambda = lambdaRecorder<CallNotificationData, Unit> {}
         val activeCallManager = FakeActiveCallManager(registerIncomingCallResult = registerIncomingCallLambda)
         val entryPoint = createEntryPoint(activeCallManager = activeCallManager)
@@ -57,13 +63,16 @@ class DefaultElementCallEntryPointTest {
             textContent = "textContent",
         )
 
+        advanceTimeBy(1.seconds)
+
         registerIncomingCallLambda.assertions().isCalledOnce()
     }
 
-    private fun createEntryPoint(
+    private fun TestScope.createEntryPoint(
         activeCallManager: FakeActiveCallManager = FakeActiveCallManager(),
     ) = DefaultElementCallEntryPoint(
         context = InstrumentationRegistry.getInstrumentation().targetContext,
         activeCallManager = activeCallManager,
+        coroutineScope = backgroundScope,
     )
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/DefaultActiveCallManagerTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/DefaultActiveCallManagerTest.kt
@@ -290,6 +290,7 @@ class DefaultActiveCallManagerTest {
         notificationManagerCompat: NotificationManagerCompat = mockk(relaxed = true),
         coroutineScope: CoroutineScope = this,
     ) = DefaultActiveCallManager(
+        context = InstrumentationRegistry.getInstrumentation().targetContext,
         coroutineScope = coroutineScope,
         onMissedCallNotificationHandler = onMissedCallNotificationHandler,
         ringingCallNotificationCreator = RingingCallNotificationCreator(

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/FakeActiveCallManager.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/FakeActiveCallManager.kt
@@ -11,6 +11,7 @@ import io.element.android.features.call.api.CallType
 import io.element.android.features.call.impl.notifications.CallNotificationData
 import io.element.android.features.call.impl.utils.ActiveCall
 import io.element.android.features.call.impl.utils.ActiveCallManager
+import io.element.android.tests.testutils.simulateLongTask
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeActiveCallManager(
@@ -20,15 +21,15 @@ class FakeActiveCallManager(
 ) : ActiveCallManager {
     override val activeCall = MutableStateFlow<ActiveCall?>(null)
 
-    override fun registerIncomingCall(notificationData: CallNotificationData) {
+    override suspend fun registerIncomingCall(notificationData: CallNotificationData) = simulateLongTask {
         registerIncomingCallResult(notificationData)
     }
 
-    override fun hungUpCall(callType: CallType) {
+    override suspend fun hungUpCall(callType: CallType) = simulateLongTask {
         hungUpCallResult(callType)
     }
 
-    override fun joinedCall(callType: CallType) {
+    override suspend fun joinedCall(callType: CallType) = simulateLongTask {
         joinedCallResult(callType)
     }
 

--- a/features/call/test/src/main/kotlin/io/element/android/features/call/test/FakeElementCallEntryPoint.kt
+++ b/features/call/test/src/main/kotlin/io/element/android/features/call/test/FakeElementCallEntryPoint.kt
@@ -30,7 +30,7 @@ class FakeElementCallEntryPoint(
         startCallResult(callType)
     }
 
-    override fun handleIncomingCall(
+    override suspend fun handleIncomingCall(
         callType: CallType.RoomCall,
         eventId: EventId,
         senderId: UserId,

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
@@ -118,7 +118,7 @@ class DefaultPushHandler @Inject constructor(
         }
     }
 
-    private fun handleRingingCallEvent(notifiableEvent: NotifiableRingingCallEvent) {
+    private suspend fun handleRingingCallEvent(notifiableEvent: NotifiableRingingCallEvent) {
         Timber.i("## handleInternal() : Incoming call.")
         elementCallEntryPoint.handleIncomingCall(
             callType = CallType.RoomCall(notifiableEvent.sessionId, notifiableEvent.roomId),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add a wakelock to keep the app alive while a ringing incoming call notification/screen is displayed.

## Motivation and context

We already had some checks in place to automatically cancel a ringing call notification/screen when the call was no longer active, but the `RoomInfo` updates weren't being processed because the app was 'paused'.

The partial wakelock should ensure these room info updates are handled, at least it did in my local tests.

Should fix https://github.com/element-hq/element-x-android/issues/4389.

## Tests

Having 2 devices with different accounts and a DM between them:

- Lock one of the devices.
- Start a call in the DM room from the other one. The first device should display a ringing incoming call screen.
- Hang up from the calling device.
- The ringing incoming call screen should be dismissed shortly after.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 14, 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
