### PR TITLE
Enable Rust trace log packs

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/initializer/PlatformInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/PlatformInitializer.kt
@@ -37,6 +37,7 @@ class PlatformInitializer : Initializer<Unit> {
             writesToFilesConfiguration = defaultWriteToDiskConfiguration(bugReporter),
             logLevel = logLevel,
             extraTargets = listOf(ELEMENT_X_TARGET),
+            traceLogPacks = runBlocking { preferencesStore.getTracingLogPacksFlow().first() },
         )
         bugReporter.setCurrentTracingLogLevel(logLevel.name)
         platformService.init(tracingConfiguration)

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
@@ -9,11 +9,13 @@ package io.element.android.features.preferences.impl.developer
 
 import io.element.android.features.preferences.impl.developer.tracing.LogLevelItem
 import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 
 sealed interface DeveloperSettingsEvents {
     data class UpdateEnabledFeature(val feature: FeatureUiModel, val isEnabled: Boolean) : DeveloperSettingsEvents
     data class SetCustomElementCallBaseUrl(val baseUrl: String?) : DeveloperSettingsEvents
     data class SetHideImagesAndVideos(val value: Boolean) : DeveloperSettingsEvents
     data class SetTracingLogLevel(val logLevel: LogLevelItem) : DeveloperSettingsEvents
+    data class ToggleTracingLogPack(val logPack: TraceLogPack, val enabled: Boolean) : DeveloperSettingsEvents
     data object ClearCache : DeveloperSettingsEvents
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
@@ -77,6 +77,7 @@ class DeveloperSettingsPresenter @Inject constructor(
             appPreferencesStore.getTracingLogLevelFlow().map { AsyncData.Success(it.toLogLevelItem()) }
         }
         val tracingLogLevel by tracingLogLevelFlow.collectAsState(initial = AsyncData.Uninitialized)
+        val tracingLogPacks by appPreferencesStore.getTracingLogPacksFlow().collectAsState(emptySet())
 
         LaunchedEffect(Unit) {
             FeatureFlags.entries
@@ -121,6 +122,15 @@ class DeveloperSettingsPresenter @Inject constructor(
                 is DeveloperSettingsEvents.SetTracingLogLevel -> coroutineScope.launch {
                     appPreferencesStore.setTracingLogLevel(event.logLevel.toLogLevel())
                 }
+                is DeveloperSettingsEvents.ToggleTracingLogPack -> coroutineScope.launch {
+                    val currentPacks = tracingLogPacks.toMutableSet()
+                    if (currentPacks.contains(event.logPack)) {
+                        currentPacks.remove(event.logPack)
+                    } else {
+                        currentPacks.add(event.logPack)
+                    }
+                    appPreferencesStore.setTracingLogPacks(currentPacks)
+                }
             }
         }
 
@@ -135,6 +145,7 @@ class DeveloperSettingsPresenter @Inject constructor(
             ),
             hideImagesAndVideos = hideImagesAndVideos,
             tracingLogLevel = tracingLogLevel,
+            tracingLogPacks = tracingLogPacks,
             eventSink = ::handleEvents
         )
     }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
