### PR TITLE
Render kick and ban reason in the timeline when available

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/RoomMembershipContentFormatter.kt
@@ -26,6 +26,7 @@ class RoomMembershipContentFormatter @Inject constructor(
         val userId = membershipContent.userId
         val memberIsYou = matrixClient.isMe(userId)
         val userDisplayNameOrId = membershipContent.userDisplayName ?: userId.value
+        val reason = membershipContent.reason?.takeIf { it.isNotBlank() }
         return when (membershipContent.change) {
             MembershipChange.JOINED -> if (memberIsYou) {
                 sp.getString(R.string.state_event_room_join_by_you)
@@ -38,9 +39,17 @@ class RoomMembershipContentFormatter @Inject constructor(
                 sp.getString(R.string.state_event_room_leave, senderDisambiguatedDisplayName)
             }
             MembershipChange.BANNED, MembershipChange.KICKED_AND_BANNED -> if (senderIsYou) {
-                sp.getString(R.string.state_event_room_ban_by_you, userDisplayNameOrId)
+                if (reason != null) {
+                    sp.getString(R.string.state_event_room_ban_by_you_with_reason, userDisplayNameOrId, reason)
+                } else {
+                    sp.getString(R.string.state_event_room_ban_by_you, userDisplayNameOrId)
+                }
             } else {
-                sp.getString(R.string.state_event_room_ban, senderDisambiguatedDisplayName, userDisplayNameOrId)
+                if (reason != null) {
+                    sp.getString(R.string.state_event_room_ban_with_reason, senderDisambiguatedDisplayName, userDisplayNameOrId, reason)
+                } else {
+                    sp.getString(R.string.state_event_room_ban, senderDisambiguatedDisplayName, userDisplayNameOrId)
+                }
             }
             MembershipChange.UNBANNED -> if (senderIsYou) {
                 sp.getString(R.string.state_event_room_unban_by_you, userDisplayNameOrId)
@@ -48,9 +57,17 @@ class RoomMembershipContentFormatter @Inject constructor(
                 sp.getString(R.string.state_event_room_unban, senderDisambiguatedDisplayName, userDisplayNameOrId)
             }
             MembershipChange.KICKED -> if (senderIsYou) {
-                sp.getString(R.string.state_event_room_remove_by_you, userDisplayNameOrId)
+                if (reason != null) {
+                    sp.getString(R.string.state_event_room_remove_by_you_with_reason, userDisplayNameOrId, reason)
+                } else {
+                    sp.getString(R.string.state_event_room_remove_by_you, userDisplayNameOrId)
+                }
             } else {
-                sp.getString(R.string.state_event_room_remove, senderDisambiguatedDisplayName, userDisplayNameOrId)
+                if (reason != null) {
+                    sp.getString(R.string.state_event_room_remove_with_reason, senderDisambiguatedDisplayName, userDisplayNameOrId, reason)
+                } else {
+                    sp.getString(R.string.state_event_room_remove, senderDisambiguatedDisplayName, userDisplayNameOrId)
+                }
             }
             MembershipChange.INVITED -> if (senderIsYou) {
                 sp.getString(R.string.state_event_room_invite_by_you, userDisplayNameOrId)

--- a/libraries/eventformatter/impl/src/main/res/values/localazy.xml
+++ b/libraries/eventformatter/impl/src/main/res/values/localazy.xml
@@ -19,6 +19,8 @@
   <string name="state_event_room_avatar_removed_by_you">"You removed the room avatar"</string>
   <string name="state_event_room_ban">"%1$s banned %2$s"</string>
   <string name="state_event_room_ban_by_you">"You banned %1$s"</string>
+  <string name="state_event_room_ban_by_you_with_reason">"You banned %1$s: %2$s"</string>
+  <string name="state_event_room_ban_with_reason">"%1$s banned %2$s: %3$s"</string>
   <string name="state_event_room_created">"%1$s created the room"</string>
   <string name="state_event_room_created_by_you">"You created the room"</string>
   <string name="state_event_room_invite">"%1$s invited %2$s"</string>
@@ -55,6 +57,8 @@
   <string name="state_event_room_reject_by_you">"You rejected the invitation"</string>
   <string name="state_event_room_remove">"%1$s removed %2$s"</string>
   <string name="state_event_room_remove_by_you">"You removed %1$s"</string>
+  <string name="state_event_room_remove_by_you_with_reason">"You removed %1$s: %2$s"</string>
+  <string name="state_event_room_remove_with_reason">"%1$s removed %2$s: %3$s"</string>
   <string name="state_event_room_third_party_invite">"%1$s sent an invitation to %2$s to join the room"</string>
   <string name="state_event_room_third_party_invite_by_you">"You sent an invitation to %1$s to join the room"</string>
   <string name="state_event_room_third_party_revoked_invite">"%1$s revoked the invitation for %2$s to join the room"</string>

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultBaseRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultBaseRoomLastMessageFormatterTest.kt
@@ -37,6 +37,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.UnableToDecry
 import io.element.android.libraries.matrix.api.timeline.item.event.UnknownContent
 import io.element.android.libraries.matrix.api.timeline.item.event.VideoMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.VoiceMessageType
+import io.element.android.libraries.matrix.test.A_REASON
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.media.aMediaSource
@@ -346,6 +347,33 @@ class DefaultBaseRoomLastMessageFormatterTest {
 
     @Test
     @Config(qualifiers = "en")
+    fun `Membership change - banned with reason`() {
+        val otherName = "Other"
+        val third = "Someone"
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED, A_REASON)
+        val youKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED, A_REASON)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED, A_REASON)
+        val someoneKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED, A_REASON)
+
+        val youBannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
+        val youBanned = formatter.format(youBannedEvent, false)
+        assertThat(youBanned).isEqualTo("You banned $third: $A_REASON")
+
+        val youKickBannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youKickedContent)
+        val youKickedBanned = formatter.format(youKickBannedEvent, false)
+        assertThat(youKickedBanned).isEqualTo("You banned $third: $A_REASON")
+
+        val someoneBannedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = someoneContent)
+        val someoneBanned = formatter.format(someoneBannedEvent, false)
+        assertThat(someoneBanned).isEqualTo("$otherName banned $third: $A_REASON")
+
+        val someoneKickBannedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = someoneKickedContent)
+        val someoneKickBanned = formatter.format(someoneKickBannedEvent, false)
+        assertThat(someoneKickBanned).isEqualTo("$otherName banned $third: $A_REASON")
+    }
+
+    @Test
+    @Config(qualifiers = "en")
     fun `Membership change - unban`() {
         val otherName = "Other"
         val third = "Someone"
@@ -376,6 +404,23 @@ class DefaultBaseRoomLastMessageFormatterTest {
         val someoneKickedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = someoneContent)
         val someoneKicked = formatter.format(someoneKickedEvent, false)
         assertThat(someoneKicked).isEqualTo("$otherName removed $third")
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    fun `Membership change - kicked with reason`() {
+        val otherName = "Other"
+        val third = "Someone"
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED, A_REASON)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED, A_REASON)
+
+        val youKickedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
+        val youKicked = formatter.format(youKickedEvent, false)
+        assertThat(youKicked).isEqualTo("You removed $third: $A_REASON")
+
+        val someoneKickedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = someoneContent)
+        val someoneKicked = formatter.format(someoneKickedEvent, false)
+        assertThat(someoneKicked).isEqualTo("$otherName removed $third: $A_REASON")
     }
 
     @Test

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultBaseRoomLastMessageFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultBaseRoomLastMessageFormatterTest.kt
@@ -30,7 +30,6 @@ import io.element.android.libraries.matrix.api.timeline.item.event.NoticeMessage
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
 import io.element.android.libraries.matrix.api.timeline.item.event.RedactedContent
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StickerMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
@@ -47,6 +46,7 @@ import io.element.android.libraries.matrix.test.timeline.aProfileChangeMessageCo
 import io.element.android.libraries.matrix.test.timeline.aProfileTimelineDetails
 import io.element.android.libraries.matrix.test.timeline.aStickerContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 import io.element.android.services.toolbox.impl.strings.AndroidStringProvider
 import org.junit.Before
 import org.junit.Test
