### PR TITLE
Make `RustMatrixRoom.liveTimeline` loading async

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/PinnedEventsTimelineProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/PinnedEventsTimelineProvider.kt
@@ -41,7 +41,7 @@ class PinnedEventsTimelineProvider @Inject constructor(
     private val _timelineStateFlow: MutableStateFlow<AsyncData<Timeline>> =
         MutableStateFlow(AsyncData.Uninitialized)
 
-    override fun activeTimelineFlow(): StateFlow<Timeline?> {
+    override suspend fun activeTimelineFlow(): StateFlow<Timeline?> {
         return _timelineStateFlow
             .mapState { value ->
                 value.dataOrNull()

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -307,7 +307,7 @@ class TimelinePresenter @AssistedInject constructor(
             val eventId = getLastEventIdBeforeOrAt(firstVisibleIndex, timelineItems)
             if (eventId != null && eventId != lastReadReceiptId.value) {
                 lastReadReceiptId.value = eventId
-                room.liveTimeline.sendReadReceipt(eventId = eventId, receiptType = readReceiptType)
+                room.liveTimeline().sendReadReceipt(eventId = eventId, receiptType = readReceiptType)
             }
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -281,9 +281,8 @@ class TimelinePresenter @AssistedInject constructor(
             newMostRecentItemId != prevMostRecentItemIdValue
 
         if (hasNewEvent) {
-            val newMostRecentEvent = newMostRecentItem as? TimelineItem.Event
             // Scroll to bottom if the new event is from me, even if sent from another device
-            val fromMe = newMostRecentEvent?.isMine == true
+            val fromMe = newMostRecentItem.isMine == true
             newEventState.value = if (fromMe) {
                 NewEventState.FromMe
             } else {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineControllerTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineControllerTest.kt
@@ -36,6 +36,9 @@ class TimelineControllerTest {
         val sut = TimelineController(matrixRoom)
 
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
             }
@@ -75,6 +78,9 @@ class TimelineControllerTest {
         val sut = TimelineController(matrixRoom)
 
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
             }
@@ -102,6 +108,9 @@ class TimelineControllerTest {
         )
         val sut = TimelineController(matrixRoom)
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+            // Assert live timeline
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
             }
@@ -121,6 +130,9 @@ class TimelineControllerTest {
         )
         val sut = TimelineController(matrixRoom)
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
             }
@@ -171,6 +183,9 @@ class TimelineControllerTest {
         )
         val sut = TimelineController(matrixRoom)
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+
             sut.focusOnEvent(AN_EVENT_ID)
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
@@ -197,6 +212,9 @@ class TimelineControllerTest {
         val sut = TimelineController(matrixRoom)
 
         sut.activeTimelineFlow().test {
+            // Wait until the live timeline is emitted
+            skipItems(1)
+
             awaitItem().also { state ->
                 assertThat(state).isEqualTo(liveTimeline)
             }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -75,7 +76,8 @@ import java.util.Date
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class) class TimelinePresenterTest {
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimelinePresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
 
@@ -109,6 +111,10 @@ import kotlin.time.Duration.Companion.seconds
             val initialState = awaitItem()
             initialState.eventSink.invoke(TimelineEvents.LoadMore(Timeline.PaginationDirection.BACKWARDS))
             initialState.eventSink.invoke(TimelineEvents.LoadMore(Timeline.PaginationDirection.FORWARDS))
+
+            // Wait until the live timeline is emitted
+            advanceTimeBy(1.seconds)
+
             assert(paginateLambda)
                 .isCalledExactly(2)
                 .withSequence(
@@ -685,7 +691,7 @@ import kotlin.time.Duration.Companion.seconds
             sendPollResponseAction = sendPollResponseAction,
             sessionPreferencesStore = sessionPreferencesStore,
             timelineItemIndexer = timelineItemIndexer,
-            timelineController = TimelineController(room),
+            timelineController = TimelineController(room, backgroundScope),
             resolveVerifiedUserSendFailurePresenter = { aResolveVerifiedUserSendFailureState() },
             typingNotificationPresenter = { aTypingNotificationState() },
             roomCallStatePresenter = { aStandByCallState() },

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -311,8 +311,6 @@ class RoomListPresenter @Inject constructor(
 
     private fun CoroutineScope.clearCacheOfRoom(roomId: RoomId) = launch {
         client.getRoom(roomId)?.use { room ->
-            // Ideally we wouldn't have a live timeline at this point, but right now we instantiate one when retrieving the room
-            room.liveTimeline.close()
             room.clearEventCacheStorage()
         }
     }

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/SuspendLazy.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/SuspendLazy.kt
@@ -7,19 +7,15 @@
 
 package io.element.android.libraries.core.coroutine
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 fun <T> suspendLazy(coroutineContext: CoroutineContext = EmptyCoroutineContext, block: suspend () -> T): Lazy<Deferred<T>> {
     return lazy(LazyThreadSafetyMode.NONE) {
-        val deferred = CompletableDeferred<T>()
-        CoroutineScope(coroutineContext).launch {
-            deferred.complete(block())
-        }
-        deferred
+        CoroutineScope(coroutineContext).async(start = CoroutineStart.LAZY) { block() }
     }
 }

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/SuspendLazy.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/SuspendLazy.kt
@@ -14,8 +14,17 @@ import kotlinx.coroutines.async
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-fun <T> suspendLazy(coroutineContext: CoroutineContext = EmptyCoroutineContext, block: suspend () -> T): Lazy<Deferred<T>> {
-    return lazy(LazyThreadSafetyMode.NONE) {
-        CoroutineScope(coroutineContext).async(start = CoroutineStart.LAZY) { block() }
+class SuspendLazy<T>(
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    private val block: suspend CoroutineScope.() -> T,
+) {
+    private val coroutineScope = CoroutineScope(coroutineContext)
+
+    operator fun getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): Deferred<T> {
+        return coroutineScope.async(start = CoroutineStart.LAZY, block = block)
     }
+}
+
+fun <T> suspendLazy(coroutineContext: CoroutineContext = EmptyCoroutineContext, block: suspend CoroutineScope.() -> T): SuspendLazy<T> {
+    return SuspendLazy(coroutineContext, block = block)
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/MatrixRoom.kt
@@ -100,7 +100,7 @@ interface MatrixRoom : Closeable {
     /**
      * The live timeline of the room. Must be used to send Event to a room.
      */
-    val liveTimeline: Timeline
+    suspend fun liveTimeline(): Timeline
 
     /**
      * Create a new timeline.

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/TimelineProvider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/TimelineProvider.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.first
  * By default, the active timeline is the live timeline.
  */
 interface TimelineProvider {
-    fun activeTimelineFlow(): StateFlow<Timeline?>
+    suspend fun activeTimelineFlow(): StateFlow<Timeline?>
 }
 
 suspend fun TimelineProvider.getActiveTimeline(): Timeline = activeTimelineFlow().filterNotNull().first()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -199,6 +199,7 @@ class RustMatrixClient(
         timelineEventTypeFilterFactory = timelineEventTypeFilterFactory,
         featureFlagService = featureFlagService,
         roomMembershipObserver = roomMembershipObserver,
+        innerClient = innerClient,
     )
 
     override val mediaLoader: MatrixMediaLoader = RustMediaLoader(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notificationsettings/RustNotificationSettingsService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notificationsettings/RustNotificationSettingsService.kt
@@ -44,7 +44,9 @@ class RustNotificationSettingsService(
     }
 
     suspend fun destroy() {
-        notificationSettings.await().setDelegate(null)
+        if (notificationSettings.isCompleted && !notificationSettings.isCancelled) {
+            notificationSettings.await().setDelegate(null)
+        }
     }
 
     override suspend fun getRoomNotificationSettings(roomId: RoomId, isEncrypted: Boolean, isOneToOne: Boolean): Result<RoomNotificationSettings> =

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -108,7 +108,6 @@ import uniffi.matrix_sdk.RoomPowerLevelChanges
 import uniffi.matrix_sdk_base.EncryptionState
 import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.coroutineContext
 import org.matrix.rustcomponents.sdk.IdentityStatusChange as RustIdentityStateChange
 import org.matrix.rustcomponents.sdk.KnockRequest as InnerKnockRequest
 import org.matrix.rustcomponents.sdk.Room as InnerRoom

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustMatrixRoom.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.matrix.impl.room
 
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.coroutine.childScope
+import io.element.android.libraries.core.coroutine.suspendLazy
 import io.element.android.libraries.core.data.tryOrNull
 import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.featureflag.api.FeatureFlagService
@@ -71,9 +72,7 @@ import io.element.android.libraries.matrix.impl.widget.RustWidgetDriver
 import io.element.android.libraries.matrix.impl.widget.generateWidgetWebViewUrl
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -109,6 +108,7 @@ import uniffi.matrix_sdk.RoomPowerLevelChanges
 import uniffi.matrix_sdk_base.EncryptionState
 import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.coroutineContext
 import org.matrix.rustcomponents.sdk.IdentityStatusChange as RustIdentityStateChange
 import org.matrix.rustcomponents.sdk.KnockRequest as InnerKnockRequest
 import org.matrix.rustcomponents.sdk.Room as InnerRoom
@@ -194,7 +194,7 @@ class RustMatrixRoom(
     private val _roomNotificationSettingsStateFlow = MutableStateFlow<MatrixRoomNotificationSettingsState>(MatrixRoomNotificationSettingsState.Unknown)
     override val roomNotificationSettingsStateFlow: StateFlow<MatrixRoomNotificationSettingsState> = _roomNotificationSettingsStateFlow
 
-    private val lazyLiveTimeline = roomCoroutineScope.async(start = CoroutineStart.LAZY) {
+    private val lazyLiveTimeline by suspendLazy(coroutineContext = roomCoroutineScope.coroutineContext) {
         createTimeline(innerTimelineInitializer(), mode = Timeline.Mode.LIVE) {
             _syncUpdateFlow.value = systemClock.epochMillis()
         }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -114,6 +114,7 @@ class RustRoomFactory(
                 deviceId = deviceId,
                 innerRoom = roomReferences.room,
                 innerTimelineInitializer = {
+                    // Ideally we'd use `Room.initTimeline` but its behaviour in the SDK doesn't match the `initTimeline` one yet
                     roomReferences.roomListItem.initTimeline(eventFilters, "LIVE")
                     roomReferences.room.timeline()
                 },

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -115,7 +115,9 @@ class RustRoomFactory(
                 innerRoom = roomReferences.room,
                 innerTimelineInitializer = {
                     // Ideally we'd use `Room.initTimeline` but its behaviour in the SDK doesn't match the `initTimeline` one yet
-                    roomReferences.roomListItem.initTimeline(eventFilters, "LIVE")
+                    if (!roomReferences.roomListItem.isTimelineInitialized()) {
+                        roomReferences.roomListItem.initTimeline(eventFilters, "LIVE")
+                    }
                     roomReferences.room.timeline()
                 },
                 sessionCoroutineScope = sessionCoroutineScope,

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
@@ -13,6 +13,7 @@ import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.impl.memory.InMemorySessionStore
 import io.element.android.libraries.sessionstorage.test.aSessionData
 import io.element.android.tests.testutils.testCoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
@@ -46,8 +47,9 @@ class RustClientSessionDelegateTest {
 
 fun TestScope.aRustClientSessionDelegate(
     sessionStore: SessionStore = InMemorySessionStore(),
+    appCoroutineScope: CoroutineScope = this,
 ) = RustClientSessionDelegate(
     sessionStore = sessionStore,
-    appCoroutineScope = this,
+    appCoroutineScope = appCoroutineScope,
     coroutineDispatchers = testCoroutineDispatchers(),
 )

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientTest.kt
@@ -43,7 +43,7 @@ class RustMatrixClientTest {
             client = FakeRustClient(
                 clearCachesResult = clearCachesResult,
                 closeResult = closeResult,
-            )
+            ),
         )
         client.clearCache()
         clearCachesResult.assertions().isCalledOnce()
@@ -61,6 +61,7 @@ class RustMatrixClientTest {
         appCoroutineScope = backgroundScope,
         sessionDelegate = aRustClientSessionDelegate(
             sessionStore = sessionStore,
+            appCoroutineScope = backgroundScope,
         ),
         innerSyncService = FakeRustSyncService(),
         dispatchers = testCoroutineDispatchers(),

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeMatrixRoom.kt
@@ -68,7 +68,7 @@ class FakeMatrixRoom(
     override val sessionId: SessionId = A_SESSION_ID,
     override val roomId: RoomId = A_ROOM_ID,
     val notificationSettingsService: NotificationSettingsService = FakeNotificationSettingsService(),
-    override val liveTimeline: Timeline = FakeTimeline(),
+    private val liveTimeline: Timeline = FakeTimeline(),
     initialRoomInfo: MatrixRoomInfo = aRoomInfo(),
     override val roomCoroutineScope: CoroutineScope = TestScope(),
     private var roomPermalinkResult: () -> Result<String> = { lambdaError() },
@@ -147,6 +147,8 @@ class FakeMatrixRoom(
     private val enableEncryptionResult: () -> Result<Unit> = { lambdaError() },
     private val updateJoinRuleResult: (JoinRule) -> Result<Unit> = { lambdaError() },
 ) : MatrixRoom {
+    override suspend fun liveTimeline(): Timeline = simulateLongTask { liveTimeline }
+
     private val _roomInfoFlow: MutableStateFlow<MatrixRoomInfo> = MutableStateFlow(initialRoomInfo)
     override val roomInfoFlow: StateFlow<MatrixRoomInfo> = _roomInfoFlow
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/LiveTimelineProvider.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/LiveTimelineProvider.kt
@@ -16,5 +16,5 @@ import kotlinx.coroutines.flow.StateFlow
 class LiveTimelineProvider(
     private val room: MatrixRoom,
 ) : TimelineProvider {
-    override fun activeTimelineFlow(): StateFlow<Timeline> = MutableStateFlow(room.liveTimeline)
+    override suspend fun activeTimelineFlow(): StateFlow<Timeline> = MutableStateFlow(room.liveTimeline())
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -237,7 +237,7 @@ class MediaViewerPresenter @AssistedInject constructor(
     }
 
     private fun CoroutineScope.delete(eventId: EventId) = launch {
-        room.liveTimeline.redactEvent(eventId.toEventOrTransactionId(), null)
+        room.liveTimeline().redactEvent(eventId.toEventOrTransactionId(), null)
             .onFailure {
                 val snackbarMessage = SnackbarMessage(CommonStrings.error_unknown)
                 snackbarDispatcher.post(snackbarMessage)

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
@@ -47,6 +47,7 @@ import io.mockk.mockk
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -471,6 +472,10 @@ class MediaViewerPresenterTest {
                     eventId = AN_EVENT_ID,
                 )
             )
+
+            // Give time to the live timeline to load and process the deletion action
+            advanceUntilIdle()
+
             val finalState = awaitItem()
             assertThat(finalState.mediaBottomSheetState).isEqualTo(MediaBottomSheetState.Hidden)
             redactEventLambda.assertions()

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
@@ -159,7 +159,7 @@ class NotificationBroadcastReceiverHandler @Inject constructor(
         onNotifiableEventReceived.onNotifiableEventReceived(notifiableMessageEvent)
 
         if (threadId != null) {
-            room.liveTimeline.replyMessage(
+            room.liveTimeline().replyMessage(
                 eventId = threadId.asEventId(),
                 body = message,
                 htmlBody = null,
@@ -167,7 +167,7 @@ class NotificationBroadcastReceiverHandler @Inject constructor(
                 fromNotification = true,
             )
         } else {
-            room.liveTimeline.sendMessage(
+            room.liveTimeline().sendMessage(
                 body = message,
                 htmlBody = null,
                 intentionalMentions = emptyList()

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/SyncOnNotifiableEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/SyncOnNotifiableEvent.kt
@@ -70,7 +70,7 @@ class SyncOnNotifiableEvent @Inject constructor(
 
     private suspend fun MatrixRoom.waitsUntilEventIsKnown(eventId: EventId, timeout: Duration) {
         withTimeoutOrNull(timeout) {
-            liveTimeline.timelineItems.first { timelineItems ->
+            liveTimeline().timelineItems.first { timelineItems ->
                 timelineItems.any { timelineItem ->
                     when (timelineItem) {
                         is MatrixTimelineItem.Event -> timelineItem.eventId == eventId

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
@@ -49,6 +49,7 @@ import io.element.android.tests.testutils.lambda.value
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -359,7 +360,7 @@ class NotificationBroadcastReceiverHandlerTest {
                 roomId = A_ROOM_ID,
             ),
         )
-        runCurrent()
+        advanceUntilIdle()
         sendMessage.assertions()
             .isCalledOnce()
             .with(value(A_MESSAGE), value(null), value(emptyList<IntentionalMention>()))
@@ -426,7 +427,7 @@ class NotificationBroadcastReceiverHandlerTest {
                 threadId = A_THREAD_ID,
             ),
         )
-        runCurrent()
+        advanceUntilIdle()
         sendMessage.assertions()
             .isNeverCalled()
         onNotifiableEventReceivedResult.assertions()


### PR DESCRIPTION
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
