### PR TITLE
Fix flaky incoming verification tests

### DIFF
--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/incoming/IncomingVerificationPresenter.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/incoming/IncomingVerificationPresenter.kt
@@ -30,7 +30,6 @@ import io.element.android.libraries.matrix.api.verification.SessionVerificationS
 import io.element.android.libraries.matrix.api.verification.VerificationFlowState
 import io.element.android.libraries.matrix.api.verification.VerificationRequest
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -57,7 +56,7 @@ class IncomingVerificationPresenter @AssistedInject constructor(
 
     @Composable
     override fun present(): IncomingVerificationState {
-        val coroutineScope = rememberCoroutineScope { Dispatchers.IO }
+        val coroutineScope = rememberCoroutineScope()
 
         val stateAndDispatch = stateMachine.rememberStateAndDispatch()
 

--- a/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/incoming/IncomingVerificationPresenterTest.kt
+++ b/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/incoming/IncomingVerificationPresenterTest.kt
@@ -131,6 +131,9 @@ class IncomingVerificationPresenterTest {
                     isWaiting = false,
                 )
             )
+
+            advanceTimeBy(1.seconds)
+
             resetLambda.assertions().isCalledOnce().with(value(false))
             acknowledgeVerificationRequestLambda.assertions().isCalledOnce().with(value(anIncomingSessionVerificationRequest))
             acceptVerificationRequestLambda.assertions().isNeverCalled()
@@ -139,7 +142,9 @@ class IncomingVerificationPresenterTest {
             skipItems(1)
             val initialWaitingState = awaitItem()
             assertThat((initialWaitingState.step as IncomingVerificationState.Step.Initial).isWaiting).isTrue()
-            advanceUntilIdle()
+
+            advanceTimeBy(1.seconds)
+
             acceptVerificationRequestLambda.assertions().isCalledOnce()
             // Remote sent the data
             fakeSessionVerificationService.emitVerificationFlowState(VerificationFlowState.DidAcceptVerificationRequest)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Use a provided `dispatchers.io` value in `IncomingVerificationPresenter`, not the default one, so we can provide it in the tests.
- Make sure we advance the time in the tests so the disposable effect has had time to be applied before the checks.

## Motivation and context

We had a couple of flaky tests making the development slower as we had to retry the test job several times.

## Tests

If the CI is happy, we're happy.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
