### PR TITLE
Fetch the initial ignored user list manually when subscribing

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -221,6 +221,9 @@ class RustMatrixClient(
     override val userProfile: StateFlow<MatrixUser> = _userProfile
 
     override val ignoredUsersFlow = mxCallbackFlow<ImmutableList<UserId>> {
+        // Fetch the initial value manually, the SDK won't return it automatically
+        channel.trySend(innerClient.ignoredUsers().map(::UserId).toPersistentList())
+
         innerClient.subscribeToIgnoredUsers(object : IgnoredUsersListener {
             override fun call(ignoredUserIds: List<String>) {
                 channel.trySend(ignoredUserIds.map(::UserId).toPersistentList())


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

The SDK won't return it automatically, so we need to fetch it manually.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4597

## Tests

- You should see the ignored user list as soon as you open the settings screen if you had any ignored users.
- If you comment out the changes and restart the app, it'll be missing until you ignore/unignore someone.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
