### PR TITLE
Fix bullet points not having leading margin on timeline items

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -7,7 +7,7 @@
 
 package io.element.android.features.messages.impl.timeline.components.event
 
-import android.text.SpannableString
+import android.text.SpannedString
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.LocalContentColor
@@ -71,7 +71,7 @@ fun TimelineItemTextView(
 internal fun getTextWithResolvedMentions(content: TimelineItemTextBasedContent): CharSequence {
     val mentionSpanUpdater = LocalMentionSpanUpdater.current
     val bodyWithResolvedMentions = mentionSpanUpdater.rememberMentionSpans(content.formattedBody)
-    return SpannableString(bodyWithResolvedMentions)
+    return SpannedString.valueOf(bodyWithResolvedMentions)
 }
 
 @PreviewsDayNight

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ClickableLinkText.kt
@@ -135,7 +135,7 @@ fun ClickableLinkText(
 
 fun AnnotatedString.linkify(linkStyle: SpanStyle): AnnotatedString {
     val original = this
-    val spannable = SpannableString(this.text)
+    val spannable = SpannableString.valueOf(this.text)
     LinkifyCompat.addLinks(spannable, Linkify.WEB_URLS or Linkify.PHONE_NUMBERS or Linkify.EMAIL_ADDRESSES)
 
     val spans = spannable.getSpans(0, spannable.length, URLSpan::class.java)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/AnnotatedStrings.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/AnnotatedStrings.kt
@@ -8,7 +8,7 @@
 package io.element.android.libraries.designsystem.text
 
 import android.graphics.Typeface
-import android.text.SpannableString
+import android.text.SpannedString
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
@@ -26,7 +26,7 @@ import io.element.android.compound.theme.LinkColor
 
 fun String.toAnnotatedString(): AnnotatedString = buildAnnotatedString {
     append(this@toAnnotatedString)
-    val spannable = SpannableString(this@toAnnotatedString)
+    val spannable = SpannedString.valueOf(this@toAnnotatedString)
     spannable.getSpans(0, spannable.length, Any::class.java).forEach { span ->
         val start = spannable.getSpanStart(span)
         val end = spannable.getSpanEnd(span)

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/StableCharSequence.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/StableCharSequence.kt
@@ -16,11 +16,11 @@ import io.element.android.libraries.core.extensions.orEmpty
 
 @Stable
 class StableCharSequence(initialText: CharSequence = "") {
-    private var value by mutableStateOf<SpannableString>(SpannableString(initialText))
+    private var value by mutableStateOf<SpannableString>(SpannableString.valueOf(initialText))
     private var needsDisplaying by mutableStateOf(false)
 
     fun update(newText: CharSequence?, needsDisplaying: Boolean) {
-        value = SpannableString(newText.orEmpty())
+        value = SpannableString.valueOf(newText.orEmpty())
         this.needsDisplaying = needsDisplaying
     }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/MarkdownTextEditorState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/MarkdownTextEditorState.kt
@@ -9,7 +9,6 @@ package io.element.android.libraries.textcomposer.model
 
 import android.os.Parcelable
 import android.text.Spannable
-import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import androidx.compose.runtime.Composable
@@ -118,8 +117,7 @@ class MarkdownTextEditorState(
     }
 
     fun getMentions(): List<IntentionalMention> {
-        val text = SpannableString(text.value())
-        val mentionSpans = text.getMentionSpans()
+        val mentionSpans = text.value().getMentionSpans()
         return mentionSpans.mapNotNull { mentionSpan ->
             when (mentionSpan.type) {
                 is MentionType.User -> IntentionalMention.User(mentionSpan.type.userId)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Change the `SpannableString(value)` constructor to `SpannedString.valueOf`, as it was always creating a new spannable string, instead of just returning the existing one if it had the right type. Apparently, this messed up the leading margin spans.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4525#issuecomment-2778388389.

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="68" alt="image" src="https://github.com/user-attachments/assets/4d34569f-fe7c-44ac-bf3b-f00361f42ea2" />|<img width="62" alt="image" src="https://github.com/user-attachments/assets/7ea3373e-4b6b-40e7-b06e-ee5750093d32" />|

## Tests

Open a room with a timeline message with nested list items, they should have the proper leading margin.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
