### PR TITLE
Simplify syncing the room list when receiving a push

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/SyncOnNotifiableEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/SyncOnNotifiableEvent.kt
@@ -8,21 +8,15 @@
 package io.element.android.libraries.push.impl.push
 
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.core.coroutine.parallelMap
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.MatrixClientProvider
-import io.element.android.libraries.matrix.api.core.EventId
-import io.element.android.libraries.matrix.api.room.JoinedRoom
-import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
-import io.element.android.services.appnavstate.api.ActiveRoomsHolder
 import io.element.android.services.appnavstate.api.AppForegroundStateService
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
 import javax.inject.Inject
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class SyncOnNotifiableEvent @Inject constructor(
@@ -30,7 +24,6 @@ class SyncOnNotifiableEvent @Inject constructor(
     private val featureFlagService: FeatureFlagService,
     private val appForegroundStateService: AppForegroundStateService,
     private val dispatchers: CoroutineDispatchers,
-    private val activeRoomsHolder: ActiveRoomsHolder,
 ) {
     suspend operator fun invoke(notifiableEvents: List<NotifiableEvent>) = withContext(dispatchers.io) {
         if (!featureFlagService.isFeatureEnabled(FeatureFlags.SyncOnPush)) {
@@ -41,6 +34,7 @@ class SyncOnNotifiableEvent @Inject constructor(
             val eventsBySession = notifiableEvents.groupBy { it.sessionId }
 
             appForegroundStateService.updateIsSyncingNotificationEvent(true)
+            Timber.d("Starting opportunistic room list sync | In foreground: ${appForegroundStateService.isInForeground.value}")
 
             for ((sessionId, events) in eventsBySession) {
                 val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: continue
@@ -49,38 +43,13 @@ class SyncOnNotifiableEvent @Inject constructor(
                 client.roomListService.subscribeToVisibleRooms(eventsByRoomId.keys.toList())
 
                 if (!appForegroundStateService.isInForeground.value) {
-                    for ((roomId, eventsInRoom) in eventsByRoomId) {
-                        val activeRoom = activeRoomsHolder.getActiveRoomMatching(sessionId, roomId)
-                        val room = activeRoom ?: client.getJoinedRoom(roomId)
-
-                        if (room != null) {
-                            eventsInRoom.parallelMap { event ->
-                                room.waitsUntilEventIsKnown(event.eventId, timeout = 10.seconds)
-                            }
-                        }
-
-                        if (room != null && activeRoom == null) {
-                            // Destroy the room we just instantiated to reset its live timeline
-                            room.destroy()
-                        }
-                    }
+                    // Give the sync some time to complete in background
+                    delay(10.seconds)
                 }
             }
         } finally {
+            Timber.d("Finished opportunistic room list sync")
             appForegroundStateService.updateIsSyncingNotificationEvent(false)
-        }
-    }
-
-    private suspend fun JoinedRoom.waitsUntilEventIsKnown(eventId: EventId, timeout: Duration) {
-        withTimeoutOrNull(timeout) {
-            liveTimeline.timelineItems.first { timelineItems ->
-                timelineItems.any { timelineItem ->
-                    when (timelineItem) {
-                        is MatrixTimelineItem.Event -> timelineItem.eventId == eventId
-                        else -> false
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

We were previously creating a timeline for every room that received a push notification and waiting until the event was resolved for it before stopping the sync. Creating this timeline *could* be causing the unexpected UTD increase we've seen lately since the UTD hook now applies to any timeline, so we'll just give the sync a few seconds to run in background instead.

## Motivation and context

Try to avoid UTDs and false marked-as-unread rooms.

## Tests

With the app on background:

1. Receive a push.
2. Check the opportunistic room list sync starts (you can search for 'opportunistic' in the logs).
3. Check after ~10s the sync is stopped.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