@@ -289,8 +289,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - joined`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.JOINED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.JOINED)
 
         val youJoinedRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youJoinedRoom = formatter.format(youJoinedRoomEvent, false)
@@ -305,8 +305,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - left`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.LEFT)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.LEFT)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.LEFT)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.LEFT)
 
         val youLeftRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youLeftRoom = formatter.format(youLeftRoomEvent, false)
@@ -322,10 +322,10 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - banned`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
-        val youKickedContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
-        val someoneKickedContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
+        val youKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
+        val someoneKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
 
         val youBannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youBanned = formatter.format(youBannedEvent, false)
@@ -349,8 +349,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - unban`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
 
         val youUnbannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youUnbanned = formatter.format(youUnbannedEvent, false)
@@ -366,8 +366,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - kicked`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
 
         val youKickedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youKicked = formatter.format(youKickedEvent, false)
@@ -383,8 +383,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - invited`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITED)
 
         val youWereInvitedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = youContent)
         val youWereInvited = formatter.format(youWereInvitedEvent, false)
@@ -403,8 +403,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - invitation accepted`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_ACCEPTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_ACCEPTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_ACCEPTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_ACCEPTED)
 
         val youAcceptedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youAcceptedInvite = formatter.format(youAcceptedInviteEvent, false)
@@ -419,8 +419,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - invitation rejected`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_REJECTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_REJECTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_REJECTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_REJECTED)
 
         val youRejectedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youRejectedInvite = formatter.format(youRejectedInviteEvent, false)
