### PR TITLE
Fix login flow

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/login/LoginModeView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/login/LoginModeView.kt
@@ -81,6 +81,8 @@ fun LoginModeView(
                 LoginMode.PasswordLogin -> onNeedLoginPassword()
                 is LoginMode.AccountCreation -> onCreateAccountContinue(loginModeData.url)
             }
+            // Also clear the data, to let the next screen be able to go back
+            onClearError()
         }
         AsyncData.Uninitialized -> Unit
     }

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
@@ -88,7 +88,7 @@ fun ConfirmAccountProviderView(
                 TextButton(
                     text = stringResource(id = R.string.screen_account_provider_change),
                     onClick = onChange,
-                    enabled = true,
+                    enabled = !isLoading,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(TestTags.loginChangeServer)

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnboardingViewTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnboardingViewTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.login.impl.R
+import io.element.android.features.login.impl.login.LoginMode
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.auth.OidcDetails
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
@@ -183,6 +184,53 @@ class OnboardingViewTest {
         )
         val text = rule.activity.getString(CommonStrings.common_report_a_problem)
         rule.onNodeWithText(text).assertDoesNotExist()
+    }
+
+    @Test
+    fun `when success PasswordLogin - the expected callback is invoked and the event is received`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>()
+        ensureCalledOnce { callback ->
+            rule.setOnboardingView(
+                state = anOnBoardingState(
+                    loginMode = AsyncData.Success(LoginMode.PasswordLogin),
+                    eventSink = eventSink,
+                ),
+                onNeedLoginPassword = callback,
+            )
+        }
+        eventSink.assertSingle(OnBoardingEvents.ClearError)
+    }
+
+    @Test
+    fun `when success Oidc - the expected callback is invoked and the event is received`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>()
+        val oidcDetails = OidcDetails("aUrl")
+        ensureCalledOnceWithParam(oidcDetails) { callback ->
+            rule.setOnboardingView(
+                state = anOnBoardingState(
+                    loginMode = AsyncData.Success(LoginMode.Oidc(oidcDetails)),
+                    eventSink = eventSink,
+                ),
+                onOidcDetails = callback,
+            )
+        }
+        eventSink.assertSingle(OnBoardingEvents.ClearError)
+    }
+
+    @Test
+    fun `when success AccountCreation - the expected callback is invoked and the event is received`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>()
+        val oidcDetails = OidcDetails("aUrl")
+        ensureCalledOnceWithParam(oidcDetails.url) { callback ->
+            rule.setOnboardingView(
+                state = anOnBoardingState(
+                    loginMode = AsyncData.Success(LoginMode.AccountCreation("aUrl")),
+                    eventSink = eventSink,
+                ),
+                onCreateAccountContinue = callback,
+            )
+        }
+        eventSink.assertSingle(OnBoardingEvents.ClearError)
     }
 
     private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setOnboardingView(

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnboardingViewTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/onboarding/OnboardingViewTest.kt
@@ -36,9 +36,13 @@ class OnboardingViewTest {
 
     @Test
     fun `when can create account - clicking on create account calls the expected callback`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         ensureCalledOnce { callback ->
             rule.setOnboardingView(
-                state = anOnBoardingState(canCreateAccount = true),
+                state = anOnBoardingState(
+                    canCreateAccount = true,
+                    eventSink = eventSink,
+                ),
                 onCreateAccount = callback,
             )
             rule.clickOn(R.string.screen_onboarding_sign_up)
@@ -47,9 +51,13 @@ class OnboardingViewTest {
 
     @Test
     fun `when can login with QR code - clicking on sign in with QR code calls the expected callback`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         ensureCalledOnce { callback ->
             rule.setOnboardingView(
-                state = anOnBoardingState(canLoginWithQrCode = true),
+                state = anOnBoardingState(
+                    canLoginWithQrCode = true,
+                    eventSink = eventSink,
+                ),
                 onSignInWithQrCode = callback,
             )
             rule.clickOn(R.string.screen_onboarding_sign_in_with_qr_code)
@@ -73,11 +81,13 @@ class OnboardingViewTest {
     private fun `when can login with QR code - clicking on sign in manually calls the expected callback`(
         mustChooseAccountProvider: Boolean,
     ) {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         ensureCalledOnceWithParam(mustChooseAccountProvider) { callback ->
             rule.setOnboardingView(
                 state = anOnBoardingState(
                     canLoginWithQrCode = true,
                     mustChooseAccountProvider = mustChooseAccountProvider,
+                    eventSink = eventSink,
                 ),
                 onSignIn = callback,
             )
@@ -102,12 +112,14 @@ class OnboardingViewTest {
     private fun `when cannot login with QR code or create account - clicking on continue calls the sign in callback`(
         mustChooseAccountProvider: Boolean,
     ) {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         ensureCalledOnceWithParam(mustChooseAccountProvider) { callback ->
             rule.setOnboardingView(
                 state = anOnBoardingState(
                     canLoginWithQrCode = false,
                     canCreateAccount = false,
                     mustChooseAccountProvider = mustChooseAccountProvider,
+                    eventSink = eventSink,
                 ),
                 onSignIn = callback,
             )
@@ -145,10 +157,12 @@ class OnboardingViewTest {
 
     @Test
     fun `clicking on report a problem calls the sign in callback`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         ensureCalledOnce { callback ->
             rule.setOnboardingView(
                 state = anOnBoardingState(
                     canReportBug = true,
+                    eventSink = eventSink,
                 ),
                 onReportProblem = callback,
             )
@@ -160,9 +174,11 @@ class OnboardingViewTest {
 
     @Test
     fun `cannot report a problem when the feature is disabled`() {
+        val eventSink = EventsRecorder<OnBoardingEvents>(expectEvents = false)
         rule.setOnboardingView(
             state = anOnBoardingState(
                 canReportBug = false,
+                eventSink = eventSink,
             ),
         )
         val text = rule.activity.getString(CommonStrings.common_report_a_problem)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
First commit: Ensure that it's possible to navigate back from the login with password screen
Second commit: disable `Change account provider` button during the loading of data to avoid double navigation.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Less bug in the login flows.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run the login flow and see that it's less buggy.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