@@ -12,6 +12,7 @@ import io.element.android.features.rageshake.api.preferences.RageshakePreference
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import kotlinx.collections.immutable.ImmutableList
 
 data class DeveloperSettingsState(
@@ -22,6 +23,7 @@ data class DeveloperSettingsState(
     val customElementCallBaseUrlState: CustomElementCallBaseUrlState,
     val hideImagesAndVideos: Boolean,
     val tracingLogLevel: AsyncData<LogLevelItem>,
+    val tracingLogPacks: Set<TraceLogPack>,
     val eventSink: (DeveloperSettingsEvents) -> Unit
 )
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
@@ -13,6 +13,7 @@ import io.element.android.features.rageshake.api.preferences.aRageshakePreferenc
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.featureflag.ui.model.aFeatureUiModelList
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 
 open class DeveloperSettingsStateProvider : PreviewParameterProvider<DeveloperSettingsState> {
     override val values: Sequence<DeveloperSettingsState>
@@ -33,6 +34,7 @@ fun aDeveloperSettingsState(
     clearCacheAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     customElementCallBaseUrlState: CustomElementCallBaseUrlState = aCustomElementCallBaseUrlState(),
     hideImagesAndVideos: Boolean = false,
+    traceLogPacks: Set<TraceLogPack> = emptySet(),
     eventSink: (DeveloperSettingsEvents) -> Unit = {},
 ) = DeveloperSettingsState(
     features = aFeatureUiModelList(),
@@ -42,6 +44,7 @@ fun aDeveloperSettingsState(
     customElementCallBaseUrlState = customElementCallBaseUrlState,
     hideImagesAndVideos = hideImagesAndVideos,
     tracingLogLevel = AsyncData.Success(LogLevelItem.INFO),
+    tracingLogPacks = traceLogPacks,
     eventSink = eventSink,
 )
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.featureflag.ui.FeatureListView
 import io.element.android.libraries.featureflag.ui.model.FeatureUiModel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.collections.immutable.toPersistentList
 
@@ -56,6 +57,7 @@ fun DeveloperSettingsView(
             FeatureListContent(state)
         }
         ElementCallCategory(state = state)
+
         PreferenceCategory(title = "Rust SDK") {
             PreferenceDropdown(
                 title = "Tracing log level",
@@ -67,6 +69,16 @@ fun DeveloperSettingsView(
                 }
             )
         }
+        PreferenceCategory(title = "Enable trace logs per feature") {
+            for (logPack in TraceLogPack.entries) {
+                PreferenceSwitch(
+                    title = logPack.name,
+                    isChecked = state.tracingLogPacks.contains(logPack),
+                    onCheckedChange = { isChecked -> state.eventSink(DeveloperSettingsEvents.ToggleTracingLogPack(logPack, isChecked)) }
+                )
+            }
+        }
+
         PreferenceCategory(title = "Showkase") {
             ListItem(
                 headlineContent = {

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -69,10 +69,10 @@ fun DeveloperSettingsView(
                 }
             )
         }
-        PreferenceCategory(title = "Enable trace logs per feature") {
+        PreferenceCategory(title = "Enable trace logs per SDK feature") {
             for (logPack in TraceLogPack.entries) {
                 PreferenceSwitch(
-                    title = logPack.name,
+                    title = logPack.title,
                     isChecked = state.tracingLogPacks.contains(logPack),
                     onCheckedChange = { isChecked -> state.eventSink(DeveloperSettingsEvents.ToggleTracingLogPack(logPack, isChecked)) }
                 )

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsViewTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsViewTest.kt
@@ -68,7 +68,7 @@ class DeveloperSettingsViewTest {
         eventsRecorder.assertSingle(DeveloperSettingsEvents.SetCustomElementCallBaseUrl("https://call.element.dev"))
     }
 
-    @Config(qualifiers = "h1024dp")
+    @Config(qualifiers = "h1200dp")
     @Test
     fun `clicking on open showkase invokes the expected callback`() {
         val eventsRecorder = EventsRecorder<DeveloperSettingsEvents>(expectEvents = false)
@@ -97,7 +97,7 @@ class DeveloperSettingsViewTest {
         eventsRecorder.assertSingle(DeveloperSettingsEvents.SetTracingLogLevel(LogLevelItem.DEBUG))
     }
 
-    @Config(qualifiers = "h1500dp")
+    @Config(qualifiers = "h1700dp")
     @Test
     fun `clicking on clear cache emits the expected event`() {
         val eventsRecorder = EventsRecorder<DeveloperSettingsEvents>()

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TraceLogPack.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TraceLogPack.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.tracing
+
+enum class TraceLogPack(val key: String) {
+    EVENT_CACHE("event_cache") {
+        override val title: String = "Event Cache"
+    },
+    SEND_QUEUE("send_queue") {
+        override val title: String = "Send Queue"
+    },
+    TIMELINE("timeline") {
+        override val title: String = "Timeline"
+    };
+
+    abstract val title: String
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingConfiguration.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/tracing/TracingConfiguration.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.matrix.api.tracing
 data class TracingConfiguration(
     val logLevel: LogLevel,
     val extraTargets: List<String>,
+    val traceLogPacks: Set<TraceLogPack>,
     val writesToLogcat: Boolean,
     val writesToFilesConfiguration: WriteToFilesConfiguration,
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/tracing/RustTracingService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/tracing/RustTracingService.kt
@@ -51,7 +51,6 @@ fun TracingConfiguration.map(): org.matrix.rustcomponents.sdk.TracingConfigurati
     writeToStdoutOrSystem = writesToLogcat,
     logLevel = logLevel.toRustLogLevel(),
     extraTargets = extraTargets,
-    // WARNING: this should be used only to debug issues, changes to this value should *never* be published
-    traceLogPacks = emptyList(),
+    traceLogPacks = traceLogPacks.map(),
     writeToFiles = writesToFilesConfiguration.toTracingFileConfiguration(),
 )

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/tracing/TraceLogPacksMapping.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/tracing/TraceLogPacksMapping.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.tracing
+
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
+import org.matrix.rustcomponents.sdk.TraceLogPacks as RustTraceLogPack
+
+fun TraceLogPack.map(): RustTraceLogPack = when (this) {
+    TraceLogPack.SEND_QUEUE -> RustTraceLogPack.SEND_QUEUE
+    TraceLogPack.EVENT_CACHE -> RustTraceLogPack.EVENT_CACHE
+    TraceLogPack.TIMELINE -> RustTraceLogPack.TIMELINE
+}
+
+fun Collection<TraceLogPack>.map(): List<RustTraceLogPack> {
+    return map { it.map() }
+}

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.preferences.api.store
 
 import io.element.android.libraries.matrix.api.tracing.LogLevel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import kotlinx.coroutines.flow.Flow
 
 interface AppPreferencesStore {
@@ -25,6 +26,9 @@ interface AppPreferencesStore {
 
     suspend fun setTracingLogLevel(logLevel: LogLevel)
     fun getTracingLogLevelFlow(): Flow<LogLevel>
+
+    suspend fun setTracingLogPacks(targets: Set<TraceLogPack>)
+    fun getTracingLogPacksFlow(): Flow<Set<TraceLogPack>>
 
     suspend fun reset()
 }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
 import io.element.android.libraries.matrix.api.tracing.LogLevel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -32,6 +33,7 @@ private val customElementCallBaseUrlKey = stringPreferencesKey("elementCallBaseU
 private val themeKey = stringPreferencesKey("theme")
 private val hideImagesAndVideosKey = booleanPreferencesKey("hideImagesAndVideos")
 private val logLevelKey = stringPreferencesKey("logLevel")
+private val traceLogPacksKey = stringPreferencesKey("traceLogPacks")
 
 @ContributesBinding(AppScope::class)
 class DefaultAppPreferencesStore @Inject constructor(
@@ -102,6 +104,23 @@ class DefaultAppPreferencesStore @Inject constructor(
     override fun getTracingLogLevelFlow(): Flow<LogLevel> {
         return store.data.map { prefs ->
             prefs[logLevelKey]?.let { LogLevel.valueOf(it) } ?: buildMeta.defaultLogLevel()
+        }
+    }
+
+    override suspend fun setTracingLogPacks(targets: Set<TraceLogPack>) {
+        val value = targets.joinToString(",") { it.key }
+        store.edit { prefs ->
+            prefs[traceLogPacksKey] = value
+        }
+    }
+
+    override fun getTracingLogPacksFlow(): Flow<Set<TraceLogPack>> {
+        return store.data.map { prefs ->
+            prefs[traceLogPacksKey]
+                ?.split(",")
+                ?.mapNotNull { value -> TraceLogPack.entries.find { it.key == value } }
+                ?.toSet()
+                ?: emptySet()
         }
     }
 

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.preferences.test
 
 import io.element.android.libraries.matrix.api.tracing.LogLevel
+import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,6 +20,7 @@ class InMemoryAppPreferencesStore(
     theme: String? = null,
     simplifiedSlidingSyncEnabled: Boolean = false,
     logLevel: LogLevel = LogLevel.INFO,
+    traceLockPacks: Set<TraceLogPack> = emptySet(),
 ) : AppPreferencesStore {
     private val isDeveloperModeEnabled = MutableStateFlow(isDeveloperModeEnabled)
     private val hideImagesAndVideos = MutableStateFlow(hideImagesAndVideos)
@@ -26,6 +28,7 @@ class InMemoryAppPreferencesStore(
     private val theme = MutableStateFlow(theme)
     private val simplifiedSlidingSyncEnabled = MutableStateFlow(simplifiedSlidingSyncEnabled)
     private val logLevel = MutableStateFlow(logLevel)
+    private val tracingLogPacks = MutableStateFlow(traceLockPacks)
 
     override suspend fun setDeveloperModeEnabled(enabled: Boolean) {
         isDeveloperModeEnabled.value = enabled
@@ -65,6 +68,14 @@ class InMemoryAppPreferencesStore(
 
     override fun getTracingLogLevelFlow(): Flow<LogLevel> {
         return logLevel
+    }
+
+    override suspend fun setTracingLogPacks(logPacks: Set<TraceLogPack>) {
+        tracingLogPacks.value = logPacks
+    }
+
+    override fun getTracingLogPacksFlow(): Flow<Set<TraceLogPack>> {
+        return tracingLogPacks
     }
 
     override suspend fun reset() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Adds new section in developer options to allow uploading trace logs for some specific features of the SDK.

## Motivation and context

This is a way to forcefully enable trace logs only for a few Rust crates in a safe way, it was added in the previous upgrade of the Rust SDK bindings.

## Screenshots / GIFs

<img width="338" alt="image" src="https://github.com/user-attachments/assets/f4e5c984-9336-41c4-ba73-267b8c8709c3" />

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
