### PR TITLE
Change : composer suggestions

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessor.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessor.kt
@@ -53,7 +53,11 @@ class SuggestionsProcessor @Inject constructor() {
             }
             SuggestionType.Room -> {
                 roomAliasSuggestions
-                    .filter { it.roomAlias.value.contains(suggestion.text, ignoreCase = true) }
+                    .filter { roomAliasSuggestion ->
+                        // Filter by either room alias or room name (if available)
+                        roomAliasSuggestion.roomAlias.value.contains(suggestion.text, ignoreCase = true) ||
+                            roomAliasSuggestion.roomName?.contains(suggestion.text, ignoreCase = true) == true
+                    }
                     .map {
                         ResolvedSuggestion.Alias(
                             roomAlias = it.roomAlias,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessorTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessorTest.kt
@@ -133,7 +133,7 @@ class SuggestionsProcessorTest {
     }
 
     @Test
-    fun `processing Room suggestion with aliases will return a suggestion`() = runTest {
+    fun `processing Room suggestion with aliases will return a suggestion when matching on alias`() = runTest {
         val aRoomSummary = aRoomSummary(canonicalAlias = A_ROOM_ALIAS)
         val result = suggestionsProcessor.process(
             suggestion = aRoomSuggestion("ali"),
@@ -171,7 +171,56 @@ class SuggestionsProcessorTest {
                 RoomAliasSuggestion(
                     roomAlias = A_ROOM_ALIAS,
                     roomId = aRoomSummary.roomId,
-                    roomName = aRoomSummary.info.name,
+                    roomName = "Element",
+                    roomAvatarUrl = aRoomSummary.info.avatarUrl,
+                )
+            ),
+            currentUserId = A_USER_ID,
+            canSendRoomMention = { true },
+        )
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `processing Room suggestion will return a suggestion when matching on room name`() = runTest {
+        val aRoomSummary = aRoomSummary(canonicalAlias = A_ROOM_ALIAS)
+        val result = suggestionsProcessor.process(
+            suggestion = aRoomSuggestion("lement"),
+            roomMembersState = MatrixRoomMembersState.Ready(persistentListOf()),
+            roomAliasSuggestions = listOf(
+                RoomAliasSuggestion(
+                    roomAlias = A_ROOM_ALIAS,
+                    roomId = aRoomSummary.roomId,
+                    roomName = "Element",
+                    roomAvatarUrl = aRoomSummary.info.avatarUrl,
+                )
+            ),
+            currentUserId = A_USER_ID,
+            canSendRoomMention = { true },
+        )
+        assertThat(result).isEqualTo(
+            listOf(
+                ResolvedSuggestion.Alias(
+                    roomAlias = A_ROOM_ALIAS,
+                    roomId = aRoomSummary.roomId,
+                    roomName = "Element",
+                    roomAvatarUrl = aRoomSummary.info.avatarUrl,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `processing Room suggestion will not return a suggestion when room has no name`() = runTest {
+        val aRoomSummary = aRoomSummary(canonicalAlias = A_ROOM_ALIAS)
+        val result = suggestionsProcessor.process(
+            suggestion = aRoomSuggestion("lement"),
+            roomMembersState = MatrixRoomMembersState.Ready(persistentListOf()),
+            roomAliasSuggestions = listOf(
+                RoomAliasSuggestion(
+                    roomAlias = A_ROOM_ALIAS,
+                    roomId = aRoomSummary.roomId,
+                    roomName = null,
                     roomAvatarUrl = aRoomSummary.info.avatarUrl,
                 )
             ),

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
@@ -80,7 +80,7 @@ class DeveloperSettingsPresenterTest {
         presenter.test {
             skipItems(2)
             awaitItem().also { state ->
-                val feature = state.features.first()
+                val feature = state.features.first { !it.isEnabled }
                 state.eventSink(DeveloperSettingsEvents.UpdateEnabledFeature(feature, !feature.isEnabled))
             }
             awaitItem().also { state ->

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -54,20 +54,6 @@ enum class FeatureFlags(
         defaultValue = { true },
         isFinished = true,
     ),
-    Mentions(
-        key = "feature.mentions",
-        title = "Mentions",
-        description = "Type `@` to get mention suggestions and insert them",
-        defaultValue = { true },
-        isFinished = false,
-    ),
-    RoomAliasSuggestions(
-        key = "feature.roomAliasSuggestions",
-        title = "Room alias suggestions",
-        description = "Type `#` to get room alias suggestions and insert them",
-        defaultValue = { false },
-        isFinished = false,
-    ),
     MarkAsUnread(
         key = "feature.markAsUnread",
         title = "Mark as unread",


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
This PR takes care of : 
- removing the 2 feature flags associated with suggestions
- allow filtering room suggestions by name, as for user.
<!-- Describe shortly what has been changed -->

## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/4412
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui change.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
