### PR TITLE
Make sure the live timeline is destroyed before clearing a room's cache

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -311,6 +311,7 @@ class RoomListPresenter @Inject constructor(
 
     private fun CoroutineScope.clearCacheOfRoom(roomId: RoomId) = launch {
         client.getRoom(roomId)?.use { room ->
+            room.liveTimeline.close()
             room.clearEventCacheStorage()
         }
     }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -311,6 +311,7 @@ class RoomListPresenter @Inject constructor(
 
     private fun CoroutineScope.clearCacheOfRoom(roomId: RoomId) = launch {
         client.getRoom(roomId)?.use { room ->
+            // Ideally we wouldn't have a live timeline at this point, but right now we instantiate one when retrieving the room
             room.liveTimeline.close()
             room.clearEventCacheStorage()
         }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -81,6 +81,10 @@ class RustRoomFactory(
         withContext(NonCancellable + dispatcher) {
             mutex.withLock {
                 Timber.d("Destroying room factory")
+                cache.snapshot().values.forEach { (listItem, innerRoom) ->
+                    innerRoom.destroy()
+                    listItem.destroy()
+                }
                 cache.evictAll()
                 isDestroyed = true
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Destroy live timeline instantiated right before clearing the room's cache. In a future refactor we should avoid creating the timeline at all, but at the moment this is the best we can do.
- Destroy all room references before evicting them from the LRU cache when destroying `RustMatrixClient` on logout / clear cache. This *should* also destroy their live timelines.

## Motivation and context

According to the SDK team, having a live timeline while clearing the cache could lead to DB issues.

## Tests

Clear the cache from the developer settings or the room's context menu. If it still works as expected, the change didn't cause new issues, and *should* improve existing ones.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
