### PR TITLE
Annotate Composable functions with `@ReadOnlyComposable` where it's possible

### DIFF
--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/setup/pin/SetupPinView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -124,6 +125,7 @@ private fun SetupPinContent(
 }
 
 @Composable
+@ReadOnlyComposable
 private fun SetupPinFailure.content(): String {
     return when (this) {
         SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_content)
@@ -132,6 +134,7 @@ private fun SetupPinFailure.content(): String {
 }
 
 @Composable
+@ReadOnlyComposable
 private fun SetupPinFailure.title(): String {
     return when (this) {
         SetupPinFailure.ForbiddenPin -> stringResource(id = R.string.screen_app_lock_setup_pin_forbidden_dialog_title)

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/error/ChangeServerError.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/error/ChangeServerError.kt
@@ -9,6 +9,7 @@ package io.element.android.features.login.impl.error
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.res.stringResource
 import io.element.android.features.login.impl.R
 import io.element.android.features.login.impl.changeserver.UnauthorizedAccountProviderException
@@ -21,6 +22,7 @@ sealed class ChangeServerError : Throwable() {
         val messageStr: String? = null,
     ) : ChangeServerError() {
         @Composable
+        @ReadOnlyComposable
         fun message(): String = messageStr ?: stringResource(messageId ?: CommonStrings.error_unknown)
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/actionlist/ActionListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -394,6 +395,7 @@ private fun VerifiedUserSendFailureView(
     modifier: Modifier = Modifier,
 ) {
     @Composable
+    @ReadOnlyComposable
     fun VerifiedUserSendFailure.headline(): String {
         return when (this) {
             is None -> ""

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/advanced/AdvancedSettingsState.kt
@@ -8,6 +8,7 @@
 package io.element.android.features.preferences.impl.advanced
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.res.stringResource
 import io.element.android.libraries.designsystem.components.preferences.DropdownOption
 import io.element.android.libraries.matrix.api.media.MediaPreviewValue
@@ -26,14 +27,17 @@ data class AdvancedSettingsState(
 enum class ThemeOption : DropdownOption {
     System {
         @Composable
+        @ReadOnlyComposable
         override fun getText(): String = stringResource(CommonStrings.common_system)
     },
     Dark {
         @Composable
+        @ReadOnlyComposable
         override fun getText(): String = stringResource(CommonStrings.common_dark)
     },
     Light {
         @Composable
+        @ReadOnlyComposable
         override fun getText(): String = stringResource(CommonStrings.common_light)
     }
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/DpScale.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/DpScale.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,6 +28,7 @@ import io.element.android.libraries.designsystem.theme.components.Text
  * will be smaller.
  */
 @Composable
+@ReadOnlyComposable
 fun Dp.applyScaleDown(): Dp = with(LocalDensity.current) {
     return this@applyScaleDown * fontScale.coerceAtMost(1f)
 }
@@ -37,6 +39,7 @@ fun Dp.applyScaleDown(): Dp = with(LocalDensity.current) {
  * will be bigger.
  */
 @Composable
+@ReadOnlyComposable
 fun Dp.applyScaleUp(): Dp = with(LocalDensity.current) {
     return this@applyScaleUp * fontScale.coerceAtLeast(1f)
 }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/UnitConverters.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/text/UnitConverters.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.designsystem.text
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -17,6 +18,7 @@ import androidx.compose.ui.unit.TextUnit
  * Can be used for instance to use Dp unit for text.
  */
 @Composable
+@ReadOnlyComposable
 fun Dp.toSp(): TextUnit = with(LocalDensity.current) { toSp() }
 
 /**
@@ -24,22 +26,26 @@ fun Dp.toSp(): TextUnit = with(LocalDensity.current) { toSp() }
  * Can be used for instance to use Sp unit for size.
  */
 @Composable
+@ReadOnlyComposable
 fun TextUnit.toDp(): Dp = with(LocalDensity.current) { toDp() }
 
 /**
  * Convert Px value to Dp, regarding current density.
  */
 @Composable
+@ReadOnlyComposable
 fun Int.toDp(): Dp = with(LocalDensity.current) { toDp() }
 
 /**
  * Convert Dp value to pixels, regarding current density.
  */
 @Composable
+@ReadOnlyComposable
 fun Dp.toPx(): Float = with(LocalDensity.current) { toPx() }
 
 /**
  * Convert Dp value to pixels, regarding current density.
  */
 @Composable
+@ReadOnlyComposable
 fun Dp.roundToPx(): Int = with(LocalDensity.current) { roundToPx() }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/WindowInsetsExtension.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/utils/WindowInsetsExtension.kt
@@ -9,10 +9,12 @@ package io.element.android.libraries.designsystem.utils
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 
 @Composable
+@ReadOnlyComposable
 fun WindowInsets.copy(
     top: Int? = null,
     right: Int? = null,

--- a/libraries/permissions/api/src/main/kotlin/io/element/android/libraries/permissions/api/PermissionsView.kt
+++ b/libraries/permissions/api/src/main/kotlin/io/element/android/libraries/permissions/api/PermissionsView.kt
@@ -9,6 +9,7 @@ package io.element.android.libraries.permissions.api
 
 import android.Manifest
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -41,6 +42,7 @@ fun PermissionsView(
 }
 
 @Composable
+@ReadOnlyComposable
 private fun String.toDialogContent(): String {
     return when (this) {
         Manifest.permission.POST_NOTIFICATIONS -> stringResource(id = R.string.dialog_permission_notification)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Annotate Composable functions with `@ReadOnlyComposable` where it's possible

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Improve compose performance hence the gain is probably highly negligible!

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No change

## Tests

<!-- Explain how you tested your development -->

- No change

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
