### PR TITLE
Refactor account provider

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProvider.kt
@@ -7,11 +7,15 @@
 
 package io.element.android.features.login.impl.accountprovider
 
+import io.element.android.appconfig.AuthenticationConfig
+
 data class AccountProvider(
     val url: String,
     val title: String = url.removePrefix("https://").removePrefix("http://"),
-    val subtitle: String? = null,
+    val descriptionResourceId: Int? = null,
     val isPublic: Boolean = false,
-    val isMatrixOrg: Boolean = false,
-    val isValid: Boolean = false,
-)
+) {
+    fun isMatrixOrg(): Boolean {
+        return url == AuthenticationConfig.MATRIX_ORG_URL
+    }
+}

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSource.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSource.kt
@@ -9,6 +9,7 @@ package io.element.android.features.login.impl.accountprovider
 
 import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.features.enterprise.api.EnterpriseService
+import io.element.android.features.login.impl.R
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.SingleIn
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,20 +19,32 @@ import javax.inject.Inject
 
 @SingleIn(AppScope::class)
 class AccountProviderDataSource @Inject constructor(
-    enterpriseService: EnterpriseService,
+    enterpriseService: EnterpriseService? = null,
 ) {
-    private val defaultAccountProvider = (enterpriseService.defaultHomeserver() ?: AuthenticationConfig.MATRIX_ORG_URL).let { url ->
+    val matrixOrgAccountProvider = AccountProvider(
+        url = AuthenticationConfig.MATRIX_ORG_URL,
+        descriptionResourceId = R.string.screen_change_account_provider_matrix_org_subtitle,
+        isPublic = true,
+    )
+    // add more hard coded AccountProvider here if you need them
+
+    private val defaultAccountProvider = if (enterpriseService?.defaultHomeserver() != null &&
+        enterpriseService.defaultHomeserver() != AuthenticationConfig.MATRIX_ORG_URL) {
         AccountProvider(
-            url = url,
-            subtitle = null,
-            isPublic = url == AuthenticationConfig.MATRIX_ORG_URL,
-            isMatrixOrg = url == AuthenticationConfig.MATRIX_ORG_URL,
+            enterpriseService.defaultHomeserver()!!,
         )
+    } else {
+        matrixOrgAccountProvider
     }
 
     private val accountProvider: MutableStateFlow<AccountProvider> = MutableStateFlow(
         defaultAccountProvider
     )
+
+    val accountProvidersList = listOf(
+        defaultAccountProvider,
+        matrixOrgAccountProvider
+    ).distinct()
 
     val flow: StateFlow<AccountProvider> = accountProvider.asStateFlow()
 

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderProvider.kt
@@ -9,22 +9,17 @@ package io.element.android.features.login.impl.accountprovider
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.appconfig.AuthenticationConfig
+import io.element.android.features.login.impl.R
 
 open class AccountProviderProvider : PreviewParameterProvider<AccountProvider> {
+    val defaultAccountProvider = AccountProviderDataSource().defaultAccountProvider
+    val longAccountProvider = AccountProvider(url="https://default-title.for.really-long-url.with.many.subdomains.co.uk"),
     override val values: Sequence<AccountProvider>
         get() = sequenceOf(
-            anAccountProvider(),
-            anAccountProvider().copy(subtitle = null),
-            anAccountProvider().copy(subtitle = null, title = "invalid", isValid = false),
-            anAccountProvider().copy(subtitle = null, title = "Other", isPublic = false, isMatrixOrg = false),
-            // Add other state here
+            defaultAccountProvider
+            defaultAccountProvider.copy(descriptionResourceId = null),
+            longAccountProvider,
+            longAccountProvider.copy(title = "custom title"),
+            defaultAccountProvider.copy(descriptionResourceId = null, title = "Other", isPublic = false),
         )
 }
-
-fun anAccountProvider() = AccountProvider(
-    url = AuthenticationConfig.MATRIX_ORG_URL,
-    subtitle = "Matrix.org is an open network for secure, decentralized communication.",
-    isPublic = true,
-    isMatrixOrg = true,
-    isValid = true,
-)

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderView.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
@@ -57,7 +58,7 @@ fun AccountProviderView(
                     .heightIn(min = 44.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (item.isMatrixOrg) {
+                if (item.isMatrixOrg()) {
                     RoundedIconAtom(
                         size = RoundedIconAtomSize.Medium,
                         resourceId = R.drawable.ic_matrix,
@@ -89,11 +90,11 @@ fun AccountProviderView(
                     )
                 }
             }
-            if (item.subtitle != null) {
+            if (item.descriptionResourceId != null) {
                 Text(
                     modifier = Modifier
                         .padding(start = 46.dp, bottom = 12.dp, end = 26.dp),
-                    text = item.subtitle,
+                    text = stringResource(id = item.descriptionResourceId),
                     style = ElementTheme.typography.fontBodyMdRegular,
                     color = ElementTheme.colors.textSecondary,
                 )

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenter.kt
@@ -8,29 +8,20 @@
 package io.element.android.features.login.impl.screens.changeaccountprovider
 
 import androidx.compose.runtime.Composable
-import io.element.android.appconfig.AuthenticationConfig
-import io.element.android.features.login.impl.accountprovider.AccountProvider
+import io.element.android.features.login.impl.accountprovider.AccountProviderDataSource
 import io.element.android.features.login.impl.changeserver.ChangeServerState
 import io.element.android.libraries.architecture.Presenter
 import javax.inject.Inject
 
 class ChangeAccountProviderPresenter @Inject constructor(
     private val changeServerPresenter: Presenter<ChangeServerState>,
+    private val accountProviderDataSource: AccountProviderDataSource,
 ) : Presenter<ChangeAccountProviderState> {
     @Composable
     override fun present(): ChangeAccountProviderState {
         val changeServerState = changeServerPresenter.present()
         return ChangeAccountProviderState(
-            // Just matrix.org by default for now
-            accountProviders = listOf(
-                AccountProvider(
-                    url = AuthenticationConfig.MATRIX_ORG_URL,
-                    subtitle = null,
-                    isPublic = true,
-                    isMatrixOrg = true,
-                    isValid = true,
-                )
-            ),
+            accountProviders = accountProviderDataSource.accountProvidersList,
             changeServerState = changeServerState,
         )
     }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderView.kt
@@ -79,18 +79,10 @@ fun ChangeAccountProviderView(
                 )
 
                 state.accountProviders.forEach { item ->
-                    val alteredItem = if (item.isMatrixOrg) {
-                        // Set the subtitle from the resource
-                        item.copy(
-                            subtitle = stringResource(id = R.string.screen_change_account_provider_matrix_org_subtitle),
-                        )
-                    } else {
-                        item
-                    }
                     AccountProviderView(
-                        item = alteredItem,
+                        item = item,
                         onClick = {
-                            state.changeServerState.eventSink.invoke(ChangeServerEvents.ChangeServer(alteredItem))
+                            state.changeServerState.eventSink.invoke(ChangeServerEvents.ChangeServer(item))
                         }
                     )
                 }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
@@ -42,6 +42,7 @@ import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.login.impl.R
 import io.element.android.features.login.impl.accountprovider.AccountProvider
+import io.element.android.features.login.impl.accountprovider.AccountProviderDataSource
 import io.element.android.features.login.impl.accountprovider.AccountProviderView
 import io.element.android.features.login.impl.changeserver.ChangeServerEvents
 import io.element.android.features.login.impl.changeserver.ChangeServerView
@@ -183,18 +184,14 @@ fun SearchAccountProviderView(
     }
 }
 
-@Composable
 private fun HomeserverData.toAccountProvider(): AccountProvider {
-    val isMatrixOrg = homeserverUrl == AuthenticationConfig.MATRIX_ORG_URL
-    return AccountProvider(
-        url = homeserverUrl,
-        subtitle = if (isMatrixOrg) stringResource(id = R.string.screen_change_account_provider_matrix_org_subtitle) else null,
-        // There is no need to know for other servers right now
-        isPublic = isMatrixOrg,
-        isMatrixOrg = isMatrixOrg,
-        isValid = isWellknownValid,
-    )
-}
+    return if (homeserverUrl == AuthenticationConfig.MATRIX_ORG_URL) {
+        AccountProviderDataSource().matrixOrgAccountProvider
+    } else {
+        AccountProvider(
+            url = homeserverUrl
+        )
+    }
 
 @PreviewsDayNight
 @Composable

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSourceTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderDataSourceTest.kt
@@ -11,6 +11,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.appconfig.AuthenticationConfig
 import io.element.android.features.enterprise.test.FakeEnterpriseService
+import io.element.android.features.login.impl.R
 import io.element.android.tests.testutils.WarmUpRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -28,11 +29,6 @@ class AccountProviderDataSourceTest {
             assertThat(initialState).isEqualTo(
                 AccountProvider(
                     url = FakeEnterpriseService.A_FAKE_HOMESERVER,
-                    title = FakeEnterpriseService.A_FAKE_HOMESERVER,
-                    subtitle = null,
-                    isPublic = false,
-                    isMatrixOrg = false,
-                    isValid = false,
                 )
             )
         }
@@ -47,12 +43,10 @@ class AccountProviderDataSourceTest {
             val initialState = awaitItem()
             assertThat(initialState).isEqualTo(
                 AccountProvider(
-                    url = AuthenticationConfig.MATRIX_ORG_URL,
+                    url = "https://matrix.org",
                     title = "matrix.org",
-                    subtitle = null,
+                    descriptionResourceId = R.string.screen_change_account_provider_matrix_org_subtitle,
                     isPublic = true,
-                    isMatrixOrg = true,
-                    isValid = false,
                 )
             )
         }
@@ -70,10 +64,8 @@ class AccountProviderDataSourceTest {
                 AccountProvider(
                     url = "https://example.com",
                     title = "example.com",
-                    subtitle = null,
+                    descriptionResourceId = null,
                     isPublic = false,
-                    isMatrixOrg = false,
-                    isValid = false,
                 )
             )
             sut.reset()

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/changeaccountprovider/ChangeAccountProviderPresenterTest.kt
@@ -11,7 +11,9 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.features.login.impl.R
 import io.element.android.features.login.impl.accountprovider.AccountProvider
+import io.element.android.features.login.impl.accountprovider.AccountProviderDataSource
 import io.element.android.features.login.impl.changeserver.aChangeServerState
 import io.element.android.tests.testutils.WarmUpRule
 import kotlinx.coroutines.test.runTest
@@ -25,7 +27,8 @@ class ChangeAccountProviderPresenterTest {
     @Test
     fun `present - initial state`() = runTest {
         val presenter = ChangeAccountProviderPresenter(
-            changeServerPresenter = { aChangeServerState() }
+            changeServerPresenter = { aChangeServerState() },
+            accountProviderDataSource = AccountProviderDataSource()
         )
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
@@ -36,13 +39,12 @@ class ChangeAccountProviderPresenterTest {
                     AccountProvider(
                         url = "https://matrix.org",
                         title = "matrix.org",
-                        subtitle = null,
+                        descriptionResourceId = R.string.screen_change_account_provider_matrix_org_subtitle,
                         isPublic = true,
-                        isMatrixOrg = true,
-                        isValid = true,
                     )
                 )
             )
+            assertThat(initialState.accountProviders[0].isMatrixOrg()).isTrue()
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
UI: String for description of matrix.org changed in some places (now consistent and localized everywhere). Future UI development can use the resourceID from the AccountProvider or use something else if they want.

AccountProvider.subtitle: String is now AccountProvider.descriptionResourceId: Int

NOT YET IMPLEMENTED
AccountProvider renamed to ....? In addition to not using the keyword "Provider", it might make more sense to name it what it is, and not what it is being used for in the loginFlow. Homeserver appears to be the correct name in the Matrix universe, but it seems it is already used elsewhere in this project to refer only to Homeservers that come down the ElementEnterprise pipeline. Host? Server? ChatHost? ChatServer? People probably have feelings and ideas, but please not "Account" and not "Provider". 
PLEASE COMMENT

Deleted AccountProvider.isValid as it wasn't being used anywhere.

created AccountProviderDataSource.accountProvidersList to replace list creation in the UI and support having more than one item in the list and always include Matrix.Org

AccountProvider.isMatrixOrg is now AccountProvider.isMatrixOrg() (yes, in a data class. Kotlin allows it. Please comment.)

Cleaner code in Views, Presenters, Tests

AccountProviderDataSource.enterpriseService is now nullable and AccountProviderDataSource can be constructed with no parameters.

NOT FULLY IMPLEMENTED
Better unit testing of AccountProvider and login flow

## Motivation and context

1. AccoundProvider info for matrix.org was being hard-coded in many different places. Sometimes English strings, sometimes stringResrouces being used. Sometimes isValid = true, sometimes isValid = false. Logic in Views that probably shouldn't be there. Hard coded lists in the presentation layer. Lots of duplicated logic to set a few booleans that really only need to be set once at creation.
2. The name "Provider" is already used as a keyword for something else in many classes in this project. We end up with brain-cancer-inducing names like AccountProviderStateProvider. AccountProvider is not a UI Provider for Account, and actually isn't an account at all, but a server address and description. This adds unnecessary cognitive overhead to navigating the code.
3. "subtitle" is a keyword used by our UI elements. This adds unnecessary cognitive overhead to navigating the code.
4. nearly all uses of isMatrixOrg were work-arounds, and I saw a codebase where they just set MATRIX_ORG_URL to something else and element-x-android then just sets isMatrixOrg to true.
5. duplicate logic and duplicate hard coded values in Views and Presenters
6. Some places were hurting for quick and easy access to AccountProviderDataSource
7. Desire to preserve the sanctity of Matrix.Org and its inclusion in the UI even if the defaultAccountProvider is changed.
8. Increase centralization and encapsulation of AccountProviders.
9. Improve UnitTests for login flow

## Tests

1. manual testing of login flow using virtual device Medium Phone API 36 light and dark mode with matrix.org (logout, change, search, login), invalid server, other valid server (search, login attempt, wrong password)
2. ./tools/quality/check.sh (I think all are passing, needs to be run again)
3. ./gradlew ktlintFormat
4. ./gradlew knitCheck
5. ./gradlew test (MEDIA UPLOAD IS FAILING. I am 99% certain I didn't touch media upload in any way. Need to check)


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): macOS Sequoia 15.3.1, Android Studio Meerkat | 2024.3.1, Medium Phone API 36


## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24 (IT WAS HORRIBLE, but it ran. Probably nothing related to my changes.)
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR