### PR TITLE
Ensure that we have only one single instance of SeenInviteStore per session

### DIFF
--- a/features/invite/api/src/main/kotlin/io/element/android/features/invite/api/SeenInvitesStoreFactory.kt
+++ b/features/invite/api/src/main/kotlin/io/element/android/features/invite/api/SeenInvitesStoreFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.invite.api
+
+import io.element.android.libraries.matrix.api.core.SessionId
+import kotlinx.coroutines.CoroutineScope
+
+fun interface SeenInvitesStoreFactory {
+    fun getOrCreate(
+        sessionId: SessionId,
+        sessionCoroutineScope: CoroutineScope,
+    ): SeenInvitesStore
+}

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DefaultSeenInvitesStore.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DefaultSeenInvitesStore.kt
@@ -12,36 +12,25 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
-import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.features.invite.api.SeenInvitesStore
 import io.element.android.libraries.androidutils.file.safeDelete
 import io.element.android.libraries.androidutils.hash.hash
-import io.element.android.libraries.di.ApplicationContext
-import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.di.SingleIn
-import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
-import io.element.android.libraries.matrix.api.user.CurrentSessionIdHolder
 import io.element.android.libraries.sessionstorage.api.observer.SessionListener
 import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 private val seenInvitesKey = stringSetPreferencesKey("seenInvites")
 
