### PR TITLE
Ensure the CI is marked as failed when Maestro test is failing

### DIFF
--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -56,7 +56,7 @@ jobs:
   maestro-cloud:
     name: Maestro test suite
     runs-on: ubuntu-latest
-    needs: [build-apk]
+    needs: [ build-apk ]
     # Allow one per PR.
     concurrency:
       group: ${{ format('maestro-{0}', github.ref) }}
@@ -80,6 +80,7 @@ jobs:
       - name: Install maestro
         run: curl -fsSL "https://get.maestro.mobile.dev" | bash
       - name: Run Maestro tests in emulator
+        id: maestro_test
         uses: reactivecircus/android-emulator-runner@v2
         continue-on-error: true
         env:
@@ -109,3 +110,8 @@ jobs:
           retention-days: 5
           overwrite: true
           if-no-files-found: error
+      - name: Fail the workflow in case of error in test
+        if: steps.maestro_test.outcome != 'success'
+        run: |
+          echo "Maestro tests failed. Please check the logs."
+          exit 1


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
