### PR TITLE
a11y: improve accessibility on rich text editor options.

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/FormattingOption.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/FormattingOption.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -21,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -32,9 +35,10 @@ import io.element.android.libraries.designsystem.theme.iconSuccessPrimaryBackgro
 @Composable
 internal fun FormattingOption(
     state: FormattingOptionState,
+    toggleable: Boolean,
     onClick: () -> Unit,
     imageVector: ImageVector,
-    contentDescription: String?,
+    contentDescription: String,
     modifier: Modifier = Modifier,
 ) {
     val backgroundColor = when (state) {
@@ -52,6 +56,7 @@ internal fun FormattingOption(
         modifier = modifier
             .clickable(
                 onClick = onClick,
+                enabled = state != FormattingOptionState.Disabled,
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(
                     bounded = false,
@@ -59,6 +64,20 @@ internal fun FormattingOption(
                 ),
             )
             .size(48.dp)
+            .then(
+                if (toggleable) {
+                    Modifier.toggleable(
+                        value = state == FormattingOptionState.Selected,
+                        enabled = state != FormattingOptionState.Disabled,
+                        onValueChange = { onClick() },
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .clearAndSetSemantics {
+                this.contentDescription = contentDescription
+            }
     ) {
         Box(
             modifier = Modifier
@@ -84,21 +103,24 @@ internal fun FormattingOptionPreview() = ElementPreview {
     Row {
         FormattingOption(
             state = FormattingOptionState.Default,
+            toggleable = false,
             onClick = { },
             imageVector = CompoundIcons.Bold(),
-            contentDescription = null,
+            contentDescription = "",
         )
         FormattingOption(
             state = FormattingOptionState.Selected,
+            toggleable = true,
             onClick = { },
             imageVector = CompoundIcons.Italic(),
-            contentDescription = null,
+            contentDescription = "",
         )
         FormattingOption(
             state = FormattingOptionState.Disabled,
+            toggleable = false,
             onClick = { },
             imageVector = CompoundIcons.Underline(),
-            contentDescription = null,
+            contentDescription = "",
         )
     }
 }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/TextFormatting.kt
@@ -104,24 +104,28 @@ internal fun TextFormatting(
     ) {
         FormattingOption(
             state = state.actions[ComposerAction.BOLD].toButtonState(),
+            toggleable = true,
             onClick = { onInlineFormatClick(InlineFormat.Bold) },
             imageVector = CompoundIcons.Bold(),
             contentDescription = stringResource(R.string.rich_text_editor_format_bold)
         )
         FormattingOption(
             state = state.actions[ComposerAction.ITALIC].toButtonState(),
+            toggleable = true,
             onClick = { onInlineFormatClick(InlineFormat.Italic) },
             imageVector = CompoundIcons.Italic(),
             contentDescription = stringResource(R.string.rich_text_editor_format_italic)
         )
         FormattingOption(
             state = state.actions[ComposerAction.UNDERLINE].toButtonState(),
+            toggleable = true,
             onClick = { onInlineFormatClick(InlineFormat.Underline) },
             imageVector = CompoundIcons.Underline(),
             contentDescription = stringResource(R.string.rich_text_editor_format_underline)
         )
         FormattingOption(
             state = state.actions[ComposerAction.STRIKE_THROUGH].toButtonState(),
+            toggleable = true,
             onClick = { onInlineFormatClick(InlineFormat.StrikeThrough) },
             imageVector = CompoundIcons.Strikethrough(),
             contentDescription = stringResource(R.string.rich_text_editor_format_strikethrough)
@@ -141,6 +145,7 @@ internal fun TextFormatting(
 
         FormattingOption(
             state = state.actions[ComposerAction.LINK].toButtonState(),
+            toggleable = true,
             onClick = { linkDialogAction = state.linkAction },
             imageVector = CompoundIcons.Link(),
             contentDescription = stringResource(R.string.rich_text_editor_link)
@@ -148,42 +153,49 @@ internal fun TextFormatting(
 
         FormattingOption(
             state = state.actions[ComposerAction.UNORDERED_LIST].toButtonState(),
+            toggleable = true,
             onClick = { onToggleListClick(ordered = false) },
             imageVector = CompoundIcons.ListBulleted(),
             contentDescription = stringResource(R.string.rich_text_editor_bullet_list)
         )
         FormattingOption(
             state = state.actions[ComposerAction.ORDERED_LIST].toButtonState(),
+            toggleable = true,
             onClick = { onToggleListClick(ordered = true) },
             imageVector = CompoundIcons.ListNumbered(),
             contentDescription = stringResource(R.string.rich_text_editor_numbered_list)
         )
         FormattingOption(
             state = state.actions[ComposerAction.INDENT].toButtonState(),
+            toggleable = false,
             onClick = { onIndentClick() },
             imageVector = CompoundIcons.IndentIncrease(),
             contentDescription = stringResource(R.string.rich_text_editor_indent)
         )
         FormattingOption(
             state = state.actions[ComposerAction.UNINDENT].toButtonState(),
+            toggleable = false,
             onClick = { onUnindentClick() },
             imageVector = CompoundIcons.IndentDecrease(),
             contentDescription = stringResource(R.string.rich_text_editor_unindent)
         )
         FormattingOption(
             state = state.actions[ComposerAction.INLINE_CODE].toButtonState(),
+            toggleable = true,
             onClick = { onInlineFormatClick(InlineFormat.InlineCode) },
             imageVector = CompoundIcons.InlineCode(),
             contentDescription = stringResource(R.string.rich_text_editor_inline_code)
         )
         FormattingOption(
             state = state.actions[ComposerAction.CODE_BLOCK].toButtonState(),
+            toggleable = true,
             onClick = { onCodeBlockClick() },
             imageVector = CompoundIcons.Code(),
             contentDescription = stringResource(R.string.rich_text_editor_code_block)
         )
         FormattingOption(
             state = state.actions[ComposerAction.QUOTE].toButtonState(),
+            toggleable = true,
             onClick = { onQuoteClick() },
             imageVector = CompoundIcons.Quote(),
             contentDescription = stringResource(R.string.rich_text_editor_quote)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that talkback (aka screen reader) give the state of the various rich text editor option. The state can be disabled, selected, or not selected, depending on the type of formatting option.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Improve accessibility of the rich text editor.

Note: iOS PR is https://github.com/element-hq/element-x-ios/pull/4194, but we do not need to use the strings created there, we can use the facilities provided by the compose framework instead.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
