### PR TITLE
Use the right live timeline instance in `RustRoomFactory`

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -84,12 +84,7 @@ class RustRoomFactory(
     }
 
     private suspend fun getBaseRoom(roomListItem: RoomListItem): RustBaseRoom? {
-        val room = if (roomListItem.isTimelineInitialized()) {
-            roomListItem.fullRoom()
-        } else {
-            innerClient.getRoom(roomListItem.id())
-        } ?: return null
-
+        val room = innerClient.getRoom(roomListItem.id()) ?: return null
         val initialRoomInfo = room.roomInfo()
         return RustBaseRoom(
             sessionId = sessionId,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -114,11 +114,7 @@ class RustRoomFactory(
 
             if (roomListItem.membership() == Membership.JOINED) {
                 // Init the live timeline in the SDK from the RoomListItem
-                val sdkRoom = if (!roomListItem.isTimelineInitialized()) {
-                    roomListItem.fullRoomWithTimeline(eventFilters)
-                } else {
-                    roomListItem.fullRoom()
-                }
+                val sdkRoom = roomListItem.fullRoomWithTimeline(eventFilters)
 
                 GetRoomResult.Joined(
                     JoinedRustRoom(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -78,8 +78,8 @@ class RustRoomFactory(
                 Timber.d("Room factory is destroyed, returning null for $roomId")
                 return@withContext null
             }
-            val roomReferences = awaitRoomListItem(roomId) ?: return@withContext null
-            getBaseRoom(roomReferences)
+            val roomListItem = awaitRoomListItem(roomId) ?: return@withContext null
+            getBaseRoom(roomListItem)
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- `RustRoomFactory` now uses the right live timeline when returning a joined room.
- Removed `RustRoomReferences` helper class.

## Motivation and context

Otherwise, some parameters like the initial events and event filters are ignored.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room.
- Start a call, then end it once the EC UI appears.
- You should see the 'call started' event in the timeline but should not see the call member events (hidden by the timeline event filter).
- The room should also load a bit faster.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
