### PR TITLE
Limit the text length in the 'in reply to' preview

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/DefaultMessageSummaryFormatter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/messagesummary/DefaultMessageSummaryFormatter.kt
@@ -26,6 +26,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemUnknownContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVoiceContent
+import io.element.android.libraries.core.extensions.toSafeLength
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.ui.strings.CommonStrings
@@ -35,11 +36,6 @@ import javax.inject.Inject
 class DefaultMessageSummaryFormatter @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : MessageSummaryFormatter {
-    companion object {
-        // Max characters to display in the summary message. This works around https://github.com/element-hq/element-x-android/issues/2105
-        private const val MAX_SAFE_LENGTH = 500
-    }
-
     override fun format(event: TimelineItem.Event): String {
         return when (event.content) {
             is TimelineItemTextBasedContent -> event.content.plainText
@@ -58,6 +54,8 @@ class DefaultMessageSummaryFormatter @Inject constructor(
             is TimelineItemAudioContent -> context.getString(CommonStrings.common_audio)
             is TimelineItemLegacyCallInviteContent -> context.getString(CommonStrings.common_unsupported_call)
             is TimelineItemCallNotifyContent -> context.getString(CommonStrings.common_call_started)
-        }.take(MAX_SAFE_LENGTH)
+        }
+            // Truncate the message to a safe length to avoid crashes in Compose
+            .toSafeLength()
     }
 }

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/extensions/BasicExtensions.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/extensions/BasicExtensions.kt
@@ -98,3 +98,22 @@ fun String.ensureEndsLeftToRight() = if (containsRtLOverride()) "$this$LTR_OVERR
 fun String.containsRtLOverride() = contains(RTL_OVERRIDE_CHAR)
 
 fun String.filterDirectionOverrides() = filterNot { it == RTL_OVERRIDE_CHAR || it == LTR_OVERRIDE_CHAR }
+
+/**
+ * This works around https://github.com/element-hq/element-x-android/issues/2105.
+ * @param maxLength Max characters to retrieve. Defaults to `500`.
+ * @param ellipsize Whether to add an ellipsis (`…`) char at the end or not. Defaults to `false`.
+ * @return The string truncated to [maxLength] characters, with an optional ellipsis if larger.
+ */
+fun String.toSafeLength(
+    maxLength: Int = 500,
+    ellipsize: Boolean = false,
+): String {
+    return if (ellipsize) {
+        ellipsize(maxLength)
+    } else if (length > maxLength) {
+        take(maxLength)
+    } else {
+        this
+    }
+}

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
-import io.element.android.libraries.core.extensions.ellipsize
 import io.element.android.libraries.core.extensions.toSafeLength
 import io.element.android.libraries.designsystem.atomic.atoms.PlaceholderAtom
 import io.element.android.libraries.designsystem.icons.CompoundDrawables

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.core.extensions.ellipsize
+import io.element.android.libraries.core.extensions.toSafeLength
 import io.element.android.libraries.designsystem.atomic.atoms.PlaceholderAtom
 import io.element.android.libraries.designsystem.icons.CompoundDrawables
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -154,9 +155,9 @@ private fun ReplyToContentText(metadata: InReplyToMetadata?) {
         InReplyToMetadata.Redacted -> stringResource(id = CommonStrings.common_message_removed)
         InReplyToMetadata.UnableToDecrypt -> stringResource(id = CommonStrings.common_waiting_for_decryption_key)
         // Add a limit to the text length to avoid a crash in Compose
-        is InReplyToMetadata.Text -> metadata.text.ellipsize(512)
+        is InReplyToMetadata.Text -> metadata.text.toSafeLength()
         // Add a limit to the text length to avoid a crash in Compose
-        is InReplyToMetadata.Thumbnail -> metadata.text.ellipsize(512)
+        is InReplyToMetadata.Thumbnail -> metadata.text.toSafeLength()
         null -> ""
     }
     val iconResourceId = when (metadata) {

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToView.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
+import io.element.android.libraries.core.extensions.ellipsize
 import io.element.android.libraries.designsystem.atomic.atoms.PlaceholderAtom
 import io.element.android.libraries.designsystem.icons.CompoundDrawables
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -152,8 +153,10 @@ private fun ReplyToContentText(metadata: InReplyToMetadata?) {
     val text = when (metadata) {
         InReplyToMetadata.Redacted -> stringResource(id = CommonStrings.common_message_removed)
         InReplyToMetadata.UnableToDecrypt -> stringResource(id = CommonStrings.common_waiting_for_decryption_key)
-        is InReplyToMetadata.Text -> metadata.text
-        is InReplyToMetadata.Thumbnail -> metadata.text
+        // Add a limit to the text length to avoid a crash in Compose
+        is InReplyToMetadata.Text -> metadata.text.ellipsize(512)
+        // Add a limit to the text length to avoid a crash in Compose
+        is InReplyToMetadata.Thumbnail -> metadata.text.ellipsize(512)
         null -> ""
     }
     val iconResourceId = when (metadata) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

Otherwise, very long texts with no line breaks can cause a Compose crash.

Fixes https://github.com/element-hq/element-x-android/issues/3772

## Screenshots / GIFs

There shouldn't be any visual change, unless you have a huge screen that can display in reply to previews of > 512 chars.

## Tests

<!-- Explain how you tested your development -->

- Generate a very long text, > 20k characters, maybe using a lorem ipsum and *make sure there are no line breaks*.
- Send the text.
- Try to reply to the message.

If the app doesn't crash, we worked around the Compose bug.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
