### PR TITLE
Fix issues on JoinedRoom / BaseRoom

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/BaseRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/BaseRoom.kt
@@ -56,6 +56,12 @@ interface BaseRoom : Closeable {
     fun info(): RoomInfo = roomInfoFlow.value
 
     /**
+     * A one-to-one is a room with exactly 2 members.
+     * See [the Matrix spec](https://spec.matrix.org/latest/client-server-api/#default-underride-rules).
+     */
+    val isOneToOne: Boolean get() = info().activeMembersCount == 2L
+
+    /**
      * Try to load the room members and update the membersFlow.
      */
     suspend fun updateMembers()

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
@@ -51,12 +51,6 @@ interface JoinedRoom : BaseRoom {
     val knockRequestsFlow: Flow<List<KnockRequest>>
 
     /**
-     * A one-to-one is a room with exactly 2 members.
-     * See [the Matrix spec](https://spec.matrix.org/latest/client-server-api/#default-underride-rules).
-     */
-    val isOneToOne: Boolean get() = info().activeMembersCount == 2L
-
-    /**
      * The live timeline of the room. Must be used to send Event to a room.
      */
     val liveTimeline: Timeline

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -60,7 +60,6 @@ import io.element.android.libraries.matrix.impl.util.mxCallbackFlow
 import io.element.android.libraries.matrix.impl.widget.RustWidgetDriver
 import io.element.android.libraries.matrix.impl.widget.generateWidgetWebViewUrl
 import io.element.android.services.toolbox.api.systemclock.SystemClock
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -646,7 +645,6 @@ class JoinedRustRoom(
     override fun destroy() {
         baseRoom.destroy()
         liveInnerTimeline.destroy()
-        roomCoroutineScope.cancel()
     }
 
     private fun InnerTimeline.map(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.CreateTimelineParams
 import io.element.android.libraries.matrix.api.room.IntentionalMention
 import io.element.android.libraries.matrix.api.room.JoinedRoom
+import io.element.android.libraries.matrix.api.room.RoomInfo
 import io.element.android.libraries.matrix.api.room.RoomNotificationSettingsState
 import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.room.join.JoinRule
@@ -112,7 +113,7 @@ class JoinedRustRoom(
 
     override val syncUpdateFlow = MutableStateFlow(0L)
 
-    override val roomInfoFlow: StateFlow<io.element.android.libraries.matrix.api.room.RoomInfo> = mxCallbackFlow {
+    override val roomInfoFlow: StateFlow<RoomInfo> = mxCallbackFlow {
         innerRoom.subscribeToRoomInfoUpdates(object : RoomInfoListener {
             override fun call(roomInfo: InnerRoomInfo) {
                 channel.trySend(roomInfoMapper.map(roomInfo))

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
@@ -31,11 +31,14 @@ import io.element.android.libraries.matrix.impl.room.member.RoomMemberMapper
 import io.element.android.libraries.matrix.impl.room.powerlevels.RoomPowerLevelsMapper
 import io.element.android.libraries.matrix.impl.roomdirectory.map
 import io.element.android.libraries.matrix.impl.timeline.toRustReceiptType
+import io.element.android.libraries.matrix.impl.util.mxCallbackFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
+import org.matrix.rustcomponents.sdk.RoomInfoListener
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import uniffi.matrix_sdk_base.EncryptionState
@@ -49,6 +52,7 @@ class RustBaseRoom(
     private val roomSyncSubscriber: RoomSyncSubscriber,
     private val roomMembershipObserver: RoomMembershipObserver,
     sessionCoroutineScope: CoroutineScope,
+    roomInfoMapper: RoomInfoMapper,
     initialRoomInfo: RoomInfo,
 ) : BaseRoom {
     override val roomId = RoomId(innerRoom.id())
@@ -63,9 +67,15 @@ class RustBaseRoom(
 
     override val membersStateFlow: StateFlow<RoomMembersState> = roomMemberListFetcher.membersFlow
 
-    override val roomInfoFlow: StateFlow<RoomInfo> = MutableStateFlow(initialRoomInfo)
-
     override val roomCoroutineScope = sessionCoroutineScope.childScope(coroutineDispatchers.main, "RoomScope-$roomId")
+
+    override val roomInfoFlow: StateFlow<RoomInfo> = mxCallbackFlow {
+        innerRoom.subscribeToRoomInfoUpdates(object : RoomInfoListener {
+            override fun call(roomInfo: org.matrix.rustcomponents.sdk.RoomInfo) {
+                channel.trySend(roomInfoMapper.map(roomInfo))
+            }
+        })
+    }.stateIn(roomCoroutineScope, started = SharingStarted.Lazily, initialValue = initialRoomInfo)
 
     override suspend fun subscribeToSync() = roomSyncSubscriber.subscribe(roomId)
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.matrix.impl.room.powerlevels.RoomPowerLevels
 import io.element.android.libraries.matrix.impl.roomdirectory.map
 import io.element.android.libraries.matrix.impl.timeline.toRustReceiptType
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
@@ -98,6 +99,7 @@ class RustBaseRoom(
 
     override fun destroy() {
         innerRoom.destroy()
+        roomCoroutineScope.cancel()
     }
 
     override suspend fun userDisplayName(userId: UserId): Result<String?> = withContext(roomDispatcher) {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -98,6 +98,7 @@ class RustRoomFactory(
             coroutineDispatchers = dispatchers,
             roomSyncSubscriber = roomSyncSubscriber,
             roomMembershipObserver = roomMembershipObserver,
+            roomInfoMapper = roomInfoMapper,
             initialRoomInfo = roomInfoMapper.map(initialRoomInfo),
             sessionCoroutineScope = sessionCoroutineScope,
         )
@@ -127,7 +128,6 @@ class RustRoomFactory(
                         liveInnerTimeline = roomReferences.room.timeline(),
                         coroutineDispatchers = dispatchers,
                         systemClock = systemClock,
-                        roomInfoMapper = roomInfoMapper,
                         featureFlagService = featureFlagService,
                     )
                 )

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.impl.room
 
+import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeRustRoom
 import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeRustRoomListService
@@ -15,6 +16,7 @@ import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.room.aRoomInfo
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -26,7 +28,9 @@ class RustBaseRoomTest {
             // Not using backgroundScope here, but the test scope
             sessionCoroutineScope = this
         )
+        assertThat(rustBaseRoom.roomCoroutineScope.isActive).isTrue()
         rustBaseRoom.destroy()
+        assertThat(rustBaseRoom.roomCoroutineScope.isActive).isFalse()
     }
 
     private fun TestScope.createRustBaseRoom(

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.room
+
+import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeRustRoom
+import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeRustRoomListService
+import io.element.android.libraries.matrix.test.A_DEVICE_ID
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.matrix.test.room.aRoomInfo
+import io.element.android.tests.testutils.testCoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RustBaseRoomTest {
+    @Test
+    fun `RustBaseRoom should cancel the room coroutine scope when it is destroyed`() = runTest {
+        val rustBaseRoom = createRustBaseRoom(
+            // Not using backgroundScope here, but the test scope
+            sessionCoroutineScope = this
+        )
+        rustBaseRoom.destroy()
+    }
+
+    private fun TestScope.createRustBaseRoom(
+        sessionCoroutineScope: CoroutineScope,
+    ): RustBaseRoom {
+        val dispatchers = testCoroutineDispatchers()
+        return RustBaseRoom(
+            sessionId = A_SESSION_ID,
+            deviceId = A_DEVICE_ID,
+            innerRoom = FakeRustRoom(),
+            coroutineDispatchers = dispatchers,
+            roomSyncSubscriber = RoomSyncSubscriber(
+                roomListService = FakeRustRoomListService(),
+                dispatchers = dispatchers,
+            ),
+            roomMembershipObserver = RoomMembershipObserver(),
+            sessionCoroutineScope = sessionCoroutineScope,
+            initialRoomInfo = aRoomInfo(),
+        )
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoomTest.kt
@@ -44,6 +44,7 @@ class RustBaseRoomTest {
             ),
             roomMembershipObserver = RoomMembershipObserver(),
             sessionCoroutineScope = sessionCoroutineScope,
+            roomInfoMapper = RoomInfoMapper(),
             initialRoomInfo = aRoomInfo(),
         )
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
This PR fixes issue detected in the code that could lead to leak.
It may fixes issue related to incoming call not cancelled when answered else where, as well as other issues where the room state was observed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Stable code.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- 

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
