### PR TITLE
Fix wrong member count in join room screen for invitation

### DIFF
--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -121,7 +121,13 @@ class JoinRoomPresenter @AssistedInject constructor(
                         }
                         else -> null to null
                     }
-                    value = roomInfo.get().toContentState(sender, reason)
+                    val preview = matrixClient.getRoomPreview(roomIdOrAlias, serverNames)
+                    val joinedMembersCountOverride = preview.getOrNull()?.previewInfo?.numberOfJoinedMembers
+                    value = roomInfo.get().toContentState(
+                        membershipSender = sender,
+                        joinedMembersCountOverride = joinedMembersCountOverride,
+                        reason = reason,
+                    )
                 }
                 roomDescription.isPresent -> {
                     value = roomDescription.get().toContentState()
@@ -296,13 +302,17 @@ internal fun RoomDescription.toContentState(): ContentState {
 }
 
 @VisibleForTesting
-internal fun RoomInfo.toContentState(membershipSender: RoomMember?, reason: String?): ContentState {
+internal fun RoomInfo.toContentState(
+    membershipSender: RoomMember?,
+    joinedMembersCountOverride: Long?,
+    reason: String?,
+): ContentState {
     return ContentState.Loaded(
         roomId = id,
         name = name,
         topic = topic,
         alias = canonicalAlias,
-        numberOfMembers = joinedMembersCount,
+        numberOfMembers = joinedMembersCountOverride ?: joinedMembersCount,
         isDm = isDm,
         roomType = if (isSpace) RoomType.Space else RoomType.Room,
         roomAvatarUrl = avatarUrl,

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -108,12 +108,12 @@ class JoinRoomPresenter @AssistedInject constructor(
             when {
                 isDismissingContent -> value = ContentState.Dismissing
                 roomInfo.isPresent -> {
+                    val notJoinedRoom = matrixClient.getRoomPreview(roomIdOrAlias, serverNames).getOrNull()
                     val (sender, reason) = when (roomInfo.get().currentUserMembership) {
                         CurrentUserMembership.BANNED -> {
                             // Workaround to get info about the sender for banned rooms
                             // TODO re-do this once we have a better API in the SDK
-                            val preview = matrixClient.getRoomPreview(roomIdOrAlias, serverNames)
-                            val membershipDetails = preview.getOrNull()?.membershipDetails()?.getOrNull()
+                            val membershipDetails = notJoinedRoom?.membershipDetails()?.getOrNull()
                             membershipDetails?.senderMember to membershipDetails?.currentUserMember?.membershipChangeReason
                         }
                         CurrentUserMembership.INVITED -> {
@@ -121,8 +121,7 @@ class JoinRoomPresenter @AssistedInject constructor(
                         }
                         else -> null to null
                     }
-                    val preview = matrixClient.getRoomPreview(roomIdOrAlias, serverNames)
-                    val joinedMembersCountOverride = preview.getOrNull()?.previewInfo?.numberOfJoinedMembers
+                    val joinedMembersCountOverride = notJoinedRoom?.previewInfo?.numberOfJoinedMembers
                     value = roomInfo.get().toContentState(
                         membershipSender = sender,
                         joinedMembersCountOverride = joinedMembersCountOverride,

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -113,8 +113,8 @@ class JoinRoomPresenter @AssistedInject constructor(
                             // Workaround to get info about the sender for banned rooms
                             // TODO re-do this once we have a better API in the SDK
                             val preview = matrixClient.getRoomPreview(roomIdOrAlias, serverNames)
-                            val membershipDetalis = preview.getOrNull()?.membershipDetails()?.getOrNull()
-                            membershipDetalis?.senderMember to membershipDetalis?.currentUserMember?.membershipChangeReason
+                            val membershipDetails = preview.getOrNull()?.membershipDetails()?.getOrNull()
+                            membershipDetails?.senderMember to membershipDetails?.currentUserMember?.membershipChangeReason
                         }
                         CurrentUserMembership.INVITED -> {
                             roomInfo.get().inviter to null

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinBaseRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinBaseRoomPresenterTest.kt
@@ -55,7 +55,6 @@ import io.element.android.tests.testutils.lambda.assert
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.lambda.value
 import io.element.android.tests.testutils.test
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -268,7 +267,6 @@ class JoinBaseRoomPresenterTest {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `present - when room is banned, then join authorization is equal to IsBanned`() = runTest {
         val roomSummary = aRoomSummary(currentUserMembership = CurrentUserMembership.BANNED, joinRule = JoinRule.Public)

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -84,7 +84,9 @@ class JoinRoomPresenterTest {
     @Test
     fun `present - when room is joined then content state is filled with his data`() = runTest {
         val roomSummary = aRoomSummary()
-        val matrixClient = FakeMatrixClient().apply {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        ).apply {
             getRoomSummaryFlowLambda = { _ ->
                 flowOf(Optional.of(roomSummary))
             }
@@ -93,7 +95,7 @@ class JoinRoomPresenterTest {
             matrixClient = matrixClient
         )
         presenter.test {
-            skipItems(1)
+            skipItems(2)
             awaitItem().also { state ->
                 val contentState = state.contentState as ContentState.Loaded
                 assertThat(contentState.roomId).isEqualTo(A_ROOM_ID)
@@ -110,7 +112,9 @@ class JoinRoomPresenterTest {
     @Test
     fun `present - when room is invited then join authorization is equal to invited`() = runTest {
         val roomSummary = aRoomSummary(currentUserMembership = CurrentUserMembership.INVITED)
-        val matrixClient = FakeMatrixClient().apply {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        ).apply {
             getRoomSummaryFlowLambda = { _ ->
                 flowOf(Optional.of(roomSummary))
             }
@@ -122,7 +126,7 @@ class JoinRoomPresenterTest {
         )
         assertThat(seenInvitesStore.seenRoomIds().first()).isEmpty()
         presenter.test {
-            skipItems(1)
+            skipItems(2)
             awaitItem().also { state ->
                 assertThat(state.joinAuthorisationStatus).isEqualTo(JoinAuthorisationStatus.IsInvited(null))
             }
@@ -137,9 +141,12 @@ class JoinRoomPresenterTest {
         val expectedInviteSender = inviter.toInviteSender()
         val roomSummary = aRoomSummary(
             currentUserMembership = CurrentUserMembership.INVITED,
+            joinedMembersCount = 5,
             inviter = inviter,
         )
-        val matrixClient = FakeMatrixClient().apply {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        ).apply {
             getRoomSummaryFlowLambda = { _ ->
                 flowOf(Optional.of(roomSummary))
             }
@@ -148,9 +155,43 @@ class JoinRoomPresenterTest {
             matrixClient = matrixClient
         )
         presenter.test {
-            skipItems(1)
+            skipItems(2)
             awaitItem().also { state ->
                 assertThat(state.joinAuthorisationStatus).isEqualTo(JoinAuthorisationStatus.IsInvited(expectedInviteSender))
+                assertThat((state.contentState as ContentState.Loaded).numberOfMembers).isEqualTo(5)
+            }
+        }
+    }
+
+    @Test
+    fun `present - when room is invited read the number of member from the room preview`() = runTest {
+        val roomSummary = aRoomSummary(
+            currentUserMembership = CurrentUserMembership.INVITED,
+            // It seems that the SDK does not provide this value.
+            joinedMembersCount = 0,
+        )
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ ->
+                Result.success(
+                    aRoomPreview(
+                        info = aRoomPreviewInfo(
+                            numberOfJoinedMembers = 10,
+                        )
+                    )
+                )
+            },
+        ).apply {
+            getRoomSummaryFlowLambda = { _ ->
+                flowOf(Optional.of(roomSummary))
+            }
+        }
+        val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient
+        )
+        presenter.test {
+            skipItems(2)
+            awaitItem().also { state ->
+                assertThat((state.contentState as ContentState.Loaded).numberOfMembers).isEqualTo(10)
             }
         }
     }
@@ -196,7 +237,11 @@ class JoinRoomPresenterTest {
         val joinRoomLambda = lambdaRecorder { _: RoomIdOrAlias, _: List<String>, _: JoinedRoom.Trigger ->
             Result.success(Unit)
         }
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        )
         val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient,
             trigger = aTrigger,
             serverNames = A_SERVER_LIST,
             joinRoomLambda = joinRoomLambda,
@@ -220,7 +265,11 @@ class JoinRoomPresenterTest {
 
     @Test
     fun `present - when room is joined with error, it is possible to clear the error`() = runTest {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        )
         val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient,
             joinRoomLambda = { _, _, _ ->
                 Result.failure(AN_EXCEPTION)
             },
@@ -315,7 +364,9 @@ class JoinRoomPresenterTest {
     @Test
     fun `present - when room is left and public then join authorization is equal to canJoin`() = runTest {
         val roomSummary = aRoomSummary(currentUserMembership = CurrentUserMembership.LEFT, joinRule = JoinRule.Public)
-        val matrixClient = FakeMatrixClient().apply {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        ).apply {
             getRoomSummaryFlowLambda = { _ ->
                 flowOf(Optional.of(roomSummary))
             }
@@ -324,7 +375,7 @@ class JoinRoomPresenterTest {
             matrixClient = matrixClient
         )
         presenter.test {
-            skipItems(1)
+            skipItems(2)
             awaitItem().also { state ->
                 assertThat(state.joinAuthorisationStatus).isEqualTo(JoinAuthorisationStatus.CanJoin)
             }
@@ -334,7 +385,9 @@ class JoinRoomPresenterTest {
     @Test
     fun `present - when room is left and join rule null then join authorization is equal to Unknown`() = runTest {
         val roomSummary = aRoomSummary(currentUserMembership = CurrentUserMembership.LEFT, joinRule = null)
-        val matrixClient = FakeMatrixClient().apply {
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        ).apply {
             getRoomSummaryFlowLambda = { _ ->
                 flowOf(Optional.of(roomSummary))
             }
@@ -343,7 +396,7 @@ class JoinRoomPresenterTest {
             matrixClient = matrixClient
         )
         presenter.test {
-            skipItems(1)
+            skipItems(2)
             awaitItem().also { state ->
                 assertThat(state.joinAuthorisationStatus).isEqualTo(JoinAuthorisationStatus.Unknown)
             }
@@ -437,7 +490,13 @@ class JoinRoomPresenterTest {
             Result.failure<Unit>(RuntimeException("Failed to knock room $roomIdOrAlias"))
         }
         val fakeKnockRoom = FakeKnockRoom(knockRoomSuccess)
-        val presenter = createJoinRoomPresenter(knockRoom = fakeKnockRoom)
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        )
+        val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient,
+            knockRoom = fakeKnockRoom,
+        )
         presenter.test {
             skipItems(1)
             awaitItem().also { state ->
@@ -476,7 +535,13 @@ class JoinRoomPresenterTest {
             Result.failure<Unit>(RuntimeException("Failed to knock room $roomId"))
         }
         val cancelKnockRoom = FakeCancelKnockRoom(cancelKnockRoomSuccess)
-        val presenter = createJoinRoomPresenter(cancelKnockRoom = cancelKnockRoom)
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        )
+        val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient,
+            cancelKnockRoom = cancelKnockRoom,
+        )
         presenter.test {
             skipItems(1)
             awaitItem().also { state ->
@@ -514,7 +579,13 @@ class JoinRoomPresenterTest {
             Result.failure<Unit>(RuntimeException("Failed to forget room"))
         }
         val fakeForgetRoom = FakeForgetRoom(forgetRoomSuccess)
-        val presenter = createJoinRoomPresenter(forgetRoom = fakeForgetRoom)
+        val matrixClient = FakeMatrixClient(
+            getNotJoinedRoomResult = { _, _ -> Result.failure(AN_EXCEPTION) },
+        )
+        val presenter = createJoinRoomPresenter(
+            matrixClient = matrixClient,
+            forgetRoom = fakeForgetRoom,
+        )
         presenter.test {
             skipItems(1)
             awaitItem().also { state ->

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -63,7 +63,7 @@ import org.junit.Test
 import java.util.Optional
 
 @Suppress("LargeClass")
-class JoinBaseRoomPresenterTest {
+class JoinRoomPresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
 

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomViewTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomViewTest.kt
@@ -25,7 +25,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class JoinBaseRoomViewTest {
+class JoinRoomViewTest {
     @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
     @Test

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -78,7 +78,7 @@ class FakeMatrixClient(
             Optional.of(ResolvedRoomAlias(A_ROOM_ID, emptyList()))
         )
     },
-    private val getNotJoinedRoomResult: (RoomIdOrAlias, List<String>) -> Result<NotJoinedRoom> = { _, _ -> Result.failure(AN_EXCEPTION) },
+    private val getNotJoinedRoomResult: (RoomIdOrAlias, List<String>) -> Result<NotJoinedRoom> = { _, _ -> lambdaError() },
     private val clearCacheLambda: () -> Unit = { lambdaError() },
     private val userIdServerNameLambda: () -> String = { lambdaError() },
     private val getUrlLambda: (String) -> Result<String> = { lambdaError() },


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
It appears that the value from the room info is not correct. For invitation in DM, I have observe that the room member count can be 0 or 2 (if the user has previously left the room). With this fix, the value is 1, which is OK.

No change for group rooms AFAICT.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix issue.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No impact

## Tests

<!-- Explain how you tested your development -->

- Get an invite and observe the room member count in the room invite screen

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ac093d4b-6df0-45b1-b0ed-7de3673aa2dc" />

<img width="82" alt="image" src="https://github.com/user-attachments/assets/1e384aa8-acf9-4db0-875e-8c4da13c323a" />


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
