### PR TITLE
Reduce API of JoinedRoom, caller must use the Timeline API from liveTimeline instead

### DIFF
--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/send/SendLocationPresenter.kt
@@ -101,7 +101,7 @@ class SendLocationPresenter @Inject constructor(
         when (mode) {
             SendLocationState.Mode.PinLocation -> {
                 val geoUri = event.cameraPosition.toGeoUri()
-                room.sendLocation(
+                room.liveTimeline.sendLocation(
                     body = generateBody(geoUri),
                     geoUri = geoUri,
                     description = null,
@@ -119,7 +119,7 @@ class SendLocationPresenter @Inject constructor(
             }
             SendLocationState.Mode.SenderLocation -> {
                 val geoUri = event.toGeoUri()
-                room.sendLocation(
+                room.liveTimeline.sendLocation(
                     body = generateBody(geoUri),
                     geoUri = geoUri,
                     description = null,

--- a/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
+++ b/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/send/SendLocationPresenterTest.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.toEventOrTran
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.timeline.FakeTimeline
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
@@ -266,7 +267,9 @@ class SendLocationPresenterTest {
             Result.success(Unit)
         }
         val joinedRoom = FakeJoinedRoom(
-            sendLocationResult = sendLocationResult,
+            liveTimeline = FakeTimeline().apply {
+                sendLocationLambda = sendLocationResult
+            },
         )
         val sendLocationPresenter = createSendLocationPresenter(joinedRoom)
         fakePermissionsPresenter.givenState(
@@ -327,7 +330,9 @@ class SendLocationPresenterTest {
             Result.success(Unit)
         }
         val joinedRoom = FakeJoinedRoom(
-            sendLocationResult = sendLocationResult,
+            liveTimeline = FakeTimeline().apply {
+                sendLocationLambda = sendLocationResult
+            },
         )
         val sendLocationPresenter = createSendLocationPresenter(joinedRoom)
         fakePermissionsPresenter.givenState(
@@ -388,7 +393,9 @@ class SendLocationPresenterTest {
             Result.success(Unit)
         }
         val joinedRoom = FakeJoinedRoom(
-            sendLocationResult = sendLocationResult,
+            liveTimeline = FakeTimeline().apply {
+                sendLocationLambda = sendLocationResult
+            },
         )
         val sendLocationPresenter = createSendLocationPresenter(joinedRoom)
         fakePermissionsPresenter.givenState(

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -424,7 +424,7 @@ class MessageComposerPresenter @AssistedInject constructor(
         resetComposer(markdownTextEditorState, richTextEditorState, fromEdit = capturedMode is MessageComposerMode.Edit)
         when (capturedMode) {
             is MessageComposerMode.Attachment,
-            is MessageComposerMode.Normal -> room.sendMessage(
+            is MessageComposerMode.Normal -> room.liveTimeline.sendMessage(
                 body = message.markdown,
                 htmlBody = message.html,
                 intentionalMentions = message.intentionalMentions

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesPresenterTest.kt
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package io.element.android.features.messages.impl
 
 import androidx.lifecycle.Lifecycle
@@ -96,6 +98,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -173,12 +176,14 @@ class MessagesPresenterTest {
             skipItems(1)
             val initialState = awaitItem()
             initialState.eventSink(MessagesEvents.ToggleReaction("👍", AN_EVENT_ID.toEventOrTransactionId()))
+            advanceUntilIdle()
             assert(toggleReactionSuccess)
                 .isCalledOnce()
                 .with(value("👍"), value(AN_EVENT_ID.toEventOrTransactionId()))
             // No crashes when sending a reaction failed
-            timeline.apply { toggleReactionLambda = toggleReactionFailure }
+            timeline.toggleReactionLambda = toggleReactionFailure
             initialState.eventSink(MessagesEvents.ToggleReaction("👍", AN_EVENT_ID.toEventOrTransactionId()))
+            advanceUntilIdle()
             assert(toggleReactionFailure)
                 .isCalledOnce()
                 .with(value("👍"), value(AN_EVENT_ID.toEventOrTransactionId()))
@@ -209,6 +214,7 @@ class MessagesPresenterTest {
             val initialState = awaitItem()
             initialState.eventSink(MessagesEvents.ToggleReaction("👍", AN_EVENT_ID.toEventOrTransactionId()))
             initialState.eventSink(MessagesEvents.ToggleReaction("👍", AN_EVENT_ID.toEventOrTransactionId()))
+            advanceUntilIdle()
             assert(toggleReactionSuccess)
                 .isCalledExactly(2)
                 .withSequence(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -35,6 +35,7 @@ import io.element.android.libraries.matrix.test.A_CAPTION
 import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.permalink.FakePermalinkBuilder
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.timeline.FakeTimeline
 import io.element.android.libraries.mediaupload.api.MediaPreProcessor
 import io.element.android.libraries.mediaupload.api.MediaSender
 import io.element.android.libraries.mediaupload.api.MediaUploadInfo
@@ -108,15 +109,18 @@ class AttachmentsPreviewPresenterTest {
     fun `present - send media success scenario`() = runTest {
         val sendFileResult =
             lambdaRecorder<File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?, Result<FakeMediaUploadHandler>> { _, _, _, _, _, _ ->
-            Result.success(FakeMediaUploadHandler())
-        }
+                Result.success(FakeMediaUploadHandler())
+            }
         val room = FakeJoinedRoom(
-            progressCallbackValues = listOf(
-                Pair(0, 10),
-                Pair(5, 10),
-                Pair(10, 10)
-            ),
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline(
+                progressCallbackValues = listOf(
+                    Pair(0, 10),
+                    Pair(5, 10),
+                    Pair(10, 10)
+                ),
+            ).apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val presenter = createAttachmentsPreviewPresenter(
@@ -146,10 +150,12 @@ class AttachmentsPreviewPresenterTest {
     fun `present - send media after pre-processing success scenario`() = runTest {
         val sendFileResult =
             lambdaRecorder<File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?, Result<FakeMediaUploadHandler>> { _, _, _, _, _, _ ->
-            Result.success(FakeMediaUploadHandler())
-        }
+                Result.success(FakeMediaUploadHandler())
+            }
         val room = FakeJoinedRoom(
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline().apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val processLatch = CompletableDeferred<Unit>()
@@ -182,10 +188,12 @@ class AttachmentsPreviewPresenterTest {
     fun `present - send media before pre-processing success scenario`() = runTest {
         val sendFileResult =
             lambdaRecorder<File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?, Result<FakeMediaUploadHandler>> { _, _, _, _, _, _ ->
-            Result.success(FakeMediaUploadHandler())
-        }
+                Result.success(FakeMediaUploadHandler())
+            }
         val room = FakeJoinedRoom(
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline().apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val processLatch = CompletableDeferred<Unit>()
@@ -298,7 +306,9 @@ class AttachmentsPreviewPresenterTest {
             givenImageResult()
         }
         val room = FakeJoinedRoom(
-            sendImageResult = sendImageResult,
+            liveTimeline = FakeTimeline().apply {
+                sendImageLambda = sendImageResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val presenter = createAttachmentsPreviewPresenter(
@@ -340,7 +350,9 @@ class AttachmentsPreviewPresenterTest {
             givenVideoResult()
         }
         val room = FakeJoinedRoom(
-            sendVideoResult = sendVideoResult,
+            liveTimeline = FakeTimeline().apply {
+                sendVideoLambda = sendVideoResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val presenter = createAttachmentsPreviewPresenter(
@@ -382,7 +394,9 @@ class AttachmentsPreviewPresenterTest {
             givenAudioResult()
         }
         val room = FakeJoinedRoom(
-            sendAudioResult = sendAudioResult,
+            liveTimeline = FakeTimeline().apply {
+                sendAudioLambda = sendAudioResult
+            },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val presenter = createAttachmentsPreviewPresenter(
@@ -416,10 +430,12 @@ class AttachmentsPreviewPresenterTest {
         val failure = MediaPreProcessor.Failure(null)
         val sendFileResult =
             lambdaRecorder<File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?, Result<FakeMediaUploadHandler>> { _, _, _, _, _, _ ->
-            Result.failure(failure)
-        }
+                Result.failure(failure)
+            }
         val room = FakeJoinedRoom(
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline().apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val presenter = createAttachmentsPreviewPresenter(room = room, mediaUploadOnSendQueueEnabled = false)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -445,11 +461,13 @@ class AttachmentsPreviewPresenterTest {
         val failure = MediaPreProcessor.Failure(null)
         val sendFileResult =
             lambdaRecorder<File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?, Result<FakeMediaUploadHandler>> { _, _, _, _, _, _ ->
-            Result.failure(failure)
-        }
+                Result.failure(failure)
+            }
         val onDoneListenerResult = lambdaRecorder<Unit> {}
         val room = FakeJoinedRoom(
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline().apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val presenter = createAttachmentsPreviewPresenter(room = room, mediaUploadOnSendQueueEnabled = true, onDoneListener = onDoneListenerResult)
         moleculeFlow(RecompositionMode.Immediate) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
@@ -384,7 +384,9 @@ class MessageComposerPresenterTest {
         val presenter = createPresenter(
             coroutineScope = this,
             room = FakeJoinedRoom(
-                sendMessageResult = { _, _, _ -> Result.success(Unit) },
+                liveTimeline = FakeTimeline().apply {
+                    sendMessageLambda = { _, _, _ -> Result.success(Unit) }
+                },
                 typingNoticeResult = { Result.success(Unit) }
             ),
         )
@@ -418,7 +420,9 @@ class MessageComposerPresenterTest {
             coroutineScope = this,
             isRichTextEditorEnabled = false,
             room = FakeJoinedRoom(
-                sendMessageResult = { _, _, _ -> Result.success(Unit) },
+                liveTimeline = FakeTimeline().apply {
+                    sendMessageLambda = { _, _, _ -> Result.success(Unit) }
+                },
                 typingNoticeResult = { Result.success(Unit) }
             ),
         )
@@ -1118,16 +1122,16 @@ class MessageComposerPresenterTest {
         val editMessageLambda = lambdaRecorder { _: EventOrTransactionId, _: String, _: String?, _: List<IntentionalMention> ->
             Result.success(Unit)
         }
-        val timeline = FakeTimeline().apply {
-            this.replyMessageLambda = replyMessageLambda
-            this.editMessageLambda = editMessageLambda
-        }
         val sendMessageResult = lambdaRecorder { _: String, _: String?, _: List<IntentionalMention> ->
             Result.success(Unit)
         }
+        val timeline = FakeTimeline().apply {
+            this.replyMessageLambda = replyMessageLambda
+            this.editMessageLambda = editMessageLambda
+            sendMessageLambda = sendMessageResult
+        }
         val room = FakeJoinedRoom(
             liveTimeline = timeline,
-            sendMessageResult = sendMessageResult,
             typingNoticeResult = { Result.success(Unit) }
         )
         val presenter = createPresenter(room = room, coroutineScope = this)

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/VoiceMessageComposerPresenterTest.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.matrix.api.media.AudioInfo
 import io.element.android.libraries.matrix.api.room.message.ReplyParameters
 import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.timeline.FakeTimeline
 import io.element.android.libraries.mediaplayer.test.FakeMediaPlayer
 import io.element.android.libraries.mediaupload.api.MediaSender
 import io.element.android.libraries.mediaupload.test.FakeMediaPreProcessor
@@ -45,6 +46,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -65,7 +67,9 @@ class VoiceMessageComposerPresenterTest {
             Result.success(FakeMediaUploadHandler())
         }
     private val joinedRoom = FakeJoinedRoom(
-        sendVoiceMessageResult = sendVoiceMessageResult
+        liveTimeline = FakeTimeline().apply {
+            sendVoiceMessageLambda = sendVoiceMessageResult
+        },
     )
     private val mediaPreProcessor = FakeMediaPreProcessor().apply { givenAudioResult() }
     private val mediaSender = MediaSender(mediaPreProcessor, joinedRoom, InMemorySessionPreferencesStore())
@@ -295,7 +299,6 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecorderEvent(VoiceMessageRecorderEvent.Stop))
             awaitItem().eventSink(VoiceMessageComposerEvents.SendVoiceMessage)
             assertThat(awaitItem().voiceMessageState).isEqualTo(aPreviewState().toSendingState())
-
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isCalledOnce()
@@ -317,7 +320,7 @@ class VoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvents.RecorderEvent(VoiceMessageRecorderEvent.Stop))
             awaitItem().eventSink(VoiceMessageComposerEvents.SendVoiceMessage)
             skipItems(1) // Sending state
-
+            advanceUntilIdle()
             // Now reply with a voice message
             messageComposerContext.composerMode = aReplyMode()
             awaitItem().eventSink(VoiceMessageComposerEvents.RecorderEvent(VoiceMessageRecorderEvent.Start))
@@ -653,7 +656,7 @@ class VoiceMessageComposerPresenterTest {
         permissionsPresenter: PermissionsPresenter = createFakePermissionsPresenter(),
     ): VoiceMessageComposerPresenter {
         return VoiceMessageComposerPresenter(
-            this,
+            backgroundScope,
             voiceRecorder,
             analyticsService,
             mediaSender,

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/actions/DefaultEndPollAction.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/actions/DefaultEndPollAction.kt
@@ -22,7 +22,7 @@ class DefaultEndPollAction @Inject constructor(
     private val analyticsService: AnalyticsService,
 ) : EndPollAction {
     override suspend fun execute(pollStartId: EventId): Result<Unit> {
-        return room.endPoll(
+        return room.liveTimeline.endPoll(
             pollStartId = pollStartId,
             text = "The poll with event id: $pollStartId has ended."
         ).onSuccess {

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/actions/DefaultSendPollResponseAction.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/actions/DefaultSendPollResponseAction.kt
@@ -22,7 +22,7 @@ class DefaultSendPollResponseAction @Inject constructor(
     private val analyticsService: AnalyticsService,
 ) : SendPollResponseAction {
     override suspend fun execute(pollStartId: EventId, answerId: String): Result<Unit> {
-        return room.sendPollResponse(
+        return room.liveTimeline.sendPollResponse(
             pollStartId = pollStartId,
             answers = listOf(answerId),
         ).onSuccess {

--- a/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/data/PollRepository.kt
+++ b/features/poll/impl/src/main/kotlin/io/element/android/features/poll/impl/data/PollRepository.kt
@@ -41,7 +41,7 @@ class PollRepository @Inject constructor(
         pollKind: PollKind,
         maxSelections: Int,
     ): Result<Unit> = when (existingPollId) {
-        null -> room.createPoll(
+        null -> room.liveTimeline.createPoll(
             question = question,
             answers = answers,
             maxSelections = maxSelections,

--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
@@ -94,7 +94,7 @@ class SharePresenter @AssistedInject constructor(
                 onPlainText = { text ->
                     roomIds
                         .map { roomId ->
-                            matrixClient.getJoinedRoom(roomId)?.sendMessage(
+                            matrixClient.getJoinedRoom(roomId)?.liveTimeline?.sendMessage(
                                 body = text,
                                 htmlBody = null,
                                 intentionalMentions = emptyList(),

--- a/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/SharePresenterTest.kt
+++ b/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/SharePresenterTest.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.timeline.FakeTimeline
 import io.element.android.libraries.mediaupload.api.MediaPreProcessor
 import io.element.android.libraries.mediaupload.test.FakeMediaPreProcessor
 import io.element.android.libraries.preferences.test.InMemorySessionPreferencesStore
@@ -91,7 +92,9 @@ class SharePresenterTest {
     @Test
     fun `present - send text ok`() = runTest {
         val joinedRoom = FakeJoinedRoom(
-            sendMessageResult = { _, _, _ -> Result.success(Unit) },
+            liveTimeline = FakeTimeline().apply {
+                sendMessageLambda = { _, _, _ -> Result.success(Unit) }
+            },
         )
         val matrixClient = FakeMatrixClient().apply {
             givenGetRoomResult(A_ROOM_ID, joinedRoom)
@@ -122,7 +125,9 @@ class SharePresenterTest {
             Result.success(FakeMediaUploadHandler())
         }
         val joinedRoom = FakeJoinedRoom(
-            sendFileResult = sendFileResult,
+            liveTimeline = FakeTimeline().apply {
+                sendFileLambda = sendFileResult
+            },
         )
         val matrixClient = FakeMatrixClient().apply {
             givenGetRoomResult(A_ROOM_ID, joinedRoom)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
@@ -9,34 +9,21 @@ package io.element.android.libraries.matrix.api.room
 
 import io.element.android.libraries.matrix.api.core.DeviceId
 import io.element.android.libraries.matrix.api.core.EventId
-import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SendHandle
-import io.element.android.libraries.matrix.api.core.TransactionId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityStateChange
-import io.element.android.libraries.matrix.api.media.AudioInfo
-import io.element.android.libraries.matrix.api.media.FileInfo
-import io.element.android.libraries.matrix.api.media.ImageInfo
-import io.element.android.libraries.matrix.api.media.MediaUploadHandler
-import io.element.android.libraries.matrix.api.media.VideoInfo
-import io.element.android.libraries.matrix.api.poll.PollKind
 import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.knock.KnockRequest
-import io.element.android.libraries.matrix.api.room.location.AssetType
-import io.element.android.libraries.matrix.api.room.message.ReplyParameters
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevels
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import io.element.android.libraries.matrix.api.timeline.Timeline
-import io.element.android.libraries.matrix.api.timeline.item.event.EventOrTransactionId
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import java.io.File
 
 interface JoinedRoom : BaseRoom {
     val syncUpdateFlow: StateFlow<Long>
@@ -63,134 +50,13 @@ interface JoinedRoom : BaseRoom {
         createTimelineParams: CreateTimelineParams,
     ): Result<Timeline>
 
-    suspend fun sendMessage(body: String, htmlBody: String?, intentionalMentions: List<IntentionalMention>): Result<Unit>
-
     suspend fun editMessage(eventId: EventId, body: String, htmlBody: String?, intentionalMentions: List<IntentionalMention>): Result<Unit>
-
-    suspend fun sendImage(
-        file: File,
-        thumbnailFile: File?,
-        imageInfo: ImageInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler>
-
-    suspend fun sendVideo(
-        file: File,
-        thumbnailFile: File?,
-        videoInfo: VideoInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler>
-
-    suspend fun sendAudio(
-        file: File,
-        audioInfo: AudioInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler>
-
-    suspend fun sendFile(
-        file: File,
-        fileInfo: FileInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler>
-
-    suspend fun sendVoiceMessage(
-        file: File,
-        audioInfo: AudioInfo,
-        waveform: List<Float>,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler>
-
-    /**
-     * Share a location message in the room.
-     *
-     * @param body A human readable textual representation of the location.
-     * @param geoUri A geo URI (RFC 5870) representing the location e.g. `geo:51.5008,0.1247;u=35`.
-     *  Respectively: latitude, longitude, and (optional) uncertainty.
-     * @param description Optional description of the location to display to the user.
-     * @param zoomLevel Optional zoom level to display the map at.
-     * @param assetType Optional type of the location asset.
-     *  Set to SENDER if sharing own location. Set to PIN if sharing any location.
-     */
-    suspend fun sendLocation(
-        body: String,
-        geoUri: String,
-        description: String? = null,
-        zoomLevel: Int? = null,
-        assetType: AssetType? = null,
-    ): Result<Unit>
-
-    /**
-     * Create a poll in the room.
-     *
-     * @param question The question to ask.
-     * @param answers The list of answers.
-     * @param maxSelections The maximum number of answers that can be selected.
-     * @param pollKind The kind of poll to create.
-     */
-    suspend fun createPoll(
-        question: String,
-        answers: List<String>,
-        maxSelections: Int,
-        pollKind: PollKind,
-    ): Result<Unit>
-
-    /**
-     * Edit a poll in the room.
-     *
-     * @param pollStartId The event ID of the poll start event.
-     * @param question The question to ask.
-     * @param answers The list of answers.
-     * @param maxSelections The maximum number of answers that can be selected.
-     * @param pollKind The kind of poll to create.
-     */
-    suspend fun editPoll(
-        pollStartId: EventId,
-        question: String,
-        answers: List<String>,
-        maxSelections: Int,
-        pollKind: PollKind,
-    ): Result<Unit>
-
-    /**
-     * Send a response to a poll.
-     *
-     * @param pollStartId The event ID of the poll start event.
-     * @param answers The list of answer ids to send.
-     */
-    suspend fun sendPollResponse(pollStartId: EventId, answers: List<String>): Result<Unit>
-
-    /**
-     * Ends a poll in the room.
-     *
-     * @param pollStartId The event ID of the poll start event.
-     * @param text Fallback text of the poll end event.
-     */
-    suspend fun endPoll(pollStartId: EventId, text: String): Result<Unit>
 
     /**
      * Send a typing notification.
      * @param isTyping True if the user is typing, false otherwise.
      */
     suspend fun typingNotice(isTyping: Boolean): Result<Unit>
-
-    suspend fun toggleReaction(emoji: String, eventOrTransactionId: EventOrTransactionId): Result<Unit>
-
-    suspend fun forwardEvent(eventId: EventId, roomIds: List<RoomId>): Result<Unit>
-
-    suspend fun cancelSend(transactionId: TransactionId): Result<Unit>
 
     suspend fun inviteUserById(id: UserId): Result<Unit>
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -13,20 +13,11 @@ import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.matrix.api.core.DeviceId
 import io.element.android.libraries.matrix.api.core.EventId
-import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SendHandle
-import io.element.android.libraries.matrix.api.core.TransactionId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityStateChange
-import io.element.android.libraries.matrix.api.media.AudioInfo
-import io.element.android.libraries.matrix.api.media.FileInfo
-import io.element.android.libraries.matrix.api.media.ImageInfo
-import io.element.android.libraries.matrix.api.media.MediaUploadHandler
-import io.element.android.libraries.matrix.api.media.VideoInfo
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
-import io.element.android.libraries.matrix.api.poll.PollKind
 import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.CreateTimelineParams
 import io.element.android.libraries.matrix.api.room.IntentionalMention
@@ -35,14 +26,11 @@ import io.element.android.libraries.matrix.api.room.RoomNotificationSettingsStat
 import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.knock.KnockRequest
-import io.element.android.libraries.matrix.api.room.location.AssetType
-import io.element.android.libraries.matrix.api.room.message.ReplyParameters
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevels
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.room.roomNotificationSettings
 import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import io.element.android.libraries.matrix.api.timeline.Timeline
-import io.element.android.libraries.matrix.api.timeline.item.event.EventOrTransactionId
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
 import io.element.android.libraries.matrix.impl.core.RustSendHandle
@@ -84,7 +72,6 @@ import org.matrix.rustcomponents.sdk.getElementCallRequiredPermissions
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import uniffi.matrix_sdk.RoomPowerLevelChanges
-import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
 import org.matrix.rustcomponents.sdk.IdentityStatusChange as RustIdentityStateChange
 import org.matrix.rustcomponents.sdk.KnockRequest as InnerKnockRequest
@@ -249,10 +236,6 @@ class JoinedRustRoom(
         }
     }
 
-    override suspend fun sendMessage(body: String, htmlBody: String?, intentionalMentions: List<IntentionalMention>): Result<Unit> {
-        return liveTimeline.sendMessage(body, htmlBody, intentionalMentions)
-    }
-
     override suspend fun editMessage(
         eventId: EventId,
         body: String,
@@ -266,157 +249,10 @@ class JoinedRustRoom(
         }
     }
 
-    override suspend fun sendImage(
-        file: File,
-        thumbnailFile: File?,
-        imageInfo: ImageInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> {
-        return liveTimeline.sendImage(
-            file = file,
-            thumbnailFile = thumbnailFile,
-            imageInfo = imageInfo,
-            caption = caption,
-            formattedCaption = formattedCaption,
-            progressCallback = progressCallback,
-            replyParameters = replyParameters
-        )
-    }
-
-    override suspend fun sendVideo(
-        file: File,
-        thumbnailFile: File?,
-        videoInfo: VideoInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> {
-        return liveTimeline.sendVideo(
-            file = file,
-            thumbnailFile = thumbnailFile,
-            videoInfo = videoInfo,
-            caption = caption,
-            formattedCaption = formattedCaption,
-            progressCallback = progressCallback,
-            replyParameters = replyParameters
-        )
-    }
-
-    override suspend fun sendAudio(
-        file: File,
-        audioInfo: AudioInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> {
-        return liveTimeline.sendAudio(
-            file = file,
-            audioInfo = audioInfo,
-            caption = caption,
-            formattedCaption = formattedCaption,
-            progressCallback = progressCallback,
-            replyParameters = replyParameters,
-        )
-    }
-
-    override suspend fun sendFile(
-        file: File,
-        fileInfo: FileInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> {
-        return liveTimeline.sendFile(
-            file = file,
-            fileInfo = fileInfo,
-            caption = caption,
-            formattedCaption = formattedCaption,
-            progressCallback = progressCallback,
-            replyParameters = replyParameters,
-        )
-    }
-
-    override suspend fun sendVoiceMessage(
-        file: File,
-        audioInfo: AudioInfo,
-        waveform: List<Float>,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> {
-        return liveTimeline.sendVoiceMessage(
-            file = file,
-            audioInfo = audioInfo,
-            waveform = waveform,
-            progressCallback = progressCallback,
-            replyParameters = replyParameters,
-        )
-    }
-
-    override suspend fun sendLocation(
-        body: String,
-        geoUri: String,
-        description: String?,
-        zoomLevel: Int?,
-        assetType: AssetType?,
-    ): Result<Unit> {
-        return liveTimeline.sendLocation(body, geoUri, description, zoomLevel, assetType)
-    }
-
-    override suspend fun createPoll(
-        question: String,
-        answers: List<String>,
-        maxSelections: Int,
-        pollKind: PollKind,
-    ): Result<Unit> {
-        return liveTimeline.createPoll(question, answers, maxSelections, pollKind)
-    }
-
-    override suspend fun editPoll(
-        pollStartId: EventId,
-        question: String,
-        answers: List<String>,
-        maxSelections: Int,
-        pollKind: PollKind,
-    ): Result<Unit> {
-        return liveTimeline.editPoll(pollStartId, question, answers, maxSelections, pollKind)
-    }
-
-    override suspend fun sendPollResponse(
-        pollStartId: EventId,
-        answers: List<String>
-    ): Result<Unit> {
-        return liveTimeline.sendPollResponse(pollStartId, answers)
-    }
-
-    override suspend fun endPoll(
-        pollStartId: EventId,
-        text: String
-    ): Result<Unit> {
-        return liveTimeline.endPoll(pollStartId, text)
-    }
-
     override suspend fun typingNotice(isTyping: Boolean) = withContext(roomDispatcher) {
         runCatching {
             innerRoom.typingNotice(isTyping)
         }
-    }
-
-    override suspend fun toggleReaction(emoji: String, eventOrTransactionId: EventOrTransactionId): Result<Unit> {
-        return liveTimeline.toggleReaction(emoji, eventOrTransactionId)
-    }
-
-    override suspend fun forwardEvent(eventId: EventId, roomIds: List<RoomId>): Result<Unit> {
-        return liveTimeline.forwardEvent(eventId, roomIds)
-    }
-
-    override suspend fun cancelSend(transactionId: TransactionId): Result<Unit> {
-        return liveTimeline.cancelSend(transactionId)
     }
 
     override suspend fun inviteUserById(id: UserId): Result<Unit> = withContext(roomDispatcher) {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeJoinedRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeJoinedRoom.kt
@@ -12,17 +12,9 @@ import io.element.android.libraries.matrix.api.core.DeviceId
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.core.RoomAlias
-import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SendHandle
-import io.element.android.libraries.matrix.api.core.TransactionId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityStateChange
-import io.element.android.libraries.matrix.api.media.AudioInfo
-import io.element.android.libraries.matrix.api.media.FileInfo
-import io.element.android.libraries.matrix.api.media.ImageInfo
-import io.element.android.libraries.matrix.api.media.MediaUploadHandler
-import io.element.android.libraries.matrix.api.media.VideoInfo
-import io.element.android.libraries.matrix.api.poll.PollKind
 import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.CreateTimelineParams
 import io.element.android.libraries.matrix.api.room.IntentionalMention
@@ -33,16 +25,12 @@ import io.element.android.libraries.matrix.api.room.RoomNotificationSettingsStat
 import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.knock.KnockRequest
-import io.element.android.libraries.matrix.api.room.location.AssetType
-import io.element.android.libraries.matrix.api.room.message.ReplyParameters
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevels
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import io.element.android.libraries.matrix.api.timeline.Timeline
-import io.element.android.libraries.matrix.api.timeline.item.event.EventOrTransactionId
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetDriver
 import io.element.android.libraries.matrix.api.widget.MatrixWidgetSettings
-import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.timeline.FakeTimeline
 import io.element.android.tests.testutils.lambda.lambdaError
@@ -53,7 +41,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.TestScope
-import java.io.File
 
 class FakeJoinedRoom(
     val baseRoom: FakeBaseRoom = FakeBaseRoom(),
@@ -63,35 +50,16 @@ class FakeJoinedRoom(
     override val roomTypingMembersFlow: Flow<List<UserId>> = MutableStateFlow(emptyList()),
     override val identityStateChangesFlow: Flow<List<IdentityStateChange>> = MutableStateFlow(emptyList()),
     override val roomNotificationSettingsStateFlow: StateFlow<RoomNotificationSettingsState> =
-    MutableStateFlow(RoomNotificationSettingsState.Unknown),
+        MutableStateFlow(RoomNotificationSettingsState.Unknown),
     override val knockRequestsFlow: Flow<List<KnockRequest>> = MutableStateFlow(emptyList()),
     private val roomNotificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
     private var createTimelineResult: (CreateTimelineParams) -> Result<Timeline> = { lambdaError() },
-    private val sendMessageResult: (String, String?, List<IntentionalMention>) -> Result<Unit> = { _, _, _ -> lambdaError() },
     private val editMessageLambda: (EventId, String, String?, List<IntentionalMention>) -> Result<Unit> = { _, _, _, _ -> lambdaError() },
-    private val sendImageResult: (File, File?, ImageInfo, String?, String?, ProgressCallback?, ReplyParameters?) -> Result<FakeMediaUploadHandler> =
-        { _, _, _, _, _, _, _ -> lambdaError() },
-    private val sendVideoResult: (File, File?, VideoInfo, String?, String?, ProgressCallback?, ReplyParameters?) -> Result<FakeMediaUploadHandler> =
-        { _, _, _, _, _, _, _ -> lambdaError() },
-    private val sendFileResult: (File, FileInfo, String?, String?, ProgressCallback?, ReplyParameters?) -> Result<FakeMediaUploadHandler> =
-        { _, _, _, _, _, _ -> lambdaError() },
-    private val sendAudioResult: (File, AudioInfo, String?, String?, ProgressCallback?, ReplyParameters?) -> Result<FakeMediaUploadHandler> =
-        { _, _, _, _, _, _ -> lambdaError() },
-    private val sendVoiceMessageResult: (File, AudioInfo, List<Float>, ProgressCallback?, ReplyParameters?) -> Result<FakeMediaUploadHandler> =
-        { _, _, _, _, _ -> lambdaError() },
-    private val sendLocationResult: (String, String, String?, Int?, AssetType?) -> Result<Unit> = { _, _, _, _, _ -> lambdaError() },
     private val sendCallNotificationIfNeededResult: () -> Result<Unit> = { lambdaError() },
     private val progressCallbackValues: List<Pair<Long, Long>> = emptyList(),
-    private val createPollResult: (String, List<String>, Int, PollKind) -> Result<Unit> = { _, _, _, _ -> lambdaError() },
-    private val editPollResult: (EventId, String, List<String>, Int, PollKind) -> Result<Unit> = { _, _, _, _, _ -> lambdaError() },
-    private val sendPollResponseResult: (EventId, List<String>) -> Result<Unit> = { _, _ -> lambdaError() },
-    private val endPollResult: (EventId, String) -> Result<Unit> = { _, _ -> lambdaError() },
     private val generateWidgetWebViewUrlResult: (MatrixWidgetSettings, String, String?, String?) -> Result<String> = { _, _, _, _ -> lambdaError() },
     private val getWidgetDriverResult: (MatrixWidgetSettings) -> Result<MatrixWidgetDriver> = { lambdaError() },
     private val typingNoticeResult: (Boolean) -> Result<Unit> = { lambdaError() },
-    private val toggleReactionResult: (String, EventOrTransactionId) -> Result<Unit> = { _, _ -> lambdaError() },
-    private val forwardEventResult: (EventId, List<RoomId>) -> Result<Unit> = { _, _ -> lambdaError() },
-    private val cancelSendResult: (TransactionId) -> Result<Unit> = { lambdaError() },
     private val inviteUserResult: (UserId) -> Result<Unit> = { lambdaError() },
     private val setNameResult: (String) -> Result<Unit> = { lambdaError() },
     private val setTopicResult: (String) -> Result<Unit> = { lambdaError() },
@@ -127,10 +95,6 @@ class FakeJoinedRoom(
         createTimelineResult(createTimelineParams)
     }
 
-    override suspend fun sendMessage(body: String, htmlBody: String?, intentionalMentions: List<IntentionalMention>): Result<Unit> = simulateLongTask {
-        sendMessageResult(body, htmlBody, intentionalMentions)
-    }
-
     override suspend fun editMessage(
         eventId: EventId,
         body: String,
@@ -140,172 +104,8 @@ class FakeJoinedRoom(
         editMessageLambda(eventId, body, htmlBody, intentionalMentions)
     }
 
-    override suspend fun sendImage(
-        file: File,
-        thumbnailFile: File?,
-        imageInfo: ImageInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> = simulateLongTask {
-        simulateSendMediaProgress(progressCallback)
-        sendImageResult(
-            file,
-            thumbnailFile,
-            imageInfo,
-            caption,
-            formattedCaption,
-            progressCallback,
-            replyParameters,
-        )
-    }
-
-    override suspend fun sendVideo(
-        file: File,
-        thumbnailFile: File?,
-        videoInfo: VideoInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> = simulateLongTask {
-        simulateSendMediaProgress(progressCallback)
-        sendVideoResult(
-            file,
-            thumbnailFile,
-            videoInfo,
-            caption,
-            formattedCaption,
-            progressCallback,
-            replyParameters,
-        )
-    }
-
-    override suspend fun sendAudio(
-        file: File,
-        audioInfo: AudioInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> = simulateLongTask {
-        simulateSendMediaProgress(progressCallback)
-        sendAudioResult(
-            file,
-            audioInfo,
-            caption,
-            formattedCaption,
-            progressCallback,
-            replyParameters,
-        )
-    }
-
-    override suspend fun sendFile(
-        file: File,
-        fileInfo: FileInfo,
-        caption: String?,
-        formattedCaption: String?,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> = simulateLongTask {
-        simulateSendMediaProgress(progressCallback)
-        sendFileResult(
-            file,
-            fileInfo,
-            caption,
-            formattedCaption,
-            progressCallback,
-            replyParameters,
-        )
-    }
-
-    override suspend fun sendVoiceMessage(
-        file: File,
-        audioInfo: AudioInfo,
-        waveform: List<Float>,
-        progressCallback: ProgressCallback?,
-        replyParameters: ReplyParameters?,
-    ): Result<MediaUploadHandler> = simulateLongTask {
-        simulateSendMediaProgress(progressCallback)
-        sendVoiceMessageResult(
-            file,
-            audioInfo,
-            waveform,
-            progressCallback,
-            replyParameters,
-        )
-    }
-
-    override suspend fun sendLocation(
-        body: String,
-        geoUri: String,
-        description: String?,
-        zoomLevel: Int?,
-        assetType: AssetType?,
-    ): Result<Unit> = simulateLongTask {
-        return sendLocationResult(
-            body,
-            geoUri,
-            description,
-            zoomLevel,
-            assetType,
-        )
-    }
-
-    override suspend fun createPoll(question: String, answers: List<String>, maxSelections: Int, pollKind: PollKind): Result<Unit> = simulateLongTask {
-        return createPollResult(
-            question,
-            answers,
-            maxSelections,
-            pollKind,
-        )
-    }
-
-    override suspend fun editPoll(
-        pollStartId: EventId,
-        question: String,
-        answers: List<String>,
-        maxSelections: Int,
-        pollKind: PollKind
-    ): Result<Unit> = simulateLongTask {
-        return editPollResult(
-            pollStartId,
-            question,
-            answers,
-            maxSelections,
-            pollKind,
-        )
-    }
-
-    override suspend fun sendPollResponse(pollStartId: EventId, answers: List<String>): Result<Unit> = simulateLongTask {
-        return sendPollResponseResult(
-            pollStartId,
-            answers,
-        )
-    }
-
-    override suspend fun endPoll(pollStartId: EventId, text: String): Result<Unit> = simulateLongTask {
-        endPollResult(
-            pollStartId,
-            text,
-        )
-    }
-
     override suspend fun typingNotice(isTyping: Boolean): Result<Unit> = simulateLongTask {
         typingNoticeResult(isTyping)
-    }
-
-    override suspend fun toggleReaction(emoji: String, eventOrTransactionId: EventOrTransactionId): Result<Unit> = simulateLongTask {
-        toggleReactionResult(emoji, eventOrTransactionId)
-    }
-
-    override suspend fun forwardEvent(eventId: EventId, roomIds: List<RoomId>): Result<Unit> = simulateLongTask {
-        forwardEventResult(eventId, roomIds)
-    }
-
-    override suspend fun cancelSend(transactionId: TransactionId): Result<Unit> = simulateLongTask {
-        cancelSendResult(transactionId)
     }
 
     override suspend fun inviteUserById(id: UserId): Result<Unit> = simulateLongTask {

--- a/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
+++ b/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
@@ -13,6 +13,7 @@ import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.media.MediaUploadHandler
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.message.ReplyParameters
+import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -49,7 +50,7 @@ class MediaSender @Inject constructor(
         progressCallback: ProgressCallback?,
         replyParameters: ReplyParameters?,
     ): Result<Unit> {
-        return room.sendMedia(
+        return room.liveTimeline.sendMedia(
             uploadInfo = mediaUploadInfo,
             progressCallback = progressCallback,
             caption = caption,
@@ -76,7 +77,7 @@ class MediaSender @Inject constructor(
                 compressIfPossible = compressIfPossible,
             )
             .flatMapCatching { info ->
-                room.sendMedia(
+                room.liveTimeline.sendMedia(
                     uploadInfo = info,
                     progressCallback = progressCallback,
                     caption = caption,
@@ -108,7 +109,7 @@ class MediaSender @Inject constructor(
                     audioInfo = audioInfo,
                     waveform = waveForm,
                 )
-                room.sendMedia(
+                room.liveTimeline.sendMedia(
                     uploadInfo = newInfo,
                     progressCallback = progressCallback,
                     caption = null,
@@ -130,7 +131,7 @@ class MediaSender @Inject constructor(
             ongoingUploadJobs.remove(Job)
         }
 
-    private suspend fun JoinedRoom.sendMedia(
+    private suspend fun Timeline.sendMedia(
         uploadInfo: MediaUploadInfo,
         progressCallback: ProgressCallback?,
         caption: String?,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
@@ -366,7 +366,7 @@ class NotificationBroadcastReceiverHandlerTest {
                 roomId = A_ROOM_ID,
             ),
         )
-        runCurrent()
+        advanceUntilIdle()
         sendMessage.assertions()
             .isCalledOnce()
             .with(value(A_MESSAGE), value(null), value(emptyList<IntentionalMention>()))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Reduce API of `JoinedRoom`, caller must use the Timeline API from `liveTimeline` instead

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Removes lots of boilerplate code
Improve test coverage.

<img width="327" alt="image" src="https://github.com/user-attachments/assets/56eec1ab-1842-40f0-b81e-d435cbe75b64" />

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- No particular thing to check

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
