### PR TITLE
Add a inderminate progress bar when loging out and in Waiting state.

### DIFF
--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutState.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutState.kt
@@ -18,6 +18,7 @@ data class LogoutState(
     val doesBackupExistOnServer: Boolean,
     val recoveryState: RecoveryState,
     val backupUploadState: BackupUploadState,
+    val waitingForALongTime: Boolean,
     val logoutAction: AsyncAction<Unit>,
     val eventSink: (LogoutEvents) -> Unit,
 )

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutStateProvider.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutStateProvider.kt
@@ -29,6 +29,15 @@ open class LogoutStateProvider : PreviewParameterProvider<LogoutState> {
             aLogoutState(isLastDevice = true, recoveryState = RecoveryState.DISABLED),
             // Last session no backup
             aLogoutState(isLastDevice = true, backupState = BackupState.UNKNOWN, doesBackupExistOnServer = false),
+            aLogoutState(
+                isLastDevice = false,
+                backupUploadState = BackupUploadState.Waiting,
+            ),
+            aLogoutState(
+                isLastDevice = false,
+                backupUploadState = BackupUploadState.Waiting,
+                waitingForALongTime = true,
+            ),
         )
 }
 
@@ -38,6 +47,7 @@ fun aLogoutState(
     doesBackupExistOnServer: Boolean = true,
     recoveryState: RecoveryState = RecoveryState.ENABLED,
     backupUploadState: BackupUploadState = BackupUploadState.Unknown,
+    waitingForALongTime: Boolean = false,
     logoutAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     eventSink: (LogoutEvents) -> Unit = {},
 ) = LogoutState(
@@ -46,6 +56,7 @@ fun aLogoutState(
     doesBackupExistOnServer = doesBackupExistOnServer,
     recoveryState = recoveryState,
     backupUploadState = backupUploadState,
+    waitingForALongTime = waitingForALongTime,
     logoutAction = logoutAction,
     eventSink = eventSink,
 )

--- a/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutView.kt
+++ b/features/logout/impl/src/main/kotlin/io/element/android/features/logout/impl/LogoutView.kt
@@ -143,24 +143,41 @@ private fun ColumnScope.Buttons(
 @Composable
 private fun Content(
     state: LogoutState,
+    modifier: Modifier = Modifier,
 ) {
-    if (state.backupUploadState is BackupUploadState.Uploading) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 60.dp, start = 20.dp, end = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
-                progress = { state.backupUploadState.backedUpCount.toFloat() / state.backupUploadState.totalCount.toFloat() },
-                trackColor = ElementTheme.colors.progressIndicatorTrackColor,
-            )
-            Text(
-                modifier = Modifier.align(Alignment.End),
-                text = "${state.backupUploadState.backedUpCount} / ${state.backupUploadState.totalCount}",
-                style = ElementTheme.typography.fontBodySmRegular,
-            )
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 60.dp, start = 20.dp, end = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        when (state.backupUploadState) {
+            is BackupUploadState.Uploading -> {
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    progress = { state.backupUploadState.backedUpCount.toFloat() / state.backupUploadState.totalCount.toFloat() },
+                    trackColor = ElementTheme.colors.progressIndicatorTrackColor,
+                )
+                Text(
+                    modifier = Modifier.align(Alignment.End),
+                    text = "${state.backupUploadState.backedUpCount} / ${state.backupUploadState.totalCount}",
+                    style = ElementTheme.typography.fontBodySmRegular,
+                )
+            }
+            BackupUploadState.Waiting -> {
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    trackColor = ElementTheme.colors.progressIndicatorTrackColor,
+                )
+                if (state.waitingForALongTime) {
+                    Text(
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                        text = stringResource(CommonStrings.common_please_check_internet_connection),
+                        style = ElementTheme.typography.fontBodySmRegular,
+                    )
+                }
+            }
+            else -> Unit
         }
     }
 }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -216,6 +216,7 @@ Reason: %1$s."</string>
   <string name="common_permalink">"Permalink"</string>
   <string name="common_permission">"Permission"</string>
   <string name="common_pinned">"Pinned"</string>
+  <string name="common_please_check_internet_connection">"Please check your internet connection"</string>
   <string name="common_please_wait">"Please wait…"</string>
   <string name="common_poll_end_confirmation">"Are you sure you want to end this poll?"</string>
   <string name="common_poll_summary">"Poll: %1$s"</string>

--- a/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Day_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Day_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b005a634331a485e2f80fb773a147207c782eaf2d923d1a87c5b45597309c658
+size 25794

--- a/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Day_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Day_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d800ec0c02e8e2f8fff755d12d2e657d6fbae10a8b9f070bb627b3ccf9d3e159
+size 30566

--- a/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Night_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Night_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27587909106650e33d7bc7854c0f2dd7ca6e2dad0aaf6487bf266753288ec6f6
+size 24898

--- a/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Night_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.logout.impl_LogoutView_Night_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e65635400bfda5d242d07ebe31113e3ef2d039f21208421023f099997d5e4f9
+size 29603


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When logging out and the key back up state is `Waiting`, a new progress bar is displayed. After 2s a Text is displayed to, to ask the user to check their internet connection.

Note that if they are network error, we should be in the state `BackupUploadState.SteadyException`, so there is maybe an issue SDK side.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Close internal issue.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
See recorded one

## Tests

<!-- Explain how you tested your development -->

- Login to an account
- send/receive a few message to e2e room
- switch to airplane mode
- try to logout
- with a bit of luck you'll have unsaved keys and the new screen will be rendered.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
