### PR TITLE
[a11y] Ensure that the focus is not lost when the send button state change

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/SendButton.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/SendButton.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.LinearGradientShader
 import androidx.compose.ui.graphics.ShaderBrush
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -32,7 +31,6 @@ import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.item.event.toEventOrTransactionId
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
-import io.element.android.libraries.ui.strings.CommonStrings
 
 /**
  * Send button for the message composer.
@@ -60,10 +58,6 @@ internal fun SendButton(
             composerMode.isEditing -> 0.dp
             else -> 2.dp
         }
-        val contentDescription = when {
-            composerMode.isEditing -> stringResource(CommonStrings.action_edit)
-            else -> stringResource(CommonStrings.action_send)
-        }
         Box(
             modifier = Modifier
                 .clip(CircleShape)
@@ -81,7 +75,8 @@ internal fun SendButton(
                     .padding(start = iconStartPadding)
                     .align(Alignment.Center),
                 imageVector = iconVector,
-                contentDescription = contentDescription,
+                // Note: accessibility is managed in TextComposer.
+                contentDescription = null,
                 tint = if (canSendMessage) {
                     if (ElementTheme.colors.isLight) {
                         ElementTheme.colors.iconOnSolidPrimary

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessageRecorderButton.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/VoiceMessageRecorderButton.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -26,7 +25,6 @@ import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.IconButton
 import io.element.android.libraries.designsystem.utils.CommonDrawables
 import io.element.android.libraries.textcomposer.model.VoiceMessageRecorderEvent
-import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 internal fun VoiceMessageRecorderButton(
@@ -70,7 +68,8 @@ private fun StartButton(
     Icon(
         modifier = Modifier.size(24.dp),
         imageVector = CompoundIcons.MicOn(),
-        contentDescription = stringResource(CommonStrings.a11y_voice_message_record),
+        // Note: accessibility is managed in TextComposer.
+        contentDescription = null,
         tint = ElementTheme.colors.iconSecondary,
     )
 }
@@ -95,7 +94,8 @@ private fun StopButton(
     Icon(
         modifier = Modifier.size(24.dp),
         resourceId = CommonDrawables.ic_stop,
-        contentDescription = stringResource(CommonStrings.a11y_voice_message_stop_recording),
+        // Note: accessibility is managed in TextComposer.
+        contentDescription = null,
         tint = ElementTheme.colors.iconOnSolidPrimary,
     )
 }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -12,7 +12,7 @@
   <string name="a11y_jump_to_bottom">"Jump to bottom"</string>
   <string name="a11y_notifications_mentions_only">"Mentions only"</string>
   <string name="a11y_notifications_muted">"Muted"</string>
-  <string name="a11y_other_user_avatar">"Other user avatar"</string>
+  <string name="a11y_other_user_avatar">"Other user\'s avatar"</string>
   <string name="a11y_page_n">"Page %1$d"</string>
   <string name="a11y_pause">"Pause"</string>
   <string name="a11y_paused_voice_message">"Voice message, duration: %1$s, current position: %2$s"</string>
@@ -125,7 +125,9 @@
   <string name="action_save">"Save"</string>
   <string name="action_search">"Search"</string>
   <string name="action_send">"Send"</string>
+  <string name="action_send_edited_message">"Send edited message"</string>
   <string name="action_send_message">"Send message"</string>
+  <string name="action_send_voice_message">"Send voice message"</string>
   <string name="action_share">"Share"</string>
   <string name="action_share_link">"Share link"</string>
   <string name="action_show">"Show"</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Handle semantic of the send button in the "parent" composable to ensure that the focus is not reset to the "Back" button when the send button changes between states.

- When you start recording a voice message using the keypad, the focus must be on the Stop button so that the message recording can be conveniently ended.
- If the recording has been stopped, the focus must placed on the send button.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes https://github.com/element-hq/customer-success/issues/556

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable screen reader
- Record a voice message and send it
- Observe that the accessibility focus is not lost and stay on the composer main button

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
