### PR TITLE
Fix crash when using Element Call on API <= 30

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
@@ -15,6 +15,7 @@ import android.os.Build
 import android.os.PowerManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
+import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -66,23 +67,26 @@ class WebViewAudioManager(
     /**
      * This listener tracks the current communication device and updates the WebView when it changes.
      */
-    private val commsDeviceChangedListener = AudioManager.OnCommunicationDeviceChangedListener { device ->
-        if (device != null && device.id == expectedNewCommunicationDeviceId) {
-            expectedNewCommunicationDeviceId = null
-            Timber.d("Audio device changed, type: ${device.type}")
-            updateSelectedAudioDeviceInWebView(device.id.toString())
-        } else if (device != null && device.id != expectedNewCommunicationDeviceId) {
-            // We were expecting a device change but it didn't happen, so we should retry
-            val expectedDeviceId = expectedNewCommunicationDeviceId
-            if (expectedDeviceId != null) {
-                // Remove the expected id so we only retry once
+    @get:RequiresApi(Build.VERSION_CODES.S)
+    private val commsDeviceChangedListener by lazy {
+        AudioManager.OnCommunicationDeviceChangedListener { device ->
+            if (device != null && device.id == expectedNewCommunicationDeviceId) {
                 expectedNewCommunicationDeviceId = null
-                audioManager.selectAudioDevice(expectedDeviceId.toString())
+                Timber.d("Audio device changed, type: ${device.type}")
+                updateSelectedAudioDeviceInWebView(device.id.toString())
+            } else if (device != null && device.id != expectedNewCommunicationDeviceId) {
+                // We were expecting a device change but it didn't happen, so we should retry
+                val expectedDeviceId = expectedNewCommunicationDeviceId
+                if (expectedDeviceId != null) {
+                    // Remove the expected id so we only retry once
+                    expectedNewCommunicationDeviceId = null
+                    audioManager.selectAudioDevice(expectedDeviceId.toString())
+                }
+            } else {
+                Timber.d("Audio device cleared")
+                expectedNewCommunicationDeviceId = null
+                audioManager.selectAudioDevice(null)
             }
-        } else {
-            Timber.d("Audio device cleared")
-            expectedNewCommunicationDeviceId = null
-            audioManager.selectAudioDevice(null)
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Make `commsDeviceChangedListener` a lazy property to avoid crashes related to API versions (thanks @bmarty for the idea!).

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4844

`commsDeviceChangedListener` is added as a non-null property but the `AudioManager.OnCommunicationDeviceChangedListener` class it implements is only available on API 31+. Although it's not used in APIs <= 30 the property definition is still there and the app will crash when trying to run the code.

## Tests

On a device with Android 11 or lower, start or join a call.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
