### PR TITLE
Add fallback notifications from UTDs to the push history

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -236,7 +236,12 @@ class DefaultNotifiableEventResolver @Inject constructor(
             }
             NotificationContent.MessageLike.RoomEncrypted -> {
                 Timber.tag(loggerTag.value).w("Notification with encrypted content -> fallback")
-                val fallbackNotifiableEvent = fallbackNotificationFactory.create(userId, roomId, eventId)
+                val fallbackNotifiableEvent = fallbackNotificationFactory.create(
+                    sessionId = userId,
+                    roomId = roomId,
+                    eventId = eventId,
+                    cause = "Unable to decrypt event content",
+                )
                 ResolvedPushEvent.Event(fallbackNotifiableEvent)
             }
             is NotificationContent.MessageLike.RoomRedaction -> {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/FallbackNotificationFactory.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/FallbackNotificationFactory.kt
@@ -24,6 +24,7 @@ class FallbackNotificationFactory @Inject constructor(
         sessionId: SessionId,
         roomId: RoomId,
         eventId: EventId,
+        cause: String?,
     ): FallbackNotifiableEvent = FallbackNotifiableEvent(
         sessionId = sessionId,
         roomId = roomId,
@@ -34,5 +35,6 @@ class FallbackNotificationFactory @Inject constructor(
         isUpdated = false,
         timestamp = clock.epochMillis(),
         description = stringProvider.getString(R.string.notification_fallback_content),
+        cause = cause,
     )
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/FallbackNotifiableEvent.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/model/FallbackNotifiableEvent.kt
@@ -25,4 +25,5 @@ data class FallbackNotifiableEvent(
     override val isRedacted: Boolean,
     override val isUpdated: Boolean,
     val timestamp: Long,
+    val cause: String?,
 ) : NotifiableEvent

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -625,6 +625,7 @@ class DefaultNotifiableEventResolverTest {
                 isRedacted = false,
                 isUpdated = false,
                 timestamp = A_FAKE_TIMESTAMP,
+                cause = "Unable to decrypt event content",
             )
         )
         assertThat(result.getEvent(request)).isEqualTo(Result.success(expectedResult))

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -71,6 +71,7 @@ class DefaultNotificationCreatorTest {
                 isRedacted = false,
                 isUpdated = false,
                 timestamp = A_FAKE_TIMESTAMP,
+                cause = null,
             )
         )
         result.commonAssertions(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When `DefaultPushHandler` receives a fallback notifiable event as a result, notify it to the push history service.

Alternatively, we could add `PushHistoryService` to `DefaultNotifiableEventResolver` and when we find an encrypted event in `NotificationData.asNotifiableEvent` add it to the history, but it seemed better to centralise the usage of `PushHistoryService` in `DefaultPushHandler` instead.

## Motivation and context

This is important for fallback notifications caused by UTDs, which weren't previously added to the history.

## Tests

It's difficult to test unless you can force an UTD, but there are unit tests.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