@@ -436,7 +436,7 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - invitation revoked`() {
         val otherName = "Other"
         val third = "Someone"
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITATION_REVOKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITATION_REVOKED)
 
         val youRevokedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youRevokedInvite = formatter.format(youRevokedInviteEvent, false)
@@ -451,8 +451,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - knocked`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCKED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.KNOCKED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.KNOCKED)
 
         val youKnockedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youKnocked = formatter.format(youKnockedEvent, false)
@@ -468,7 +468,7 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - knock accepted`() {
         val otherName = "Other"
         val third = "Someone"
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_ACCEPTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_ACCEPTED)
 
         val youAcceptedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youAcceptedKnock = formatter.format(youAcceptedKnockEvent, false)
@@ -483,8 +483,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - knock retracted`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCK_RETRACTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), null, MembershipChange.KNOCK_RETRACTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCK_RETRACTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), null, MembershipChange.KNOCK_RETRACTED)
 
         val youRetractedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youRetractedKnock = formatter.format(youRetractedKnockEvent, false)
@@ -500,8 +500,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     fun `Membership change - knock denied`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(A_USER_ID, third, MembershipChange.KNOCK_DENIED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_DENIED)
+        val youContent = aRoomMembershipContent(A_USER_ID, third, MembershipChange.KNOCK_DENIED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_DENIED)
 
         val youDeniedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youDeniedKnock = formatter.format(youDeniedKnockEvent, false)
