### PR TITLE
Fix `toPlainText` where `<ol start='n'>` tags appear

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
@@ -57,10 +57,16 @@ private class PlainTextNodeVisitor : NodeVisitor {
         if (node is TextNode && node.text().isNotBlank()) {
             builder.append(node.text())
         } else if (node is Element && node.tagName() == "li") {
-            val index = node.elementSiblingIndex()
+            val index = node.elementSiblingIndex() + 1
             val isOrdered = node.parent()?.nodeName()?.lowercase() == "ol"
             if (isOrdered) {
-                builder.append("${index + 1}. ")
+                val startIndex = node.parent()?.attr("start")?.toIntOrNull()
+                val actualIndex = if (startIndex != null) {
+                    startIndex + index - 1
+                } else {
+                    index
+                }
+                builder.append("$actualIndex. ")
             } else {
                 builder.append("• ")
             }

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
@@ -97,6 +97,29 @@ class ToPlainTextTest {
     }
 
     @Test
+    fun `TextMessageType toPlainText - respects the ol start attr if present`() {
+        val messageType = TextMessageType(
+            body = "1. First item\n2. Second item\n",
+            formatted = FormattedBody(
+                format = MessageFormat.HTML,
+                body = """
+                    <ol start='11'>
+                        <li>First item.</li>
+                        <li>Second item.</li>  
+                    </ol>
+                    <br />
+                """.trimIndent()
+            )
+        )
+        assertThat(messageType.toPlainText(permalinkParser = FakePermalinkParser())).isEqualTo(
+            """
+            11. First item.
+            12. Second item.
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun `TextMessageType toPlainText - returns the markdown body if the formatted one cannot be parsed`() {
         val messageType = TextMessageType(
             body = "This is the fallback text",


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

This fixes the plain text representation used for last messages, pinned events and notifications.

## Tests

There are unit tests that check this, but you can manually test it too.

In a room, send:

```
2. First item.
3. Second item.
```

In the room list you should see the last event looking exactly like that. If you send it from another client, the notification should also look like that.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
