### PR TITLE
Improve audio focus management

### DIFF
--- a/features/call/impl/build.gradle.kts
+++ b/features/call/impl/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(projects.features.enterprise.api)
     implementation(projects.libraries.architecture)
     implementation(projects.libraries.androidutils)
+    implementation(projects.libraries.audio.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.designsystem)
     implementation(projects.libraries.featureflag.api)

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -127,7 +127,7 @@ class ElementCallActivity :
 
     private fun setCallIsActive() {
         audioFocus.requestAudioFocus(
-            mode = AudioFocusRequester.ElementCall,
+            requester = AudioFocusRequester.ElementCall,
             onFocusLost = {
                 // If the audio focus is lost, we do not stop the call.
                 Timber.tag(loggerTag.value).w("Audio focus lost")

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -126,7 +126,13 @@ class ElementCallActivity :
     }
 
     private fun setCallIsActive() {
-        audioFocus.requestAudioFocus(AudioFocusRequester.ElementCall)
+        audioFocus.requestAudioFocus(
+            mode = AudioFocusRequester.ElementCall,
+            onFocusLost = {
+                // If the audio focus is lost, we do not stop the call.
+                Timber.tag(loggerTag.value).w("Audio focus lost")
+            }
+        )
         CallForegroundService.start(this)
     }
 

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/ElementCallActivity.kt
@@ -10,9 +10,6 @@ package io.element.android.features.call.impl.ui
 import android.Manifest
 import android.app.PictureInPictureParams
 import android.content.Intent
-import android.media.AudioAttributes
-import android.media.AudioFocusRequest
-import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Rational
@@ -46,6 +43,8 @@ import io.element.android.features.call.impl.utils.CallIntentDataParser
 import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.bindings
+import io.element.android.libraries.audio.api.AudioFocus
+import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.designsystem.theme.ElementThemeApp
@@ -65,15 +64,11 @@ class ElementCallActivity :
     @Inject lateinit var enterpriseService: EnterpriseService
     @Inject lateinit var pictureInPicturePresenter: PictureInPicturePresenter
     @Inject lateinit var buildMeta: BuildMeta
+    @Inject lateinit var audioFocus: AudioFocus
 
     private lateinit var presenter: Presenter<CallScreenState>
 
-    private lateinit var audioManager: AudioManager
-
     private var requestPermissionCallback: RequestPermissionCallback? = null
-
-    private var audiofocusRequest: AudioFocusRequest? = null
-    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
 
     private val requestPermissionsLauncher = registerPermissionResultLauncher()
 
@@ -101,8 +96,6 @@ class ElementCallActivity :
         }
 
         pictureInPicturePresenter.setPipView(this)
-
-        audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
 
         setContent {
             val pipState = pictureInPicturePresenter.present()
@@ -133,7 +126,7 @@ class ElementCallActivity :
     }
 
     private fun setCallIsActive() {
-        requestAudioFocus()
+        audioFocus.requestAudioFocus(AudioFocusRequester.ElementCall)
         CallForegroundService.start(this)
     }
 
@@ -175,7 +168,7 @@ class ElementCallActivity :
 
     override fun onDestroy() {
         super.onDestroy()
-        releaseAudioFocus()
+        audioFocus.releaseAudioFocus()
         CallForegroundService.stop(this)
         pictureInPicturePresenter.setPipView(null)
     }
@@ -238,37 +231,6 @@ class ElementCallActivity :
             }
             callback(permissionsToGrant.toTypedArray())
             requestPermissionCallback = null
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun requestAudioFocus() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val audioAttributes = AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                .build()
-            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-                .setAudioAttributes(audioAttributes)
-                .build()
-            audioManager.requestAudioFocus(request)
-            audiofocusRequest = request
-        } else {
-            val listener = AudioManager.OnAudioFocusChangeListener { }
-            audioManager.requestAudioFocus(
-                listener,
-                AudioManager.STREAM_VOICE_CALL,
-                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
-            )
-            audioFocusChangeListener = listener
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun releaseAudioFocus() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            audiofocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
-        } else {
-            audioFocusChangeListener?.let { audioManager.abandonAudioFocus(it) }
         }
     }
 

