### PR TITLE
a11y: Make isTalkbackActive() live.

### DIFF
--- a/libraries/ui-utils/src/main/kotlin/io/element/android/libraries/ui/utils/time/IsTalkbackEnabled.kt
+++ b/libraries/ui-utils/src/main/kotlin/io/element/android/libraries/ui/utils/time/IsTalkbackEnabled.kt
@@ -9,12 +9,26 @@ package io.element.android.libraries.ui.utils.time
 
 import android.view.accessibility.AccessibilityManager
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
 fun isTalkbackActive(): Boolean {
     val context = LocalContext.current
     val accessibilityManager = remember { context.getSystemService(AccessibilityManager::class.java) }
-    return accessibilityManager.isTouchExplorationEnabled
+    var isTouchExplorationEnabled by remember { mutableStateOf(accessibilityManager.isTouchExplorationEnabled) }
+    DisposableEffect(Unit) {
+        val listener = AccessibilityManager.TouchExplorationStateChangeListener { enabled ->
+            isTouchExplorationEnabled = enabled
+        }
+        accessibilityManager.addTouchExplorationStateChangeListener(listener)
+        onDispose {
+            accessibilityManager.removeTouchExplorationStateChangeListener(listener)
+        }
+    }
+    return isTouchExplorationEnabled
 }


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
We made the assumption that the user needs to navigate to the setting to enable or disable the talkback, but there is a way to add a talkback switch on the bottom navigation bar. So the talkback can be enabled/disabled when the application is resumed. Since the UI may render differently depending on the talkback state, we need to make the composable `isTalkbackActive()` backed on a mutable state.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Ensure the UI is responsive regarading the talkback state.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->


https://github.com/user-attachments/assets/e51a2861-39cd-4f1e-8dd3-41bfaddc7eae


## Tests

<!-- Explain how you tested your development -->

- From the talkback (screen reader) setting, enable the shortcut. On my device, this is like this:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9e63fa6c-243c-4a87-b1ae-4f6c54b1b2e6" />
- open EXA
- open a timeline
- toggle the accessibility shortcut
- observe that the timeline is now getting reverse when the screen reader is enabled.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
