### PR TITLE
Note how to switch back to the published SDK after building locally

### DIFF
--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -157,6 +157,8 @@ Troubleshooting:
  - If you get the error `Unsupported class file major version <n>`, try changing your JVM version by setting
    `JAVA_HOME` and, if building via Android Studio, "File | Settings | Build, Execution, Deployment | Build Tools | Gradle | Gradle JDK".
 
+You can switch back to using the published version of the SDK by deleting `libraries/rustsdk/matrix-rust-sdk.aar`.
+
 ### The Android project
 
 The project should compile out of the box.


### PR DESCRIPTION
Added a line to the documentation about how to switch back after building the Rust SDK locally.

I am not sure what it says is correct, so would appreciate someone taking a look and suggesting improvements.

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