--- a/libraries/audio/api/build.gradle.kts
+++ b/libraries/audio/api/build.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+plugins {
+    id("io.element.android-library")
+}
+
+android {
+    namespace = "io.element.android.libraries.audio.api"
+}

--- a/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
+++ b/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.audio.api
 enum class AudioFocusRequester {
     ElementCall,
     VoiceMessage,
+    MediaViewer,
 }
 
 interface AudioFocus {

--- a/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
+++ b/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.audio.api
 
 enum class AudioFocusRequester {
     ElementCall,
+    VoiceMessage,
 }
 
 interface AudioFocus {

--- a/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
+++ b/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.audio.api
+
+enum class AudioFocusRequester {
+    ElementCall,
+}
+
+interface AudioFocus {
+    fun requestAudioFocus(mode: AudioFocusRequester)
+    fun releaseAudioFocus()
+}

--- a/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
+++ b/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
@@ -14,10 +14,19 @@ enum class AudioFocusRequester {
 }
 
 interface AudioFocus {
+    /**
+     * Request audio focus for the given requester.
+     * @param requester The mode for which to request audio focus.
+     * @param onFocusLost Callback to be invoked when the audio focus is lost.
+     * @return true if the audio focus was successfully requested, false otherwise.
+     */
     fun requestAudioFocus(
-        mode: AudioFocusRequester,
+        requester: AudioFocusRequester,
         onFocusLost: () -> Unit,
     )
 
+    /**
+     * Release the audio focus.
+     */
     fun releaseAudioFocus()
 }

--- a/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
+++ b/libraries/audio/api/src/main/kotlin/io/element/android/libraries/audio/api/AudioFocus.kt
@@ -14,6 +14,10 @@ enum class AudioFocusRequester {
 }
 
 interface AudioFocus {
-    fun requestAudioFocus(mode: AudioFocusRequester)
+    fun requestAudioFocus(
+        mode: AudioFocusRequester,
+        onFocusLost: () -> Unit,
+    )
+
     fun releaseAudioFocus()
 }

--- a/libraries/audio/impl/build.gradle.kts
+++ b/libraries/audio/impl/build.gradle.kts
@@ -1,0 +1,25 @@
+import extension.setupAnvil
+
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+plugins {
+    id("io.element.android-library")
+}
+
+android {
+    namespace = "io.element.android.libraries.audio.impl"
+}
+
+setupAnvil()
+
+dependencies {
+    api(projects.libraries.audio.api)
+
+    implementation(libs.androidx.corektx)
+    implementation(libs.dagger)
+    implementation(projects.libraries.di)
+}

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -33,7 +33,7 @@ class DefaultAudioFocus @Inject constructor(
     override fun requestAudioFocus(mode: AudioFocusRequester) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val audioAttributes = AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .setUsage(mode.toAudioUsage())
                 .build()
             val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
                 .setAudioAttributes(audioAttributes)
@@ -44,7 +44,7 @@ class DefaultAudioFocus @Inject constructor(
             val listener = AudioManager.OnAudioFocusChangeListener { }
             audioManager.requestAudioFocus(
                 listener,
-                AudioManager.STREAM_VOICE_CALL,
+                mode.toAudioStream(),
                 AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
             )
             audioFocusChangeListener = listener
@@ -58,5 +58,21 @@ class DefaultAudioFocus @Inject constructor(
         } else {
             audioFocusChangeListener?.let { audioManager.abandonAudioFocus(it) }
         }
+    }
+}
+
+private fun AudioFocusRequester.toAudioUsage(): Int {
+    return when (this) {
+        AudioFocusRequester.ElementCall,
+        AudioFocusRequester.VoiceMessage -> AudioAttributes.USAGE_VOICE_COMMUNICATION
+        AudioFocusRequester.MediaViewer -> AudioAttributes.USAGE_MEDIA
+    }
+}
+
+private fun AudioFocusRequester.toAudioStream(): Int {
+    return when (this) {
+        AudioFocusRequester.ElementCall,
+        AudioFocusRequester.VoiceMessage -> AudioManager.STREAM_VOICE_CALL
+        AudioFocusRequester.MediaViewer -> AudioManager.STREAM_MUSIC
     }
 }

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -47,13 +47,14 @@ class DefaultAudioFocus @Inject constructor(
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ) {
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(mode.toAudioUsage())
                 .build()
             val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
                 .setAudioAttributes(audioAttributes)
                 .setOnAudioFocusChangeListener(listener)
+                .setWillPauseWhenDucked(mode.willPausedWhenDucked())
                 .build()
             audioManager.requestAudioFocus(request)
             audioFocusRequest = request
@@ -90,5 +91,16 @@ private fun AudioFocusRequester.toAudioStream(): Int {
         AudioFocusRequester.ElementCall,
         AudioFocusRequester.VoiceMessage -> AudioManager.STREAM_VOICE_CALL
         AudioFocusRequester.MediaViewer -> AudioManager.STREAM_MUSIC
+    }
+}
+
+private fun AudioFocusRequester.willPausedWhenDucked(): Boolean {
+    return when (this) {
+        /* (note that for Element Call, there is no action when the focus is lost) */
+        AudioFocusRequester.ElementCall,
+        AudioFocusRequester.VoiceMessage -> true
+        // For the MediaViewer, we let the system automatically handle the ducking
+        // https://developer.android.com/media/optimize/audio-focus#automatic-ducking
+        AudioFocusRequester.MediaViewer -> false
     }
 }

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -31,7 +31,7 @@ class DefaultAudioFocus @Inject constructor(
 
     @Suppress("DEPRECATION")
     override fun requestAudioFocus(
-        mode: AudioFocusRequester,
+        requester: AudioFocusRequester,
         onFocusLost: () -> Unit,
     ) {
         val listener = AudioManager.OnAudioFocusChangeListener {
@@ -49,19 +49,19 @@ class DefaultAudioFocus @Inject constructor(
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ) {
             val audioAttributes = AudioAttributes.Builder()
-                .setUsage(mode.toAudioUsage())
+                .setUsage(requester.toAudioUsage())
                 .build()
             val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
                 .setAudioAttributes(audioAttributes)
                 .setOnAudioFocusChangeListener(listener)
-                .setWillPauseWhenDucked(mode.willPausedWhenDucked())
+                .setWillPauseWhenDucked(requester.willPausedWhenDucked())
                 .build()
             audioManager.requestAudioFocus(request)
             audioFocusRequest = request
         } else {
             audioManager.requestAudioFocus(
                 listener,
-                mode.toAudioStream(),
+                requester.toAudioStream(),
                 AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
             )
             audioFocusChangeListener = listener

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -47,7 +47,7 @@ class DefaultAudioFocus @Inject constructor(
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(requester.toAudioUsage())
                 .build()

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.audio.impl
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import androidx.core.content.getSystemService
+import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.audio.api.AudioFocus
+import io.element.android.libraries.audio.api.AudioFocusRequester
+import io.element.android.libraries.di.AppScope
+import io.element.android.libraries.di.ApplicationContext
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class DefaultAudioFocus @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AudioFocus {
+    private val audioManager = requireNotNull(context.getSystemService<AudioManager>())
+
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
+
+    @Suppress("DEPRECATION")
+    override fun requestAudioFocus(mode: AudioFocusRequester) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val audioAttributes = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .build()
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(audioAttributes)
+                .build()
+            audioManager.requestAudioFocus(request)
+            audioFocusRequest = request
+        } else {
+            val listener = AudioManager.OnAudioFocusChangeListener { }
+            audioManager.requestAudioFocus(
+                listener,
+                AudioManager.STREAM_VOICE_CALL,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
+            )
+            audioFocusChangeListener = listener
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun releaseAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        } else {
+            audioFocusChangeListener?.let { audioManager.abandonAudioFocus(it) }
+        }
+    }
+}

--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -96,7 +96,7 @@ private fun AudioFocusRequester.toAudioStream(): Int {
 
 private fun AudioFocusRequester.willPausedWhenDucked(): Boolean {
     return when (this) {
-        /* (note that for Element Call, there is no action when the focus is lost) */
+        // (note that for Element Call, there is no action when the focus is lost)
         AudioFocusRequester.ElementCall,
         AudioFocusRequester.VoiceMessage -> true
         // For the MediaViewer, we let the system automatically handle the ducking

--- a/libraries/audio/test/build.gradle.kts
+++ b/libraries/audio/test/build.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+plugins {
+    id("io.element.android-library")
+}
+
+android {
+    namespace = "io.element.android.libraries.audio.test"
+}
+
+dependencies {
+    api(projects.libraries.audio.api)
+    implementation(projects.tests.testutils)
+}

--- a/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocus.kt
+++ b/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocus.kt
@@ -16,10 +16,10 @@ class FakeAudioFocus(
     private val releaseAudioFocusResult: () -> Unit = { lambdaError() },
 ) : AudioFocus {
     override fun requestAudioFocus(
-        mode: AudioFocusRequester,
+        requester: AudioFocusRequester,
         onFocusLost: () -> Unit,
     ) {
-        requestAudioFocusResult(mode, onFocusLost)
+        requestAudioFocusResult(requester, onFocusLost)
     }
 
     override fun releaseAudioFocus() {

--- a/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocus.kt
+++ b/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocus.kt
@@ -11,7 +11,7 @@ import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.tests.testutils.lambda.lambdaError
 
-class FakeAudioFocusRequester(
+class FakeAudioFocus(
     private val requestAudioFocusResult: (AudioFocusRequester, () -> Unit) -> Unit = { _, _ -> lambdaError() },
     private val releaseAudioFocusResult: () -> Unit = { lambdaError() },
 ) : AudioFocus {

--- a/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocusRequester.kt
+++ b/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocusRequester.kt
@@ -12,11 +12,14 @@ import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.tests.testutils.lambda.lambdaError
 
 class FakeAudioFocusRequester(
-    private val requestAudioFocusResult: (AudioFocusRequester) -> Unit = { lambdaError() },
+    private val requestAudioFocusResult: (AudioFocusRequester, () -> Unit) -> Unit = { _, _ -> lambdaError() },
     private val releaseAudioFocusResult: () -> Unit = { lambdaError() },
 ) : AudioFocus {
-    override fun requestAudioFocus(mode: AudioFocusRequester) {
-        requestAudioFocusResult(mode)
+    override fun requestAudioFocus(
+        mode: AudioFocusRequester,
+        onFocusLost: () -> Unit,
+    ) {
+        requestAudioFocusResult(mode, onFocusLost)
     }
 
     override fun releaseAudioFocus() {

--- a/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocusRequester.kt
+++ b/libraries/audio/test/src/main/kotlin/io/element/android/libraries/mediaplayer/test/FakeAudioFocusRequester.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.mediaplayer.test
+
+import io.element.android.libraries.audio.api.AudioFocus
+import io.element.android.libraries.audio.api.AudioFocusRequester
+import io.element.android.tests.testutils.lambda.lambdaError
+
+class FakeAudioFocusRequester(
+    private val requestAudioFocusResult: (AudioFocusRequester) -> Unit = { lambdaError() },
+    private val releaseAudioFocusResult: () -> Unit = { lambdaError() },
+) : AudioFocus {
+    override fun requestAudioFocus(mode: AudioFocusRequester) {
+        requestAudioFocusResult(mode)
+    }
+
+    override fun releaseAudioFocus() {
+        releaseAudioFocusResult()
+    }
+}

--- a/libraries/mediaplayer/impl/build.gradle.kts
+++ b/libraries/mediaplayer/impl/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.coroutines.core)
 
     testImplementation(projects.tests.testutils)
+    testImplementation(projects.libraries.audio.test)
     testImplementation(libs.test.junit)
     testImplementation(libs.test.truth)
     testImplementation(libs.test.mockk)

--- a/libraries/mediaplayer/impl/build.gradle.kts
+++ b/libraries/mediaplayer/impl/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.androidx.media3.exoplayer)
 
     implementation(libs.dagger)
+    implementation(projects.libraries.audio.api)
     implementation(projects.libraries.di)
 
     implementation(libs.coroutines.core)

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
@@ -122,7 +122,14 @@ class DefaultMediaPlayer @Inject constructor(
     }
 
     override fun play() {
-        audioFocus.requestAudioFocus(AudioFocusRequester.VoiceMessage)
+        audioFocus.requestAudioFocus(
+            mode = AudioFocusRequester.VoiceMessage,
+            onFocusLost = {
+                if (player.isPlaying()) {
+                    player.pause()
+                }
+            },
+        )
         if (player.playbackState == Player.STATE_ENDED) {
             // There's a bug with some ogg files that somehow report to
             // have no duration.

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
@@ -123,7 +123,7 @@ class DefaultMediaPlayer @Inject constructor(
 
     override fun play() {
         audioFocus.requestAudioFocus(
-            mode = AudioFocusRequester.VoiceMessage,
+            requester = AudioFocusRequester.VoiceMessage,
             onFocusLost = {
                 if (player.isPlaying()) {
                     player.pause()

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/DefaultMediaPlayer.kt
@@ -11,6 +11,8 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.squareup.anvil.annotations.ContributesBinding
+import io.element.android.libraries.audio.api.AudioFocus
+import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.di.SingleIn
 import io.element.android.libraries.mediaplayer.api.MediaPlayer
@@ -36,6 +38,7 @@ import kotlin.time.Duration.Companion.seconds
 class DefaultMediaPlayer @Inject constructor(
     private val player: SimplePlayer,
     private val coroutineScope: CoroutineScope,
+    private val audioFocus: AudioFocus,
 ) : MediaPlayer {
     private val listener = object : SimplePlayer.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -49,6 +52,7 @@ class DefaultMediaPlayer @Inject constructor(
             if (isPlaying) {
                 job = coroutineScope.launch { updateCurrentPosition() }
             } else {
+                audioFocus.releaseAudioFocus()
                 job?.cancel()
             }
         }
@@ -118,6 +122,7 @@ class DefaultMediaPlayer @Inject constructor(
     }
 
     override fun play() {
+        audioFocus.requestAudioFocus(AudioFocusRequester.VoiceMessage)
         if (player.playbackState == Player.STATE_ENDED) {
             // There's a bug with some ogg files that somehow report to
             // have no duration.

--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -30,6 +30,7 @@ interface SimplePlayer {
     fun getCurrentMediaItem(): MediaItem?
     fun prepare()
     fun play()
+    fun isPlaying(): Boolean
     fun pause()
     fun seekTo(positionMs: Long)
     fun release()
@@ -79,6 +80,8 @@ class DefaultSimplePlayer(
     override fun prepare() = p.prepare()
 
     override fun play() = p.play()
+
+    override fun isPlaying() = p.isPlaying
 
     override fun pause() = p.pause()
 

--- a/libraries/mediaplayer/impl/src/test/kotlin/io/element/android/libraries/mediaplayer/impl/FakeSimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/test/kotlin/io/element/android/libraries/mediaplayer/impl/FakeSimplePlayer.kt
@@ -16,6 +16,7 @@ class FakeSimplePlayer(
     private val getCurrentMediaItemLambda: () -> MediaItem? = { lambdaError() },
     private val prepareLambda: () -> Unit = { lambdaError() },
     private val playLambda: () -> Unit = { lambdaError() },
+    private val isPlayingLambda: () -> Boolean = { lambdaError() },
     private val pauseLambda: () -> Unit = { lambdaError() },
     private val seekToLambda: (Long) -> Unit = { lambdaError() },
     private val releaseLambda: () -> Unit = { lambdaError() },
@@ -40,6 +41,7 @@ class FakeSimplePlayer(
     override fun getCurrentMediaItem(): MediaItem? = getCurrentMediaItemLambda()
     override fun prepare() = prepareLambda()
     override fun play() = playLambda()
+    override fun isPlaying() = isPlayingLambda()
     override fun pause() = pauseLambda()
     override fun seekTo(positionMs: Long) = seekToLambda(positionMs)
     override fun release() = releaseLambda()

--- a/libraries/mediaviewer/impl/build.gradle.kts
+++ b/libraries/mediaviewer/impl/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(projects.features.viewfolder.api)
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.architecture)
+    implementation(projects.libraries.audio.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.dateformatter.api)
     implementation(projects.libraries.di)

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/DefaultLocalMediaRenderer.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/DefaultLocalMediaRenderer.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.features.viewfolder.api.TextFileViewer
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
 import io.element.android.libraries.mediaviewer.api.local.LocalMediaRenderer
@@ -23,6 +24,7 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class DefaultLocalMediaRenderer @Inject constructor(
     private val textFileViewer: TextFileViewer,
+    private val audioFocus: AudioFocus,
 ) : LocalMediaRenderer {
     @Composable
     override fun Render(localMedia: LocalMedia) {
@@ -37,7 +39,8 @@ class DefaultLocalMediaRenderer @Inject constructor(
             localMedia = localMedia,
             localMediaViewState = localMediaViewState,
             textFileViewer = textFileViewer,
-            onClick = {}
+            audioFocus = audioFocus,
+            onClick = {},
         )
     }
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.mediaviewer.impl.local
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.element.android.features.viewfolder.api.TextFileViewer
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeAudio
 import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeImage
@@ -27,6 +28,7 @@ import io.element.android.libraries.mediaviewer.impl.local.video.MediaVideoView
 fun LocalMediaView(
     localMedia: LocalMedia?,
     bottomPaddingInPixels: Int,
+    audioFocus: AudioFocus?,
     onClick: () -> Unit,
     textFileViewer: TextFileViewer,
     modifier: Modifier = Modifier,
@@ -49,6 +51,7 @@ fun LocalMediaView(
             bottomPaddingInPixels = bottomPaddingInPixels,
             localMedia = localMedia,
             autoplay = isUserSelected,
+            audioFocus = audioFocus,
             modifier = modifier,
         )
         mimeType == MimeTypes.PlainText -> TextFileView(
@@ -68,6 +71,7 @@ fun LocalMediaView(
             bottomPaddingInPixels = bottomPaddingInPixels,
             localMedia = localMedia,
             info = mediaInfo,
+            audioFocus = audioFocus,
             modifier = modifier,
         )
         else -> MediaFileView(

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
@@ -52,6 +52,7 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.designsystem.components.media.WaveformPlaybackView
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -80,6 +81,7 @@ fun MediaAudioView(
     bottomPaddingInPixels: Int,
     localMedia: LocalMedia?,
     info: MediaInfo?,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
     isDisplayed: Boolean = true,
 ) {
@@ -91,6 +93,7 @@ fun MediaAudioView(
         exoPlayer = exoPlayer,
         localMedia = localMedia,
         info = info,
+        audioFocus = audioFocus,
         modifier = modifier,
     )
 }
@@ -104,6 +107,7 @@ private fun ExoPlayerMediaAudioView(
     exoPlayer: ExoPlayer,
     localMedia: LocalMedia?,
     info: MediaInfo?,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -294,6 +298,7 @@ private fun ExoPlayerMediaAudioView(
             onToggleMute = {
                 // Cannot happen for audio files
             },
+            audioFocus = audioFocus,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
@@ -369,6 +374,7 @@ internal fun MediaAudioViewPreview(
         bottomPaddingInPixels = 0,
         localMediaViewState = rememberLocalMediaViewState(),
         info = info,
+        audioFocus = null,
         localMedia = null,
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
@@ -44,6 +44,7 @@ import io.element.android.libraries.designsystem.theme.components.Slider
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.mediaviewer.impl.util.bgCanvasWithTransparency
 import io.element.android.libraries.ui.strings.CommonStrings
+import timber.log.Timber
 
 @Composable
 fun MediaPlayerControllerView(
@@ -57,7 +58,13 @@ fun MediaPlayerControllerView(
     if (audioFocus != null) {
         LaunchedEffect(state.isPlaying) {
             if (state.isPlaying) {
-                audioFocus.requestAudioFocus(AudioFocusRequester.MediaViewer)
+                audioFocus.requestAudioFocus(
+                    mode = AudioFocusRequester.MediaViewer,
+                    onFocusLost = {
+                        Timber.w("Audio focus lost")
+                        onTogglePlay()
+                    },
+                )
             } else {
                 audioFocus.releaseAudioFocus()
             }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,13 +57,14 @@ fun MediaPlayerControllerView(
     modifier: Modifier = Modifier,
 ) {
     if (audioFocus != null) {
+        val latestOnTogglePlay by rememberUpdatedState(onTogglePlay)
         LaunchedEffect(state.isPlaying) {
             if (state.isPlaying) {
                 audioFocus.requestAudioFocus(
                     mode = AudioFocusRequester.MediaViewer,
                     onFocusLost = {
                         Timber.w("Audio focus lost")
-                        onTogglePlay()
+                        latestOnTogglePlay()
                     },
                 )
             } else {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
+import io.element.android.libraries.audio.api.AudioFocus
+import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.libraries.dateformatter.api.toHumanReadableDuration
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -48,8 +51,19 @@ fun MediaPlayerControllerView(
     onTogglePlay: () -> Unit,
     onSeekChange: (Float) -> Unit,
     onToggleMute: () -> Unit,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
+    if (audioFocus != null) {
+        LaunchedEffect(state.isPlaying) {
+            if (state.isPlaying) {
+                audioFocus.requestAudioFocus(AudioFocusRequester.MediaViewer)
+            } else {
+                audioFocus.releaseAudioFocus()
+            }
+        }
+    }
+
     AnimatedVisibility(
         visible = state.isVisible,
         modifier = modifier,
@@ -167,5 +181,6 @@ internal fun MediaPlayerControllerViewPreview(
         onTogglePlay = {},
         onSeekChange = {},
         onToggleMute = {},
+        audioFocus = null,
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
@@ -61,7 +61,7 @@ fun MediaPlayerControllerView(
         LaunchedEffect(state.isPlaying) {
             if (state.isPlaying) {
                 audioFocus.requestAudioFocus(
-                    mode = AudioFocusRequester.MediaViewer,
+                    requester = AudioFocusRequester.MediaViewer,
                     onFocusLost = {
                         Timber.w("Audio focus lost")
                         latestOnTogglePlay()

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -37,6 +37,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import io.element.android.compound.theme.ElementTheme
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.toDp
@@ -63,6 +64,7 @@ fun MediaVideoView(
     bottomPaddingInPixels: Int,
     localMedia: LocalMedia?,
     autoplay: Boolean,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     val exoPlayer = rememberExoPlayer()
@@ -73,6 +75,7 @@ fun MediaVideoView(
         exoPlayer = exoPlayer,
         localMedia = localMedia,
         autoplay = autoplay,
+        audioFocus = audioFocus,
         modifier = modifier,
     )
 }
@@ -86,6 +89,7 @@ private fun ExoPlayerMediaVideoView(
     exoPlayer: ExoPlayer,
     localMedia: LocalMedia?,
     autoplay: Boolean,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -248,6 +252,7 @@ private fun ExoPlayerMediaVideoView(
                 autoHideController++
                 exoPlayer.volume = if (exoPlayer.volume == 1f) 0f else 1f
             },
+            audioFocus = audioFocus,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
@@ -278,6 +283,7 @@ internal fun MediaVideoViewPreview() = ElementPreview {
         bottomPaddingInPixels = 0,
         localMediaViewState = rememberLocalMediaViewState(),
         localMedia = null,
+        audioFocus = null,
         autoplay = false,
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerNode.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerNode.kt
@@ -19,6 +19,7 @@ import io.element.android.anvilannotations.ContributesNode
 import io.element.android.compound.theme.ForcedDarkElementTheme
 import io.element.android.features.viewfolder.api.TextFileViewer
 import io.element.android.libraries.architecture.inputs
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.matrix.api.core.EventId
@@ -44,6 +45,7 @@ class MediaViewerNode @AssistedInject constructor(
     systemClock: SystemClock,
     pagerKeysHandler: PagerKeysHandler,
     private val textFileViewer: TextFileViewer,
+    private val audioFocus: AudioFocus,
 ) : Node(buildContext, plugins = plugins),
     MediaViewerNavigator {
     private val inputs = inputs<MediaViewerEntryPoint.Params>()
@@ -129,7 +131,8 @@ class MediaViewerNode @AssistedInject constructor(
                 state = state,
                 textFileViewer = textFileViewer,
                 modifier = modifier,
-                onBackClick = ::onDone
+                audioFocus = audioFocus,
+                onBackClick = ::onDone,
             )
         }
     }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -51,6 +51,7 @@ import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.viewfolder.api.TextFileViewer
 import io.element.android.libraries.architecture.AsyncData
+import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
 import io.element.android.libraries.designsystem.components.async.AsyncFailure
@@ -91,6 +92,7 @@ fun MediaViewerView(
     state: MediaViewerState,
     textFileViewer: TextFileViewer,
     onBackClick: () -> Unit,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     val snackbarHostState = rememberSnackbarHostState(snackbarMessage = state.snackbarMessage)
@@ -163,6 +165,7 @@ fun MediaViewerView(
                             onShowOverlayChange = {
                                 showOverlay = it
                             },
+                            audioFocus = audioFocus,
                             isUserSelected = (state.listData[page] as? MediaViewerPageData.MediaViewerData)?.eventId == state.initiallySelectedEventId,
                         )
                         // Bottom bar
@@ -284,6 +287,7 @@ private fun MediaViewerPage(
     onRetry: () -> Unit,
     onDismissError: () -> Unit,
     onShowOverlayChange: (Boolean) -> Unit,
+    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     val currentShowOverlay by rememberUpdatedState(showOverlay)
@@ -336,6 +340,7 @@ private fun MediaViewerPage(
                         }
                     },
                     isUserSelected = isUserSelected,
+                    audioFocus = audioFocus,
                 )
                 ThumbnailView(
                     mediaInfo = data.mediaInfo,
@@ -578,7 +583,8 @@ private fun ErrorView(
 internal fun MediaViewerViewPreview(@PreviewParameter(MediaViewerStateProvider::class) state: MediaViewerState) = ElementPreviewDark {
     MediaViewerView(
         state = state,
+        audioFocus = null,
         textFileViewer = { _, _ -> },
-        onBackClick = {}
+        onBackClick = {},
     )
 }

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
@@ -252,6 +252,7 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setMedia
     setContent {
         MediaViewerView(
             state = state,
+            audioFocus = null,
             textFileViewer = { _, _ -> },
             onBackClick = onBackClick,
         )

--- a/libraries/voiceplayer/impl/build.gradle.kts
+++ b/libraries/voiceplayer/impl/build.gradle.kts
@@ -19,6 +19,7 @@ setupAnvil()
 dependencies {
     api(projects.libraries.voiceplayer.api)
 
+    implementation(projects.libraries.audio.api)
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)
     implementation(projects.libraries.matrix.api)

--- a/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
+++ b/plugins/src/main/kotlin/extension/DependencyHandleScope.kt
@@ -68,7 +68,7 @@ fun DependencyHandlerScope.allLibrariesImpl() {
     implementation(project(":libraries:eventformatter:impl"))
     implementation(project(":libraries:indicator:impl"))
     implementation(project(":libraries:permissions:impl"))
-    implementation(project(":libraries:push:impl"))
+    implementation(project(":libraries:audio:impl"))
     implementation(project(":libraries:push:impl"))
     implementation(project(":libraries:featureflag:impl"))
     implementation(project(":libraries:pushstore:impl"))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
- When the user starts playing a voice message / an audio file / a video: request audio focus to the system so that any other application currently playing audio will pause. This was done for Element Call but not for those use cases. First commit extract the code from Element Call to reuse it at other places
- When Element X is currently playing voice message / audio or video file and the user starts an audio stream from another app (ex: resume Spotify playback from the notification drawer), audio focus is lost and in this case, the application pauses the current playback. For Element Call, nothing is done when the audio focus is lost.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4617 and better integration with the system.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No change in the UI

## Tests

<!-- Explain how you tested your development -->

- This is a challenge: try to have an audio output from Element X in the same time than audio output from every other (decent) applications. It should not be possible anymore.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
