### PR TITLE
Make sure any `JoinedRustRoom` is destroyed after being used

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -241,7 +241,7 @@ class CallScreenPresenter @AssistedInject constructor(
 
     private suspend fun MatrixClient.notifyCallStartIfNeeded(roomId: RoomId) {
         if (!notifiedCallStart) {
-            getJoinedRoom(roomId)?.sendCallNotificationIfNeeded()
+            getJoinedRoom(roomId)?.use { it.sendCallNotificationIfNeeded() }
                 ?.onSuccess { notifiedCallStart = true }
         }
     }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
@@ -47,8 +47,11 @@ class DefaultCallWidgetProvider @Inject constructor(
             theme = theme,
         ).getOrThrow()
 
+        val driver = room.getWidgetDriver(widgetSettings).getOrThrow()
+        room.destroy()
+
         CallWidgetProvider.GetWidgetResult(
-            driver = room.getWidgetDriver(widgetSettings).getOrThrow(),
+            driver = driver,
             url = callUrl,
         )
     }

--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
@@ -86,6 +86,7 @@ class SharePresenter @AssistedInject constructor(
                                         ).isSuccess
                                     }
                                     .all { it }
+                                    .also { room.destroy() }
                             }
                             .all { it }
                     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -639,9 +639,11 @@ class JoinedRustRoom(
         }
     }
 
+    override fun close() = destroy()
+
     override fun destroy() {
         baseRoom.destroy()
-        liveInnerTimeline.close()
+        liveInnerTimeline.destroy()
         roomCoroutineScope.cancel()
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
@@ -94,6 +94,8 @@ class RustBaseRoom(
         }
     }
 
+    override fun close() = destroy()
+
     override fun destroy() {
         innerRoom.destroy()
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Make sure the `JoinedRustRoom` is destroyed everywhere it's used. And most importantly, that `JoinedRustRoom.close()` actually calls `JoinedRustRoom.destroy()`.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4676.

This was probably failing because `JoinedRustRoom.close()`, used in the `.use { ... }` block in `SyncOnNotifiableEvent` called `RustBaseRoom.close()`, which didn't redirect to `JoinedRustRoom.destroy()` and cleared everything.

## Tests

<!-- Explain how you tested your development -->

- Receive a push notification for a room, wait until the latest event appears in the room list.
- Open the room, it should be almost instant, then close it.
- Open the room again. If it's still fast, then it's working.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
