### PR TITLE
Feature/fga/advanced settings moderation and safety

### DIFF
--- a/features/joinroom/impl/build.gradle.kts
+++ b/features/joinroom/impl/build.gradle.kts
@@ -48,5 +48,4 @@ dependencies {
     testImplementation(libs.androidx.compose.ui.test.junit)
     testImplementation(projects.libraries.preferences.test)
     testReleaseImplementation(libs.androidx.compose.ui.test.manifest)
-
 }

--- a/features/joinroom/impl/build.gradle.kts
+++ b/features/joinroom/impl/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.features.invite.api)
     implementation(projects.features.roomdirectory.api)
     implementation(projects.services.analytics.api)
+    implementation(projects.libraries.preferences.api)
 
     testImplementation(libs.test.junit)
     testImplementation(libs.coroutines.test)
@@ -45,5 +46,7 @@ dependencies {
     testImplementation(projects.libraries.matrix.test)
     testImplementation(projects.tests.testutils)
     testImplementation(libs.androidx.compose.ui.test.junit)
+    testImplementation(projects.libraries.preferences.test)
     testReleaseImplementation(libs.androidx.compose.ui.test.manifest)
+
 }

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -50,6 +50,7 @@ import io.element.android.libraries.matrix.api.room.join.JoinRoom
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.preview.RoomPreviewInfo
 import io.element.android.libraries.matrix.ui.model.toInviteSender
