### PR TITLE
Revert "fix(deps): update dependency io.element.android:element-call-embedded to v0.10.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -207,7 +207,7 @@ anvil_compiler_api = { module = "dev.zacsweers.anvil:compiler-api", version.ref 
 anvil_compiler_utils = { module = "dev.zacsweers.anvil:compiler-utils", version.ref = "anvil" }
 
 # Element Call
-element_call_embedded = "io.element.android:element-call-embedded:0.10.0"
+element_call_embedded = "io.element.android:element-call-embedded:0.9.0"
 
 # Auto services
 google_autoservice = { module = "com.google.auto.service:auto-service", version.ref = "autoservice" }


### PR DESCRIPTION
Reverts element-hq/element-x-android#4667

This version wasn't ready to be merged and was merged by mistake.