### PR TITLE
Disable Continue button when the login field is cleared.

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordState.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordState.kt
@@ -28,7 +28,7 @@ data class LoginPasswordState(
 @Parcelize
 data class LoginFormState(
     val login: String,
-    val password: String
+    val password: String,
 ) : Parcelable {
     companion object {
         val Default = LoginFormState("", "")

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordStateProvider.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordStateProvider.kt
@@ -8,23 +8,38 @@
 package io.element.android.features.login.impl.screens.loginpassword
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.element.android.features.login.impl.accountprovider.AccountProvider
 import io.element.android.features.login.impl.accountprovider.anAccountProvider
 import io.element.android.libraries.architecture.AsyncData
+import io.element.android.libraries.matrix.api.core.SessionId
 
 open class LoginPasswordStateProvider : PreviewParameterProvider<LoginPasswordState> {
     override val values: Sequence<LoginPasswordState>
         get() = sequenceOf(
             aLoginPasswordState(),
             // Loading
-            aLoginPasswordState().copy(loginAction = AsyncData.Loading()),
+            aLoginPasswordState(loginAction = AsyncData.Loading()),
             // Error
-            aLoginPasswordState().copy(loginAction = AsyncData.Failure(Exception("An error occurred"))),
+            aLoginPasswordState(loginAction = AsyncData.Failure(Exception("An error occurred"))),
         )
 }
 
-fun aLoginPasswordState() = LoginPasswordState(
-    accountProvider = anAccountProvider(),
-    formState = LoginFormState.Default,
-    loginAction = AsyncData.Uninitialized,
-    eventSink = {}
+fun aLoginPasswordState(
+    accountProvider: AccountProvider = anAccountProvider(),
+    formState: LoginFormState = LoginFormState.Default,
+    loginAction: AsyncData<SessionId> = AsyncData.Uninitialized,
+    eventSink: (LoginPasswordEvents) -> Unit = {},
+) = LoginPasswordState(
+    accountProvider = accountProvider,
+    formState = formState,
+    loginAction = loginAction,
+    eventSink = eventSink,
+)
+
+fun aLoginFormState(
+    login: String = "",
+    password: String = "",
+) = LoginFormState(
+    login = login,
+    password = password,
 )

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -201,6 +201,7 @@ private fun LoginForm(
                 {
                     Box(Modifier.clickable {
                         loginFieldState = ""
+                        eventSink(LoginPasswordEvents.SetLogin(""))
                     }) {
                         Icon(
                             imageVector = CompoundIcons.Close(),

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordViewTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordViewTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.login.impl.screens.loginpassword
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.libraries.matrix.test.A_PASSWORD
+import io.element.android.libraries.matrix.test.A_USER_NAME
+import io.element.android.libraries.ui.strings.CommonStrings
+import io.element.android.tests.testutils.EnsureNeverCalled
+import io.element.android.tests.testutils.EventsRecorder
+import io.element.android.tests.testutils.clickOn
+import io.element.android.tests.testutils.ensureCalledOnce
+import io.element.android.tests.testutils.pressBack
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+class LoginPasswordViewTest {
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `clicking on back invoke back callback`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>(expectEvents = false)
+        ensureCalledOnce { callback ->
+            rule.setLoginPasswordView(
+                aLoginPasswordState(
+                    eventSink = eventsRecorder
+                ),
+                onBackClick = callback,
+            )
+            rule.pressBack()
+        }
+    }
+
+    @Test
+    fun `changing login invokes the expected event`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                eventSink = eventsRecorder,
+            ),
+        )
+        val userNameHint = rule.activity.getString(CommonStrings.common_username)
+        rule.onNodeWithText(userNameHint).performTextInput(A_USER_NAME)
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetLogin(A_USER_NAME)
+        )
+    }
+
+    @Test
+    fun `changing login removes new lines the expected event`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                eventSink = eventsRecorder,
+            ),
+        )
+        val userNameHint = rule.activity.getString(CommonStrings.common_username)
+        rule.onNodeWithText(userNameHint).performTextInput("a\nb")
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetLogin("ab")
+        )
+    }
+
+    @Test
+    fun `clearing login invokes the expected event`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                formState = aLoginFormState(A_USER_NAME),
+                eventSink = eventsRecorder,
+            ),
+        )
+        val a11yClear = rule.activity.getString(CommonStrings.action_clear)
+        rule.onNodeWithContentDescription(a11yClear).performClick()
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetLogin("")
+        )
+    }
+
+    @Test
+    fun `changing password invokes the expected event`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                eventSink = eventsRecorder,
+            ),
+        )
+        val userNameHint = rule.activity.getString(CommonStrings.common_password)
+        rule.onNodeWithText(userNameHint).performTextInput(A_PASSWORD)
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetPassword(A_PASSWORD)
+        )
+    }
+
+    @Test
+    fun `reveal password makes the password visible`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>(expectEvents = false)
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                formState = aLoginFormState(password = A_PASSWORD),
+                eventSink = eventsRecorder,
+            ),
+        )
+        rule.onNodeWithText(A_PASSWORD).assertDoesNotExist()
+        // Show password
+        val a11yShowPassword = rule.activity.getString(CommonStrings.a11y_show_password)
+        rule.onNodeWithContentDescription(a11yShowPassword).performClick()
+        rule.onNodeWithText(A_PASSWORD).assertExists()
+        // Hide password
+        val a11yHidePassword = rule.activity.getString(CommonStrings.a11y_hide_password)
+        rule.onNodeWithContentDescription(a11yHidePassword).performClick()
+        rule.onNodeWithText(A_PASSWORD).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when login is empty, continue button is not enabled`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>(expectEvents = false)
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                formState = aLoginFormState(password = A_PASSWORD),
+                eventSink = eventsRecorder,
+            ),
+        )
+        val continueStr = rule.activity.getString(CommonStrings.action_continue)
+        rule.onNodeWithText(continueStr).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `when password is empty, continue button is not enabled`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>(expectEvents = false)
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                formState = aLoginFormState(login = A_USER_NAME),
+                eventSink = eventsRecorder,
+            ),
+        )
+        val continueStr = rule.activity.getString(CommonStrings.action_continue)
+        rule.onNodeWithText(continueStr).assertIsNotEnabled()
+    }
+
+    @Config(qualifiers = "h1024dp")
+    @Test
+    fun `clicking on Continue sends expected event`() {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        rule.setLoginPasswordView(
+            aLoginPasswordState(
+                formState = aLoginFormState(login = A_USER_NAME, password = A_PASSWORD),
+                eventSink = eventsRecorder,
+            ),
+        )
+        val continueStr = rule.activity.getString(CommonStrings.action_continue)
+        rule.onNodeWithText(continueStr).assertIsEnabled()
+        rule.clickOn(CommonStrings.action_continue)
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.Submit
+        )
+    }
+}
+
+private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setLoginPasswordView(
+    state: LoginPasswordState,
+    onBackClick: () -> Unit = EnsureNeverCalled(),
+) {
+    setContent {
+        LoginPasswordView(
+            state = state,
+            onBackClick = onBackClick,
+        )
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
First commit is the fix, second commit is adding missing unit tests.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4691 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See #4691  for steps on how to repro the issue and observe that with this change issue cannot be repro.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
