### PR TITLE
Make `ContentAvoidingLayoutData` an immutable data class

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/layout/ContentAvoidingLayout.kt
@@ -112,12 +112,11 @@ fun ContentAvoidingLayout(
  * @param nonOverlappingContentWidth The width of the part of the content that can't overlap with the timestamp.
  * @param nonOverlappingContentHeight The height of the part of the content that can't overlap with the timestamp.
  */
-@Suppress("DataClassShouldBeImmutable")
 data class ContentAvoidingLayoutData(
-    var contentWidth: Int = 0,
-    var contentHeight: Int = 0,
-    var nonOverlappingContentWidth: Int = contentWidth,
-    var nonOverlappingContentHeight: Int = contentHeight,
+    val contentWidth: Int = 0,
+    val contentHeight: Int = 0,
+    val nonOverlappingContentWidth: Int = contentWidth,
+    val nonOverlappingContentHeight: Int = contentHeight,
 )
 
 /**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This *may* fix the issue causing the message contents to sometimes be clipped to a very tiny size while the message bubble has the right size. This was part of some optimisation we tried doing a long time ago and later removed as it didn't work as expected, and this data class wasn't reverted to the non-mutable version.

## Motivation and context

Try to fix https://github.com/element-hq/element-x-android/issues/4867, but it's difficult to check since I've never reproduced it.

## Tests

If you can reproduce the issue easily, scroll through the messages and check no messages have their contents clipped. Otherwise ¯\\_(ツ)\_/¯.


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
