### PR TITLE
Add video autoplay to media gallery

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
@@ -19,6 +19,7 @@ import io.element.android.libraries.mediaviewer.impl.model.GroupedMediaItems
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
@@ -85,7 +86,9 @@ class TimelineMediaGalleryDataSource @Inject constructor(
             }
         }.flatMapLatest {
             timelineMediaItemsFactory.timelineItems
-        }.map { timelineItems ->
+        }
+        .distinctUntilChanged()
+        .map { timelineItems ->
             mediaItemsPostProcessor.process(mediaItems = timelineItems)
         }.map {
             mediaTimeline.orCache(it)

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
@@ -89,10 +89,10 @@ class TimelineMediaGalleryDataSource @Inject constructor(
         }
         .distinctUntilChanged()
         .map { timelineItems ->
-            mediaItemsPostProcessor.process(mediaItems = timelineItems)
-        }.map {
-            mediaTimeline.orCache(it)
-        }.onEach { groupedMediaItems ->
+            val groupedItems = mediaItemsPostProcessor.process(mediaItems = timelineItems)
+            mediaTimeline.orCache(groupedItems)
+        }
+        .onEach { groupedMediaItems ->
             groupedMediaItemsFlow.emit(AsyncData.Success(groupedMediaItems))
         }
             .onCompletion {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
@@ -31,6 +31,7 @@ fun LocalMediaView(
     textFileViewer: TextFileViewer,
     modifier: Modifier = Modifier,
     isDisplayed: Boolean = true,
+    isUserSelected: Boolean = false,
     localMediaViewState: LocalMediaViewState = rememberLocalMediaViewState(),
     mediaInfo: MediaInfo? = localMedia?.info,
 ) {
@@ -47,6 +48,7 @@ fun LocalMediaView(
             localMediaViewState = localMediaViewState,
             bottomPaddingInPixels = bottomPaddingInPixels,
             localMedia = localMedia,
+            autoplay = isUserSelected,
             modifier = modifier,
         )
         mimeType == MimeTypes.PlainText -> TextFileView(

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
@@ -111,6 +111,7 @@ private fun ExoPlayerMediaAudioView(
             MediaPlayerControllerState(
                 isVisible = true,
                 isPlaying = false,
+                isReady = false,
                 progressInMillis = 0,
                 durationInMillis = 0,
                 canMute = false,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerState.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerState.kt
@@ -12,6 +12,7 @@ import androidx.annotation.FloatRange
 data class MediaPlayerControllerState(
     val isVisible: Boolean,
     val isPlaying: Boolean,
+    val isReady: Boolean,
     val progressInMillis: Long,
     val durationInMillis: Long,
     val canMute: Boolean,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerStateProvider.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerStateProvider.kt
@@ -27,6 +27,7 @@ open class MediaPlayerControllerStateProvider : PreviewParameterProvider<MediaPl
 private fun aMediaPlayerControllerState(
     isVisible: Boolean = true,
     isPlaying: Boolean = false,
+    isReady: Boolean = false,
     progressInMillis: Long = 0,
     // Default to 1 minute and 23 seconds
     durationInMillis: Long = 83_000,
@@ -35,6 +36,7 @@ private fun aMediaPlayerControllerState(
 ) = MediaPlayerControllerState(
     isVisible = isVisible,
     isPlaying = isPlaying,
+    isReady = isReady,
     progressInMillis = progressInMillis,
     durationInMillis = durationInMillis,
     canMute = canMute,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -176,11 +176,14 @@ private fun ExoPlayerMediaVideoView(
         }
     }
 
-    LaunchedEffect(autoplay, isDisplayed, mediaPlayerControllerState.isReady) {
+    var needsAutoPlay by remember { mutableStateOf(autoplay) }
+
+    LaunchedEffect(needsAutoPlay, isDisplayed, mediaPlayerControllerState.isReady) {
         val isReadyAndNotPlaying = mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying
-        if (autoplay && isDisplayed && isReadyAndNotPlaying) {
+        if (needsAutoPlay && isDisplayed && isReadyAndNotPlaying) {
             // When displayed, start autoplaying from the beginning
             exoPlayer.play()
+            needsAutoPlay = false
         } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {
             // If not displayed, make sure to pause the video
             exoPlayer.pause()

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -177,8 +177,8 @@ private fun ExoPlayerMediaVideoView(
     }
 
     LaunchedEffect(autoplay, isDisplayed, mediaPlayerControllerState.isReady) {
-        val isReadyAndPlaying = mediaPlayerControllerState.isReady && mediaPlayerControllerState.isPlaying
-        if (autoplay && isDisplayed && isReadyAndPlaying) {
+        val isReadyAndNotPlaying = mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying
+        if (autoplay && isDisplayed && isReadyAndNotPlaying) {
             // When displayed, start autoplaying from the beginning
             exoPlayer.play()
         } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -181,13 +181,12 @@ private fun ExoPlayerMediaVideoView(
     LaunchedEffect(needsAutoPlay, isDisplayed, mediaPlayerControllerState.isReady) {
         val isReadyAndNotPlaying = mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying
         if (needsAutoPlay && isDisplayed && isReadyAndNotPlaying) {
-            // When displayed, start autoplaying from the beginning
+            // When displayed, start autoplaying
             exoPlayer.play()
             needsAutoPlay = false
         } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {
             // If not displayed, make sure to pause the video
             exoPlayer.pause()
-            exoPlayer.seekTo(0)
         }
     }
     if (localMedia?.uri != null) {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Player.STATE_READY
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
@@ -61,6 +62,7 @@ fun MediaVideoView(
     localMediaViewState: LocalMediaViewState,
     bottomPaddingInPixels: Int,
     localMedia: LocalMedia?,
+    autoplay: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val exoPlayer = rememberExoPlayer()
@@ -70,6 +72,7 @@ fun MediaVideoView(
         bottomPaddingInPixels = bottomPaddingInPixels,
         exoPlayer = exoPlayer,
         localMedia = localMedia,
+        autoplay = autoplay,
         modifier = modifier,
     )
 }
@@ -82,6 +85,7 @@ private fun ExoPlayerMediaVideoView(
     bottomPaddingInPixels: Int,
     exoPlayer: ExoPlayer,
     localMedia: LocalMedia?,
+    autoplay: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -89,6 +93,7 @@ private fun ExoPlayerMediaVideoView(
             MediaPlayerControllerState(
                 isVisible = true,
                 isPlaying = false,
+                isReady = false,
                 progressInMillis = 0,
                 durationInMillis = 0,
                 canMute = true,
@@ -135,6 +140,12 @@ private fun ExoPlayerMediaVideoView(
                         }
                 }
             }
+
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                mediaPlayerControllerState = mediaPlayerControllerState.copy(
+                    isReady = playbackState == STATE_READY,
+                )
+            }
         }
     }
 
@@ -164,10 +175,15 @@ private fun ExoPlayerMediaVideoView(
             )
         }
     }
-    LaunchedEffect(isDisplayed) {
-        // If not displayed, make sure to pause the video
-        if (!isDisplayed) {
+
+    LaunchedEffect(autoplay, isDisplayed, mediaPlayerControllerState.isReady) {
+        if (autoplay && isDisplayed && mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying) {
+            // When displayed, start autoplaying from the beginning
+            exoPlayer.play()
+        } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {
+            // If not displayed, make sure to pause the video
             exoPlayer.pause()
+            exoPlayer.seekTo(0)
         }
     }
     if (localMedia?.uri != null) {
@@ -259,5 +275,6 @@ internal fun MediaVideoViewPreview() = ElementPreview {
         bottomPaddingInPixels = 0,
         localMediaViewState = rememberLocalMediaViewState(),
         localMedia = null,
+        autoplay = false,
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -177,7 +177,8 @@ private fun ExoPlayerMediaVideoView(
     }
 
     LaunchedEffect(autoplay, isDisplayed, mediaPlayerControllerState.isReady) {
-        if (autoplay && isDisplayed && mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying) {
+        val isReadyAndPlaying = mediaPlayerControllerState.isReady && mediaPlayerControllerState.isPlaying
+        if (autoplay && isDisplayed && isReadyAndPlaying) {
             // When displayed, start autoplaying from the beginning
             exoPlayer.play()
         } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.libraries.mediaviewer.impl.viewer
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -75,8 +74,7 @@ class MediaViewerDataSource(
         return remember { dataFlow() }.collectAsState(initialData())
     }
 
-    @VisibleForTesting
-    fun dataFlow(): Flow<PersistentList<MediaViewerPageData>> {
+    internal fun dataFlow(): Flow<PersistentList<MediaViewerPageData>> {
         return galleryDataSource.groupedMediaItemsFlow()
             .map { groupedItems ->
                 when (groupedItems) {
@@ -105,7 +103,7 @@ class MediaViewerDataSource(
             }
     }
 
-    private fun initialData(): PersistentList<MediaViewerPageData> {
+    fun initialData(): PersistentList<MediaViewerPageData> {
         val initialMediaItems =
             galleryDataSource.getLastData().dataOrNull()?.getItems(galleryMode).orEmpty()
         return buildMediaViewerPageList(initialMediaItems)

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.mediaviewer.impl.viewer
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -74,6 +75,7 @@ class MediaViewerDataSource(
         return remember { dataFlow() }.collectAsState(initialData())
     }
 
+    @VisibleForTesting
     internal fun dataFlow(): Flow<PersistentList<MediaViewerPageData>> {
         return galleryDataSource.groupedMediaItemsFlow()
             .map { groupedItems ->
@@ -103,7 +105,7 @@ class MediaViewerDataSource(
             }
     }
 
-    fun initialData(): PersistentList<MediaViewerPageData> {
+    private fun initialData(): PersistentList<MediaViewerPageData> {
         val initialMediaItems =
             galleryDataSource.getLastData().dataOrNull()?.getItems(galleryMode).orEmpty()
         return buildMediaViewerPageList(initialMediaItems)

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -148,6 +148,7 @@ class MediaViewerPresenter @AssistedInject constructor(
         }
 
         return MediaViewerState(
+            initiallySelectedEventId = inputs.eventId,
             listData = data.value,
             currentIndex = currentIndex.intValue,
             snackbarMessage = snackbarMessage,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerState.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerState.kt
@@ -19,6 +19,7 @@ import io.element.android.libraries.mediaviewer.impl.details.MediaBottomSheetSta
 import kotlinx.collections.immutable.ImmutableList
 
 data class MediaViewerState(
+    val initiallySelectedEventId: EventId?,
     val listData: ImmutableList<MediaViewerPageData>,
     val currentIndex: Int,
     val snackbarMessage: SnackbarMessage?,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerStateProvider.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerStateProvider.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.designsystem.components.media.aWaveForm
+import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaviewer.api.MediaInfo
@@ -202,6 +203,7 @@ fun aMediaViewerState(
     mediaBottomSheetState: MediaBottomSheetState = MediaBottomSheetState.Hidden,
     eventSink: (MediaViewerEvents) -> Unit = {},
 ) = MediaViewerState(
+    initiallySelectedEventId = EventId("\$a:b"),
     listData = listData.toPersistentList(),
     currentIndex = currentIndex,
     snackbarMessage = null,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -142,8 +142,13 @@ fun MediaViewerView(
                     Box(
                         modifier = Modifier.fillMaxSize()
                     ) {
+                        val isDisplayed = remember(pagerState.settledPage) {
+                            // This 'item provider' lambda will be called when the data source changes with an outdated `settlePage` value
+                            // So we need to update this value only when the `settledPage` value changes. It seems like a bug that needs to be fixed in Compose.
+                            page == pagerState.settledPage
+                        }
                         MediaViewerPage(
-                            isDisplayed = page == pagerState.settledPage,
+                            isDisplayed = isDisplayed,
                             showOverlay = showOverlay,
                             bottomPaddingInPixels = bottomPaddingInPixels,
                             data = dataForPage,
@@ -157,7 +162,8 @@ fun MediaViewerView(
                             },
                             onShowOverlayChange = {
                                 showOverlay = it
-                            }
+                            },
+                            isUserSelected = (state.listData[page] as? MediaViewerPageData.MediaViewerData)?.eventId == state.initiallySelectedEventId,
                         )
                         // Bottom bar
                         AnimatedVisibility(visible = showOverlay, enter = fadeIn(), exit = fadeOut()) {
@@ -273,6 +279,7 @@ private fun MediaViewerPage(
     bottomPaddingInPixels: Int,
     data: MediaViewerPageData.MediaViewerData,
     textFileViewer: TextFileViewer,
+    isUserSelected: Boolean,
     onDismiss: () -> Unit,
     onRetry: () -> Unit,
     onDismissError: () -> Unit,
@@ -328,6 +335,7 @@ private fun MediaViewerPage(
                             currentOnShowOverlayChange(!currentShowOverlay)
                         }
                     },
+                    isUserSelected = isUserSelected,
                 )
                 ThumbnailView(
                     mediaInfo = data.mediaInfo,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Add video autoplay to any video the user explicitly opens (either from the timeline or the media gallery). Scrolling between videos in the gallery shouldn't result in autoplaying any other videos.
- Make sure reloading the media gallery items doesn't result in the video playback being paused then shortly resumed again.

## Motivation and context

Fixes https://github.com/element-hq/element-meta/issues/2797, achieving parity with iOS.

## Tests

- Open a video from the timeline, it should be displayed in the media gallery of the room you're in and autoplayed.
- If you scroll to some other video, this one should not autoplay.
- There are no accidental play/pause changes when new items are added to the media gallery.
- Scrubbing the video, moving to a different timestamp, should keep working as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