@@ -520,8 +520,8 @@ class DefaultBaseRoomLastMessageFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - None`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.NONE)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.NONE)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.NONE)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.NONE)
 
         val youNoneRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youNoneRoom = formatter.format(youNoneRoomEvent, false)
@@ -538,7 +538,7 @@ class DefaultBaseRoomLastMessageFormatterTest {
         val otherChanges = arrayOf(MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED, null)
 
         val results = otherChanges.map { change ->
-            val content = RoomMembershipContent(A_USER_ID, null, change)
+            val content = aRoomMembershipContent(A_USER_ID, null, change)
             val event = createRoomEvent(sentByYou = false, senderDisplayName = "Someone", content = content)
             val result = formatter.format(event, false)
             change to result

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultPinnedMessagesBannerFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultPinnedMessagesBannerFormatterTest.kt
@@ -30,7 +30,6 @@ import io.element.android.libraries.matrix.api.timeline.item.event.NoticeMessage
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
 import io.element.android.libraries.matrix.api.timeline.item.event.RedactedContent
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StickerMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
@@ -47,6 +46,7 @@ import io.element.android.libraries.matrix.test.timeline.aProfileChangeMessageCo
 import io.element.android.libraries.matrix.test.timeline.aProfileTimelineDetails
 import io.element.android.libraries.matrix.test.timeline.aStickerContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.toolbox.impl.strings.AndroidStringProvider
 import org.junit.Before
@@ -198,8 +198,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - joined`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.JOINED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.JOINED)
 
         val youJoinedRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youJoinedRoom = formatter.format(youJoinedRoomEvent)
@@ -214,8 +214,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - left`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.LEFT)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.LEFT)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.LEFT)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.LEFT)
 
         val youLeftRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youLeftRoom = formatter.format(youLeftRoomEvent)
@@ -231,10 +231,10 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - banned`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
-        val youKickedContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
-        val someoneKickedContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
+        val youKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.BANNED)
+        val someoneKickedContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED_AND_BANNED)
 
         val youBannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youBanned = formatter.format(youBannedEvent)
@@ -258,8 +258,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - unban`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.UNBANNED)
 
         val youUnbannedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youUnbanned = formatter.format(youUnbannedEvent)
@@ -275,8 +275,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - kicked`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
+        val youContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KICKED)
 
         val youKickedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youKicked = formatter.format(youKickedEvent)
@@ -292,8 +292,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - invited`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITED)
 
         val youWereInvitedEvent = createRoomEvent(sentByYou = false, senderDisplayName = otherName, content = youContent)
         val youWereInvited = formatter.format(youWereInvitedEvent)
@@ -312,8 +312,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - invitation accepted`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_ACCEPTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_ACCEPTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_ACCEPTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_ACCEPTED)
 
         val youAcceptedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youAcceptedInvite = formatter.format(youAcceptedInviteEvent)
@@ -328,8 +328,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - invitation rejected`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_REJECTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_REJECTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.INVITATION_REJECTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.INVITATION_REJECTED)
 
         val youRejectedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youRejectedInvite = formatter.format(youRejectedInviteEvent)
@@ -345,7 +345,7 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - invitation revoked`() {
         val otherName = "Other"
         val third = "Someone"
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITATION_REVOKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.INVITATION_REVOKED)
 
         val youRevokedInviteEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youRevokedInvite = formatter.format(youRevokedInviteEvent)
@@ -360,8 +360,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - knocked`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCKED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.KNOCKED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCKED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.KNOCKED)
 
         val youKnockedEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youKnocked = formatter.format(youKnockedEvent)
@@ -377,7 +377,7 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - knock accepted`() {
         val otherName = "Other"
         val third = "Someone"
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_ACCEPTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_ACCEPTED)
 
         val youAcceptedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youAcceptedKnock = formatter.format(youAcceptedKnockEvent)
