### PR TITLE
Disable mutliple click (parallel or serial) on a room

### DIFF
--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
@@ -32,7 +32,6 @@ import io.element.android.features.reportroom.api.ReportRoomEntryPoint
 import io.element.android.features.roomlist.api.RoomListEntryPoint
 import io.element.android.features.roomlist.impl.components.RoomListMenuAction
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
-import io.element.android.libraries.androidutils.throttler.FirstThrottler
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.deeplink.usecase.InviteFriendsUseCase
@@ -68,8 +67,6 @@ class RoomListFlowNode @AssistedInject constructor(
         )
     }
 
-    private val firstThrottler = FirstThrottler(300)
-
     sealed interface NavTarget : Parcelable {
         @Parcelize
         data object Root : NavTarget
@@ -82,17 +79,14 @@ class RoomListFlowNode @AssistedInject constructor(
     }
 
     private fun onRoomClick(roomId: RoomId) {
-        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onRoomClick(roomId) }
     }
 
     private fun onOpenSettings() {
-        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onSettingsClick() }
     }
 
     private fun onCreateRoomClick() {
-        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onCreateRoomClick() }
     }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
@@ -32,6 +32,7 @@ import io.element.android.features.reportroom.api.ReportRoomEntryPoint
 import io.element.android.features.roomlist.api.RoomListEntryPoint
 import io.element.android.features.roomlist.impl.components.RoomListMenuAction
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
+import io.element.android.libraries.androidutils.throttler.FirstThrottler
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.deeplink.usecase.InviteFriendsUseCase
@@ -67,6 +68,8 @@ class RoomListFlowNode @AssistedInject constructor(
         )
     }
 
+    private val firstThrottler = FirstThrottler(300)
+
     sealed interface NavTarget : Parcelable {
         @Parcelize
         data object Root : NavTarget
@@ -79,14 +82,17 @@ class RoomListFlowNode @AssistedInject constructor(
     }
 
     private fun onRoomClick(roomId: RoomId) {
+        if (firstThrottler.canHandleAsBoolean().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onRoomClick(roomId) }
     }
 
     private fun onOpenSettings() {
+        if (firstThrottler.canHandleAsBoolean().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onSettingsClick() }
     }
 
     private fun onCreateRoomClick() {
+        if (firstThrottler.canHandleAsBoolean().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onCreateRoomClick() }
     }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListFlowNode.kt
@@ -82,17 +82,17 @@ class RoomListFlowNode @AssistedInject constructor(
     }
 
     private fun onRoomClick(roomId: RoomId) {
-        if (firstThrottler.canHandleAsBoolean().not()) return
+        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onRoomClick(roomId) }
     }
 
     private fun onOpenSettings() {
-        if (firstThrottler.canHandleAsBoolean().not()) return
+        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onSettingsClick() }
     }
 
     private fun onCreateRoomClick() {
-        if (firstThrottler.canHandleAsBoolean().not()) return
+        if (firstThrottler.canHandle().not()) return
         plugins<RoomListEntryPoint.Callback>().forEach { it.onCreateRoomClick() }
     }
 

--- a/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
+++ b/features/roomlist/impl/src/main/kotlin/io/element/android/features/roomlist/impl/RoomListView.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -30,6 +32,7 @@ import io.element.android.features.roomlist.impl.components.RoomListMenuAction
 import io.element.android.features.roomlist.impl.components.RoomListTopBar
 import io.element.android.features.roomlist.impl.model.RoomListRoomSummary
 import io.element.android.features.roomlist.impl.search.RoomListSearchView
