### PR TITLE
fix: Ignore global proxy settings if system thinks there's none

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/proxy/DefaultProxyProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/proxy/DefaultProxyProvider.kt
@@ -8,7 +8,9 @@
 package io.element.android.libraries.matrix.impl.proxy
 
 import android.content.Context
+import android.net.ConnectivityManager
 import android.provider.Settings
+import androidx.core.content.getSystemService
 import com.squareup.anvil.annotations.ContributesBinding
 import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.di.ApplicationContext
@@ -32,6 +34,13 @@ class DefaultProxyProvider @Inject constructor(
     private val context: Context
 ) : ProxyProvider {
     override fun provides(): String? {
+        val defaultProxy = context.getSystemService<ConnectivityManager>()?.defaultProxy
+        if (defaultProxy == null) {
+            // Note: can be tested by running:
+            // adb shell settings put global http_proxy :0
+            Timber.d("No default proxy")
+            return null
+        }
         return Settings.Global.getString(context.contentResolver, Settings.Global.HTTP_PROXY)
             ?.also {
                 Timber.d("Using global proxy")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ignore global proxy settings from `Settings.Global.getString(context.contentResolver, Settings.Global.HTTP_PROXY)` if the system says we have no proxy

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes #3447

See https://github.com/element-hq/element-x-android/issues/3447#issuecomment-2841110041 for technical details.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1: In the provisioned device, Run `adb shell settings put global http_proxy :0`
- Step 2: Check if Element X Android can select a identity provider without saying `We couldn't reach the homeserver`

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
