### PR TITLE
fix: Make `Client.findDM` return a `Result`

### DIFF
--- a/features/userprofile/impl/src/main/kotlin/io/element/android/features/userprofile/impl/root/UserProfilePresenter.kt
+++ b/features/userprofile/impl/src/main/kotlin/io/element/android/features/userprofile/impl/root/UserProfilePresenter.kt
@@ -55,7 +55,7 @@ class UserProfilePresenter @AssistedInject constructor(
     @Composable
     private fun getDmRoomId(): State<RoomId?> {
         return produceState<RoomId?>(initialValue = null) {
-            value = client.findDM(userId)
+            value = client.findDM(userId).getOrNull()
         }
     }
 

--- a/features/userprofile/impl/src/test/kotlin/io/element/android/features/userprofile/impl/UserProfilePresenterTest.kt
+++ b/features/userprofile/impl/src/test/kotlin/io/element/android/features/userprofile/impl/UserProfilePresenterTest.kt
@@ -141,7 +141,8 @@ class UserProfilePresenterTest {
             if (canFindRoom) {
                 givenGetRoomResult(A_ROOM_ID, room)
             }
-            givenFindDmResult(dmRoom)
+            givenFindDmResult(Result.success(dmRoom))
+            givenFindDmResult(Result.success(dmRoom))
         }
         val presenter = createUserProfilePresenter(
             userId = A_USER_ID_2,

--- a/features/userprofile/impl/src/test/kotlin/io/element/android/features/userprofile/impl/UserProfilePresenterTest.kt
+++ b/features/userprofile/impl/src/test/kotlin/io/element/android/features/userprofile/impl/UserProfilePresenterTest.kt
@@ -142,7 +142,6 @@ class UserProfilePresenterTest {
                 givenGetRoomResult(A_ROOM_ID, room)
             }
             givenFindDmResult(Result.success(dmRoom))
-            givenFindDmResult(Result.success(dmRoom))
         }
         val presenter = createUserProfilePresenter(
             userId = A_USER_ID_2,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -55,7 +55,7 @@ interface MatrixClient {
     val ignoredUsersFlow: StateFlow<ImmutableList<UserId>>
     suspend fun getJoinedRoom(roomId: RoomId): JoinedRoom?
     suspend fun getRoom(roomId: RoomId): BaseRoom?
-    suspend fun findDM(userId: UserId): RoomId?
+    suspend fun findDM(userId: UserId): Result<RoomId?>
     suspend fun ignoreUser(userId: UserId): Result<Unit>
     suspend fun unignoreUser(userId: UserId): Result<Unit>
     suspend fun createRoom(createRoomParams: CreateRoomParameters): Result<RoomId>

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/StartDM.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/StartDM.kt
@@ -18,17 +18,24 @@ suspend fun MatrixClient.startDM(
     userId: UserId,
     createIfDmDoesNotExist: Boolean,
 ): StartDMResult {
-    val existingDM = findDM(userId)
-    return if (existingDM != null) {
-        StartDMResult.Success(existingDM, isNew = false)
-    } else if (createIfDmDoesNotExist) {
-        createDM(userId).fold(
-            { StartDMResult.Success(it, isNew = true) },
-            { StartDMResult.Failure(it) }
+    return findDM(userId)
+        .fold(
+            onSuccess = { existingDM ->
+                if (existingDM != null) {
+                    StartDMResult.Success(existingDM, isNew = false)
+                } else if (createIfDmDoesNotExist) {
+                    createDM(userId).fold(
+                        { StartDMResult.Success(it, isNew = true) },
+                        { StartDMResult.Failure(it) }
+                    )
+                } else {
+                    StartDMResult.DmDoesNotExist
+                }
+            },
+            onFailure = { error ->
+                StartDMResult.Failure(error)
+            }
         )
-    } else {
-        StartDMResult.DmDoesNotExist
-    }
 }
 
 sealed interface StartDMResult {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -297,8 +297,10 @@ class RustMatrixClient(
         }
     }
 
-    override suspend fun findDM(userId: UserId): RoomId? = withContext(sessionDispatcher) {
-        innerClient.getDmRoom(userId.value)?.use { RoomId(it.id()) }
+    override suspend fun findDM(userId: UserId): Result<RoomId?> = withContext(sessionDispatcher) {
+        runCatchingExceptions {
+            innerClient.getDmRoom(userId.value)?.use { RoomId(it.id()) }
+        }
     }
 
     override suspend fun ignoreUser(userId: UserId): Result<Unit> = withContext(sessionDispatcher) {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -103,7 +103,7 @@ class FakeMatrixClient(
 
     private var createRoomResult: Result<RoomId> = Result.success(A_ROOM_ID)
     private var createDmResult: Result<RoomId> = Result.success(A_ROOM_ID)
-    private var findDmResult: RoomId? = A_ROOM_ID
+    private var findDmResult: Result<RoomId?> = Result.success(A_ROOM_ID)
     private val getRoomResults = mutableMapOf<RoomId, BaseRoom>()
     private val searchUserResults = mutableMapOf<String, Result<MatrixSearchUserResults>>()
     private val getProfileResults = mutableMapOf<UserId, Result<MatrixUser>>()
@@ -133,7 +133,7 @@ class FakeMatrixClient(
         return getRoomResults[roomId] as? JoinedRoom
     }
 
-    override suspend fun findDM(userId: UserId): RoomId? {
+    override suspend fun findDM(userId: UserId): Result<RoomId?> {
         return findDmResult
     }
 
@@ -248,7 +248,7 @@ class FakeMatrixClient(
         createDmResult = result
     }
 
-    fun givenFindDmResult(result: RoomId?) {
+    fun givenFindDmResult(result: Result<RoomId?>) {
         findDmResult = result
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. If finding the associated DM fails with an exception, the 'start DM' flow will fail too now.

## Motivation and context

The SDK performs some checks on this function that can throw, so we need to guard the client.

I found this crash in the rageshakes:

```
Thread: main, Exception: org.matrix.rustcomponents.sdk.ClientException$Generic: msg=server name is not a valid IP address or domain name, details=InvalidServerName
at org.matrix.rustcomponents.sdk.FfiConverterTypeClientError.read(SourceFile:112)
at org.matrix.rustcomponents.sdk.FfiConverterTypeClientError.read(SourceFile:1)
at org.matrix.rustcomponents.sdk.FfiConverterRustBuffer$DefaultImpls.liftFromRustBuffer(SourceFile:13)
at org.matrix.rustcomponents.sdk.FfiConverterTypeClientError.liftFromRustBuffer(SourceFile:1)
at org.matrix.rustcomponents.sdk.FfiConverterRustBuffer$DefaultImpls.lift(SourceFile:6)
at org.matrix.rustcomponents.sdk.ClientException$ErrorHandler.lift(SourceFile:8)
at org.matrix.rustcomponents.sdk.Matrix_sdk_ffiKt.access$uniffiCheckCallStatus(SourceFile:123)
at io.element.android.libraries.matrix.impl.RustMatrixClient$findDM$2.invokeSuspend(SourceFile:124)
```

## Tests

I'm not exactly sure how to test this other than adding a unit test.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