+import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Optional
@@ -67,6 +68,7 @@ class JoinRoomPresenter @AssistedInject constructor(
     private val forgetRoom: ForgetRoom,
     private val acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState>,
     private val buildMeta: BuildMeta,
+    private val appPreferencesStore: AppPreferencesStore,
 ) : Presenter<JoinRoomState> {
     interface Factory {
         fun create(
@@ -89,6 +91,7 @@ class JoinRoomPresenter @AssistedInject constructor(
         val forgetRoomAction: MutableState<AsyncAction<Unit>> = remember { mutableStateOf(AsyncAction.Uninitialized) }
         var knockMessage by rememberSaveable { mutableStateOf("") }
         var isDismissingContent by remember { mutableStateOf(false) }
+        val shouldHideAvatars by appPreferencesStore.getHideInviteAvatarsFlow().collectAsState(initial = false)
         val contentState by produceState<ContentState>(
             initialValue = ContentState.Loading,
             key1 = roomInfo,
@@ -193,6 +196,7 @@ class JoinRoomPresenter @AssistedInject constructor(
             cancelKnockAction = cancelKnockAction.value,
             applicationName = buildMeta.applicationName,
             knockMessage = knockMessage,
+            shouldHideAvatars = shouldHideAvatars,
             eventSink = ::handleEvents
         )
     }

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomState.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomState.kt
@@ -31,6 +31,7 @@ data class JoinRoomState(
     val cancelKnockAction: AsyncAction<Unit>,
     private val applicationName: String,
     val knockMessage: String,
+    val shouldHideAvatars: Boolean,
     val eventSink: (JoinRoomEvents) -> Unit
 ) {
     val isJoinActionUnauthorized = joinAction is AsyncAction.Failure && joinAction.error is JoinRoomFailures.UnauthorizedJoin

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomStateProvider.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomStateProvider.kt
@@ -171,6 +171,7 @@ fun aJoinRoomState(
     forgetAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     cancelKnockAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     knockMessage: String = "",
+    shouldHideAvatars: Boolean = false,
     eventSink: (JoinRoomEvents) -> Unit = {}
 ) = JoinRoomState(
     roomIdOrAlias = roomIdOrAlias,
@@ -182,6 +183,7 @@ fun aJoinRoomState(
     forgetAction = forgetAction,
     applicationName = "AppName",
     knockMessage = knockMessage,
+    shouldHideAvatars = shouldHideAvatars,
     eventSink = eventSink
 )
 

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomView.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomView.kt
@@ -97,6 +97,7 @@ fun JoinRoomView(
                     roomIdOrAlias = state.roomIdOrAlias,
                     contentState = state.contentState,
                     knockMessage = state.knockMessage,
+                    shouldHideAvatars = state.shouldHideAvatars,
                     onKnockMessageUpdate = { state.eventSink(JoinRoomEvents.UpdateKnockMessage(it)) },
                 )
             },
@@ -371,6 +372,7 @@ private fun JoinRoomContent(
     roomIdOrAlias: RoomIdOrAlias,
     contentState: ContentState,
     knockMessage: String,
+    shouldHideAvatars: Boolean,
     onKnockMessageUpdate: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -385,13 +387,14 @@ private fun JoinRoomContent(
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             val inviteSender = (contentState.joinAuthorisationStatus as? JoinAuthorisationStatus.IsInvited)?.inviteSender
                             if (inviteSender != null) {
-                                InviteSenderView(inviteSender = inviteSender)
+                                InviteSenderView(inviteSender = inviteSender, hideAvatarImage = shouldHideAvatars)
                                 Spacer(modifier = Modifier.height(32.dp))
                             }
                             DefaultLoadedContent(
                                 modifier = Modifier.verticalScroll(rememberScrollState()),
                                 contentState = contentState,
                                 knockMessage = knockMessage,
+                                shouldHideAvatars = shouldHideAvatars,
                                 onKnockMessageUpdate = onKnockMessageUpdate
                             )
                         }
@@ -474,13 +477,14 @@ private fun IsKnockedLoadedContent(modifier: Modifier = Modifier) {
 private fun DefaultLoadedContent(
     contentState: ContentState.Loaded,
     knockMessage: String,
+    shouldHideAvatars: Boolean,
     onKnockMessageUpdate: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RoomPreviewOrganism(
         modifier = modifier,
         avatar = {
-            Avatar(contentState.avatarData(AvatarSize.RoomHeader))
+            Avatar(contentState.avatarData(AvatarSize.RoomHeader), hideImage = shouldHideAvatars)
         },
         title = {
             if (contentState.name != null) {

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
 import io.element.android.libraries.matrix.api.room.join.JoinRoom
+import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import java.util.Optional
 
 @Module
@@ -35,6 +36,7 @@ object JoinRoomModule {
         forgetRoom: ForgetRoom,
         acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState>,
         buildMeta: BuildMeta,
+        appPreferencesStore: AppPreferencesStore,
     ): JoinRoomPresenter.Factory {
         return object : JoinRoomPresenter.Factory {
             override fun create(
@@ -57,6 +59,7 @@ object JoinRoomModule {
                     cancelKnockRoom = cancelKnockRoom,
                     acceptDeclineInvitePresenter = acceptDeclineInvitePresenter,
                     buildMeta = buildMeta,
+                    appPreferencesStore = appPreferencesStore,
                 )
             }
         }

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -45,6 +45,8 @@ import io.element.android.libraries.matrix.test.room.aRoomPreviewInfo
 import io.element.android.libraries.matrix.test.room.aRoomSummary
 import io.element.android.libraries.matrix.test.room.join.FakeJoinRoom
 import io.element.android.libraries.matrix.ui.model.toInviteSender
+import io.element.android.libraries.preferences.api.store.AppPreferencesStore
+import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.lambda.any
 import io.element.android.tests.testutils.lambda.assert
@@ -759,7 +761,8 @@ class JoinRoomPresenterTest {
         cancelKnockRoom: CancelKnockRoom = FakeCancelKnockRoom(),
         forgetRoom: ForgetRoom = FakeForgetRoom(),
         buildMeta: BuildMeta = aBuildMeta(applicationName = "AppName"),
-        acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState> = Presenter { anAcceptDeclineInviteState() }
+        acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState> = Presenter { anAcceptDeclineInviteState() },
+        appPreferencesStore: AppPreferencesStore = InMemoryAppPreferencesStore()
     ): JoinRoomPresenter {
         return JoinRoomPresenter(
             roomId = roomId,
@@ -773,7 +776,8 @@ class JoinRoomPresenterTest {
             cancelKnockRoom = cancelKnockRoom,
             forgetRoom = forgetRoom,
             buildMeta = buildMeta,
-            acceptDeclineInvitePresenter = acceptDeclineInvitePresenter
+            acceptDeclineInvitePresenter = acceptDeclineInvitePresenter,
+            appPreferencesStore = appPreferencesStore,
         )
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenter.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import kotlinx.collections.immutable.toImmutableSet
 import javax.inject.Inject
@@ -25,14 +26,14 @@ class TimelineProtectionPresenter @Inject constructor(
 ) : Presenter<TimelineProtectionState> {
     @Composable
     override fun present(): TimelineProtectionState {
-        val hideMediaContent by appPreferencesStore.doesHideImagesAndVideosFlow().collectAsState(initial = false)
+        val mediaPreviewValue = appPreferencesStore.getTimelineMediaPreviewValueFlow().collectAsState(initial = MediaPreviewValue.Off)
         var allowedEvents by remember { mutableStateOf<Set<EventId>>(setOf()) }
-        val protectionState by remember(hideMediaContent) {
+        val protectionState by remember {
             derivedStateOf {
-                if (hideMediaContent) {
-                    ProtectionState.RenderOnly(eventIds = allowedEvents.toImmutableSet())
-                } else {
+                if (mediaPreviewValue.value == MediaPreviewValue.On) {
                     ProtectionState.RenderAll
+                } else {
+                    ProtectionState.RenderOnly(eventIds = allowedEvents.toImmutableSet())
                 }
             }
         }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenterTest.kt
@@ -8,7 +8,12 @@
 package io.element.android.features.messages.impl.timeline.protection
 
 import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
+import io.element.android.libraries.matrix.api.room.MatrixRoom
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.room.FakeMatrixRoom
+import io.element.android.libraries.matrix.test.room.aRoomInfo
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
 import io.element.android.tests.testutils.WarmUpRule
@@ -32,8 +37,8 @@ class TimelineProtectionPresenterTest {
     }
 
     @Test
-    fun `present - protected`() = runTest {
-        val appPreferencesStore = InMemoryAppPreferencesStore(hideImagesAndVideos = true)
+    fun `present - media preview value off`() = runTest {
+        val appPreferencesStore = InMemoryAppPreferencesStore(timelineMediaPreviewValue = MediaPreviewValue.Off)
         val presenter = createPresenter(appPreferencesStore)
         presenter.test {
             skipItems(1)
@@ -47,9 +52,42 @@ class TimelineProtectionPresenterTest {
         }
     }
 
+    @Test
+    fun `present - media preview value private in public room`() = runTest {
+        val appPreferencesStore = InMemoryAppPreferencesStore(timelineMediaPreviewValue = MediaPreviewValue.Private)
+        val room = FakeMatrixRoom(initialRoomInfo = aRoomInfo(joinRule = JoinRule.Public))
+        val presenter = createPresenter(appPreferencesStore, room)
+        presenter.test {
+            skipItems(1)
+            val initialState = awaitItem()
+            assertThat(initialState.protectionState).isEqualTo(ProtectionState.RenderOnly(persistentSetOf()))
+            // ShowContent with null should have no effect.
+            initialState.eventSink(TimelineProtectionEvent.ShowContent(eventId = null))
+            initialState.eventSink(TimelineProtectionEvent.ShowContent(eventId = AN_EVENT_ID))
+            val finalState = awaitItem()
+            assertThat(finalState.protectionState).isEqualTo(ProtectionState.RenderOnly(persistentSetOf(AN_EVENT_ID)))
+        }
+    }
+
+    @Test
+    fun `present - media preview value private in non public room`() = runTest {
+        val appPreferencesStore = InMemoryAppPreferencesStore(timelineMediaPreviewValue = MediaPreviewValue.Private)
+        val room = FakeMatrixRoom(initialRoomInfo = aRoomInfo(joinRule = JoinRule.Invite))
+        val presenter = createPresenter(appPreferencesStore, room)
+        presenter.test {
+            val initialState = awaitItem()
+            assertThat(initialState.protectionState).isEqualTo(ProtectionState.RenderAll)
+            // ShowContent with null should have no effect.
+            initialState.eventSink(TimelineProtectionEvent.ShowContent(eventId = null))
+            initialState.eventSink(TimelineProtectionEvent.ShowContent(eventId = AN_EVENT_ID))
+        }
+    }
+
     private fun createPresenter(
         appPreferencesStore: AppPreferencesStore = InMemoryAppPreferencesStore(),
+        room: MatrixRoom = FakeMatrixRoom(),
     ) = TimelineProtectionPresenter(
         appPreferencesStore = appPreferencesStore,
+        room = room,
     )
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsEvents.kt
@@ -8,6 +8,7 @@
 package io.element.android.features.preferences.impl.advanced
 
 import io.element.android.compound.theme.Theme
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 
 sealed interface AdvancedSettingsEvents {
     data class SetDeveloperModeEnabled(val enabled: Boolean) : AdvancedSettingsEvents
@@ -16,4 +17,6 @@ sealed interface AdvancedSettingsEvents {
     data object ChangeTheme : AdvancedSettingsEvents
     data object CancelChangeTheme : AdvancedSettingsEvents
     data class SetTheme(val theme: Theme) : AdvancedSettingsEvents
+    data class SetTimelineMediaPreviewValue(val value: MediaPreviewValue) : AdvancedSettingsEvents
+    data class SetHideInviteAvatars(val value: Boolean) : AdvancedSettingsEvents
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsPresenter.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import io.element.android.compound.theme.Theme
 import io.element.android.compound.theme.mapToTheme
 import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
 import kotlinx.coroutines.launch
@@ -44,6 +45,14 @@ class AdvancedSettingsPresenter @Inject constructor(
             .collectAsState(initial = Theme.System)
         var showChangeThemeDialog by remember { mutableStateOf(false) }
 
+        val hideInviteAvatars by remember {
+            appPreferencesStore.getHideInviteAvatarsFlow()
+        }.collectAsState(false)
+
+        val timelineMediaPreviewValue by remember {
+            appPreferencesStore.getTimelineMediaPreviewValueFlow()
+        }.collectAsState(initial = MediaPreviewValue.On)
+
         fun handleEvents(event: AdvancedSettingsEvents) {
             when (event) {
                 is AdvancedSettingsEvents.SetDeveloperModeEnabled -> localCoroutineScope.launch {
@@ -61,6 +70,12 @@ class AdvancedSettingsPresenter @Inject constructor(
                     appPreferencesStore.setTheme(event.theme.name)
                     showChangeThemeDialog = false
                 }
+                is AdvancedSettingsEvents.SetHideInviteAvatars -> localCoroutineScope.launch {
+                    appPreferencesStore.setHideInviteAvatars(event.value)
+                }
+                is AdvancedSettingsEvents.SetTimelineMediaPreviewValue -> localCoroutineScope.launch {
+                    appPreferencesStore.setTimelineMediaPreviewValue(event.value)
+                }
             }
         }
 
@@ -70,6 +85,8 @@ class AdvancedSettingsPresenter @Inject constructor(
             doesCompressMedia = doesCompressMedia,
             theme = theme,
             showChangeThemeDialog = showChangeThemeDialog,
+            hideInviteAvatars = hideInviteAvatars,
+            timelineMediaPreviewValue = timelineMediaPreviewValue,
             eventSink = { handleEvents(it) }
         )
     }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
@@ -8,6 +8,7 @@
 package io.element.android.features.preferences.impl.advanced
 
 import io.element.android.compound.theme.Theme
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 
 data class AdvancedSettingsState(
     val isDeveloperModeEnabled: Boolean,
@@ -15,5 +16,7 @@ data class AdvancedSettingsState(
     val doesCompressMedia: Boolean,
     val theme: Theme,
     val showChangeThemeDialog: Boolean,
+    val hideInviteAvatars: Boolean,
+    val timelineMediaPreviewValue: MediaPreviewValue,
     val eventSink: (AdvancedSettingsEvents) -> Unit
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsStateProvider.kt
@@ -9,6 +9,7 @@ package io.element.android.features.preferences.impl.advanced
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.compound.theme.Theme
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 
 open class AdvancedSettingsStateProvider : PreviewParameterProvider<AdvancedSettingsState> {
     override val values: Sequence<AdvancedSettingsState>
@@ -18,6 +19,8 @@ open class AdvancedSettingsStateProvider : PreviewParameterProvider<AdvancedSett
             aAdvancedSettingsState(showChangeThemeDialog = true),
             aAdvancedSettingsState(isSharePresenceEnabled = true),
             aAdvancedSettingsState(doesCompressMedia = true),
+            aAdvancedSettingsState(hideInviteAvatars = true),
+            aAdvancedSettingsState(timelineMediaPreviewValue = MediaPreviewValue.Off)
         )
 }
 
@@ -26,6 +29,8 @@ fun aAdvancedSettingsState(
     isSharePresenceEnabled: Boolean = false,
     doesCompressMedia: Boolean = false,
     showChangeThemeDialog: Boolean = false,
+    hideInviteAvatars: Boolean = false,
+    timelineMediaPreviewValue: MediaPreviewValue = MediaPreviewValue.On,
     eventSink: (AdvancedSettingsEvents) -> Unit = {},
 ) = AdvancedSettingsState(
     isDeveloperModeEnabled = isDeveloperModeEnabled,
@@ -33,5 +38,7 @@ fun aAdvancedSettingsState(
     doesCompressMedia = doesCompressMedia,
     theme = Theme.System,
     showChangeThemeDialog = showChangeThemeDialog,
+    hideInviteAvatars = hideInviteAvatars,
+    timelineMediaPreviewValue = timelineMediaPreviewValue,
     eventSink = eventSink
 )

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -20,7 +20,6 @@ import io.element.android.libraries.designsystem.components.dialogs.ListOption
 import io.element.android.libraries.designsystem.components.dialogs.SingleSelectionDialog
 import io.element.android.libraries.designsystem.components.list.ListItemContent
 import io.element.android.libraries.designsystem.components.preferences.PreferenceCategory
-import io.element.android.libraries.designsystem.components.preferences.PreferenceDivider
 import io.element.android.libraries.designsystem.components.preferences.PreferencePage
 import io.element.android.libraries.designsystem.components.preferences.PreferenceSwitch
 import io.element.android.libraries.designsystem.preview.ElementPreview

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.features.preferences.impl.advanced
 
+import android.preference.PreferenceCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -18,11 +19,18 @@ import io.element.android.features.preferences.impl.R
 import io.element.android.libraries.designsystem.components.dialogs.ListOption
 import io.element.android.libraries.designsystem.components.dialogs.SingleSelectionDialog
 import io.element.android.libraries.designsystem.components.list.ListItemContent
+import io.element.android.libraries.designsystem.components.preferences.PreferenceCategory
+import io.element.android.libraries.designsystem.components.preferences.PreferenceDivider
 import io.element.android.libraries.designsystem.components.preferences.PreferencePage
+import io.element.android.libraries.designsystem.components.preferences.PreferenceSwitch
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.ListItem
+import io.element.android.libraries.designsystem.theme.components.ListSectionHeader
+import io.element.android.libraries.designsystem.theme.components.ListSupportingText
+import io.element.android.libraries.designsystem.theme.components.ListSupportingTextDefaults
 import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.analytics.compose.LocalAnalyticsService
 import io.element.android.services.analyticsproviders.api.trackers.captureInteraction
@@ -98,6 +106,7 @@ fun AdvancedSettingsView(
                 state.eventSink(AdvancedSettingsEvents.SetCompressMedia(newValue))
             }
         )
+        ModerationAndSafety(state)
     }
 
     if (state.showChangeThemeDialog) {
@@ -112,6 +121,57 @@ fun AdvancedSettingsView(
                 )
             },
             onDismissRequest = { state.eventSink(AdvancedSettingsEvents.CancelChangeTheme) },
+        )
+    }
+}
+
+@Composable
+private fun ModerationAndSafety(
+    state: AdvancedSettingsState,
+    modifier: Modifier = Modifier,
+) {
+    PreferenceCategory(
+        modifier = modifier,
+        title = stringResource(R.string.screen_advanced_settings_moderation_and_safety_section_title),
+        showTopDivider = true
+    ) {
+        PreferenceSwitch(
+            title = stringResource(R.string.screen_advanced_settings_hide_invite_avatars_toggle_title),
+            isChecked = state.hideInviteAvatars,
+            onCheckedChange = {
+                state.eventSink(AdvancedSettingsEvents.SetHideInviteAvatars(it))
+            },
+        )
+        ListSectionHeader(
+            title = stringResource(R.string.screen_advanced_settings_show_media_timeline_title),
+            hasDivider = false,
+            description = {
+                ListSupportingText(
+                    text = stringResource(R.string.screen_advanced_settings_show_media_timeline_subtitle),
+                    contentPadding = ListSupportingTextDefaults.Padding.None,
+                )
+            }
+        )
+        ListItem(
+            headlineContent = { Text(text = stringResource(R.string.screen_advanced_settings_show_media_timeline_always_hide)) },
+            leadingContent = ListItemContent.RadioButton(selected = state.timelineMediaPreviewValue == MediaPreviewValue.Off, compact = true),
+            onClick = {
+                state.eventSink(AdvancedSettingsEvents.SetTimelineMediaPreviewValue(MediaPreviewValue.Off))
+            },
+        )
+        ListItem(
+            headlineContent = { Text(text = stringResource(R.string.screen_advanced_settings_show_media_timeline_private_rooms)) },
+            leadingContent = ListItemContent.RadioButton(selected = state.timelineMediaPreviewValue == MediaPreviewValue.Private, compact = true),
+            onClick = {
+                state.eventSink(AdvancedSettingsEvents.SetTimelineMediaPreviewValue(MediaPreviewValue.Private))
+            },
+        )
+        ListItem(
+            headlineContent = { Text(text = stringResource(R.string.screen_advanced_settings_show_media_timeline_always_show)) },
+            leadingContent = ListItemContent.RadioButton(selected = state.timelineMediaPreviewValue == MediaPreviewValue.On, compact = true),
+            onClick = {
+                state.eventSink(AdvancedSettingsEvents.SetTimelineMediaPreviewValue(MediaPreviewValue.On))
+            },
         )
     }
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsEvents.kt
@@ -14,7 +14,6 @@ import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 sealed interface DeveloperSettingsEvents {
     data class UpdateEnabledFeature(val feature: FeatureUiModel, val isEnabled: Boolean) : DeveloperSettingsEvents
     data class SetCustomElementCallBaseUrl(val baseUrl: String?) : DeveloperSettingsEvents
-    data class SetHideImagesAndVideos(val value: Boolean) : DeveloperSettingsEvents
     data class SetTracingLogLevel(val logLevel: LogLevelItem) : DeveloperSettingsEvents
     data class ToggleTracingLogPack(val logPack: TraceLogPack, val enabled: Boolean) : DeveloperSettingsEvents
     data object ClearCache : DeveloperSettingsEvents

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenter.kt
@@ -74,9 +74,6 @@ class DeveloperSettingsPresenter @Inject constructor(
         val customElementCallBaseUrl by appPreferencesStore
             .getCustomElementCallBaseUrlFlow()
             .collectAsState(initial = null)
-        val hideImagesAndVideos by appPreferencesStore
-            .doesHideImagesAndVideosFlow()
-            .collectAsState(initial = false)
 
         val tracingLogLevelFlow = remember {
             appPreferencesStore.getTracingLogLevelFlow().map { AsyncData.Success(it.toLogLevelItem()) }
@@ -126,9 +123,6 @@ class DeveloperSettingsPresenter @Inject constructor(
                     appPreferencesStore.setCustomElementCallBaseUrl(urlToSave)
                 }
                 DeveloperSettingsEvents.ClearCache -> coroutineScope.clearCache(clearCacheAction)
-                is DeveloperSettingsEvents.SetHideImagesAndVideos -> coroutineScope.launch {
-                    appPreferencesStore.setHideImagesAndVideos(event.value)
-                }
                 is DeveloperSettingsEvents.SetTracingLogLevel -> coroutineScope.launch {
                     appPreferencesStore.setTracingLogLevel(event.logLevel.toLogLevel())
                 }
@@ -153,7 +147,6 @@ class DeveloperSettingsPresenter @Inject constructor(
                 baseUrl = customElementCallBaseUrl,
                 validator = ::customElementCallUrlValidator,
             ),
-            hideImagesAndVideos = hideImagesAndVideos,
             tracingLogLevel = tracingLogLevel,
             tracingLogPacks = tracingLogPacks,
             eventSink = ::handleEvents

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsState.kt
@@ -21,7 +21,6 @@ data class DeveloperSettingsState(
     val rageshakeState: RageshakePreferencesState,
     val clearCacheAction: AsyncAction<Unit>,
     val customElementCallBaseUrlState: CustomElementCallBaseUrlState,
-    val hideImagesAndVideos: Boolean,
     val tracingLogLevel: AsyncData<LogLevelItem>,
     val tracingLogPacks: ImmutableList<TraceLogPack>,
     val eventSink: (DeveloperSettingsEvents) -> Unit

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsStateProvider.kt
@@ -34,7 +34,6 @@ open class DeveloperSettingsStateProvider : PreviewParameterProvider<DeveloperSe
 fun aDeveloperSettingsState(
     clearCacheAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     customElementCallBaseUrlState: CustomElementCallBaseUrlState = aCustomElementCallBaseUrlState(),
-    hideImagesAndVideos: Boolean = false,
     traceLogPacks: List<TraceLogPack> = emptyList(),
     eventSink: (DeveloperSettingsEvents) -> Unit = {},
 ) = DeveloperSettingsState(
@@ -43,7 +42,6 @@ fun aDeveloperSettingsState(
     cacheSize = AsyncData.Success("1.2 MB"),
     clearCacheAction = clearCacheAction,
     customElementCallBaseUrlState = customElementCallBaseUrlState,
-    hideImagesAndVideos = hideImagesAndVideos,
     tracingLogLevel = AsyncData.Success(LogLevelItem.INFO),
     tracingLogPacks = traceLogPacks.toPersistentList(),
     eventSink = eventSink,

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsView.kt
@@ -51,7 +51,6 @@ fun DeveloperSettingsView(
         title = stringResource(id = CommonStrings.common_developer_options)
     ) {
         // Note: this is OK to hardcode strings in this debug screen.
-        SettingsCategory(state)
         PreferenceCategory(
             title = "Feature flags",
             showTopDivider = true,
@@ -131,22 +130,6 @@ fun DeveloperSettingsView(
                 }
             )
         }
-    }
-}
-
-@Composable
-private fun SettingsCategory(
-    state: DeveloperSettingsState,
-) {
-    PreferenceCategory(title = "Preferences", showTopDivider = false) {
-        PreferenceSwitch(
-            title = "Hide image & video previews",
-            subtitle = "When toggled image & video will not render in the timeline by default.",
-            isChecked = state.hideImagesAndVideos,
-            onCheckedChange = {
-                state.eventSink(DeveloperSettingsEvents.SetHideImagesAndVideos(it))
-            }
-        )
     }
 }
 

--- a/features/preferences/impl/src/main/res/values/localazy.xml
+++ b/features/preferences/impl/src/main/res/values/localazy.xml
@@ -19,6 +19,11 @@
   <string name="screen_advanced_settings_send_read_receipts_description">"If turned off, your read receipts won\'t be sent to anyone. You will still receive read receipts from other users."</string>
   <string name="screen_advanced_settings_share_presence">"Share presence"</string>
   <string name="screen_advanced_settings_share_presence_description">"If turned off, you won’t be able to send or receive read receipts or typing notifications."</string>
+  <string name="screen_advanced_settings_show_media_timeline_always_hide">"Always hide"</string>
+  <string name="screen_advanced_settings_show_media_timeline_always_show">"Always show"</string>
+  <string name="screen_advanced_settings_show_media_timeline_private_rooms">"In private rooms"</string>
+  <string name="screen_advanced_settings_show_media_timeline_subtitle">"A hidden media can always be shown by tapping on it"</string>
+  <string name="screen_advanced_settings_show_media_timeline_title">"Show media in timeline"</string>
   <string name="screen_advanced_settings_view_source_description">"Enable option to view message source in the timeline."</string>
   <string name="screen_blocked_users_empty">"You have no blocked users"</string>
   <string name="screen_blocked_users_unblock_alert_action">"Unblock"</string>

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
@@ -148,28 +148,6 @@ class DeveloperSettingsPresenterTest {
     }
 
     @Test
-    fun `present - toggling hide image and video`() = runTest {
-        val preferences = InMemoryAppPreferencesStore()
-        val presenter = createDeveloperSettingsPresenter(preferencesStore = preferences)
-        presenter.test {
-            skipItems(2)
-            awaitItem().also { state ->
-                assertThat(state.hideImagesAndVideos).isFalse()
-                state.eventSink(DeveloperSettingsEvents.SetHideImagesAndVideos(true))
-            }
-            awaitItem().also { state ->
-                assertThat(state.hideImagesAndVideos).isTrue()
-                assertThat(preferences.doesHideImagesAndVideosFlow().first()).isTrue()
-                state.eventSink(DeveloperSettingsEvents.SetHideImagesAndVideos(false))
-            }
-            awaitItem().also { state ->
-                assertThat(state.hideImagesAndVideos).isFalse()
-                assertThat(preferences.doesHideImagesAndVideosFlow().first()).isFalse()
-            }
-        }
-    }
-
-    @Test
     fun `present - changing tracing log level`() = runTest {
         val preferences = InMemoryAppPreferencesStore()
         val presenter = createDeveloperSettingsPresenter(preferencesStore = preferences)

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsPresenterTest.kt
@@ -44,7 +44,6 @@ class DeveloperSettingsPresenterTest {
                 assertThat(state.cacheSize).isEqualTo(AsyncData.Uninitialized)
                 assertThat(state.customElementCallBaseUrlState).isNotNull()
                 assertThat(state.customElementCallBaseUrlState.baseUrl).isNull()
-                assertThat(state.hideImagesAndVideos).isFalse()
                 assertThat(state.rageshakeState.isEnabled).isFalse()
                 assertThat(state.rageshakeState.isSupported).isTrue()
                 assertThat(state.rageshakeState.sensitivity).isEqualTo(0.3f)

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsViewTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/developer/DeveloperSettingsViewTest.kt
@@ -109,18 +109,6 @@ class DeveloperSettingsViewTest {
         rule.onNodeWithText("Clear cache").performClick()
         eventsRecorder.assertSingle(DeveloperSettingsEvents.ClearCache)
     }
-
-    @Test
-    fun `clicking on the hide images and videos switch emits the expected event`() {
-        val eventsRecorder = EventsRecorder<DeveloperSettingsEvents>()
-        rule.setDeveloperSettingsView(
-            state = aDeveloperSettingsState(
-                eventSink = eventsRecorder
-            ),
-        )
-        rule.onNodeWithText("Hide image & video previews").performClick()
-        eventsRecorder.assertSingle(DeveloperSettingsEvents.SetHideImagesAndVideos(true))
-    }
 }
 
 private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setDeveloperSettingsView(

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -117,6 +117,9 @@ class RoomListPresenter @Inject constructor(
 
         // Avatar indicator
         val showAvatarIndicator by indicatorService.showRoomListTopBarIndicator()
+        val hideInvitesAvatar by remember {
+            appPreferencesStore.getHideInviteAvatarsFlow()
+        }.collectAsState(initial = false)
 
         val contextMenu = remember { mutableStateOf<RoomListState.ContextMenu>(RoomListState.ContextMenu.Hidden) }
 
@@ -171,6 +174,7 @@ class RoomListPresenter @Inject constructor(
             contentState = contentState,
             acceptDeclineInviteState = acceptDeclineInviteState,
             directLogoutState = directLogoutState,
+            hideInvitesAvatars = hideInvitesAvatar,
             eventSink = ::handleEvents,
         )
     }

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListState.kt
@@ -34,6 +34,7 @@ data class RoomListState(
     val contentState: RoomListContentState,
     val acceptDeclineInviteState: AcceptDeclineInviteState,
     val directLogoutState: DirectLogoutState,
+    val hideInvitesAvatars: Boolean,
     val eventSink: (RoomListEvents) -> Unit,
 ) {
     val displayFilters = contentState is RoomListContentState.Rooms

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListStateProvider.kt
@@ -61,6 +61,7 @@ internal fun aRoomListState(
     contentState: RoomListContentState = aRoomsContentState(),
     acceptDeclineInviteState: AcceptDeclineInviteState = anAcceptDeclineInviteState(),
     directLogoutState: DirectLogoutState = aDirectLogoutState(),
+    hideInvitesAvatars: Boolean = false,
     eventSink: (RoomListEvents) -> Unit = {}
 ) = RoomListState(
     matrixUser = matrixUser,
@@ -75,6 +76,7 @@ internal fun aRoomListState(
     contentState = contentState,
     acceptDeclineInviteState = acceptDeclineInviteState,
     directLogoutState = directLogoutState,
+    hideInvitesAvatars = hideInvitesAvatars,
     eventSink = eventSink,
 )
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -81,6 +81,7 @@ fun RoomListView(
             RoomListSearchView(
                 state = state.searchState,
                 eventSink = state.eventSink,
+                hideInvitesAvatars = state.hideInvitesAvatars,
                 onRoomClick = onRoomClick,
                 modifier = Modifier
                     .statusBarsPadding()
@@ -134,6 +135,7 @@ private fun RoomListScaffold(
             RoomListContentView(
                 contentState = state.contentState,
                 filtersState = state.filtersState,
+                hideInvitesAvatars = state.hideInvitesAvatars,
                 eventSink = state.eventSink,
                 onSetUpRecoveryClick = onSetUpRecoveryClick,
                 onConfirmRecoveryKeyClick = onConfirmRecoveryKeyClick,

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomListContentView.kt
@@ -59,6 +59,7 @@ import kotlinx.collections.immutable.ImmutableList
 fun RoomListContentView(
     contentState: RoomListContentState,
     filtersState: RoomListFiltersState,
+    hideInvitesAvatars: Boolean,
     eventSink: (RoomListEvents) -> Unit,
     onSetUpRecoveryClick: () -> Unit,
     onConfirmRecoveryKeyClick: () -> Unit,
@@ -85,6 +86,7 @@ fun RoomListContentView(
             is RoomListContentState.Rooms -> {
                 RoomsView(
                     state = contentState,
+                    hideInvitesAvatars = hideInvitesAvatars,
                     filtersState = filtersState,
                     eventSink = eventSink,
                     onSetUpRecoveryClick = onSetUpRecoveryClick,
@@ -155,6 +157,7 @@ private fun EmptyView(
 @Composable
 private fun RoomsView(
     state: RoomListContentState.Rooms,
+    hideInvitesAvatars: Boolean,
     filtersState: RoomListFiltersState,
     eventSink: (RoomListEvents) -> Unit,
     onSetUpRecoveryClick: () -> Unit,
@@ -170,6 +173,7 @@ private fun RoomsView(
     } else {
         RoomsViewList(
             state = state,
+            hideInvitesAvatars = hideInvitesAvatars,
             eventSink = eventSink,
             onSetUpRecoveryClick = onSetUpRecoveryClick,
             onConfirmRecoveryKeyClick = onConfirmRecoveryKeyClick,
@@ -182,6 +186,7 @@ private fun RoomsView(
 @Composable
 private fun RoomsViewList(
     state: RoomListContentState.Rooms,
+    hideInvitesAvatars: Boolean,
     eventSink: (RoomListEvents) -> Unit,
     onSetUpRecoveryClick: () -> Unit,
     onConfirmRecoveryKeyClick: () -> Unit,
@@ -239,6 +244,7 @@ private fun RoomsViewList(
         ) { index, room ->
             RoomSummaryRow(
                 room = room,
+                hideInviteAvatars = hideInvitesAvatars,
                 onClick = onRoomClick,
                 eventSink = eventSink,
             )
@@ -300,6 +306,7 @@ internal fun RoomListContentViewPreview(@PreviewParameter(RoomListContentStatePr
         filtersState = aRoomListFiltersState(
             filterSelectionStates = RoomListFilter.entries.map { FilterSelectionState(it, isSelected = true) }
         ),
+        hideInvitesAvatars = false,
         eventSink = {},
         onSetUpRecoveryClick = {},
         onConfirmRecoveryKeyClick = {},

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomSummaryRow.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomSummaryRow.kt
@@ -68,10 +68,12 @@ internal val minHeight = 84.dp
 @Composable
 internal fun RoomSummaryRow(
     room: RoomListRoomSummary,
+    hideInviteAvatars: Boolean,
     onClick: (RoomListRoomSummary) -> Unit,
     eventSink: (RoomListEvents) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
     Box(modifier = modifier) {
         when (room.displayType) {
             RoomSummaryDisplayType.PLACEHOLDER -> {
@@ -80,6 +82,7 @@ internal fun RoomSummaryRow(
             RoomSummaryDisplayType.INVITE -> {
                 RoomSummaryScaffoldRow(
                     room = room,
+                    hideAvatarImage = hideInviteAvatars,
                     onClick = onClick,
                     onLongClick = {
                         Timber.d("Long click on invite room")
@@ -92,6 +95,7 @@ internal fun RoomSummaryRow(
                         InviteSenderView(
                             modifier = Modifier.fillMaxWidth(),
                             inviteSender = room.inviteSender,
+                            hideAvatarImage = hideInviteAvatars
                         )
                     }
                     Spacer(modifier = Modifier.height(12.dp))
@@ -164,6 +168,7 @@ private fun RoomSummaryScaffoldRow(
     onClick: (RoomListRoomSummary) -> Unit,
     onLongClick: (RoomListRoomSummary) -> Unit,
     modifier: Modifier = Modifier,
+    hideAvatarImage: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val clickModifier = Modifier.combinedClickable(
@@ -184,6 +189,7 @@ private fun RoomSummaryScaffoldRow(
         CompositeAvatar(
             avatarData = room.avatarData,
             heroes = room.heroes,
+            hideAvatarImages = hideAvatarImage,
         )
         Spacer(modifier = Modifier.width(16.dp))
         Column(
@@ -384,6 +390,7 @@ private fun MentionIndicatorAtom() {
 internal fun RoomSummaryRowPreview(@PreviewParameter(RoomListRoomSummaryProvider::class) data: RoomListRoomSummary) = ElementPreview {
     RoomSummaryRow(
         room = data,
+        hideInviteAvatars = false,
         onClick = {},
         eventSink = {},
     )

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomSummaryRow.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/components/RoomSummaryRow.kt
@@ -73,7 +73,6 @@ internal fun RoomSummaryRow(
     eventSink: (RoomListEvents) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     Box(modifier = modifier) {
         when (room.displayType) {
             RoomSummaryDisplayType.PLACEHOLDER -> {

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/search/RoomListSearchView.kt
@@ -54,6 +54,7 @@ import io.element.android.libraries.ui.strings.CommonStrings
 @Composable
 internal fun RoomListSearchView(
     state: RoomListSearchState,
+    hideInvitesAvatars: Boolean,
     eventSink: (RoomListEvents) -> Unit,
     onRoomClick: (RoomId) -> Unit,
     modifier: Modifier = Modifier,
@@ -80,6 +81,7 @@ internal fun RoomListSearchView(
             if (state.isSearchActive) {
                 RoomListSearchContent(
                     state = state,
+                    hideInvitesAvatars = hideInvitesAvatars,
                     onRoomClick = onRoomClick,
                     eventSink = eventSink,
                 )
@@ -92,6 +94,7 @@ internal fun RoomListSearchView(
 @Composable
 private fun RoomListSearchContent(
     state: RoomListSearchState,
+    hideInvitesAvatars: Boolean,
     eventSink: (RoomListEvents) -> Unit,
     onRoomClick: (RoomId) -> Unit,
 ) {
@@ -173,6 +176,7 @@ private fun RoomListSearchContent(
                 ) { room ->
                     RoomSummaryRow(
                         room = room,
+                        hideInviteAvatars = hideInvitesAvatars,
                         onClick = ::onRoomClick,
                         eventSink = eventSink,
                     )
@@ -187,6 +191,7 @@ private fun RoomListSearchContent(
 internal fun RoomListSearchContentPreview(@PreviewParameter(RoomListSearchStateProvider::class) state: RoomListSearchState) = ElementPreview {
     RoomListSearchContent(
         state = state,
+        hideInvitesAvatars = false,
         onRoomClick = {},
         eventSink = {},
     )

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/Avatar.kt
@@ -48,11 +48,13 @@ fun Avatar(
     contentDescription: String? = null,
     // If not null, will be used instead of the size from avatarData
     forcedAvatarSize: Dp? = null,
+    // If true, will show initials even if avatarData.url is not null
+    hideImage: Boolean = false,
 ) {
     val commonModifier = modifier
         .size(forcedAvatarSize ?: avatarData.size.dp)
         .clip(CircleShape)
-    if (avatarData.url.isNullOrBlank()) {
+    if (avatarData.url.isNullOrBlank() || hideImage) {
         InitialsAvatar(
             avatarData = avatarData,
             forcedAvatarSize = forcedAvatarSize,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/CompositeAvatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/CompositeAvatar.kt
@@ -33,10 +33,16 @@ fun CompositeAvatar(
     avatarData: AvatarData,
     heroes: ImmutableList<AvatarData>,
     modifier: Modifier = Modifier,
+    hideAvatarImages: Boolean = false,
     contentDescription: String? = null,
 ) {
     if (avatarData.url != null || heroes.isEmpty()) {
-        Avatar(avatarData, modifier, contentDescription)
+        Avatar(
+            avatarData = avatarData,
+            modifier = modifier,
+            contentDescription = contentDescription,
+            hideImage = hideAvatarImages
+        )
     } else {
         val limitedHeroes = heroes.take(4)
         val numberOfHeroes = limitedHeroes.size
@@ -49,7 +55,12 @@ fun CompositeAvatar(
                 error("Unsupported number of heroes: 0")
             }
             1 -> {
-                Avatar(heroes[0], modifier, contentDescription)
+                Avatar(
+                    avatarData = heroes[0],
+                    modifier = modifier,
+                    contentDescription = contentDescription,
+                    hideImage = hideAvatarImages
+                )
             }
             else -> {
                 val angle = 2 * Math.PI / numberOfHeroes
@@ -91,8 +102,9 @@ fun CompositeAvatar(
                                 )
                         ) {
                             Avatar(
-                                heroAvatar,
+                                avatarData = heroAvatar,
                                 forcedAvatarSize = heroAvatarSize,
+                                hideImage = hideAvatarImages,
                             )
                         }
                     }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
@@ -7,6 +7,11 @@
 
 package io.element.android.libraries.matrix.api.media
 
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue.Off
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue.On
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue.Private
+import io.element.android.libraries.matrix.api.room.join.JoinRule
+
 /**
  * Represents the values for media preview settings.
  * - [On] means that media preview are enabled
@@ -17,4 +22,18 @@ enum class MediaPreviewValue {
     On,
     Off,
     Private
+}
+
+fun MediaPreviewValue.isPreviewEnabled(joinRule: JoinRule?): Boolean {
+    return when (this) {
+        On -> true
+        Off -> false
+        Private -> when (joinRule) {
+            is JoinRule.Knock,
+            is JoinRule.Invite,
+            is JoinRule.Restricted,
+            is JoinRule.KnockRestricted -> true
+            else -> false
+        }
+    }
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.media
+
+/**
+ * Represents the values for media preview settings.
+ * - [On] means that media preview are enabled
+ * - [Off] means that media preview are disabled
+ * - [Private] means that media preview are enabled only for private chats.
+ */
+enum class MediaPreviewValue {
+    On,
+    Off,
+    Private
+}

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/InviteSenderView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/InviteSenderView.kt
@@ -27,14 +27,15 @@ import io.element.android.libraries.matrix.ui.model.InviteSender
 @Composable
 fun InviteSenderView(
     inviteSender: InviteSender,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    hideAvatarImage: Boolean = false,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
         Box(modifier = Modifier.padding(vertical = 2.dp)) {
-            Avatar(avatarData = inviteSender.avatarData)
+            Avatar(avatarData = inviteSender.avatarData, hideImage = hideAvatarImage)
         }
         Text(
             text = inviteSender.annotatedString(),

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.preferences.api.store
 
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.matrix.api.tracing.LogLevel
 import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import kotlinx.coroutines.flow.Flow
@@ -21,8 +22,11 @@ interface AppPreferencesStore {
     suspend fun setTheme(theme: String)
     fun getThemeFlow(): Flow<String?>
 
-    suspend fun setHideImagesAndVideos(value: Boolean)
-    fun doesHideImagesAndVideosFlow(): Flow<Boolean>
+    suspend fun setHideInviteAvatars(value: Boolean)
+    fun getHideInviteAvatarsFlow(): Flow<Boolean>
+
+    suspend fun setTimelineMediaPreviewValue(value: MediaPreviewValue)
+    fun getTimelineMediaPreviewValueFlow(): Flow<MediaPreviewValue>
 
     suspend fun setTracingLogLevel(logLevel: LogLevel)
     fun getTracingLogLevelFlow(): Flow<LogLevel>

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
@@ -19,6 +19,7 @@ import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.matrix.api.tracing.LogLevel
 import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
@@ -31,7 +32,8 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 private val developerModeKey = booleanPreferencesKey("developerMode")
 private val customElementCallBaseUrlKey = stringPreferencesKey("elementCallBaseUrl")
 private val themeKey = stringPreferencesKey("theme")
-private val hideImagesAndVideosKey = booleanPreferencesKey("hideImagesAndVideos")
+private val hideInviteAvatarsKey = booleanPreferencesKey("hideInviteAvatars")
+private val timelineMediaPreviewValueKey = stringPreferencesKey("timelineMediaPreviewValue")
 private val logLevelKey = stringPreferencesKey("logLevel")
 private val traceLogPacksKey = stringPreferencesKey("traceLogPacks")
 
@@ -83,15 +85,27 @@ class DefaultAppPreferencesStore @Inject constructor(
         }
     }
 
-    override suspend fun setHideImagesAndVideos(value: Boolean) {
+    override suspend fun setHideInviteAvatars(value: Boolean) {
         store.edit { prefs ->
-            prefs[hideImagesAndVideosKey] = value
+            prefs[hideInviteAvatarsKey] = value
         }
     }
 
-    override fun doesHideImagesAndVideosFlow(): Flow<Boolean> {
+    override fun getHideInviteAvatarsFlow(): Flow<Boolean> {
         return store.data.map { prefs ->
-            prefs[hideImagesAndVideosKey] ?: false
+            prefs[hideInviteAvatarsKey] == true
+        }
+    }
+
+    override suspend fun setTimelineMediaPreviewValue(value: MediaPreviewValue) {
+        store.edit { prefs ->
+            prefs[timelineMediaPreviewValueKey] = value.name
+        }
+    }
+
+    override fun getTimelineMediaPreviewValueFlow(): Flow<MediaPreviewValue> {
+        return store.data.map { prefs ->
+            prefs[timelineMediaPreviewValueKey]?.let { MediaPreviewValue.valueOf(it) } ?: MediaPreviewValue.On
         }
     }
 

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.preferences.test
 
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.matrix.api.tracing.LogLevel
 import io.element.android.libraries.matrix.api.tracing.TraceLogPack
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
@@ -15,18 +16,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 class InMemoryAppPreferencesStore(
     isDeveloperModeEnabled: Boolean = false,
-    hideImagesAndVideos: Boolean = false,
     customElementCallBaseUrl: String? = null,
+    hideInviteAvatars: Boolean = false,
+    timelineMediaPreviewValue: MediaPreviewValue = MediaPreviewValue.On,
     theme: String? = null,
     logLevel: LogLevel = LogLevel.INFO,
     traceLockPacks: Set<TraceLogPack> = emptySet(),
 ) : AppPreferencesStore {
     private val isDeveloperModeEnabled = MutableStateFlow(isDeveloperModeEnabled)
-    private val hideImagesAndVideos = MutableStateFlow(hideImagesAndVideos)
     private val customElementCallBaseUrl = MutableStateFlow(customElementCallBaseUrl)
     private val theme = MutableStateFlow(theme)
     private val logLevel = MutableStateFlow(logLevel)
     private val tracingLogPacks = MutableStateFlow(traceLockPacks)
+    private val hideInviteAvatars = MutableStateFlow(hideInviteAvatars)
+    private val timelineMediaPreviewValue = MutableStateFlow(timelineMediaPreviewValue)
 
     override suspend fun setDeveloperModeEnabled(enabled: Boolean) {
         isDeveloperModeEnabled.value = enabled
@@ -52,12 +55,20 @@ class InMemoryAppPreferencesStore(
         return theme
     }
 
-    override suspend fun setHideImagesAndVideos(value: Boolean) {
-        hideImagesAndVideos.value = value
+    override suspend fun setHideInviteAvatars(value: Boolean) {
+        hideInviteAvatars.value = value
     }
 
-    override fun doesHideImagesAndVideosFlow(): Flow<Boolean> {
-        return hideImagesAndVideos
+    override fun getHideInviteAvatarsFlow(): Flow<Boolean> {
+        return hideInviteAvatars
+    }
+
+    override suspend fun setTimelineMediaPreviewValue(value: MediaPreviewValue) {
+        timelineMediaPreviewValue.value = value
+    }
+
+    override fun getTimelineMediaPreviewValueFlow(): Flow<MediaPreviewValue> {
+        return timelineMediaPreviewValue
     }
 
     override suspend fun setTracingLogLevel(logLevel: LogLevel) {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
@@ -292,7 +293,7 @@ class DefaultNotifiableEventResolver @Inject constructor(
     }
 
     private suspend fun NotificationContent.MessageLike.RoomMessage.fetchImageIfPresent(client: MatrixClient): Uri? {
-        if (appPreferencesStore.doesHideImagesAndVideosFlow().first()) {
+        if (appPreferencesStore.getTimelineMediaPreviewValueFlow().first() != MediaPreviewValue.On) {
             return null
         }
         val fileResult = when (val messageType = messageType) {
@@ -319,7 +320,7 @@ class DefaultNotifiableEventResolver @Inject constructor(
     }
 
     private suspend fun NotificationContent.MessageLike.RoomMessage.getImageMimetype(): String? {
-        if (appPreferencesStore.doesHideImagesAndVideosFlow().first()) {
+        if (appPreferencesStore.getTimelineMediaPreviewValueFlow().first() != MediaPreviewValue.On) {
             return null
         }
         return when (val messageType = messageType) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Move timeline preview setting related from developper to advanced settings, and add new value to show only in private rooms
- Also add new setting to hide avatars from invites.

<!-- Describe shortly what has been changed -->

## Motivation and context
Closes https://github.com/element-hq/element-x-android/issues/4436
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
See recorded screenshots.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
