### PR TITLE
Update wording for push provider support test. (#4079)

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTest.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTest.kt
@@ -38,10 +38,8 @@ class PushProvidersTest @Inject constructor(
         val result = sortedPushProvider.isNotEmpty()
         if (result) {
             delegate.updateState(
-                description = stringProvider.getQuantityString(
-                    resId = R.plurals.troubleshoot_notifications_test_detect_push_provider_success,
-                    quantity = sortedPushProvider.size,
-                    sortedPushProvider.size,
+                description = stringProvider.getString(
+                    resId = R.string.troubleshoot_notifications_test_detect_push_provider_success_2,
                     sortedPushProvider.joinToString { it.name }
                 ),
                 status = NotificationTroubleshootTestState.Status.Success

--- a/libraries/push/impl/src/main/res/values/localazy.xml
+++ b/libraries/push/impl/src/main/res/values/localazy.xml
@@ -58,13 +58,14 @@
   <string name="troubleshoot_notifications_test_current_push_provider_failure">"No push providers selected."</string>
   <string name="troubleshoot_notifications_test_current_push_provider_success">"Current push provider: %1$s."</string>
   <string name="troubleshoot_notifications_test_current_push_provider_title">"Current push provider"</string>
-  <string name="troubleshoot_notifications_test_detect_push_provider_description">"Ensure that the application has at least one push provider."</string>
-  <string name="troubleshoot_notifications_test_detect_push_provider_failure">"No push providers found."</string>
+  <string name="troubleshoot_notifications_test_detect_push_provider_description">"Ensure that the application supports at least one push provider."</string>
+  <string name="troubleshoot_notifications_test_detect_push_provider_failure">"No push provider support found."</string>
   <plurals name="troubleshoot_notifications_test_detect_push_provider_success">
     <item quantity="one">"Found %1$d push provider: %2$s"</item>
     <item quantity="other">"Found %1$d push providers: %2$s"</item>
   </plurals>
-  <string name="troubleshoot_notifications_test_detect_push_provider_title">"Detect push providers"</string>
+  <string name="troubleshoot_notifications_test_detect_push_provider_success_2">"The application was built with support for: %1$s"</string>
+  <string name="troubleshoot_notifications_test_detect_push_provider_title">"Push provider support"</string>
   <string name="troubleshoot_notifications_test_display_notification_description">"Check that the application can display notification."</string>
   <string name="troubleshoot_notifications_test_display_notification_failure">"The notification has not been clicked."</string>
   <string name="troubleshoot_notifications_test_display_notification_permission_failure">"Cannot display the notification."</string>

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTestTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/troubleshoot/PushProvidersTestTest.kt
@@ -53,7 +53,6 @@ class PushProvidersTestTest {
             assertThat(awaitItem().status).isEqualTo(NotificationTroubleshootTestState.Status.InProgress)
             val lastItem = awaitItem()
             assertThat(lastItem.status).isEqualTo(NotificationTroubleshootTestState.Status.Success)
-            assertThat(lastItem.description).contains("2")
             assertThat(lastItem.description).contains("foo")
             assertThat(lastItem.description).contains("bar")
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Update wording of the notification test about push provider support.
The text is quite similar, so its OK if translations are updated later. Created a `success_2` though, since we do not need a plural anymore.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4079

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

|Before|After|
|-|-|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/899934a4-9a60-42df-92b7-20244eb3bac8" />|<img width="377" alt="image" src="https://github.com/user-attachments/assets/ea3b8ac3-5762-4b0c-b618-abb2dbab863e" />|


## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