-@SingleIn(SessionScope::class)
-@ContributesBinding(SessionScope::class)
-class DefaultSeenInvitesStore @Inject constructor(
-    @ApplicationContext context: Context,
-    currentSessionIdHolder: CurrentSessionIdHolder,
-    @SessionCoroutineScope sessionCoroutineScope: CoroutineScope,
+class DefaultSeenInvitesStore(
+    context: Context,
+    sessionId: SessionId,
+    sessionCoroutineScope: CoroutineScope,
     sessionObserver: SessionObserver,
 ) : SeenInvitesStore {
-    private val sessionId: SessionId = currentSessionIdHolder.current
-
     init {
         sessionObserver.addListener(object : SessionListener {
             override suspend fun onSessionCreated(userId: String) = Unit

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DefaultSeenInvitesStoreFactory.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DefaultSeenInvitesStoreFactory.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.invite.impl
+
+import android.content.Context
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
+import io.element.android.libraries.di.SingleIn
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
+import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultSeenInvitesStoreFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val sessionObserver: SessionObserver,
+) : SeenInvitesStoreFactory {
+    // We can have only one class accessing a single data store, so keep a cache of them.
+    private val cache = ConcurrentHashMap<SessionId, SeenInvitesStore>()
+
+    override fun getOrCreate(
+        sessionId: SessionId,
+        sessionCoroutineScope: CoroutineScope,
+    ): SeenInvitesStore {
+        return cache.getOrPut(sessionId) {
+            DefaultSeenInvitesStore(
+                context = context,
+                sessionId = sessionId,
+                sessionCoroutineScope = sessionCoroutineScope,
+                sessionObserver = sessionObserver,
+            )
+        }
+    }
+}

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenter.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenter.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import im.vector.app.features.analytics.plan.JoinedRoom
-import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
 import io.element.android.features.invite.api.response.AcceptDeclineInviteEvents
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.invite.api.response.ConfirmingDeclineInvite
@@ -35,8 +35,13 @@ class AcceptDeclineInvitePresenter @Inject constructor(
     private val client: MatrixClient,
     private val joinRoom: JoinRoom,
     private val notificationCleaner: NotificationCleaner,
-    private val seenInvitesStore: SeenInvitesStore,
+    seenInvitesStoreFactory: SeenInvitesStoreFactory,
 ) : Presenter<AcceptDeclineInviteState> {
+    private val seenInvitesStore = seenInvitesStoreFactory.getOrCreate(
+        sessionId = client.sessionId,
+        sessionCoroutineScope = client.sessionCoroutineScope,
+    )
+
     @Composable
     override fun present(): AcceptDeclineInviteState {
         val localCoroutineScope = rememberCoroutineScope()

--- a/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenterTest.kt
+++ b/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/response/AcceptDeclineInvitePresenterTest.kt
@@ -369,7 +369,7 @@ class AcceptDeclineInvitePresenterTest {
             client = client,
             joinRoom = FakeJoinRoom(joinRoomLambda),
             notificationCleaner = notificationCleaner,
-            seenInvitesStore = seenInvitesStore,
+            seenInvitesStoreFactory = { _, _ -> seenInvitesStore },
         )
     }
 }

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.setValue
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import im.vector.app.features.analytics.plan.JoinedRoom
-import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
 import io.element.android.features.invite.api.response.AcceptDeclineInviteEvents
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.invite.api.response.InviteData
@@ -69,7 +69,7 @@ class JoinRoomPresenter @AssistedInject constructor(
     private val forgetRoom: ForgetRoom,
     private val acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState>,
     private val buildMeta: BuildMeta,
-    private val seenInvitesStore: SeenInvitesStore,
+    seenInvitesStoreFactory: SeenInvitesStoreFactory,
 ) : Presenter<JoinRoomState> {
     interface Factory {
         fun create(
@@ -80,6 +80,11 @@ class JoinRoomPresenter @AssistedInject constructor(
             trigger: JoinedRoom.Trigger,
         ): JoinRoomPresenter
     }
+
+    private val seenInvitesStore = seenInvitesStoreFactory.getOrCreate(
+        matrixClient.sessionId,
+        matrixClient.sessionCoroutineScope,
+    )
 
     @Composable
     override fun present(): JoinRoomState {

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/di/JoinRoomModule.kt
@@ -11,7 +11,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import im.vector.app.features.analytics.plan.JoinedRoom
-import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.joinroom.impl.JoinRoomPresenter
 import io.element.android.features.roomdirectory.api.RoomDescription
@@ -36,7 +36,7 @@ object JoinRoomModule {
         forgetRoom: ForgetRoom,
         acceptDeclineInvitePresenter: Presenter<AcceptDeclineInviteState>,
         buildMeta: BuildMeta,
-        seenInvitesStore: SeenInvitesStore,
+        seenInvitesStoreFactory: SeenInvitesStoreFactory,
     ): JoinRoomPresenter.Factory {
         return object : JoinRoomPresenter.Factory {
             override fun create(
@@ -59,7 +59,7 @@ object JoinRoomModule {
                     cancelKnockRoom = cancelKnockRoom,
                     acceptDeclineInvitePresenter = acceptDeclineInvitePresenter,
                     buildMeta = buildMeta,
-                    seenInvitesStore = seenInvitesStore,
+                    seenInvitesStoreFactory = seenInvitesStoreFactory,
                 )
             }
         }

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -783,7 +783,7 @@ class JoinRoomPresenterTest {
             forgetRoom = forgetRoom,
             buildMeta = buildMeta,
             acceptDeclineInvitePresenter = acceptDeclineInvitePresenter,
-            seenInvitesStore = seenInvitesStore,
+            seenInvitesStoreFactory = { _, _ -> seenInvitesStore },
         )
     }
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
@@ -11,7 +11,7 @@ import android.content.Context
 import coil3.SingletonImageLoader
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.features.ftue.api.state.FtueService
-import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
 import io.element.android.features.preferences.impl.DefaultCacheService
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.di.ApplicationContext
@@ -36,8 +36,13 @@ class DefaultClearCacheUseCase @Inject constructor(
     private val okHttpClient: Provider<OkHttpClient>,
     private val ftueService: FtueService,
     private val pushService: PushService,
-    private val seenInvitesStore: SeenInvitesStore,
+    seenInvitesStoreFactory: SeenInvitesStoreFactory,
 ) : ClearCacheUseCase {
+    private val seenInvitesStore = seenInvitesStoreFactory.getOrCreate(
+        matrixClient.sessionId,
+        matrixClient.sessionCoroutineScope,
+    )
+
     override suspend fun invoke() = withContext(coroutineDispatchers.io) {
         // Clear Matrix cache
         matrixClient.clearCache()

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/tasks/DefaultClearCacheUseCaseTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/tasks/DefaultClearCacheUseCaseTest.kt
@@ -54,7 +54,7 @@ class DefaultClearCacheUseCaseTest {
             okHttpClient = { OkHttpClient.Builder().build() },
             ftueService = ftueService,
             pushService = pushService,
-            seenInvitesStore = seenInvitesStore,
+            seenInvitesStoreFactory = { _, _ -> seenInvitesStore },
         )
         defaultCacheService.clearedCacheEventFlow.test {
             sut.invoke()

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListPresenter.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import im.vector.app.features.analytics.plan.Interaction
-import io.element.android.features.invite.api.SeenInvitesStore
+import io.element.android.features.invite.api.SeenInvitesStoreFactory
 import io.element.android.features.invite.api.response.AcceptDeclineInviteEvents
 import io.element.android.features.invite.api.response.AcceptDeclineInviteState
 import io.element.android.features.invite.api.response.InviteData
@@ -94,9 +94,14 @@ class RoomListPresenter @Inject constructor(
     private val logoutPresenter: Presenter<DirectLogoutState>,
     private val appPreferencesStore: AppPreferencesStore,
     private val rageshakeFeatureAvailability: RageshakeFeatureAvailability,
-    private val seenInvitesStore: SeenInvitesStore,
+    seenInvitesStoreFactory: SeenInvitesStoreFactory,
 ) : Presenter<RoomListState> {
     private val encryptionService: EncryptionService = client.encryptionService()
+
+    private val seenInvitesStore = seenInvitesStoreFactory.getOrCreate(
+        client.sessionId,
+        client.sessionCoroutineScope,
+    )
 
     @Composable
     override fun present(): RoomListState {

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListPresenterTest.kt
@@ -716,7 +716,7 @@ class RoomListPresenterTest {
         logoutPresenter = { aDirectLogoutState() },
         appPreferencesStore = appPreferencesStore,
         rageshakeFeatureAvailability = rageshakeFeatureAvailability,
-        seenInvitesStore = seenInvitesStore,
+        seenInvitesStoreFactory = { _, _ -> seenInvitesStore },
     )
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that we have only one single instance of SeenInviteStore per session by using a SeenInviteStoreFactory.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix crash:
java.lang.IllegalStateException: There are multiple DataStores active for the same file: /data/user/0/io.element.android.x/files/datastore/session_0ebb139587b6d940_seen-invites.preferences_pb. You should either maintain your DataStore as a singleton or confirm that there is no two DataStore's active on the same file (by confirming that the scope is cancelled).

Fixes #4558

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run the app
- From an external app (for instance a photo app), share something to Element X
- If the app does not crash, the bug is fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
