### PR TITLE
Send SVG images as files

### DIFF
--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/mimetype/MimeTypes.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/mimetype/MimeTypes.kt
@@ -24,6 +24,7 @@ object MimeTypes {
     const val Jpeg = "image/jpeg"
     const val Gif = "image/gif"
     const val WebP = "image/webp"
+    const val Svg = "image/svg+xml"
 
     const val Videos = "video/*"
     const val Mp4 = "video/mp4"

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -62,7 +62,7 @@ class AndroidMediaPreProcessor @Inject constructor(
          */
         private const val IMAGE_SCALE_REF_SIZE = 640
 
-        private val notCompressibleImageTypes = listOf(MimeTypes.Gif, MimeTypes.WebP)
+        private val notCompressibleImageTypes = listOf(MimeTypes.Gif, MimeTypes.WebP, MimeTypes.Svg)
     }
 
     private val contentResolver = context.contentResolver
@@ -75,6 +75,10 @@ class AndroidMediaPreProcessor @Inject constructor(
     ): Result<MediaUploadInfo> = withContext(coroutineDispatchers.computation) {
         runCatching {
             val result = when {
+                // Special case for SVG, since Android can't read its metadata or create a thumbnail, it must be sent as a file
+                mimeType == MimeTypes.Svg -> {
+                    processFile(uri, mimeType)
+                }
                 mimeType.isMimeTypeImage() -> {
                     val shouldBeCompressed = compressIfPossible && mimeType !in notCompressibleImageTypes
                     processImage(uri, mimeType, shouldBeCompressed)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Android doesn't have support for SVG files so we can't create a thumbnail or get the dimensions and other metadata needed for the `m.image` message type, so we need to send them as plain files.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4593 (partially).

## Tests

Download any SVG file, send it in some room.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
