### PR TITLE
Restore `MarkdownEditText.focusSearch` override

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownEditText.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownEditText.kt
@@ -8,6 +8,7 @@
 package io.element.android.libraries.textcomposer.components.markdown
 
 import android.content.Context
+import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
 
 internal class MarkdownEditText(
@@ -35,5 +36,11 @@ internal class MarkdownEditText(
         if (!isModifyingText) {
             onSelectionChangeListener?.invoke(selStart, selEnd)
         }
+    }
+
+    // When using the EditText within a Compose layout, we need to override focusSearch to prevent the default behavior
+    // Otherwise it can try searching for focusable nodes in the Compose hierarchy while they're being laid out, which will crash
+    override fun focusSearch(direction: Int): View? {
+        return null
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says, we had this before and we removed it because we though the issue it prevented was gone.

It *might* not be needed if https://github.com/element-hq/element-x-android/pull/4884 is merged, but it's hard to say as it's not crashing consistently after the Compose 1.8 upgrade, as it used to do in Compose 1.7.x.

## Motivation and context

This prevents a crash when embedding the view in a Compose layout.

## Tests

I don't really know how to test this, since the issue can't be reproduced consistently anymore.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
