### PR TITLE
Make sure we clean up the pre-processed and uploaded media

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -131,12 +131,17 @@ class AttachmentsPreviewPresenter @AssistedInject constructor(
                                 dismissAfterSend = !useSendQueue,
                                 replyParameters = null,
                             )
+
+                            // Clean up the pre-processed media after it's been sent
+                            mediaSender.cleanUp()
                         }
                     }
                 }
                 AttachmentsPreviewEvents.CancelAndDismiss -> {
                     // Cancel media preprocessing and sending
                     preprocessMediaJob?.cancel()
+                    // If we couldn't send the pre-processed media, remove it
+                    mediaSender.cleanUp()
                     ongoingSendAttachmentJob.value?.cancel()
 
                     // Dismiss the screen

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
@@ -66,7 +66,7 @@ fun AttachmentsPreviewView(
         state.eventSink(AttachmentsPreviewEvents.CancelAndClearSendState)
     }
 
-    BackHandler(enabled = state.sendActionState !is SendActionState.Sending) {
+    BackHandler(enabled = state.sendActionState !is SendActionState.Sending.Uploading) {
         postCancel()
     }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -123,8 +123,10 @@ class AttachmentsPreviewPresenterTest {
             },
         )
         val onDoneListener = lambdaRecorder<Unit> { }
+        val mediaPreProcessor = FakeMediaPreProcessor()
         val presenter = createAttachmentsPreviewPresenter(
             room = room,
+            mediaPreProcessor = mediaPreProcessor,
             onDoneListener = { onDoneListener() },
         )
         moleculeFlow(RecompositionMode.Immediate) {
@@ -143,6 +145,7 @@ class AttachmentsPreviewPresenterTest {
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Done)
             sendFileResult.assertions().isCalledOnce()
             onDoneListener.assertions().isCalledOnce()
+            assertThat(mediaPreProcessor.cleanUpCallCount).isEqualTo(1)
         }
     }
 
@@ -159,11 +162,10 @@ class AttachmentsPreviewPresenterTest {
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val processLatch = CompletableDeferred<Unit>()
+        val mediaPreProcessor = FakeMediaPreProcessor(processLatch)
         val presenter = createAttachmentsPreviewPresenter(
             room = room,
-            mediaPreProcessor = FakeMediaPreProcessor(
-                processLatch = processLatch,
-            ),
+            mediaPreProcessor = mediaPreProcessor,
             onDoneListener = { onDoneListener() },
         )
         moleculeFlow(RecompositionMode.Immediate) {
@@ -181,6 +183,7 @@ class AttachmentsPreviewPresenterTest {
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Done)
             sendFileResult.assertions().isCalledOnce()
             onDoneListener.assertions().isCalledOnce()
+            assertThat(mediaPreProcessor.cleanUpCallCount).isEqualTo(1)
         }
     }
 
@@ -197,11 +200,10 @@ class AttachmentsPreviewPresenterTest {
         )
         val onDoneListener = lambdaRecorder<Unit> { }
         val processLatch = CompletableDeferred<Unit>()
+        val mediaPreProcessor = FakeMediaPreProcessor(processLatch)
         val presenter = createAttachmentsPreviewPresenter(
             room = room,
-            mediaPreProcessor = FakeMediaPreProcessor(
-                processLatch = processLatch,
-            ),
+            mediaPreProcessor = mediaPreProcessor,
             onDoneListener = { onDoneListener() },
         )
         moleculeFlow(RecompositionMode.Immediate) {
@@ -219,6 +221,7 @@ class AttachmentsPreviewPresenterTest {
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Done)
             sendFileResult.assertions().isCalledOnce()
             onDoneListener.assertions().isCalledOnce()
+            assertThat(mediaPreProcessor.cleanUpCallCount).isEqualTo(1)
         }
     }
 
@@ -279,7 +282,9 @@ class AttachmentsPreviewPresenterTest {
     fun `present - cancel scenario`() = runTest {
         val onDoneListener = lambdaRecorder<Unit> { }
         val deleteCallback = lambdaRecorder<Uri?, Unit> {}
+        val mediaPreProcessor = FakeMediaPreProcessor()
         val presenter = createAttachmentsPreviewPresenter(
+            mediaPreProcessor = mediaPreProcessor,
             temporaryUriDeleter = FakeTemporaryUriDeleter(deleteCallback),
             onDoneListener = { onDoneListener() },
         )
@@ -293,6 +298,7 @@ class AttachmentsPreviewPresenterTest {
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Done)
             deleteCallback.assertions().isCalledOnce()
             onDoneListener.assertions().isCalledOnce()
+            assertThat(mediaPreProcessor.cleanUpCallCount).isEqualTo(1)
         }
     }
 

--- a/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaPreProcessor.kt
+++ b/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaPreProcessor.kt
@@ -22,5 +22,10 @@ interface MediaPreProcessor {
         compressIfPossible: Boolean,
     ): Result<MediaUploadInfo>
 
+    /**
+     * Clean up any temporary files or resources used during the media processing.
+     */
+    fun cleanUp()
+
     data class Failure(override val cause: Throwable?) : Exception(cause)
 }

--- a/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
+++ b/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
@@ -200,4 +200,9 @@ class MediaSender @Inject constructor(
                 uploadHandler.await()
             }
     }
+
+    /**
+     * Clean up any temporary files or resources used during the media processing.
+     */
+    fun cleanUp() = preProcessor.cleanUp()
 }

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import java.io.InputStream
+import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -104,6 +105,23 @@ class AndroidMediaPreProcessor @Inject constructor(
     }.mapFailure { MediaPreProcessor.Failure(it) }
 
     override fun cleanUp() {
+        // Clear temporary files created in older versions of the app
+        cacheDir.listFiles()?.onEach { file ->
+            if (file.isFile) {
+                val nameWithoutExtension = file.nameWithoutExtension
+                // UUIDs are 36 characters long, so we check if we can take those 36 characters
+                val nameWithoutExtensionAndRandom = if (nameWithoutExtension.length > 36) {
+                    nameWithoutExtension.substring(0, 36)
+                } else {
+                    // Not a temp file
+                    return@onEach
+                }
+                val isUUID = tryOrNull { UUID.fromString(nameWithoutExtensionAndRandom) } != null
+                if (isUUID && file.extension.isNotEmpty()) {
+                    file.delete()
+                }
+            }
+        }
         // Clear temporary files created by this pre-processor in the separate uploads directory
         baseTmpFileDir.listFiles()?.onEach { it.delete() }
     }

--- a/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaPreProcessor.kt
+++ b/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaPreProcessor.kt
@@ -26,6 +26,9 @@ class FakeMediaPreProcessor(
     var processCallCount = 0
         private set
 
+    var cleanUpCallCount = 0
+        private set
+
     private var result: Result<MediaUploadInfo> = Result.success(
         MediaUploadInfo.AnyFile(
             File("test"),
@@ -107,5 +110,9 @@ class FakeMediaPreProcessor(
                 )
             )
         )
+    }
+
+    override fun cleanUp() {
+        cleanUpCallCount += 1
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Add `MediaSender.cleanUp()` and `MediaPreProcessor.cleanUp()` to remove temporary media files - results of the media processing - that have already been uploaded or whose upload was canceled.
- Fix back handler not being triggered on the attachments preview screen while pre-processing - it should only be disabled while uploading.

## Motivation and context

Fix an issue that caused temporary media to not be cleaned up after being used.

## Tests

A few unit tests were included, but if you can access your `/data/data/...` folder you can also check temp media files are deleted after being uploaded or when the upload is cancelled.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
