### PR TITLE
Fix `Client.getJoinedRoom` crash when a room doesn't exist locally

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -267,17 +267,12 @@ class RustMatrixClient(
         }
     }
 
-    override suspend fun getRoom(roomId: RoomId): BaseRoom? {
-        return roomFactory.getBaseRoom(roomId)
+    override suspend fun getRoom(roomId: RoomId): BaseRoom? = withContext(sessionDispatcher) {
+        roomFactory.getBaseRoom(roomId)
     }
 
-    override suspend fun getJoinedRoom(roomId: RoomId): JoinedRoom? {
-        return try {
-            (roomFactory.getJoinedRoomOrPreview(roomId) as GetRoomResult.Joined).joinedRoom
-        } catch (e: ClassCastException) {
-            Timber.e(e, "Room $roomId is not a joined room")
-            null
-        }
+    override suspend fun getJoinedRoom(roomId: RoomId): JoinedRoom? = withContext(sessionDispatcher) {
+        (roomFactory.getJoinedRoomOrPreview(roomId) as? GetRoomResult.Joined)?.joinedRoom
     }
 
     /**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
What the title says. We had `NullPointerExceptions` here because I missed the `?` while down casting.

Also, make the `get...Room` methods use the session dispatcher too.

## Motivation and context

Fix the crash.

## Tests

I'm not really sure how the exception was originally triggered since it's not in the submitted stack trace.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
