### PR TITLE
Fix read receipt behavior when the timeline is opened.

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -131,7 +131,7 @@ class TimelinePresenter @AssistedInject constructor(
                         if (event.firstIndex == 0) {
                             newEventState.value = NewEventState.None
                         }
-                        println("## sendReadReceiptIfNeeded firstVisibleIndex: ${event.firstIndex}")
+                        Timber.d("## sendReadReceiptIfNeeded firstVisibleIndex: ${event.firstIndex}")
                         appScope.sendReadReceiptIfNeeded(
                             firstVisibleIndex = event.firstIndex,
                             timelineItems = timelineItems,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -28,6 +28,7 @@ import io.element.android.features.messages.impl.timeline.factories.TimelineItem
 import io.element.android.features.messages.impl.timeline.factories.TimelineItemsFactoryConfig
 import io.element.android.features.messages.impl.timeline.model.NewEventState
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemTypingNotificationModel
 import io.element.android.features.messages.impl.typing.TypingNotificationState
 import io.element.android.features.messages.impl.voicemessages.timeline.RedactedVoiceMessageManager
 import io.element.android.features.poll.api.actions.EndPollAction
@@ -278,7 +279,10 @@ class TimelinePresenter @AssistedInject constructor(
         if (newEventState.value == NewEventState.FromMe) {
             return@withContext
         }
-        val newMostRecentItem = timelineItems.firstOrNull()
+        val newMostRecentItem = timelineItems.firstOrNull {
+            // Ignore typing item
+            (it as? TimelineItem.Virtual)?.model !is TimelineItemTypingNotificationModel
+        }
         val prevMostRecentItemIdValue = prevMostRecentItemId.value
         val newMostRecentItemId = newMostRecentItem?.identifier()
         val hasNewEvent = prevMostRecentItemIdValue != null &&

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -321,7 +321,8 @@ private fun BoxScope.TimelineScrollHelper(
     }
 
     LaunchedEffect(canAutoScroll, newEventState) {
-        val shouldScrollToBottom = isScrollFinished && ((canAutoScroll && newEventState == NewEventState.FromOther) || newEventState == NewEventState.FromMe)
+        val shouldScrollToBottom = isScrollFinished &&
+            (canAutoScroll && newEventState == NewEventState.FromOther || newEventState == NewEventState.FromMe)
         if (shouldScrollToBottom) {
             scrollToBottom(force = true)
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -290,7 +290,7 @@ private fun BoxScope.TimelineScrollHelper(
         coroutineScope.launch {
             if (lazyListState.firstVisibleItemIndex > 10) {
                 lazyListState.scrollToItem(0)
-            } else if (lazyListState.firstVisibleItemIndex != 0) {
+            } else {
                 lazyListState.animateScrollToItem(0)
             }
         }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -286,6 +286,11 @@ private fun BoxScope.TimelineScrollHelper(
     }
     var jumpToLiveHandled by remember { mutableStateOf(true) }
 
+    /**
+     * @param force If true, scroll to the bottom even if the user is already seeing the most recent item.
+     * This fixes the issue where the user is seeing typing notification and so the read receipt is not sent
+     * when a new message comes in.
+     */
     fun scrollToBottom(force: Boolean) {
         coroutineScope.launch {
             if (lazyListState.firstVisibleItemIndex > 10) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -286,11 +286,11 @@ private fun BoxScope.TimelineScrollHelper(
     }
     var jumpToLiveHandled by remember { mutableStateOf(true) }
 
-    fun scrollToBottom() {
+    fun scrollToBottom(force: Boolean) {
         coroutineScope.launch {
             if (lazyListState.firstVisibleItemIndex > 10) {
                 lazyListState.scrollToItem(0)
-            } else {
+            } else if (force || lazyListState.firstVisibleItemIndex != 0) {
                 lazyListState.animateScrollToItem(0)
             }
         }
@@ -298,7 +298,7 @@ private fun BoxScope.TimelineScrollHelper(
 
     fun jumpToBottom() {
         if (isLive) {
-            scrollToBottom()
+            scrollToBottom(force = false)
         } else {
             jumpToLiveHandled = false
             onJumpToLive()
@@ -321,9 +321,9 @@ private fun BoxScope.TimelineScrollHelper(
     }
 
     LaunchedEffect(canAutoScroll, newEventState) {
-        val shouldScrollToBottom = isScrollFinished && (canAutoScroll || newEventState == NewEventState.FromMe)
+        val shouldScrollToBottom = isScrollFinished && ((canAutoScroll && newEventState == NewEventState.FromOther) || newEventState == NewEventState.FromMe)
         if (shouldScrollToBottom) {
-            scrollToBottom()
+            scrollToBottom(force = true)
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that ReadReceipt is sent when new messages are coming in and user is on the timeline.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4662 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Alice opens a room R she shares with Bob
- Bob open the same room
- Bob sees that Alice RR is at the bottom of the timeline
- Bob sends a new message
- Alice views the message from Bob and does not do anything else particular
- Bob sees Alice's RR moving down as expected. This PR fixes this, previously Alice RR did not move.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
