### PR TITLE
Improve the callback uri format and customization.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,14 +106,25 @@ android {
     logger.warnInBox("Building ${defaultConfig.applicationId} ($baseAppName)")
 
     buildTypes {
+        val oidcRedirectSchemeBase = BuildTimeConfig.METADATA_HOST_REVERSED ?: "io.element.android"
         getByName("debug") {
             resValue("string", "app_name", "$baseAppName dbg")
+            resValue(
+                "string",
+                "login_redirect_scheme",
+                "$oidcRedirectSchemeBase.debug",
+            )
             applicationIdSuffix = ".debug"
             signingConfig = signingConfigs.getByName("debug")
         }
 
         getByName("release") {
             resValue("string", "app_name", baseAppName)
+            resValue(
+                "string",
+                "login_redirect_scheme",
+                oidcRedirectSchemeBase,
+            )
             signingConfig = signingConfigs.getByName("debug")
 
             postprocessing {
@@ -131,6 +142,11 @@ android {
             applicationIdSuffix = ".nightly"
             versionNameSuffix = "-nightly"
             resValue("string", "app_name", "$baseAppName nightly")
+            resValue(
+                "string",
+                "login_redirect_scheme",
+                "$oidcRedirectSchemeBase.nightly",
+            )
             matchingFallbacks += listOf("release")
             signingConfig = signingConfigs.getByName("nightly")
 
@@ -284,6 +300,7 @@ dependencies {
     testImplementation(libs.test.truth)
     testImplementation(libs.test.turbine)
     testImplementation(projects.libraries.matrix.test)
+    testImplementation(projects.services.toolbox.test)
 
     koverDependencies()
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,8 +60,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <!-- Note: the scheme must match the scheme of the value of OidcConfig.REDIRECT_URI -->
-                <data android:scheme="io.element" />
+                <data android:scheme="@string/login_redirect_scheme" />
             </intent-filter>
             <!--
               Element web links

--- a/app/src/main/kotlin/io/element/android/x/oidc/DefaultOidcRedirectUrlProvider.kt
+++ b/app/src/main/kotlin/io/element/android/x/oidc/DefaultOidcRedirectUrlProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.x.oidc
+
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.api.auth.OidcRedirectUrlProvider
+import io.element.android.services.toolbox.api.strings.StringProvider
+import io.element.android.x.R
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class DefaultOidcRedirectUrlProvider @Inject constructor(
+    private val stringProvider: StringProvider,
+) : OidcRedirectUrlProvider {
+    override fun provide() = buildString {
+        append(stringProvider.getString(R.string.login_redirect_scheme))
+        append(":/")
+    }
+}

--- a/app/src/test/kotlin/io/element/android/x/oidc/DefaultOidcRedirectUrlProviderTest.kt
+++ b/app/src/test/kotlin/io/element/android/x/oidc/DefaultOidcRedirectUrlProviderTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.x.oidc
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.services.toolbox.test.strings.FakeStringProvider
+import io.element.android.x.R
+import org.junit.Test
+
+class DefaultOidcRedirectUrlProviderTest {
+    @Test
+    fun `test provide`() {
+        val stringProvider = FakeStringProvider(
+            defaultResult = "str"
+        )
+        val sut = DefaultOidcRedirectUrlProvider(
+            stringProvider = stringProvider,
+        )
+        val result = sut.provide()
+        assertThat(result).isEqualTo("str:/")
+        assertThat(stringProvider.lastResIdParam).isEqualTo(R.string.login_redirect_scheme)
+    }
+}

--- a/appnav/src/test/kotlin/io/element/android/appnav/intent/IntentResolverTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/intent/IntentResolverTest.kt
@@ -20,10 +20,11 @@ import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.A_THREAD_ID
+import io.element.android.libraries.matrix.test.auth.FakeOidcRedirectUrlProvider
 import io.element.android.libraries.matrix.test.permalink.FakePermalinkParser
 import io.element.android.libraries.oidc.api.OidcAction
 import io.element.android.libraries.oidc.impl.DefaultOidcIntentResolver
-import io.element.android.libraries.oidc.impl.OidcUrlParser
+import io.element.android.libraries.oidc.impl.DefaultOidcUrlParser
 import io.element.android.tests.testutils.lambda.lambdaError
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -119,7 +120,7 @@ class IntentResolverTest {
         val sut = createIntentResolver()
         val intent = Intent(RuntimeEnvironment.getApplication(), Activity::class.java).apply {
             action = Intent.ACTION_VIEW
-            data = "io.element:/callback?error=access_denied&state=IFF1UETGye2ZA8pO".toUri()
+            data = "io.element.android:/?error=access_denied&state=IFF1UETGye2ZA8pO".toUri()
         }
         val result = sut.resolve(intent)
         assertThat(result).isEqualTo(
@@ -134,13 +135,13 @@ class IntentResolverTest {
         val sut = createIntentResolver()
         val intent = Intent(RuntimeEnvironment.getApplication(), Activity::class.java).apply {
             action = Intent.ACTION_VIEW
-            data = "io.element:/callback?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB".toUri()
+            data = "io.element.android:/?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB".toUri()
         }
         val result = sut.resolve(intent)
         assertThat(result).isEqualTo(
             ResolvedIntent.Oidc(
                 oidcAction = OidcAction.Success(
-                    url = "io.element:/callback?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
+                    url = "io.element.android:/?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
                 )
             )
         )
@@ -151,7 +152,7 @@ class IntentResolverTest {
         val sut = createIntentResolver()
         val intent = Intent(RuntimeEnvironment.getApplication(), Activity::class.java).apply {
             action = Intent.ACTION_VIEW
-            data = "io.element:/callback/invalid".toUri()
+            data = "io.element.android:/invalid".toUri()
         }
         assertThrows(IllegalStateException::class.java) {
             sut.resolve(intent)
@@ -246,7 +247,9 @@ class IntentResolverTest {
         return IntentResolver(
             deeplinkParser = DeeplinkParser(),
             oidcIntentResolver = DefaultOidcIntentResolver(
-                oidcUrlParser = OidcUrlParser()
+                oidcUrlParser = DefaultOidcUrlParser(
+                    oidcRedirectUrlProvider = FakeOidcRedirectUrlProvider(),
+                )
             ),
             permalinkParser = FakePermalinkParser(
                 result = permalinkParserResult

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -11,7 +11,7 @@ Server list: https://github.com/element-hq/oidc-playground
 Metadata iOS: (from https://github.com/element-hq/element-x-ios/blob/5f9d07377cebc4f21d9668b1a25f6e3bb22f64a1/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift#L28)
 
 clientName: InfoPlistReader.main.bundleDisplayName,
-redirectUri: "io.element:/callback",
+redirectUri: "io.element.android:/",
 clientUri: "https://element.io",
 tosUri: "https://element.io/user-terms-of-service",
 policyUri: "https://element.io/privacy"
@@ -19,7 +19,7 @@ policyUri: "https://element.io/privacy"
 
 Android:
 clientName = "Element",
-redirectUri = "io.element:/callback",
+redirectUri = "io.element.android:/",
 clientUri = "https://element.io",
 tosUri = "https://element.io/user-terms-of-service",
 policyUri = "https://element.io/privacy"

--- a/libraries/matrix/api/build.gradle.kts
+++ b/libraries/matrix/api/build.gradle.kts
@@ -28,13 +28,6 @@ android {
             value = BuildTimeConfig.URL_WEBSITE ?: "https://element.io"
         )
         buildConfigFieldStr(
-            name = "REDIRECT_URI",
-            value = buildString {
-                append(BuildTimeConfig.METADATA_HOST_REVERSED ?: "io.element")
-                append(":/callback")
-            }
-        )
-        buildConfigFieldStr(
             name = "LOGO_URI",
             value = BuildTimeConfig.URL_LOGO ?: "https://element.io/mobile-icon.png"
         )

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OidcConfig.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OidcConfig.kt
@@ -12,11 +12,6 @@ import io.element.android.libraries.matrix.api.BuildConfig
 object OidcConfig {
     const val CLIENT_URI = BuildConfig.CLIENT_URI
 
-    // Notes:
-    // 1. the scheme must match the value declared in the AndroidManifest.xml
-    // 2. the scheme must be the reverse of the host of CLIENT_URI
-    const val REDIRECT_URI = BuildConfig.REDIRECT_URI
-
     // Note: host must match with the host of CLIENT_URI
     const val LOGO_URI = BuildConfig.LOGO_URI
 

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OidcRedirectUrlProvider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OidcRedirectUrlProvider.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.auth
+
+interface OidcRedirectUrlProvider {
+    fun provide(): String
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/OidcConfigurationProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/OidcConfigurationProvider.kt
@@ -9,15 +9,17 @@ package io.element.android.libraries.matrix.impl.auth
 
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.matrix.api.auth.OidcConfig
+import io.element.android.libraries.matrix.api.auth.OidcRedirectUrlProvider
 import org.matrix.rustcomponents.sdk.OidcConfiguration
 import javax.inject.Inject
 
 class OidcConfigurationProvider @Inject constructor(
     private val buildMeta: BuildMeta,
+    private val oidcRedirectUrlProvider: OidcRedirectUrlProvider,
 ) {
     fun get(): OidcConfiguration = OidcConfiguration(
         clientName = buildMeta.applicationName,
-        redirectUri = OidcConfig.REDIRECT_URI,
+        redirectUri = oidcRedirectUrlProvider.provide(),
         clientUri = OidcConfig.CLIENT_URI,
         logoUri = OidcConfig.LOGO_URI,
         tosUri = OidcConfig.TOS_URI,

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/OidcConfigurationProviderTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/OidcConfigurationProviderTest.kt
@@ -8,7 +8,8 @@
 package io.element.android.libraries.matrix.impl.auth
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.libraries.matrix.api.auth.OidcConfig
+import io.element.android.libraries.matrix.test.auth.FAKE_REDIRECT_URL
+import io.element.android.libraries.matrix.test.auth.FakeOidcRedirectUrlProvider
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import org.junit.Test
 
@@ -16,11 +17,12 @@ class OidcConfigurationProviderTest {
     @Test
     fun get() {
         val result = OidcConfigurationProvider(
-            aBuildMeta(
+            buildMeta = aBuildMeta(
                 applicationName = "myName",
-            )
+            ),
+            oidcRedirectUrlProvider = FakeOidcRedirectUrlProvider(),
         ).get()
         assertThat(result.clientName).isEqualTo("myName")
-        assertThat(result.redirectUri).isEqualTo(OidcConfig.REDIRECT_URI)
+        assertThat(result.redirectUri).isEqualTo(FAKE_REDIRECT_URL)
     }
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationServiceTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationServiceTest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.impl.createRustMatrixClientFactory
 import io.element.android.libraries.matrix.impl.paths.SessionPathsFactory
+import io.element.android.libraries.matrix.test.auth.FakeOidcRedirectUrlProvider
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.impl.memory.InMemorySessionStore
@@ -49,7 +50,10 @@ class RustMatrixAuthenticationServiceTest {
             sessionStore = sessionStore,
             rustMatrixClientFactory = rustMatrixClientFactory,
             passphraseGenerator = FakePassphraseGenerator(),
-            oidcConfigurationProvider = OidcConfigurationProvider(aBuildMeta()),
+            oidcConfigurationProvider = OidcConfigurationProvider(
+                buildMeta = aBuildMeta(),
+                oidcRedirectUrlProvider = FakeOidcRedirectUrlProvider(),
+            ),
         )
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/auth/FakeOidcRedirectUrlProvider.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/auth/FakeOidcRedirectUrlProvider.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.test.auth
+
+import io.element.android.libraries.matrix.api.auth.OidcRedirectUrlProvider
+
+const val FAKE_REDIRECT_URL = "io.element.android:/"
+
+class FakeOidcRedirectUrlProvider(
+    private val provideResult: String = FAKE_REDIRECT_URL,
+) : OidcRedirectUrlProvider {
+    override fun provide() = provideResult
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/core/BuildMeta.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/core/BuildMeta.kt
@@ -39,5 +39,5 @@ fun aBuildMeta(
     gitRevision = gitRevision,
     gitBranchName = gitBranchName,
     flavorDescription = flavorDescription,
-    flavorShortDescription = flavorShortDescription
+    flavorShortDescription = flavorShortDescription,
 )

--- a/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/OidcUrlParser.kt
+++ b/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/OidcUrlParser.kt
@@ -7,25 +7,34 @@
 
 package io.element.android.libraries.oidc.impl
 
-import io.element.android.libraries.matrix.api.auth.OidcConfig
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.matrix.api.auth.OidcRedirectUrlProvider
 import io.element.android.libraries.oidc.api.OidcAction
 import javax.inject.Inject
+
+fun interface OidcUrlParser {
+    fun parse(url: String): OidcAction?
+}
 
 /**
  * Simple parser for oidc url interception.
  * TODO Find documentation about the format.
  */
-class OidcUrlParser @Inject constructor() {
+@ContributesBinding(AppScope::class)
+class DefaultOidcUrlParser @Inject constructor(
+    private val oidcRedirectUrlProvider: OidcRedirectUrlProvider,
+) : OidcUrlParser {
     /**
      * Return a OidcAction, or null if the url is not a OidcUrl.
      * Note:
      * When user press button "Cancel", we get the url:
-     * `io.element:/callback?error=access_denied&state=IFF1UETGye2ZA8pO`
+     * `io.element.android:/?error=access_denied&state=IFF1UETGye2ZA8pO`
      * On success, we get:
-     * `io.element:/callback?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB`
+     * `io.element.android:/?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB`
      */
-    fun parse(url: String): OidcAction? {
-        if (url.startsWith(OidcConfig.REDIRECT_URI).not()) return null
+    override fun parse(url: String): OidcAction? {
+        if (url.startsWith(oidcRedirectUrlProvider.provide()).not()) return null
         if (url.contains("error=access_denied")) return OidcAction.GoBack
         if (url.contains("code=")) return OidcAction.Success(url)
 

--- a/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/webview/OidcNode.kt
+++ b/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/webview/OidcNode.kt
@@ -19,12 +19,14 @@ import io.element.android.libraries.architecture.NodeInputs
 import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.matrix.api.auth.OidcDetails
+import io.element.android.libraries.oidc.impl.OidcUrlParser
 
 @ContributesNode(AppScope::class)
 class OidcNode @AssistedInject constructor(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
     presenterFactory: OidcPresenter.Factory,
+    private val oidcUrlParser: OidcUrlParser,
 ) : Node(buildContext, plugins = plugins) {
     data class Inputs(
         val oidcDetails: OidcDetails,
@@ -38,6 +40,7 @@ class OidcNode @AssistedInject constructor(
         val state = presenter.present()
         OidcView(
             state = state,
+            oidcUrlParser = oidcUrlParser,
             modifier = modifier,
             onNavigateBack = ::navigateUp,
         )

--- a/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/webview/OidcView.kt
+++ b/libraries/oidc/impl/src/main/kotlin/io/element/android/libraries/oidc/impl/webview/OidcView.kt
@@ -34,11 +34,11 @@ import io.element.android.libraries.oidc.impl.OidcUrlParser
 @Composable
 fun OidcView(
     state: OidcState,
+    oidcUrlParser: OidcUrlParser,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isPreview = LocalInspectionMode.current
-    val oidcUrlParser = remember { OidcUrlParser() }
     var webView by remember { mutableStateOf<WebView?>(null) }
     fun shouldOverrideUrl(url: String): Boolean {
         val action = oidcUrlParser.parse(url)
@@ -111,6 +111,7 @@ fun OidcView(
 internal fun OidcViewPreview(@PreviewParameter(OidcStateProvider::class) state: OidcState) = ElementPreview {
     OidcView(
         state = state,
+        oidcUrlParser = { null },
         onNavigateBack = {},
     )
 }

--- a/libraries/oidc/impl/src/test/kotlin/io/element/android/libraries/oidc/impl/DefaultOidcUrlParserTest.kt
+++ b/libraries/oidc/impl/src/test/kotlin/io/element/android/libraries/oidc/impl/DefaultOidcUrlParserTest.kt
@@ -8,44 +8,51 @@
 package io.element.android.libraries.oidc.impl
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.libraries.matrix.api.auth.OidcConfig
+import io.element.android.libraries.matrix.test.auth.FAKE_REDIRECT_URL
+import io.element.android.libraries.matrix.test.auth.FakeOidcRedirectUrlProvider
 import io.element.android.libraries.oidc.api.OidcAction
 import org.junit.Assert
 import org.junit.Test
 
-class OidcUrlParserTest {
+class DefaultOidcUrlParserTest {
     @Test
     fun `test empty url`() {
-        val sut = OidcUrlParser()
+        val sut = createDefaultOidcUrlParser()
         assertThat(sut.parse("")).isNull()
     }
 
     @Test
     fun `test regular url`() {
-        val sut = OidcUrlParser()
+        val sut = createDefaultOidcUrlParser()
         assertThat(sut.parse("https://matrix.org")).isNull()
     }
 
     @Test
     fun `test cancel url`() {
-        val sut = OidcUrlParser()
-        val aCancelUrl = OidcConfig.REDIRECT_URI + "?error=access_denied&state=IFF1UETGye2ZA8pO"
+        val sut = createDefaultOidcUrlParser()
+        val aCancelUrl = "$FAKE_REDIRECT_URL?error=access_denied&state=IFF1UETGye2ZA8pO"
         assertThat(sut.parse(aCancelUrl)).isEqualTo(OidcAction.GoBack)
     }
 
     @Test
     fun `test success url`() {
-        val sut = OidcUrlParser()
-        val aSuccessUrl = OidcConfig.REDIRECT_URI + "?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
+        val sut = createDefaultOidcUrlParser()
+        val aSuccessUrl = "$FAKE_REDIRECT_URL?state=IFF1UETGye2ZA8pO&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
         assertThat(sut.parse(aSuccessUrl)).isEqualTo(OidcAction.Success(aSuccessUrl))
     }
 
     @Test
     fun `test unknown url`() {
-        val sut = OidcUrlParser()
-        val anUnknownUrl = OidcConfig.REDIRECT_URI + "?state=IFF1UETGye2ZA8pO&goat=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
+        val sut = createDefaultOidcUrlParser()
+        val anUnknownUrl = "$FAKE_REDIRECT_URL?state=IFF1UETGye2ZA8pO&goat=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
         Assert.assertThrows(IllegalStateException::class.java) {
             assertThat(sut.parse(anUnknownUrl))
         }
+    }
+
+    private fun createDefaultOidcUrlParser(): DefaultOidcUrlParser {
+        return DefaultOidcUrlParser(
+            oidcRedirectUrlProvider = FakeOidcRedirectUrlProvider(),
+        )
     }
 }

--- a/plugins/src/main/kotlin/config/BuildTimeConfig.kt
+++ b/plugins/src/main/kotlin/config/BuildTimeConfig.kt
@@ -21,7 +21,6 @@ object BuildTimeConfig {
     val URL_ACCEPTABLE_USE: String? = null
     val URL_PRIVACY: String? = null
     val URL_POLICY: String? = null
-    val SUPPORT_EMAIL_ADDRESS: String? = null
     val SERVICES_MAPTILER_BASE_URL: String? = null
     val SERVICES_MAPTILER_APIKEY: String? = null
     val SERVICES_MAPTILER_LIGHT_MAPID: String? = null

--- a/tools/adb/oidc.sh
+++ b/tools/adb/oidc.sh
@@ -8,7 +8,7 @@
 # Format is:
 
 # Error
-# adb shell am start -a android.intent.action.VIEW -d "io.element:/callback?error=access_denied\\&state=IFF1UETGye2ZA8pO"
+# adb shell am start -a android.intent.action.VIEW -d "io.element.android:/?error=access_denied\\&state=IFF1UETGye2ZA8pO"
 
 # Success
-adb shell am start -a android.intent.action.VIEW -d "io.element:/callback?state=IFF1UETGye2ZA8pO\\&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"
+adb shell am start -a android.intent.action.VIEW -d "io.element.android:/?state=IFF1UETGye2ZA8pO\\&code=y6X1GZeqA3xxOWcTeShgv8nkgFJXyzWB"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
The PR aims to improve how the redirection is handled during a OIDC authentication, to filter between different installed applications, by providing a different scheme for all the different version (debug/nightly/release)

Current version:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0dee9b7f-a441-4b1f-b162-b867b0812c7b" />

New version:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fbfdf9b2-1603-456a-abe0-e9c54e381999" />

This is for the debug version.

For the prod version, the text will be: "Element X at io.element.android:/ wants to access your account."
For the nightly version, the text will be: "Element X nightly at io.element.android.nightly:/ wants to access your account."

This will have the effect to avoid this screen to be displayed when the user clicks on "Continue":
<img width="438" alt="image" src="https://github.com/user-attachments/assets/b36dde53-2bf7-4105-af07-c9365c636fdc" />

Note:
- this is probably solving a problem only for developers and advanced users.
- this will help Mas to distinguish between the client. Element desktop uses io.element.desktop for instance (see https://github.com/element-hq/element-desktop/pull/2285)
- it should also solve the problem if both `Element Pro` and `Element X` are installed, since we are using the scheme `io.element` for Element Pro. The scheme `io.element.debug` will be for Element Pro debug, and the scheme `io.element.nightly` will be for Element Pro nightly.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Better UI from a user POV.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login to matrix.org or any OIDC homeserver and observe that the user story is more straight forward.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
