### PR TITLE
Cleanup element call and UI

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -10,7 +10,6 @@ package io.element.android.features.call.impl.ui
 import android.Manifest
 import android.app.PictureInPictureParams
 import android.content.Intent
-import android.content.res.Configuration
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
@@ -78,7 +77,6 @@ class ElementCallActivity :
 
     private val requestPermissionsLauncher = registerPermissionResultLauncher()
 
-    private var isDarkMode = false
     private val webViewTarget = mutableStateOf<CallType?>(null)
 
     private var eventSink: ((CallScreenEvents) -> Unit)? = null
@@ -100,10 +98,6 @@ class ElementCallActivity :
         // If presenter is not created at this point, it means we have no call to display, the Activity is finishing, so return early
         if (!::presenter.isInitialized) {
             return
-        }
-
-        if (savedInstanceState == null) {
-            updateUiMode(resources.configuration)
         }
 
         pictureInPicturePresenter.setPipView(this)
@@ -172,11 +166,6 @@ class ElementCallActivity :
                 removeOnPictureInPictureModeChangedListener(onPictureInPictureModeChangedListener)
             }
         }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        updateUiMode(newConfig)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -280,19 +269,6 @@ class ElementCallActivity :
             audiofocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
         } else {
             audioFocusChangeListener?.let { audioManager.abandonAudioFocus(it) }
-        }
-    }
-
-    private fun updateUiMode(configuration: Configuration) {
-        val prevDarkMode = isDarkMode
-        val currentNightMode = configuration.uiMode and Configuration.UI_MODE_NIGHT_YES
-        isDarkMode = currentNightMode != 0
-        if (prevDarkMode != isDarkMode) {
-            if (isDarkMode) {
-                window.setBackgroundDrawableResource(android.R.drawable.screen_background_dark)
-            } else {
-                window.setBackgroundDrawableResource(android.R.drawable.screen_background_light)
-            }
         }
     }
 

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsView.kt
@@ -49,8 +49,8 @@ fun AdvancedSettingsView(
             title = stringResource(id = CommonStrings.common_appearance),
             selectedOption = state.theme,
             options = ThemeOption.entries.toPersistentList(),
-            onSelectOption = { logLevel ->
-                state.eventSink(AdvancedSettingsEvents.SetTheme(logLevel))
+            onSelectOption = { themeOption ->
+                state.eventSink(AdvancedSettingsEvents.SetTheme(themeOption))
             }
         )
         ListItem(

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/ElementLogoAtom.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/ElementLogoAtom.kt
@@ -10,7 +10,6 @@ package io.element.android.libraries.designsystem.atomic.atoms
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -38,7 +37,7 @@ fun ElementLogoAtom(
     size: ElementLogoAtomSize,
     modifier: Modifier = Modifier,
     useBlurredShadow: Boolean = canUseBlurMaskFilter(),
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    darkTheme: Boolean = ElementTheme.isLightTheme.not(),
 ) {
     val blur = if (darkTheme) 160.dp else 24.dp
     val shadowColor = if (darkTheme) size.shadowColorDark else size.shadowColorLight

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/molecules/InfoListItemMolecule.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/molecules/InfoListItemMolecule.kt
@@ -62,7 +62,7 @@ fun InfoListItemMolecule(
 @Composable
 internal fun InfoListItemMoleculePreview() {
     ElementPreview {
-        val color = if (ElementTheme.isLightTheme) Color.LightGray else Color.DarkGray
+        val color = ElementTheme.colors.bgSubtleSecondary
         Column(
             modifier = Modifier.padding(10.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/molecules/InfoListItemMolecule.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/molecules/InfoListItemMolecule.kt
@@ -8,7 +8,6 @@
 package io.element.android.libraries.designsystem.atomic.molecules
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -62,7 +62,7 @@ fun InfoListItemMolecule(
 @Composable
 internal fun InfoListItemMoleculePreview() {
     ElementPreview {
-        val color = if (isSystemInDarkTheme()) Color.DarkGray else Color.LightGray
+        val color = if (ElementTheme.isLightTheme) Color.LightGray else Color.DarkGray
         Column(
             modifier = Modifier.padding(10.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/organisms/InfoListOrganism.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/organisms/InfoListOrganism.kt
@@ -111,7 +111,6 @@ internal fun InfoListOrganismPreview() = ElementPreview {
         InfoListItem(message = "A bottom item"),
     )
     InfoListOrganism(
-        items,
-        backgroundColor = ElementTheme.materialColors.surfaceVariant,
+        items = items,
     )
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/Scaffold.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/Scaffold.kt
@@ -10,12 +10,12 @@ package io.element.android.libraries.designsystem.theme.components
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.FabPosition
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.element.android.compound.theme.ElementTheme
 
 @Composable
 fun Scaffold(
@@ -25,7 +25,7 @@ fun Scaffold(
     snackbarHost: @Composable () -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
     floatingActionButtonPosition: FabPosition = FabPosition.End,
-    containerColor: Color = MaterialTheme.colorScheme.background,
+    containerColor: Color = ElementTheme.colors.bgCanvasDefault,
     contentColor: Color = contentColorFor(containerColor),
     contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
     content: @Composable (PaddingValues) -> Unit

--- a/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.molecules_InfoListItemMolecule_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.molecules_InfoListItemMolecule_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a1ad0dcf6187838d37d7a6f9362e6fed44af4687b0494404a5343bc2de24723
-size 17311
+oid sha256:d4e6027ed8a8c11bc294add70bb67986fc52c70a51a3410e35f6bab2a8a71a9a
+size 17211

--- a/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.molecules_InfoListItemMolecule_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.molecules_InfoListItemMolecule_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8dfb1d166afbd78aa6807be751cd98cb4f5f704dafa46a7b9c98e9376c9f7f1c
-size 16678
+oid sha256:7201f6fb1368435a944b07a557a595509afa01d70cafa9ec0f4d8ff46db95482
+size 16521


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Remove the code that set the bg of ElementCallActivity, it does not work as expected.
Do not use isSystemInDarkTheme(), since it's not taking into account the appearance setting.
Other minor change on the usage of colors.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Remove useless code.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- No impact on the app.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
