### PR TITLE
Ensure that pinning an event makes the pinned messages banner appear

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -363,7 +363,9 @@ private fun MessagesViewContent(
             },
             content = { paddingValues ->
                 Box(modifier = Modifier.padding(paddingValues)) {
-                    val scrollBehavior = PinnedMessagesBannerViewDefaults.rememberExitOnScrollBehavior()
+                    val scrollBehavior = PinnedMessagesBannerViewDefaults.rememberScrollBehavior(
+                        pinnedMessagesCount = state.pinnedMessagesBannerState.pinnedMessagesCount(),
+                    )
                     TimelineView(
                         state = state.timelineState,
                         timelineProtectionState = state.timelineProtectionState,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/banner/PinnedMessagesBannerView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/banner/PinnedMessagesBannerView.kt
@@ -265,7 +265,7 @@ internal interface PinnedMessagesBannerViewScrollBehavior {
 
 internal object PinnedMessagesBannerViewDefaults {
     @Composable
-    fun rememberExitOnScrollBehavior(): PinnedMessagesBannerViewScrollBehavior = remember {
+    fun rememberScrollBehavior(pinnedMessagesCount: Int): PinnedMessagesBannerViewScrollBehavior = remember(pinnedMessagesCount) {
         ExitOnScrollBehavior()
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When a user pin or unpin a message, make sure the the pinned messages banner is displayed.

Note that the banner will also be made visible when another user update the list of pinned event, but I do not think this is a problem, as it should not occur a lot. The banner is always visible, except if the user has scrolled to the top.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Part of #3437

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Navigate to a room where the user is allowed to pin event
- scroll to the top a bit
- pin an event
- observe that the banner is visible (new)
- scroll to the top a bit again
- the banner is automatically hidden
- pin another event
- observe that the banner is visible (new)

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
