### PR TITLE
Use Localazy's `langAliases` for Indonesian language

### DIFF
--- a/tools/localazy/downloadStrings.sh
+++ b/tools/localazy/downloadStrings.sh
@@ -38,14 +38,6 @@ if [[ $allFiles == 1 ]]; then
   find . -name 'translations.xml' -exec ./tools/localazy/formatXmlResourcesFile.py {} \;
 fi
 
-set +e
-echo "Moving files from values-id to values-in..."
-find . -type d -name 'values-id' -execdir mv {}/translations.xml {}/../values-in/translations.xml \; 2> /dev/null
-
-echo "Deleting all the folders values-id..."
-find . -type d -name 'values-id' -exec rm -rf {} \; 2> /dev/null
-set -e
-
 echo "Checking forbidden terms..."
 find . -name 'localazy.xml' -exec ./tools/localazy/checkForbiddenTerms.py {} \;
 if [[ $allFiles == 1 ]]; then

--- a/tools/localazy/generateLocalazyConfig.py
+++ b/tools/localazy/generateLocalazyConfig.py
@@ -65,7 +65,10 @@ for entry in config["modules"]:
             "excludeKeys": list(map(lambda i: "REGEX:" + i, excludeRegex)),
             "conditions": [
                 "!equals: ${langAndroidResNoScript}, en | equals: ${file}, content.json"
-            ]
+            ],
+            "langAliases": {
+                "id": "in"
+            }
         }
         allActions.append(actionTranslation)
     allRegexToExcludeFromMainModule.extend(entry["includeRegex"])
@@ -88,7 +91,10 @@ if allFiles:
         "excludeKeys": list(map(lambda i: "REGEX:" + i, allRegexToExcludeFromMainModule + regexToAlwaysExclude)),
         "conditions": [
             "!equals: ${langAndroidResNoScript}, en | equals: ${file}, content.json"
-        ]
+        ],
+        "langAliases": {
+            "id": "in"
+        }
     }
     allActions.append(mainActionTranslation)
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Instead of manually moving all the `values-id` to `values-in` in some post-processing, this instructs the CLI to already download them in the right folders.

## Motivation and context

This way we can remove the 'move all translations' step in the download strings script. I was looking at something else when I noticed this option for the Localazy CLI tool.

## Tests

I tested this locally with `./tools/localazy/downloadStrings.sh --all` and it worked as expected.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
