### PR TITLE
Add unit test on ChooseAccountProviderState so that the coverage is above 90%

### DIFF
--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/chooseaccountprovider/ChooseAccountProviderStateTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/chooseaccountprovider/ChooseAccountProviderStateTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.login.impl.screens.chooseaccountprovider
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.login.impl.accountprovider.anAccountProvider
+import io.element.android.features.login.impl.login.LoginMode
+import io.element.android.libraries.architecture.AsyncData
+import org.junit.Test
+
+class ChooseAccountProviderStateTest {
+    @Test
+    fun `submitEnabled returns false when there is no selectedAccountProvider`() {
+        val sut = aChooseAccountProviderState(
+            selectedAccountProvider = null,
+        )
+        assertThat(sut.submitEnabled).isFalse()
+    }
+
+    @Test
+    fun `submitEnabled returns true when there is a selectedAccountProvider`() {
+        val sut = aChooseAccountProviderState(
+            selectedAccountProvider = anAccountProvider(),
+        )
+        assertThat(sut.submitEnabled).isTrue()
+    }
+
+    @Test
+    fun `submitEnabled returns false when there is a selectedAccountProvider but there is an error`() {
+        val sut = aChooseAccountProviderState(
+            selectedAccountProvider = anAccountProvider(),
+            loginMode = AsyncData.Failure(Throwable("Error")),
+        )
+        assertThat(sut.submitEnabled).isFalse()
+    }
+
+    @Test
+    fun `submitEnabled returns false when there is a selectedAccountProvider but the result is successful`() {
+        val sut = aChooseAccountProviderState(
+            selectedAccountProvider = anAccountProvider(),
+            loginMode = AsyncData.Success(LoginMode.PasswordLogin),
+        )
+        assertThat(sut.submitEnabled).isFalse()
+    }
+}


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add unit test on ChooseAccountProviderState so that the coverage is above 90%

Fixes issue:
Rule 'Check code coverage of states' violated: instructions covered percentage for class 'io.element.android.features.login.impl.screens.chooseaccountprovider.ChooseAccountProviderState' is 88.571400, but expected minimum is 90


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix issue for instance here: https://github.com/element-hq/element-x-android/actions/runs/15841722065/job/44655560870
