### PR TITLE
Calculate video output size taking into account portrait mode

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/bitmap/Bitmap.kt
@@ -64,7 +64,7 @@ fun BitmapFactory.Options.calculateInSampleSize(desiredWidth: Int, desiredHeight
  * Decodes the [inputStream] into a [Bitmap] and applies the needed rotation based on [orientation].
  * This orientation value must be one of `ExifInterface.ORIENTATION_*` constants.
  */
-fun Bitmap.rotateToMetadataOrientation(orientation: Int): Bitmap {
+fun Bitmap.rotateToExifMetadataOrientation(orientation: Int): Bitmap {
     val matrix = Matrix()
     when (orientation) {
         ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ImageCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ImageCompressor.kt
@@ -13,7 +13,7 @@ import android.graphics.BitmapFactory
 import androidx.exifinterface.media.ExifInterface
 import io.element.android.libraries.androidutils.bitmap.calculateInSampleSize
 import io.element.android.libraries.androidutils.bitmap.resizeToMax
-import io.element.android.libraries.androidutils.bitmap.rotateToMetadataOrientation
+import io.element.android.libraries.androidutils.bitmap.rotateToExifMetadataOrientation
 import io.element.android.libraries.androidutils.file.createTmpFile
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.extensions.runCatchingExceptions
@@ -78,7 +78,7 @@ class ImageCompressor @Inject constructor(
             options.inJustDecodeBounds = false
             val decodedBitmap = BitmapFactory.decodeStream(input, null, options)
                 ?: error("Decoding Bitmap from InputStream failed")
-            val rotatedBitmap = decodedBitmap.rotateToMetadataOrientation(orientation)
+            val rotatedBitmap = decodedBitmap.rotateToExifMetadataOrientation(orientation)
             if (resizeMode is ResizeMode.Strict) {
                 rotatedBitmap.resizeToMax(resizeMode.maxWidth, resizeMode.maxHeight)
             } else {

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
@@ -81,8 +81,12 @@ internal class VideoResizer(
 ) {
     fun getOutputSize(inputSize: Size): Size {
         val resultMajor = min(inputSize.major(), maxSize)
-        val aspectRatio = inputSize.major().toFloat() / inputSize.minor().toFloat()
-        return Size(resultMajor, (resultMajor / aspectRatio).roundToInt())
+        val aspectRatio = inputSize.width.toFloat() / inputSize.height.toFloat()
+        return if (inputSize.width > inputSize.height) {
+            Size(resultMajor, (resultMajor / aspectRatio).roundToInt())
+        } else {
+            Size((resultMajor * aspectRatio).roundToInt(), resultMajor)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Calculate video output size taking into account if the video is in portrait/landscape mode.

## Motivation and context

This is the right configuration, as not following this botches the compression for portrait videos, as well as their thumbnails. I don't know why it seemed to work well before, maybe we had this code but was lost in one of the many tests/rebases, or it interacted with some other code that fixed this behaviour but was later removed.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

Send a portrait video, both the thumbnail and the actual video should keep the portrait orientation.

Previously, they'd be placed into a landscape orientation with black borders on both sides.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 14, 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
