### PR TITLE
Improve touch indicators for the user info UI in the timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -446,7 +446,7 @@ private fun MessageSenderInformation(
                 .testTag(TestTags.timelineItemSenderName)
                 .clip(RoundedCornerShape(6.dp))
                 .clickable(onClick = onClick)
-                .padding(start = 4.dp),
+                .padding(horizontal = 4.dp),
             senderId = senderId,
             senderProfile = senderProfile,
             senderNameMode = SenderNameMode.Timeline(avatarColors.foreground),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -23,8 +23,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -93,6 +94,7 @@ import io.element.android.libraries.matrix.ui.messages.reply.eventId
 import io.element.android.libraries.matrix.ui.messages.sender.SenderName
 import io.element.android.libraries.matrix.ui.messages.sender.SenderNameMode
 import io.element.android.libraries.testtags.TestTags
+import io.element.android.libraries.testtags.testTag
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.wysiwyg.link.Link
 import kotlinx.coroutines.launch
@@ -314,6 +316,7 @@ private fun TimelineItemEventRowContent(
                 event.senderId,
                 event.senderProfile,
                 event.senderAvatar,
+                onUserDataClick,
                 Modifier
                     .constrainAs(sender) {
                         top.linkTo(parent.top)
@@ -321,13 +324,7 @@ private fun TimelineItemEventRowContent(
                         start.linkTo(parent.start)
                     }
                     .padding(horizontal = 16.dp)
-                    .zIndex(1f)
-                    .clickable(onClick = onUserDataClick)
-                    // This is redundant when using talkback
-                    .clearAndSetSemantics {
-                        invisibleToUser()
-                        testTag = TestTags.timelineItemSenderInfo.value
-                    }
+                    .zIndex(1f),
             )
         }
 
@@ -425,13 +422,31 @@ private fun MessageSenderInformation(
     senderId: UserId,
     senderProfile: ProfileTimelineDetails,
     senderAvatar: AvatarData,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val avatarColors = AvatarColorsProvider.provide(senderAvatar.id)
-    Row(modifier = modifier) {
-        Avatar(senderAvatar)
-        Spacer(modifier = Modifier.width(4.dp))
+    Row(
+        modifier = modifier
+            // Add external clickable modifier with no indicator so the touch target is larger than just the display name
+            .clickable(onClick = onClick, enabled = true, interactionSource = remember { MutableInteractionSource() }, indication = null)
+            .clearAndSetSemantics {
+                invisibleToUser()
+            }
+    ) {
+        Avatar(
+            modifier = Modifier
+                .testTag(TestTags.timelineItemSenderAvatar)
+                .clip(CircleShape)
+                .clickable(onClick = onClick),
+            avatarData = senderAvatar,
+        )
         SenderName(
+            modifier = Modifier
+                .testTag(TestTags.timelineItemSenderName)
+                .clip(RoundedCornerShape(6.dp))
+                .clickable(onClick = onClick)
+                .padding(start = 4.dp),
             senderId = senderId,
             senderProfile = senderProfile,
             senderNameMode = SenderNameMode.Timeline(avatarColors.foreground),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -42,7 +43,6 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
 import io.element.android.libraries.testtags.TestTags
-import io.element.android.libraries.testtags.testTag
 import io.element.android.libraries.ui.strings.CommonPlurals
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.collections.immutable.ImmutableList
@@ -60,7 +60,6 @@ fun TimelineItemReadReceiptView(
                 ReadReceiptsAvatars(
                     receipts = state.receipts,
                     modifier = Modifier
-                            .testTag(TestTags.messageReadReceipts)
                             .clip(RoundedCornerShape(4.dp))
                             .clickable {
                                 onReadReceiptsClick()
@@ -135,6 +134,7 @@ private fun ReadReceiptsAvatars(
     Row(
         modifier = modifier
             .clearAndSetSemantics {
+                testTag = TestTags.messageReadReceipts.value
                 contentDescription = receiptDescription
             },
         horizontalArrangement = Arrangement.spacedBy(4.dp - avatarStrokeSize),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
@@ -104,7 +104,7 @@ class MessagesViewTest {
                 state = state,
                 onRoomDetailsClick = callback,
             )
-            rule.onNodeWithText(state.roomName.dataOrNull().orEmpty()).performClick()
+            rule.onNodeWithText(state.roomName.dataOrNull().orEmpty(), useUnmergedTree = true).performClick()
         }
     }
 
@@ -206,6 +206,7 @@ class MessagesViewTest {
     }
 
     @Test
+    @Config(qualifiers = "h1024dp")
     fun `clicking on a read receipt list emits the expected Event`() {
         val eventsRecorder = EventsRecorder<ReadReceiptBottomSheetEvents>()
         val state = aMessagesState(
@@ -229,7 +230,7 @@ class MessagesViewTest {
         rule.setMessagesView(
             state = state,
         )
-        rule.onNodeWithTag(TestTags.messageReadReceipts.value).performClick()
+        rule.onNodeWithTag(TestTags.messageReadReceipts.value, useUnmergedTree = true).performClick()
         eventsRecorder.assertSingle(ReadReceiptBottomSheetEvents.EventSelected(timelineItem))
     }
 
@@ -309,7 +310,7 @@ class MessagesViewTest {
 
     @Test
     @Config(qualifiers = "h1024dp")
-    fun `clicking on the sender of an Event invoke expected callback`() {
+    fun `clicking on the avatar of the sender of an Event invoke expected callback`() {
         val eventsRecorder = EventsRecorder<MessagesEvents>(expectEvents = false)
         val state = aMessagesState(
             eventSink = eventsRecorder
@@ -322,7 +323,26 @@ class MessagesViewTest {
                 state = state,
                 onUserDataClick = callback,
             )
-            rule.onNodeWithTag(TestTags.timelineItemSenderInfo.value).performClick()
+            rule.onNodeWithTag(TestTags.timelineItemSenderAvatar.value, useUnmergedTree = true).performClick()
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "h1024dp")
+    fun `clicking on the display name of the sender of an Event invoke expected callback`() {
+        val eventsRecorder = EventsRecorder<MessagesEvents>(expectEvents = false)
+        val state = aMessagesState(
+            eventSink = eventsRecorder
+        )
+        val timelineItem = state.timelineState.timelineItems.first()
+        ensureCalledOnceWithParam(
+            param = (timelineItem as TimelineItem.Event).senderId
+        ) { callback ->
+            rule.setMessagesView(
+                state = state,
+                onUserDataClick = callback,
+            )
+            rule.onNodeWithTag(TestTags.timelineItemSenderName.value, useUnmergedTree = true).performClick()
         }
     }
 

--- a/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileHeaderSection.kt
+++ b/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileHeaderSection.kt
@@ -60,8 +60,8 @@ fun UserProfileHeaderSection(
         Avatar(
             avatarData = AvatarData(userId.value, userName, avatarUrl, AvatarSize.UserHeader),
             modifier = Modifier
-                .clickable(enabled = avatarUrl != null) { openAvatarPreview(avatarUrl!!) }
                 .clip(CircleShape)
+                .clickable(enabled = avatarUrl != null) { openAvatarPreview(avatarUrl!!) }
                 .testTag(TestTags.memberDetailAvatar)
         )
         Spacer(modifier = Modifier.height(24.dp))

--- a/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileHeaderSection.kt
+++ b/features/userprofile/shared/src/main/kotlin/io/element/android/features/userprofile/shared/UserProfileHeaderSection.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -59,6 +61,7 @@ fun UserProfileHeaderSection(
             avatarData = AvatarData(userId.value, userName, avatarUrl, AvatarSize.UserHeader),
             modifier = Modifier
                 .clickable(enabled = avatarUrl != null) { openAvatarPreview(avatarUrl!!) }
+                .clip(CircleShape)
                 .testTag(TestTags.memberDetailAvatar)
         )
         Spacer(modifier = Modifier.height(24.dp))

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/InviteSenderView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/InviteSenderView.kt
@@ -34,8 +34,8 @@ fun InviteSenderView(
         modifier = modifier,
     ) {
         Box(modifier = Modifier.padding(vertical = 2.dp)) {
-        Avatar(avatarData = inviteSender.avatarData)
-            }
+            Avatar(avatarData = inviteSender.avatarData)
+        }
         Text(
             text = inviteSender.annotatedString(),
             style = ElementTheme.typography.fontBodyMdRegular,

--- a/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
+++ b/libraries/testtags/src/main/kotlin/io/element/android/libraries/testtags/TestTags.kt
@@ -105,7 +105,8 @@ object TestTags {
     /**
      * Timeline item.
      */
-    val timelineItemSenderInfo = TestTag("timeline_item-sender_info")
+    val timelineItemSenderAvatar = TestTag("timeline_item-sender_avatar")
+    val timelineItemSenderName = TestTag("timeline_item-sender_name")
 
     /**
      * Search field.


### PR DESCRIPTION
## Content

Instead of having a single touch target covering both the avatar and display name of the sender of a message in the timeline, and having both items display the ripple indicator, use a different indicator for each, plus an invisible one that covers both so we still have a decent touch target. Check the 'after' video to see how it behaves.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/2101

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="277" alt="image" src="https://github.com/user-attachments/assets/76c93b68-c4f5-4ba0-83cb-c806ff4eb76a" />| <video src='https://github.com/user-attachments/assets/a10ce3fe-2b3b-4d26-9748-f0b13a5aed14' /> |

## Tests

In a room, press the avatar, display name and the space immediately below the display name. All 3 should display a nice indicator and open the user details screen.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
