### PR TITLE
Fix broken Element Call in 25.05.0

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
@@ -48,7 +48,6 @@ class DefaultCallWidgetProvider @Inject constructor(
         ).getOrThrow()
 
         val driver = room.getWidgetDriver(widgetSettings).getOrThrow()
-        room.destroy()
 
         CallWidgetProvider.GetWidgetResult(
             driver = driver,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -595,6 +595,7 @@ class JoinedRustRoom(
             RustWidgetDriver(
                 widgetSettings = widgetSettings,
                 room = innerRoom,
+                joinedRustRoom = this,
                 widgetCapabilitiesProvider = object : WidgetCapabilitiesProvider {
                     override fun acquireCapabilities(capabilities: WidgetCapabilities): WidgetCapabilities {
                         return getElementCallRequiredPermissions(sessionId.value, baseRoom.deviceId.value)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/RustWidgetDriver.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.matrix.impl.widget
 
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
+import io.element.android.libraries.matrix.impl.room.JoinedRustRoom
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -24,6 +25,7 @@ import kotlin.coroutines.coroutineContext
 class RustWidgetDriver(
     widgetSettings: MatrixWidgetSettings,
     private val room: Room,
+    private val joinedRustRoom: JoinedRustRoom,
     private val widgetCapabilitiesProvider: WidgetCapabilitiesProvider,
 ) : MatrixWidgetDriver {
     // It's important to have extra capacity here to make sure we don't drop any messages
@@ -69,5 +71,6 @@ class RustWidgetDriver(
     override fun close() {
         receiveMessageJob?.cancel()
         driverAndHandle.driver.close()
+        joinedRustRoom.destroy()
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that the Rust room is not closed while the driver needs it.
I tried to make a wider rework by just using a Room (from Rust), but it does not work since we need an active timeline.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix regression introduced in #4678 and so closes #4689

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start a call
- The call starts

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
