### PR TITLE
Keep call notification ringing while a call is present in the room

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
@@ -20,8 +20,11 @@ import io.element.android.libraries.push.impl.notifications.model.NotifiableEven
 import io.element.android.libraries.push.impl.notifications.model.NotifiableRingingCallEvent
 import io.element.android.services.appnavstate.api.AppForegroundStateService
 import io.element.android.services.toolbox.api.strings.StringProvider
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Helper to resolve a valid [NotifiableEvent] from a [NotificationData].
@@ -55,13 +58,29 @@ class DefaultCallNotificationEventResolver @Inject constructor(
         val content = notificationData.content as? NotificationContent.MessageLike.CallNotify
             ?: throw ResolvingException("content is not a call notify")
 
-        appForegroundStateService.updateHasRingingCall(true)
+        val previousRingingCallStatus = appForegroundStateService.hasRingingCall.value
+        // We need the sync service working to get the updated room info
+        val isRoomCallActive = runCatching {
+            if (content.type == CallNotifyType.RING) {
+                appForegroundStateService.updateHasRingingCall(true)
 
-        val client = clientProvider.getOrNull(sessionId) ?: error("Session $sessionId not found")
-        val room = client.getRoom(notificationData.roomId) ?: error("Room ${notificationData.roomId} not found")
-        val isRoomCallActive = room.roomInfoFlow.value.hasRoomCall
+                val client = clientProvider.getOrRestore(sessionId).getOrNull() ?: throw ResolvingException("Session $sessionId not found")
+                val room = client.getRoom(notificationData.roomId) ?: throw ResolvingException("Room ${notificationData.roomId} not found")
+                // Give a few seconds for the room info flow to catch up with the sync, if needed - this is usually instant
+                val isActive = withTimeoutOrNull(3.seconds) { room.roomInfoFlow.firstOrNull { it.hasRoomCall } }?.hasRoomCall ?: false
 
-        appForegroundStateService.updateHasRingingCall(false)
+                // We no longer need the sync service to be active because of a call notification.
+                appForegroundStateService.updateHasRingingCall(previousRingingCallStatus)
+
+                isActive
+            } else {
+                // If the call notification is not of ringing type, we don't need to check if the call is active
+                false
+            }
+        }.onFailure {
+            // Make sure to reset the hasRingingCall state in case of failure
+            appForegroundStateService.updateHasRingingCall(previousRingingCallStatus)
+        }.getOrDefault(false)
 
         notificationData.run {
             if (content.type == CallNotifyType.RING && isRoomCallActive && !forceNotify) {
@@ -83,9 +102,7 @@ class DefaultCallNotificationEventResolver @Inject constructor(
                     senderAvatarUrl = senderAvatarUrl,
                 )
             } else {
-                val now = System.currentTimeMillis()
-                val elapsed = now - timestamp
-                Timber.d("Event $eventId is call notify but should not ring: $timestamp vs $now ($elapsed ms elapsed), notify: ${content.type}")
+                Timber.d("Event $eventId is call notify but should not ring: $isRoomCallActive, notify: ${content.type}")
                 // Create a simple message notification event
                 buildNotifiableMessageEvent(
                     sessionId = sessionId,

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableRingingCallEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/NotifiableRingingCallEvent.kt
@@ -12,8 +12,6 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.CallNotifyType
-import java.time.Instant
-import kotlin.time.Duration.Companion.seconds
 
 data class NotifiableRingingCallEvent(
     override val sessionId: SessionId,
@@ -31,13 +29,4 @@ data class NotifiableRingingCallEvent(
     val roomAvatarUrl: String? = null,
     val callNotifyType: CallNotifyType,
     val timestamp: Long,
-) : NotifiableEvent {
-    companion object {
-        fun shouldRing(callNotifyType: CallNotifyType, timestamp: Long): Boolean {
-            val timeout = 10.seconds.inWholeMilliseconds
-            val elapsed = Instant.now().toEpochMilli() - timestamp
-            // Only ring if the type is RING and the elapsed time is less than the timeout
-            return callNotifyType == CallNotifyType.RING && elapsed < timeout
-        }
-    }
-}
+) : NotifiableEvent

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultCallNotificationEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultCallNotificationEventResolverTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.impl.notifications
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.notification.CallNotifyType
+import io.element.android.libraries.matrix.api.notification.NotificationContent
+import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_ROOM_NAME
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.A_USER_NAME_2
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.FakeMatrixClientProvider
+import io.element.android.libraries.matrix.test.notification.aNotificationData
+import io.element.android.libraries.matrix.test.room.FakeBaseRoom
+import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.room.aRoomInfo
+import io.element.android.libraries.push.impl.notifications.model.NotifiableMessageEvent
+import io.element.android.libraries.push.impl.notifications.model.NotifiableRingingCallEvent
+import io.element.android.services.appnavstate.test.FakeAppForegroundStateService
+import io.element.android.services.toolbox.test.strings.FakeStringProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultCallNotificationEventResolverTest {
+    @Test
+    fun `resolve CallNotify - RING when call is still ongoing`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                sessionId = A_SESSION_ID,
+                roomId = A_ROOM_ID,
+                // The call is still ongoing
+                initialRoomInfo = aRoomInfo(hasRoomCall = true),
+            )
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM_ID, room)
+        }
+
+        val resolver = createDefaultNotifiableEventResolver(
+            clientProvider = FakeMatrixClientProvider(getClient = { Result.success(client) }),
+        )
+        val expectedResult = NotifiableRingingCallEvent(
+            sessionId = A_SESSION_ID,
+            roomId = A_ROOM_ID,
+            eventId = AN_EVENT_ID,
+            senderId = A_USER_ID_2,
+            roomName = A_ROOM_NAME,
+            editedEventId = null,
+            description = "📹 Incoming call",
+            timestamp = 567L,
+            canBeReplaced = true,
+            isRedacted = false,
+            isUpdated = false,
+            senderDisambiguatedDisplayName = A_USER_NAME_2,
+            senderAvatarUrl = null,
+            callNotifyType = CallNotifyType.RING,
+        )
+
+        val notificationData = aNotificationData(
+            content = NotificationContent.MessageLike.CallNotify(A_USER_ID_2, CallNotifyType.RING)
+        )
+        val result = resolver.resolveEvent(A_SESSION_ID, notificationData)
+        assertThat(result.getOrNull()).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `resolve CallNotify - NOTIFY`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                sessionId = A_SESSION_ID,
+                roomId = A_ROOM_ID,
+                // The call already ended
+                initialRoomInfo = aRoomInfo(hasRoomCall = true),
+            )
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM_ID, room)
+        }
+
+        val resolver = createDefaultNotifiableEventResolver(
+            clientProvider = FakeMatrixClientProvider(getClient = { Result.success(client) }),
+        )
+        val expectedResult = NotifiableMessageEvent(
+            sessionId = A_SESSION_ID,
+            roomId = A_ROOM_ID,
+            eventId = AN_EVENT_ID,
+            senderId = A_USER_ID_2,
+            roomName = A_ROOM_NAME,
+            editedEventId = null,
+            body = "📹 Incoming call",
+            timestamp = 567L,
+            canBeReplaced = false,
+            isRedacted = false,
+            isUpdated = false,
+            senderDisambiguatedDisplayName = A_USER_NAME_2,
+            noisy = true,
+            imageUriString = null,
+            imageMimeType = null,
+            threadId = null,
+            type = "m.call.notify",
+        )
+
+        val notificationData = aNotificationData(
+            content = NotificationContent.MessageLike.CallNotify(A_USER_ID_2, CallNotifyType.NOTIFY)
+        )
+        val result = resolver.resolveEvent(A_SESSION_ID, notificationData)
+        assertThat(result.getOrNull()).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `resolve CallNotify - RING but timed out displays the same as NOTIFY`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                sessionId = A_SESSION_ID,
+                roomId = A_ROOM_ID,
+                // The call already ended
+                initialRoomInfo = aRoomInfo(hasRoomCall = false),
+            )
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM_ID, room)
+        }
+
+        val resolver = createDefaultNotifiableEventResolver(
+            clientProvider = FakeMatrixClientProvider(getClient = { Result.success(client) }),
+        )
+        val expectedResult = NotifiableMessageEvent(
+            sessionId = A_SESSION_ID,
+            roomId = A_ROOM_ID,
+            eventId = AN_EVENT_ID,
+            senderId = A_USER_ID_2,
+            roomName = A_ROOM_NAME,
+            editedEventId = null,
+            body = "📹 Incoming call",
+            timestamp = 567L,
+            canBeReplaced = false,
+            isRedacted = false,
+            isUpdated = false,
+            senderDisambiguatedDisplayName = A_USER_NAME_2,
+            noisy = true,
+            imageUriString = null,
+            imageMimeType = null,
+            threadId = null,
+            type = "m.call.notify",
+        )
+
+        val notificationData = aNotificationData(
+            content = NotificationContent.MessageLike.CallNotify(A_USER_ID_2, CallNotifyType.RING)
+        )
+        val result = resolver.resolveEvent(A_SESSION_ID, notificationData)
+        assertThat(result.getOrNull()).isEqualTo(expectedResult)
+    }
+
+    private fun createDefaultNotifiableEventResolver(
+        stringProvider: FakeStringProvider = FakeStringProvider(defaultResult = "\uD83D\uDCF9 Incoming call"),
+        appForegroundStateService: FakeAppForegroundStateService = FakeAppForegroundStateService(),
+        clientProvider: FakeMatrixClientProvider = FakeMatrixClientProvider(),
+    ) = DefaultCallNotificationEventResolver(
+        stringProvider = stringProvider,
+        appForegroundStateService = appForegroundStateService,
+        clientProvider = clientProvider,
+    )
+}

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/FakeCallNotificationEventResolver.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/FakeCallNotificationEventResolver.kt
@@ -18,7 +18,7 @@ class FakeCallNotificationEventResolver(
         lambdaError()
     },
 ) : CallNotificationEventResolver {
-    override fun resolveEvent(sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean): Result<NotifiableEvent> {
+    override suspend fun resolveEvent(sessionId: SessionId, notificationData: NotificationData, forceNotify: Boolean): Result<NotifiableEvent> {
         return resolveEventLambda(sessionId, notificationData, forceNotify)
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This removes the 10s timeout to consider a call notification ringing, and instead uses `RoomInfo.hasRoomCall` to check if the notification should ring or not.

## Motivation and context

Mitigate or fix issues when a call notification that should be considered ringing because the other user was still calling was considered low priority instead.

## Tests

<!-- Explain how you tested your development -->

- From 2 devices with different accounts, start a call in a DM room.
- The receiving one should display the ringing notification/screen.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