+import io.element.android.libraries.androidutils.throttler.FirstThrottler
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
@@ -54,6 +57,9 @@ fun RoomListView(
     modifier: Modifier = Modifier,
     acceptDeclineInviteView: @Composable () -> Unit,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val firstThrottler = remember { FirstThrottler(300, coroutineScope) }
+
     ConnectivityIndicatorContainer(
         modifier = modifier,
         isOnline = state.hasNetworkConnection,
@@ -83,9 +89,9 @@ fun RoomListView(
                 state = state,
                 onSetUpRecoveryClick = onSetUpRecoveryClick,
                 onConfirmRecoveryKeyClick = onConfirmRecoveryKeyClick,
-                onRoomClick = onRoomClick,
-                onOpenSettings = onSettingsClick,
-                onCreateRoomClick = onCreateRoomClick,
+                onRoomClick = { if (firstThrottler.canHandle()) onRoomClick(it) },
+                onOpenSettings = { if (firstThrottler.canHandle()) onSettingsClick() },
+                onCreateRoomClick = { if (firstThrottler.canHandle()) onCreateRoomClick() },
                 onMenuActionClick = onMenuActionClick,
                 modifier = Modifier.padding(top = topPadding),
             )
@@ -94,7 +100,7 @@ fun RoomListView(
                 state = state.searchState,
                 eventSink = state.eventSink,
                 hideInvitesAvatars = state.hideInvitesAvatars,
-                onRoomClick = onRoomClick,
+                onRoomClick = { if (firstThrottler.canHandle()) onRoomClick(it) },
                 modifier = Modifier
                     .statusBarsPadding()
                     .padding(top = topPadding)

--- a/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListViewTest.kt
+++ b/features/roomlist/impl/src/test/kotlin/io/element/android/features/roomlist/impl/RoomListViewTest.kt
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package io.element.android.features.roomlist.impl
 
 import androidx.activity.ComponentActivity
@@ -27,6 +29,7 @@ import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.clickOn
 import io.element.android.tests.testutils.ensureCalledOnce
 import io.element.android.tests.testutils.ensureCalledOnceWithParam
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -165,6 +168,29 @@ class RoomListViewTest {
             rule.onNodeWithText(room0.lastMessage!!.toString()).performClick()
         }
 
+        eventsRecorder.assertEmpty()
+    }
+
+    @Test
+    fun `clicking on a room twice invokes the expected callback only once`() {
+        val eventsRecorder = EventsRecorder<RoomListEvents>()
+        val state = aRoomListState(
+            eventSink = eventsRecorder,
+        )
+        val room0 = state.contentAsRooms().summaries.first {
+            it.displayType == RoomSummaryDisplayType.ROOM
+        }
+        ensureCalledOnceWithParam(room0.roomId) { callback ->
+            rule.setRoomListView(
+                state = state,
+                onRoomClick = callback,
+            )
+            // Remove automatic initial events
+            eventsRecorder.clear()
+            rule.onNodeWithText(room0.lastMessage!!.toString())
+                .performClick()
+                .performClick()
+        }
         eventsRecorder.assertEmpty()
     }
 

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottler.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottler.kt
@@ -38,4 +38,8 @@ class FirstThrottler(private val minimumInterval: Long = 800) {
         // Too early
         return CanHandleResult.No(minimumInterval - delaySinceLast)
     }
+
+    fun canHandleAsBoolean(): Boolean {
+        return canHandle() == CanHandleResult.Yes
+    }
 }

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottler.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottler.kt
@@ -27,7 +27,7 @@ class FirstThrottler(private val minimumInterval: Long = 800) {
         }
     }
 
-    fun canHandle(): CanHandleResult {
+    fun getResult(): CanHandleResult {
         val now = SystemClock.elapsedRealtime()
         val delaySinceLast = now - lastDate
         if (delaySinceLast > minimumInterval) {
@@ -39,7 +39,7 @@ class FirstThrottler(private val minimumInterval: Long = 800) {
         return CanHandleResult.No(minimumInterval - delaySinceLast)
     }
 
-    fun canHandleAsBoolean(): Boolean {
-        return canHandle() == CanHandleResult.Yes
+    fun canHandle(): Boolean {
+        return getResult() == CanHandleResult.Yes
     }
 }

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottlerTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/throttler/FirstThrottlerTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package io.element.android.libraries.androidutils.throttler
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class FirstThrottlerTest {
+    @Test
+    fun `throttle canHandle returns the expected result`() = runTest {
+        val throttler = FirstThrottler(
+            minimumInterval = 300,
+            coroutineScope = backgroundScope,
+        )
+        assertThat(throttler.canHandle()).isTrue()
+        assertThat(throttler.canHandle()).isFalse()
+        advanceTimeBy(200)
+        assertThat(throttler.canHandle()).isFalse()
+        advanceTimeBy(110)
+        assertThat(throttler.canHandle()).isTrue()
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add minimum delay between two click handling on the room list.
Protect:
- opening the setting
- opening a room
- opening the create room screen

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #4619

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open the room list
- Tap on several rooms simultaneously
- Observe that only one room is opened by going back to the room list
- Quickly tap on a room
- Observe that only one room is opened by going back to the room list
- Tap on a room and on the user avatar icon
- Observe that the settings screen is opened or the room is opened but not both by going back to the room list
- Tap on a room and on the floating action button to create a room
- Observe that the settings to create a room is opened or the room is opened but not both by going back to the room list

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
