### PR TITLE
Fix generic mime type used when externally sharing several files

### DIFF
--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/ShareIntentHandler.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/ShareIntentHandler.kt
@@ -89,7 +89,7 @@ class DefaultShareIntentHandler @Inject constructor(
      * Use this function to retrieve files which are shared from another application or internally
      * by using android.intent.action.SEND or android.intent.action.SEND_MULTIPLE actions.
      */
-    private fun getIncomingUris(intent: Intent, type: String): List<ShareIntentHandler.UriToShare> {
+    private fun getIncomingUris(intent: Intent, fallbackMimeType: String): List<ShareIntentHandler.UriToShare> {
         val uriList = mutableListOf<Uri>()
         if (intent.action == Intent.ACTION_SEND) {
             IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
@@ -115,9 +115,12 @@ class DefaultShareIntentHandler @Inject constructor(
             }
         }
         return uriList.map { uri ->
+            // The value in fallbackMimeType can be wrong, especially if several uris were received
+            // in the same intent (i.e. 'image/*'). We need to check the mime type of each uri.
+            val mimeType = context.contentResolver.getType(uri) ?: fallbackMimeType
             ShareIntentHandler.UriToShare(
                 uri = uri,
-                mimeType = type
+                mimeType = mimeType,
             )
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Get the mime type of each uri shared with the app.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4279.

## Tests

It's difficult to test without a debugger, having access to the media server or adding some logs.

- From an external app, like a gallery, share images with different formates.
- Check the mime type of each image matches, instead of just a `image/*` mime type being used.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
