### PR TITLE
Maestro: fix MAS and EC breaking the tests

### DIFF
--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -11,7 +11,7 @@ env:
   CI_GRADLE_ARG_PROPERTIES: --stacktrace --no-daemon -Dsonar.gradle.skipCompile=true --no-configuration-cache
   ARCH: x86_64
   DEVICE: pixel_7_pro
-  API_LEVEL: 30
+  API_LEVEL: 33
   TARGET: google_apis
 
 jobs:

--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -11,7 +11,7 @@ env:
   CI_GRADLE_ARG_PROPERTIES: --stacktrace --no-daemon -Dsonar.gradle.skipCompile=true --no-configuration-cache
   ARCH: x86_64
   DEVICE: pixel_7_pro
-  API_LEVEL: 35
+  API_LEVEL: 31
   TARGET: google_apis
 
 jobs:

--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -11,7 +11,7 @@ env:
   CI_GRADLE_ARG_PROPERTIES: --stacktrace --no-daemon -Dsonar.gradle.skipCompile=true --no-configuration-cache
   ARCH: x86_64
   DEVICE: pixel_7_pro
-  API_LEVEL: 31
+  API_LEVEL: 30
   TARGET: google_apis
 
 jobs:

--- a/.maestro/allTests.yaml
+++ b/.maestro/allTests.yaml
@@ -1,4 +1,5 @@
 appId: ${MAESTRO_APP_ID}
+androidWebViewHierarchy: devtools
 ---
 ## Check that all env variables required in the whole test suite are declared (to fail faster)
 - runScript: ./scripts/checkEnv.js

--- a/.maestro/tests/account/login.yaml
+++ b/.maestro/tests/account/login.yaml
@@ -15,6 +15,11 @@ appId: ${MAESTRO_APP_ID}
     commands:
       - tapOn: "Use without an account"
 ## Working when running Maestro locally, but not on the CI yet.
+- scroll
+- extendedWaitUntil:
+      visible:
+        id: "form-1"
+      timeout: 10000
 - tapOn:
    id: "form-1"
 - inputText: ${MAESTRO_USERNAME}

--- a/.maestro/tests/account/login.yaml
+++ b/.maestro/tests/account/login.yaml
@@ -14,6 +14,11 @@ appId: ${MAESTRO_APP_ID}
       visible: 'Use without an account'
     commands:
       - tapOn: "Use without an account"
+- runFlow:
+    when:
+      visible: 'Accept & continue'
+    commands:
+      - tapOn: "Accept & continue"
 ## Working when running Maestro locally, but not on the CI yet.
 - scroll
 - extendedWaitUntil:

--- a/.maestro/tests/account/login.yaml
+++ b/.maestro/tests/account/login.yaml
@@ -26,7 +26,6 @@ appId: ${MAESTRO_APP_ID}
     commands:
       - tapOn: "No thanks"
 ## Working when running Maestro locally, but not on the CI yet.
-- scroll
 - extendedWaitUntil:
       visible:
         id: "form-1"

--- a/.maestro/tests/account/login.yaml
+++ b/.maestro/tests/account/login.yaml
@@ -14,11 +14,17 @@ appId: ${MAESTRO_APP_ID}
       visible: 'Use without an account'
     commands:
       - tapOn: "Use without an account"
+## For older chrome versions
 - runFlow:
     when:
       visible: 'Accept & continue'
     commands:
       - tapOn: "Accept & continue"
+- runFlow:
+    when:
+      visible: 'No thanks'
+    commands:
+      - tapOn: "No thanks"
 ## Working when running Maestro locally, but not on the CI yet.
 - scroll
 - extendedWaitUntil:


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

For the Maestro tests:
- Enables the webview devtools flag.
- Downgrades the emulator API level to 33 (min version supported by it).
- Adds extra pause for the first login form to appear.

I'd love to test a bit more and pinpoint the issue, but I think we already spent too much time on this, so as long as it works...

## Motivation and context

Fix the failing Maestro CI jobs.

## Tests

It worked twice already, let's hope it doesn't fail on the 3rd try 🤞 .

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
