### PR TITLE
Render caller avatar on Incoming call screen

### DIFF
--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/DefaultActiveCallManagerTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/DefaultActiveCallManagerTest.kt
@@ -325,5 +325,6 @@ class DefaultActiveCallManagerTest {
         matrixClientProvider = matrixClientProvider,
         defaultCurrentCallService = DefaultCurrentCallService(),
         appForegroundStateService = FakeAppForegroundStateService(),
+        imageLoaderHolder = FakeImageLoaderHolder(),
     )
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/background/OnboardingBackground.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/background/OnboardingBackground.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.designsystem.background
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,13 +33,17 @@ import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 @Suppress("ModifierMissing")
 @Composable
 fun OnboardingBackground() {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(ElementTheme.colors.bgCanvasDefault)
+    ) {
         val isLightTheme = ElementTheme.isLightTheme
         Canvas(
             modifier = Modifier
-            .fillMaxWidth()
-            .height(220.dp)
-            .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(220.dp)
+                .align(Alignment.BottomCenter)
         ) {
             val gradientBrush = ShaderBrush(
                 LinearGradientShader(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Ensure that the image loader is set, else the IncomingCallActivity will not be able to render the avatar.
<!-- Describe shortly what has been changed -->

Note that this is a temporary fix, we may want to revisit how we handle the Coil image loader singleton.

This PR also ensure that a background color is set else we can end up with light text on light background. 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #4633
Fixes #4629 


## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->


|Before|After|
|-|-|
|![IncomingCall-Before2](https://github.com/user-attachments/assets/09a0846b-5769-413a-ae15-c3fb310c8123)|![IncomingCall-After](https://github.com/user-attachments/assets/3d72958c-2165-4b9d-a552-a1fce2b94a71)|



## Tests

<!-- Explain how you tested your development -->

- Set the system color to light
- Set the app theme to dark
- Kill the app
- Lock the device (screen is off)
- Receive a call from a DM where other user has an avatar
- Observe that the screen now renders the caller avatar and is rendering light text on dark background. Previously it was only rendering initials avatar, with light text on light background.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
