### PR TITLE
Display error dialog if Element Call can't be joined

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/WidgetMessage.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/WidgetMessage.kt
@@ -30,6 +30,9 @@ data class WidgetMessage(
 
     @Serializable
     enum class Action {
+        @SerialName("io.element.join")
+        Join,
+
         @SerialName("im.vector.hangup")
         HangUp,
 

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
@@ -225,7 +225,7 @@ import kotlin.time.Duration.Companion.seconds
     }
 
     @Test
-    fun `present - a received room member message makes the call to be active`() = runTest {
+    fun `present - a received 'joined' action makes the call to be active`() = runTest {
         val navigator = FakeCallScreenNavigator()
         val widgetDriver = FakeMatrixWidgetDriver()
         val presenter = createCallScreenPresenter(
@@ -248,13 +248,10 @@ import kotlin.time.Duration.Companion.seconds
             messageInterceptor.givenInterceptedMessage(
                 """
                     {
-                        "action":"send_event",
+                        "action":"io.element.join",
                         "api":"fromWidget",
                         "widgetId":"1",
-                        "requestId":"1",
-                        "data":{
-                            "type":"org.matrix.msc3401.call.member"
-                        }
+                        "requestId":"1"
                     }
                 """.trimIndent()
             )

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
@@ -262,6 +262,40 @@ import kotlin.time.Duration.Companion.seconds
     }
 
     @Test
+    fun `present - if in room mode and no join action is received an error is displayed`() = runTest {
+        val navigator = FakeCallScreenNavigator()
+        val widgetDriver = FakeMatrixWidgetDriver()
+        val presenter = createCallScreenPresenter(
+            callType = CallType.RoomCall(A_SESSION_ID, A_ROOM_ID),
+            widgetDriver = widgetDriver,
+            navigator = navigator,
+            dispatchers = testCoroutineDispatchers(useUnconfinedTestDispatcher = true),
+            screenTracker = FakeScreenTracker {},
+        )
+        val messageInterceptor = FakeWidgetMessageInterceptor()
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            // Give it time to load the URL and WidgetDriver
+            advanceTimeBy(1.seconds)
+            skipItems(2)
+            val initialState = awaitItem()
+            assertThat(initialState.isCallActive).isFalse()
+            initialState.eventSink(CallScreenEvents.SetupMessageChannels(messageInterceptor))
+            skipItems(2)
+
+            // Wait for the timeout to trigger
+            advanceTimeBy(10.seconds)
+
+            val finalState = awaitItem()
+            assertThat(finalState.isCallActive).isFalse()
+            // The error dialog that will force the user to leave the call is displayed
+            assertThat(finalState.webViewError).isNotNull()
+            assertThat(finalState.webViewError).isEmpty()
+        }
+    }
+
+    @Test
     fun `present - automatically sets the isInCall state when starting the call and disposing the screen`() = runTest {
         val navigator = FakeCallScreenNavigator()
         val widgetDriver = FakeMatrixWidgetDriver()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When on room call type, we listen for the 'join' action for 10s, and if we don't receive one we display an error dialog which will close the call screen.

## Motivation and context

This will allow us to remove the top app bar in a following PR.

## Tests

It's kind of difficult to test unless you add an artificial delay before receiving the join action when joining a call, but maybe it's possible by using an unstable network connection. In my case I just added the delay.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
