### PR TITLE
Upgrade compose bom to 2025.06.01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ media3 = "1.7.1"
 camera = "1.4.2"
 
 # Compose
-compose_bom = "2025.05.01"
+compose_bom = "2025.06.01"
 composecompiler = "1.5.15"
 
 # Coroutines


### PR DESCRIPTION
Note sure why Renovate do not create a PR for this. I can't found any closed PR with this. The [dashboard](https://github.com/element-hq/element-x-android/issues/150) mentions it, but do not link a PR as for the Kotlin one:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/691909e7-c0ae-4f95-85cb-c515fb6ef970" />