@@ -392,8 +392,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - knock retracted`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCK_RETRACTED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), null, MembershipChange.KNOCK_RETRACTED)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.KNOCK_RETRACTED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), null, MembershipChange.KNOCK_RETRACTED)
 
         val youRetractedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youRetractedKnock = formatter.format(youRetractedKnockEvent)
@@ -409,8 +409,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     fun `Membership change - knock denied`() {
         val otherName = "Other"
         val third = "Someone"
-        val youContent = RoomMembershipContent(A_USER_ID, third, MembershipChange.KNOCK_DENIED)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_DENIED)
+        val youContent = aRoomMembershipContent(A_USER_ID, third, MembershipChange.KNOCK_DENIED)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), third, MembershipChange.KNOCK_DENIED)
 
         val youDeniedKnockEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = someoneContent)
         val youDeniedKnock = formatter.format(youDeniedKnockEvent)
@@ -429,8 +429,8 @@ class DefaultPinnedMessagesBannerFormatterTest {
     @Config(qualifiers = "en")
     fun `Membership change - None`() {
         val otherName = "Other"
-        val youContent = RoomMembershipContent(A_USER_ID, null, MembershipChange.NONE)
-        val someoneContent = RoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.NONE)
+        val youContent = aRoomMembershipContent(A_USER_ID, null, MembershipChange.NONE)
+        val someoneContent = aRoomMembershipContent(UserId("@someone_else:domain"), otherName, MembershipChange.NONE)
 
         val youNoneRoomEvent = createRoomEvent(sentByYou = true, senderDisplayName = null, content = youContent)
         val youNoneRoom = formatter.format(youNoneRoomEvent)
@@ -447,7 +447,7 @@ class DefaultPinnedMessagesBannerFormatterTest {
         val otherChanges = arrayOf(MembershipChange.ERROR, MembershipChange.NOT_IMPLEMENTED, null)
 
         val results = otherChanges.map { change ->
-            val content = RoomMembershipContent(A_USER_ID, null, change)
+            val content = aRoomMembershipContent(A_USER_ID, null, change)
             val event = createRoomEvent(sentByYou = false, senderDisplayName = "Someone", content = content)
             val result = formatter.format(event)
             change to result

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventContent.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/EventContent.kt
@@ -70,7 +70,8 @@ data class UnableToDecryptContent(
 data class RoomMembershipContent(
     val userId: UserId,
     val userDisplayName: String?,
-    val change: MembershipChange?
+    val change: MembershipChange?,
+    val reason: String?,
 ) : EventContent
 
 data class ProfileChangeContent(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/item/event/TimelineEventContentMapper.kt
@@ -105,7 +105,8 @@ class TimelineEventContentMapper(
                     RoomMembershipContent(
                         userId = UserId(it.userId),
                         userDisplayName = it.userDisplayName,
-                        change = it.change?.map()
+                        change = it.change?.map(),
+                        reason = it.reason,
                     )
                 }
                 is TimelineItemContent.State -> {

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/Fixtures.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/Fixtures.kt
@@ -11,13 +11,13 @@ import io.element.android.libraries.matrix.api.core.UniqueId
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
 import io.element.android.libraries.matrix.api.timeline.item.virtual.VirtualTimelineItem
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.libraries.matrix.test.timeline.aMessageContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 
 internal val timelineStartEvent = MatrixTimelineItem.Virtual(
     uniqueId = UniqueId("timeline_start"),
@@ -29,11 +29,11 @@ internal val roomCreateEvent = MatrixTimelineItem.Event(
 )
 internal val roomCreatorJoinEvent = MatrixTimelineItem.Event(
     uniqueId = UniqueId("m.room.member"),
-    event = anEventTimelineItem(content = RoomMembershipContent(A_USER_ID, null, MembershipChange.JOINED))
+    event = anEventTimelineItem(content = aRoomMembershipContent(userId = A_USER_ID, change = MembershipChange.JOINED))
 )
 internal val otherMemberJoinEvent = MatrixTimelineItem.Event(
     uniqueId = UniqueId("m.room.member_other"),
-    event = anEventTimelineItem(content = RoomMembershipContent(A_USER_ID_2, null, MembershipChange.JOINED))
+    event = anEventTimelineItem(content = aRoomMembershipContent(userId = A_USER_ID_2, change = MembershipChange.JOINED))
 )
 internal val messageEvent = MatrixTimelineItem.Event(
     uniqueId = UniqueId("m.room.message"),

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/item/event/Fixture.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/timeline/item/event/Fixture.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.test.timeline.item.event
+
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
+import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
+import io.element.android.libraries.matrix.test.A_USER_ID
+
+fun aRoomMembershipContent(
+    userId: UserId = A_USER_ID,
+    userDisplayName: String? = null,
+    change: MembershipChange? = null,
+    reason: String? = null,
+) = RoomMembershipContent(
+    userId = userId,
+    userDisplayName = userDisplayName,
+    change = change,
+    reason = reason,
+)

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToDetailTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToDetailTest.kt
@@ -13,12 +13,12 @@ import io.element.android.libraries.matrix.api.timeline.item.event.InReplyTo
 import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.permalink.FakePermalinkParser
 import io.element.android.libraries.matrix.test.timeline.aProfileTimelineDetails
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 import org.junit.Test
 
 class InReplyToDetailTest {
@@ -47,9 +47,8 @@ class InReplyToDetailTest {
             eventId = AN_EVENT_ID,
             senderId = A_USER_ID,
             senderProfile = aProfileTimelineDetails(),
-            content = RoomMembershipContent(
+            content = aRoomMembershipContent(
                 userId = A_USER_ID,
-                userDisplayName = null,
                 change = MembershipChange.INVITED,
             )
         )

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
@@ -30,7 +30,6 @@ import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileChangeContent
 import io.element.android.libraries.matrix.api.timeline.item.event.ProfileTimelineDetails
 import io.element.android.libraries.matrix.api.timeline.item.event.RedactedContent
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StickerContent
 import io.element.android.libraries.matrix.api.timeline.item.event.UnableToDecryptContent
@@ -43,6 +42,7 @@ import io.element.android.libraries.matrix.test.media.aMediaSource
 import io.element.android.libraries.matrix.test.timeline.aMessageContent
 import io.element.android.libraries.matrix.test.timeline.aPollContent
 import io.element.android.libraries.matrix.test.timeline.aProfileTimelineDetails
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 import io.element.android.libraries.matrix.ui.components.A_BLUR_HASH
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailInfo
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailType
@@ -496,7 +496,7 @@ class InReplyToMetadataKtTest {
     fun `room membership content`() = runTest {
         moleculeFlow(RecompositionMode.Immediate) {
             anInReplyToDetailsReady(
-                eventContent = RoomMembershipContent(A_USER_ID, null, null)
+                eventContent = aRoomMembershipContent(userId = A_USER_ID)
             ).metadata(hideImage = false)
         }.test {
             awaitItem().let {

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/DefaultEventItemFactoryTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/DefaultEventItemFactoryTest.kt
@@ -31,7 +31,6 @@ import io.element.android.libraries.matrix.api.timeline.item.event.NoticeMessage
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
 import io.element.android.libraries.matrix.api.timeline.item.event.RedactedContent
-import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.StickerMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
@@ -47,6 +46,7 @@ import io.element.android.libraries.matrix.test.timeline.aPollContent
 import io.element.android.libraries.matrix.test.timeline.aProfileChangeMessageContent
 import io.element.android.libraries.matrix.test.timeline.aStickerContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import io.element.android.libraries.matrix.test.timeline.item.event.aRoomMembershipContent
 import io.element.android.libraries.mediaviewer.api.MediaInfo
 import io.element.android.libraries.mediaviewer.impl.model.MediaItem
 import io.element.android.libraries.mediaviewer.test.util.FileExtensionExtractorWithoutValidation
@@ -67,10 +67,8 @@ class DefaultEventItemFactoryTest {
             aPollContent(),
             aProfileChangeMessageContent(),
             RedactedContent,
-            RoomMembershipContent(
+            aRoomMembershipContent(
                 userId = A_USER_ID,
-                userDisplayName = null,
-                change = null,
             ),
             StateContent("", OtherState.RoomCreate),
             aStickerContent(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When a reason for ban and kick is provided, render it in the timeline.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
More complete rendering of Events.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Kick someone providing a reason
- Observe that the reason is rendered in the timeline

Repeat with banning someone.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
