### PR TITLE
Adapt 'change roles' screens to the new creator/owner role

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsPickerView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsPickerView.kt
@@ -157,7 +157,7 @@ internal fun SuggestionsPickerViewPreview() {
             powerLevel = 0L,
             normalizedPowerLevel = 0L,
             isIgnored = false,
-            role = RoomMember.Role.USER,
+            role = RoomMember.Role.User,
             membershipChangeReason = null,
         )
         val anAlias = remember { RoomAlias("#room:domain.org") }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsStateProvider.kt
@@ -69,7 +69,7 @@ fun aDmRoomMember(
     powerLevel: Long = 0,
     normalizedPowerLevel: Long = powerLevel,
     isIgnored: Boolean = false,
-    role: RoomMember.Role = RoomMember.Role.USER,
+    role: RoomMember.Role = RoomMember.Role.User,
     membershipChangeReason: String? = null,
 ) = RoomMember(
     userId = userId,

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/analytics/AnalyticUtils.kt
@@ -13,10 +13,10 @@ import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevelsV
 import io.element.android.services.analytics.api.AnalyticsService
 
 internal fun RoomMember.Role.toAnalyticsMemberRole(): RoomModeration.Role = when (this) {
-    RoomMember.Role.CREATOR -> RoomModeration.Role.Administrator // TODO - distinguish creator from admin
-    RoomMember.Role.ADMIN -> RoomModeration.Role.Administrator
-    RoomMember.Role.MODERATOR -> RoomModeration.Role.Moderator
-    RoomMember.Role.USER -> RoomModeration.Role.User
+    is RoomMember.Role.Owner -> RoomModeration.Role.Administrator // TODO - distinguish creator from admin
+    RoomMember.Role.Admin -> RoomModeration.Role.Administrator
+    RoomMember.Role.Moderator -> RoomModeration.Role.Moderator
+    RoomMember.Role.User -> RoomModeration.Role.User
 }
 
 internal fun analyticsMemberRoleForPowerLevel(powerLevel: Long): RoomModeration.Role {

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStateProvider.kt
@@ -150,7 +150,7 @@ fun aRoomMember(
     powerLevel: Long = 0L,
     normalizedPowerLevel: Long = 0L,
     isIgnored: Boolean = false,
-    role: RoomMember.Role = RoomMember.Role.USER,
+    role: RoomMember.Role = RoomMember.Role.User,
     membershipChangeReason: String? = null,
 ) = RoomMember(
     userId = userId,
@@ -178,8 +178,8 @@ fun aRoomMemberList() = persistentListOf(
     aWalter(),
 )
 
-fun anAlice() = aRoomMember(UserId("@alice:server.org"), "Alice", role = RoomMember.Role.ADMIN)
-fun aBob() = aRoomMember(UserId("@bob:server.org"), "Bob", role = RoomMember.Role.MODERATOR)
+fun anAlice() = aRoomMember(UserId("@alice:server.org"), "Alice", role = RoomMember.Role.Admin)
+fun aBob() = aRoomMember(UserId("@bob:server.org"), "Bob", role = RoomMember.Role.Moderator)
 
 fun aVictor() = aRoomMember(UserId("@victor:server.org"), "Victor", membership = RoomMembershipState.INVITE)
 

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListView.kt
@@ -61,7 +61,6 @@ import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityState
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.getBestName
-import io.element.android.libraries.matrix.api.room.isOwner
 import io.element.android.libraries.matrix.api.room.toMatrixUser
 import io.element.android.libraries.matrix.ui.components.MatrixUserRow
 import io.element.android.libraries.ui.strings.CommonStrings
@@ -295,12 +294,12 @@ private fun RoomMemberListItem(
     modifier: Modifier = Modifier,
 ) {
     val member = roomMemberWithIdentity.roomMember
-    val roleText = if (member.isOwner()) {
+    val roleText = if (member.role is RoomMember.Role.Owner) {
         stringResource(R.string.screen_room_member_list_role_owner)
     } else {
         when (member.role) {
-            RoomMember.Role.ADMIN -> stringResource(R.string.screen_room_member_list_role_administrator)
-            RoomMember.Role.MODERATOR -> stringResource(R.string.screen_room_member_list_role_moderator)
+            RoomMember.Role.Admin -> stringResource(R.string.screen_room_member_list_role_administrator)
+            RoomMember.Role.Moderator -> stringResource(R.string.screen_room_member_list_role_moderator)
             else -> null
         }
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsNode.kt
@@ -61,7 +61,7 @@ class RolesAndPermissionsNode @AssistedInject constructor(
             room.roomInfoFlow
                 .filter { info ->
                     val role = info.roleOf(room.sessionId)
-                    role != RoomMember.Role.ADMIN && role != RoomMember.Role.CREATOR
+                    role != RoomMember.Role.Admin && role !is RoomMember.Role.Owner
                 }
                 .take(1)
                 .onEach { navigateUp() }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsPresenter.kt
@@ -26,6 +26,7 @@ import io.element.android.libraries.matrix.api.room.RoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.activeRoomMembers
 import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
+import io.element.android.libraries.matrix.ui.model.roleOf
 import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -50,14 +51,18 @@ class RolesAndPermissionsPresenter @Inject constructor(
         }
         val moderatorCount by remember {
             derivedStateOf {
-                roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.MODERATOR)
+                roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.Moderator)
             }
         }
         val adminCount by remember {
             derivedStateOf {
-                roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.ADMIN)
+                val admins = roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.Admin)
+                val superAdmins = roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.Owner(isCreator = false))
+                val creators = roomInfo.userCountWithRole(activeRoomMemberIds, RoomMember.Role.Owner(isCreator = true))
+                admins + superAdmins + creators
             }
         }
+        val canDemoteSelf = remember { derivedStateOf { roomInfo.roleOf(room.sessionId) !is RoomMember.Role.Owner } }
         val changeOwnRoleAction = remember { mutableStateOf<AsyncAction<Unit>>(AsyncAction.Uninitialized) }
         val resetPermissionsAction = remember { mutableStateOf<AsyncAction<Unit>>(AsyncAction.Uninitialized) }
 
@@ -85,6 +90,7 @@ class RolesAndPermissionsPresenter @Inject constructor(
         return RolesAndPermissionsState(
             adminCount = adminCount,
             moderatorCount = moderatorCount,
+            canDemoteSelf = canDemoteSelf.value,
             changeOwnRoleAction = changeOwnRoleAction.value,
             resetPermissionsAction = resetPermissionsAction.value,
             eventSink = { handleEvent(it) },

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsState.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsState.kt
@@ -12,6 +12,7 @@ import io.element.android.libraries.architecture.AsyncAction
 data class RolesAndPermissionsState(
     val adminCount: Int,
     val moderatorCount: Int,
+    val canDemoteSelf: Boolean,
     val changeOwnRoleAction: AsyncAction<Unit>,
     val resetPermissionsAction: AsyncAction<Unit>,
     val eventSink: (RolesAndPermissionsEvents) -> Unit,

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsStateProvider.kt
@@ -45,17 +45,20 @@ class RolesAndPermissionsStateProvider : PreviewParameterProvider<RolesAndPermis
                 moderatorCount = 2,
                 resetPermissionsAction = AsyncAction.Failure(IllegalStateException("Failed to reset permissions")),
             ),
+            aRolesAndPermissionsState(canDemoteSelf = false),
         )
 }
 
 internal fun aRolesAndPermissionsState(
     adminCount: Int = 0,
     moderatorCount: Int = 0,
+    canDemoteSelf: Boolean = true,
     changeOwnRoleAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     resetPermissionsAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     eventSink: (RolesAndPermissionsEvents) -> Unit = {},
 ) = RolesAndPermissionsState(
     adminCount = adminCount,
+    canDemoteSelf = canDemoteSelf,
     moderatorCount = moderatorCount,
     changeOwnRoleAction = changeOwnRoleAction,
     resetPermissionsAction = resetPermissionsAction,

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsView.kt
@@ -67,11 +67,13 @@ fun RolesAndPermissionsView(
             trailingContent = ListItemContent.Text("${state.moderatorCount}"),
             onClick = { rolesAndPermissionsNavigator.openModeratorList() },
         )
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.screen_room_roles_and_permissions_change_my_role)) },
-            onClick = { state.eventSink(RolesAndPermissionsEvents.ChangeOwnRole) },
-            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Edit()))
-        )
+        if (state.canDemoteSelf) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.screen_room_roles_and_permissions_change_my_role)) },
+                onClick = { state.eventSink(RolesAndPermissionsEvents.ChangeOwnRole) },
+                leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Edit()))
+            )
+        }
         ListSectionHeader(title = stringResource(R.string.screen_room_roles_and_permissions_permissions_header), hasDivider = true)
         ListItem(
             headlineContent = { Text(stringResource(R.string.screen_room_roles_and_permissions_room_details)) },
@@ -170,7 +172,7 @@ private fun ChangeOwnRoleBottomSheet(
             headlineContent = { Text(stringResource(R.string.screen_room_roles_and_permissions_change_role_demote_to_moderator)) },
             onClick = {
                 sheetState.hide(coroutineScope) {
-                    eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.MODERATOR))
+                    eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.Moderator))
                 }
             },
             style = ListItemStyle.Destructive,
@@ -179,7 +181,7 @@ private fun ChangeOwnRoleBottomSheet(
             headlineContent = { Text(stringResource(R.string.screen_room_roles_and_permissions_change_role_demote_to_member)) },
             onClick = {
                 sheetState.hide(coroutineScope) {
-                    eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.USER))
+                    eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.User))
                 }
             },
             style = ListItemStyle.Destructive,

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesNode.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesNode.kt
@@ -44,8 +44,8 @@ class ChangeRolesNode @AssistedInject constructor(
 
     private val presenter = presenterFactory.run {
         val role = when (inputs.listType) {
-            is ListType.Admins -> RoomMember.Role.ADMIN
-            is ListType.Moderators -> RoomMember.Role.MODERATOR
+            is ListType.Admins -> RoomMember.Role.Admin
+            is ListType.Moderators -> RoomMember.Role.Moderator
         }
         create(role)
     }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesState.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesState.kt
@@ -35,9 +35,9 @@ data class MembersByRole(
     val members: ImmutableList<RoomMember>,
 ) {
     constructor(members: List<RoomMember>) : this(
-            admins = members.filter { it.role == RoomMember.Role.ADMIN }.sorted(),
-            moderators = members.filter { it.role == RoomMember.Role.MODERATOR }.sorted(),
-            members = members.filter { it.role == RoomMember.Role.USER }.sorted(),
+            admins = members.filter { it.role.powerLevel >= RoomMember.Role.Admin.powerLevel }.sorted(),
+            moderators = members.filter { it.role == RoomMember.Role.Moderator }.sorted(),
+            members = members.filter { it.role == RoomMember.Role.User }.sorted(),
     )
 
     fun isEmpty() = admins.isEmpty() && moderators.isEmpty() && members.isEmpty()

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesStateProvider.kt
@@ -24,7 +24,7 @@ class ChangeRolesStateProvider : PreviewParameterProvider<ChangeRolesState> {
     override val values: Sequence<ChangeRolesState>
         get() = sequenceOf(
             aChangeRolesState(),
-            aChangeRolesStateWithSelectedUsers().copy(role = RoomMember.Role.MODERATOR),
+            aChangeRolesStateWithSelectedUsers().copy(role = RoomMember.Role.Moderator),
             aChangeRolesStateWithSelectedUsers().copy(hasPendingChanges = false),
             aChangeRolesStateWithSelectedUsers(),
             aChangeRolesStateWithSelectedUsers().copy(
@@ -45,7 +45,7 @@ class ChangeRolesStateProvider : PreviewParameterProvider<ChangeRolesState> {
 }
 
 internal fun aChangeRolesState(
-    role: RoomMember.Role = RoomMember.Role.ADMIN,
+    role: RoomMember.Role = RoomMember.Role.Admin,
     query: String? = null,
     isSearchActive: Boolean = false,
     searchResults: SearchBarResultState<MembersByRole> = SearchBarResultState.NoResultsFound(),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesView.kt
@@ -96,9 +96,9 @@ fun ChangeRolesView(
                 AnimatedVisibility(visible = !state.isSearchActive) {
                     TopAppBar(
                         titleStr = when (state.role) {
-                            RoomMember.Role.ADMIN -> stringResource(R.string.screen_room_change_role_administrators_title)
-                            RoomMember.Role.MODERATOR -> stringResource(R.string.screen_room_change_role_moderators_title)
-                            RoomMember.Role.CREATOR, RoomMember.Role.USER -> error("This should never be reached")
+                            RoomMember.Role.Admin -> stringResource(R.string.screen_room_change_role_administrators_title)
+                            RoomMember.Role.Moderator -> stringResource(R.string.screen_room_change_role_moderators_title)
+                            is RoomMember.Role.Owner, RoomMember.Role.User -> error("This should never be reached")
                         },
                         navigationIcon = {
                             BackButton(onClick = { state.eventSink(ChangeRolesEvent.Exit) })
@@ -187,7 +187,7 @@ fun ChangeRolesView(
 
         when (state.savingState) {
             is AsyncAction.Confirming -> {
-                if (state.role == RoomMember.Role.ADMIN) {
+                if (state.role == RoomMember.Role.Admin) {
                     // Confirm adding new admins dialogs
                     ConfirmationDialog(
                         title = stringResource(R.string.screen_room_change_role_confirm_add_admin_title),
@@ -237,7 +237,7 @@ private fun SearchResultsList(
         if (searchResults.admins.isNotEmpty()) {
             stickyHeader { ListSectionHeader(text = stringResource(R.string.screen_room_roles_and_permissions_admins)) }
             // Add a footer for the admin section in change role to moderator screen
-            if (currentRole == RoomMember.Role.MODERATOR) {
+            if (currentRole == RoomMember.Role.Moderator) {
                 item {
                     Text(
                         modifier = Modifier
@@ -303,11 +303,15 @@ private fun ListMemberItem(
 ) {
     val canToggle = canRemoveMember(roomMember.userId)
     val trailingContent: @Composable (() -> Unit) = {
-        Checkbox(
-            checked = selectedUsers.any { it.userId == roomMember.userId },
-            onCheckedChange = { onToggleSelection(roomMember) },
-            enabled = canToggle,
-        )
+        if (!canToggle && roomMember.role is RoomMember.Role.Owner) {
+            Text(stringResource(R.string.screen_room_member_list_role_owner))
+        } else {
+            Checkbox(
+                checked = selectedUsers.any { it.userId == roomMember.userId },
+                onCheckedChange = { onToggleSelection(roomMember) },
+                enabled = canToggle,
+            )
+        }
     }
     MemberRow(
         modifier = Modifier.clickable(enabled = canToggle, onClick = { onToggleSelection(roomMember) }),

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsStateProvider.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsStateProvider.kt
@@ -55,15 +55,15 @@ internal fun aChangeRoomPermissionsState(
 private fun previewPermissions(): RoomPowerLevelsValues {
     return RoomPowerLevelsValues(
         // MembershipModeration section
-        invite = RoomMember.Role.ADMIN.powerLevel,
-        kick = RoomMember.Role.MODERATOR.powerLevel,
-        ban = RoomMember.Role.USER.powerLevel,
+        invite = RoomMember.Role.Admin.powerLevel,
+        kick = RoomMember.Role.Moderator.powerLevel,
+        ban = RoomMember.Role.User.powerLevel,
         // MessagesAndContent section
-        redactEvents = RoomMember.Role.MODERATOR.powerLevel,
-        sendEvents = RoomMember.Role.ADMIN.powerLevel,
+        redactEvents = RoomMember.Role.Moderator.powerLevel,
+        sendEvents = RoomMember.Role.Admin.powerLevel,
         // RoomDetails section
-        roomName = RoomMember.Role.ADMIN.powerLevel,
-        roomAvatar = RoomMember.Role.MODERATOR.powerLevel,
-        roomTopic = RoomMember.Role.USER.powerLevel,
+        roomName = RoomMember.Role.Admin.powerLevel,
+        roomAvatar = RoomMember.Role.Moderator.powerLevel,
+        roomTopic = RoomMember.Role.User.powerLevel,
     )
 }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeRoomPermissionsView.kt
@@ -80,21 +80,21 @@ fun ChangeRoomPermissionsView(
                     ListSectionHeader(titleForSection(item = permissionItem), hasDivider = index > 0)
                     SelectRoleItem(
                         permissionsItem = permissionItem,
-                        role = RoomMember.Role.ADMIN,
+                        role = RoomMember.Role.Admin,
                         currentPermissions = state.currentPermissions
                     ) { item, role ->
                         state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(item, role))
                     }
                     SelectRoleItem(
                         permissionsItem = permissionItem,
-                        role = RoomMember.Role.MODERATOR,
+                        role = RoomMember.Role.Moderator,
                         currentPermissions = state.currentPermissions
                     ) { item, role ->
                         state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(item, role))
                     }
                     SelectRoleItem(
                         permissionsItem = permissionItem,
-                        role = RoomMember.Role.USER,
+                        role = RoomMember.Role.User,
                         currentPermissions = state.currentPermissions
                     ) { item, role ->
                         state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(item, role))
@@ -135,9 +135,10 @@ private fun SelectRoleItem(
     onClick: (RoomPermissionType, RoomMember.Role) -> Unit
 ) {
     val title = when (role) {
-        RoomMember.Role.ADMIN, RoomMember.Role.CREATOR -> stringResource(R.string.screen_room_change_permissions_administrators)
-        RoomMember.Role.MODERATOR -> stringResource(R.string.screen_room_change_permissions_moderators)
-        RoomMember.Role.USER -> stringResource(R.string.screen_room_change_permissions_everyone)
+        RoomMember.Role.Admin -> stringResource(R.string.screen_room_change_permissions_administrators)
+        RoomMember.Role.Moderator -> stringResource(R.string.screen_room_change_permissions_moderators)
+        RoomMember.Role.User -> stringResource(R.string.screen_room_change_permissions_everyone)
+        else -> error("Unsupported role selected: $role")
     }
     ListItem(
         headlineContent = { Text(text = title) },

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionPresenterTest.kt
@@ -66,7 +66,7 @@ class RolesAndPermissionPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            initialState.eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.MODERATOR))
+            initialState.eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.Moderator))
 
             runCurrent()
             assertThat(awaitItem().changeOwnRoleAction).isEqualTo(AsyncAction.Loading)
@@ -87,7 +87,7 @@ class RolesAndPermissionPresenterTest {
             presenter.present()
         }.test {
             val initialState = awaitItem()
-            initialState.eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.MODERATOR))
+            initialState.eventSink(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.Moderator))
 
             runCurrent()
             assertThat(awaitItem().changeOwnRoleAction).isEqualTo(AsyncAction.Loading)

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/RolesAndPermissionsViewTest.kt
@@ -126,7 +126,7 @@ class RolesAndPermissionsViewTest {
         )
         rule.clickOn(R.string.screen_room_roles_and_permissions_change_role_demote_to_moderator)
         rule.mainClock.advanceTimeBy(1_000L)
-        recorder.assertSingle(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.MODERATOR))
+        recorder.assertSingle(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.Moderator))
     }
 
     @Test
@@ -140,7 +140,7 @@ class RolesAndPermissionsViewTest {
         )
         rule.clickOn(R.string.screen_room_roles_and_permissions_change_role_demote_to_member)
         rule.mainClock.advanceTimeBy(1_000L)
-        recorder.assertSingle(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.USER))
+        recorder.assertSingle(RolesAndPermissionsEvents.DemoteSelfTo(RoomMember.Role.User))
     }
 
     @Test

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesPresenterTest.kt
@@ -12,6 +12,7 @@ import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
+import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.features.roomdetails.impl.members.aRoomMemberList
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
@@ -43,7 +44,7 @@ class ChangeRolesPresenterTest {
             presenter.present()
         }.test {
             with(awaitItem()) {
-                assertThat(role).isEqualTo(RoomMember.Role.ADMIN)
+                assertThat(role).isEqualTo(RoomMember.Role.Admin)
                 assertThat(query).isNull()
                 assertThat(isSearchActive).isFalse()
                 assertThat(searchResults).isInstanceOf(SearchBarResultState.Initial::class.java)
@@ -67,6 +68,28 @@ class ChangeRolesPresenterTest {
         }.test {
             skipItems(1)
             assertThat(awaitItem().searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
+        }
+    }
+
+    @Test
+    fun `present - when modifying admins, creators are displayed too`() = runTest {
+        val room = FakeJoinedRoom().apply {
+            val creatorUserId = UserId("@creator:matrix.org")
+            val memberList = aRoomMemberList()
+                .plus(aRoomMember(displayName = "CREATOR", role = RoomMember.Role.Owner(isCreator = true), userId = creatorUserId))
+                .toPersistentList()
+            givenRoomInfo(aRoomInfo(roomCreators = listOf(creatorUserId)))
+            givenRoomMembersState(RoomMembersState.Ready(memberList))
+        }
+        val presenter = createChangeRolesPresenter(room = room)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            skipItems(1)
+            awaitItem().searchResults.run {
+                assertThat(this).isInstanceOf(SearchBarResultState.Results::class.java)
+                assertThat((this as SearchBarResultState.Results).results.admins.last().role).isEqualTo(RoomMember.Role.Owner(isCreator = true))
+            }
         }
     }
 
@@ -145,7 +168,7 @@ class ChangeRolesPresenterTest {
     fun `present - UserSelectionToggle adds and removes users from the selected user list`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
         val presenter = createChangeRolesPresenter(room = room)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -167,7 +190,7 @@ class ChangeRolesPresenterTest {
     fun `present - hasPendingChanges is true when the initial selected users don't match the new ones`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
         val presenter = createChangeRolesPresenter(room = room)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -196,7 +219,7 @@ class ChangeRolesPresenterTest {
     fun `present - Exit will display success if no pending changes`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
         val presenter = createChangeRolesPresenter(room = room)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -216,7 +239,7 @@ class ChangeRolesPresenterTest {
     fun `present - CancelExit will remove exit confirmation`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
         val presenter = createChangeRolesPresenter(room = room)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -242,7 +265,7 @@ class ChangeRolesPresenterTest {
     fun `present - Exit will display a confirmation dialog if there are pending changes, calling it again will actually exit`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
         val presenter = createChangeRolesPresenter(room = room)
         moleculeFlow(RecompositionMode.Immediate) {
@@ -273,9 +296,9 @@ class ChangeRolesPresenterTest {
             baseRoom = FakeBaseRoom(updateMembersResult = { Result.success(Unit) }),
         ).apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
-        val presenter = createChangeRolesPresenter(role = RoomMember.Role.ADMIN, room = room)
+        val presenter = createChangeRolesPresenter(role = RoomMember.Role.Admin, room = room)
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
@@ -302,9 +325,9 @@ class ChangeRolesPresenterTest {
     fun `present - CancelSave will remove the confirmation dialog`() = runTest {
         val room = FakeJoinedRoom().apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.ADMIN)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Admin)))
         }
-        val presenter = createChangeRolesPresenter(role = RoomMember.Role.ADMIN, room = room)
+        val presenter = createChangeRolesPresenter(role = RoomMember.Role.Admin, room = room)
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
@@ -331,10 +354,10 @@ class ChangeRolesPresenterTest {
             baseRoom = FakeBaseRoom(updateMembersResult = { Result.success(Unit) }),
         ).apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.MODERATOR)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Moderator)))
         }
         val presenter = createChangeRolesPresenter(
-            role = RoomMember.Role.MODERATOR,
+            role = RoomMember.Role.Moderator,
             room = room,
             analyticsService = analyticsService
         )
@@ -359,14 +382,54 @@ class ChangeRolesPresenterTest {
     }
 
     @Test
+    fun `present - Save will just save the changes if the current user is a room creator and the selected users are not`() = runTest {
+        val analyticsService = FakeAnalyticsService()
+        val room = FakeJoinedRoom(
+            updateUserRoleResult = { Result.success(Unit) },
+            baseRoom = FakeBaseRoom(updateMembersResult = { Result.success(Unit) }),
+        ).apply {
+            givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
+            givenRoomInfo(
+                aRoomInfo(
+                    roomCreators = listOf(sessionId),
+                    roomPowerLevels = roomPowerLevelsWithRole(role = RoomMember.Role.Admin, userId = A_USER_ID_2)
+                )
+            )
+        }
+        val presenter = createChangeRolesPresenter(
+            role = RoomMember.Role.Admin,
+            room = room,
+            analyticsService = analyticsService
+        )
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            skipItems(1)
+            val initialState = awaitItem()
+            assertThat(initialState.selectedUsers).hasSize(1)
+
+            initialState.eventSink(ChangeRolesEvent.UserSelectionToggled(MatrixUser(A_USER_ID_2)))
+
+            awaitItem().eventSink(ChangeRolesEvent.Save)
+
+            val loadingState = awaitItem()
+            assertThat(loadingState.savingState).isInstanceOf(AsyncAction.Loading::class.java)
+            skipItems(1)
+
+            assertThat(awaitItem().savingState).isEqualTo(AsyncAction.Success(Unit))
+            assertThat(analyticsService.capturedEvents.last()).isEqualTo(RoomModeration(RoomModeration.Action.ChangeMemberRole, RoomModeration.Role.User))
+        }
+    }
+
+    @Test
     fun `present - Save can handle failures and ClearError clears them`() = runTest {
         val room = FakeJoinedRoom(
             updateUserRoleResult = { Result.failure(IllegalStateException("Failed")) }
         ).apply {
             givenRoomMembersState(RoomMembersState.Ready(aRoomMemberList()))
-            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.MODERATOR)))
+            givenRoomInfo(aRoomInfo(roomPowerLevels = roomPowerLevelsWithRole(RoomMember.Role.Moderator)))
         }
-        val presenter = createChangeRolesPresenter(role = RoomMember.Role.MODERATOR, room = room)
+        val presenter = createChangeRolesPresenter(role = RoomMember.Role.Moderator, room = room)
         moleculeFlow(RecompositionMode.Immediate) {
             presenter.present()
         }.test {
@@ -399,7 +462,7 @@ class ChangeRolesPresenterTest {
     }
 
     private fun TestScope.createChangeRolesPresenter(
-        role: RoomMember.Role = RoomMember.Role.ADMIN,
+        role: RoomMember.Role = RoomMember.Role.Admin,
         room: FakeJoinedRoom = FakeJoinedRoom(),
         dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
         analyticsService: FakeAnalyticsService = FakeAnalyticsService(),

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/ChangeRolesViewTest.kt
@@ -45,7 +45,7 @@ class ChangeRolesViewTest {
         val exception = runCatchingExceptions {
             rule.setChangeRolesContent(
                 state = aChangeRolesState(
-                    role = RoomMember.Role.USER,
+                    role = RoomMember.Role.User,
                     eventSink = EnsureNeverCalledWithParam(),
                 ),
             )
@@ -166,7 +166,7 @@ class ChangeRolesViewTest {
         val eventsRecorder = EventsRecorder<ChangeRolesEvent>()
         rule.setChangeRolesContent(
             state = aChangeRolesState(
-                role = RoomMember.Role.ADMIN,
+                role = RoomMember.Role.Admin,
                 isSearchActive = true,
                 savingState = AsyncAction.ConfirmingNoParams,
                 eventSink = eventsRecorder,
@@ -183,7 +183,7 @@ class ChangeRolesViewTest {
         val eventsRecorder = EventsRecorder<ChangeRolesEvent>()
         rule.setChangeRolesContent(
             state = aChangeRolesState(
-                role = RoomMember.Role.ADMIN,
+                role = RoomMember.Role.Admin,
                 isSearchActive = true,
                 savingState = AsyncAction.ConfirmingNoParams,
                 eventSink = eventsRecorder,

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/MembersByRoleTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/changeroles/MembersByRoleTest.kt
@@ -14,6 +14,8 @@ import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.libraries.matrix.test.A_USER_ID_3
 import io.element.android.libraries.matrix.test.A_USER_ID_4
 import io.element.android.libraries.matrix.test.A_USER_ID_5
+import io.element.android.libraries.matrix.test.A_USER_ID_6
+import io.element.android.libraries.matrix.test.A_USER_ID_7
 import io.element.android.libraries.matrix.test.room.aRoomMember
 import kotlinx.collections.immutable.persistentListOf
 import org.junit.Test
@@ -22,22 +24,26 @@ class MembersByRoleTest {
     @Test
     fun `constructor - with single member list categorizes and sorts members`() {
         val members = listOf(
-            aRoomMember(A_USER_ID_2, displayName = "Bob", role = RoomMember.Role.ADMIN),
-            aRoomMember(A_USER_ID, displayName = "Alice", role = RoomMember.Role.ADMIN),
-            aRoomMember(A_USER_ID_3, displayName = "Carol", role = RoomMember.Role.USER),
-            aRoomMember(A_USER_ID_5, displayName = "Eve", role = RoomMember.Role.USER),
-            aRoomMember(A_USER_ID_4, displayName = "David", role = RoomMember.Role.USER),
+            aRoomMember(A_USER_ID_2, displayName = "Bob", role = RoomMember.Role.Admin),
+            aRoomMember(A_USER_ID, displayName = "Alice", role = RoomMember.Role.Admin),
+            aRoomMember(A_USER_ID_3, displayName = "Carol", role = RoomMember.Role.User),
+            aRoomMember(A_USER_ID_5, displayName = "Eve", role = RoomMember.Role.User),
+            aRoomMember(A_USER_ID_4, displayName = "David", role = RoomMember.Role.User),
+            aRoomMember(A_USER_ID_6, displayName = "Justin", role = RoomMember.Role.Owner(isCreator = true)),
+            aRoomMember(A_USER_ID_7, displayName = "Mallory", role = RoomMember.Role.Owner(isCreator = false)),
         )
         val membersByRole = MembersByRole(members = members)
         assertThat(membersByRole.admins).containsExactly(
-            aRoomMember(A_USER_ID, displayName = "Alice", role = RoomMember.Role.ADMIN),
-            aRoomMember(A_USER_ID_2, displayName = "Bob", role = RoomMember.Role.ADMIN),
+            aRoomMember(A_USER_ID_6, displayName = "Justin", role = RoomMember.Role.Owner(isCreator = true)),
+            aRoomMember(A_USER_ID_7, displayName = "Mallory", role = RoomMember.Role.Owner(isCreator = false)),
+            aRoomMember(A_USER_ID, displayName = "Alice", role = RoomMember.Role.Admin),
+            aRoomMember(A_USER_ID_2, displayName = "Bob", role = RoomMember.Role.Admin),
         )
         assertThat(membersByRole.moderators).isEmpty()
         assertThat(membersByRole.members).containsExactly(
-            aRoomMember(A_USER_ID_3, displayName = "Carol", role = RoomMember.Role.USER),
-            aRoomMember(A_USER_ID_4, displayName = "David", role = RoomMember.Role.USER),
-            aRoomMember(A_USER_ID_5, displayName = "Eve", role = RoomMember.Role.USER),
+            aRoomMember(A_USER_ID_3, displayName = "Carol", role = RoomMember.Role.User),
+            aRoomMember(A_USER_ID_4, displayName = "David", role = RoomMember.Role.User),
+            aRoomMember(A_USER_ID_5, displayName = "Eve", role = RoomMember.Role.User),
         )
     }
 
@@ -47,7 +53,7 @@ class MembersByRoleTest {
         assertThat(emptyMembersByRole.isEmpty()).isTrue()
 
         val membersByRoleWithAdmins = MembersByRole(
-            admins = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.ADMIN)),
+            admins = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.Admin)),
             moderators = persistentListOf(),
             members = persistentListOf(),
         )
@@ -55,7 +61,7 @@ class MembersByRoleTest {
 
         val membersByRoleWithModerators = MembersByRole(
             admins = persistentListOf(),
-            moderators = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.MODERATOR)),
+            moderators = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.Moderator)),
             members = persistentListOf(),
         )
         assertThat(membersByRoleWithModerators.isEmpty()).isFalse()
@@ -63,7 +69,7 @@ class MembersByRoleTest {
         val membersByRoleWithMembers = MembersByRole(
             admins = persistentListOf(),
             moderators = persistentListOf(),
-            members = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.USER)),
+            members = persistentListOf(aRoomMember(A_USER_ID, role = RoomMember.Role.User)),
         )
         assertThat(membersByRoleWithMembers.isEmpty()).isFalse()
     }

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeBaseRoomPermissionsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeBaseRoomPermissionsPresenterTest.kt
@@ -15,9 +15,9 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.RoomModeration
 import io.element.android.libraries.architecture.AsyncAction
-import io.element.android.libraries.matrix.api.room.RoomMember.Role.ADMIN
-import io.element.android.libraries.matrix.api.room.RoomMember.Role.MODERATOR
-import io.element.android.libraries.matrix.api.room.RoomMember.Role.USER
+import io.element.android.libraries.matrix.api.room.RoomMember.Role.Admin
+import io.element.android.libraries.matrix.api.room.RoomMember.Role.Moderator
+import io.element.android.libraries.matrix.api.room.RoomMember.Role.User
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevelsValues
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
@@ -100,13 +100,13 @@ class ChangeBaseRoomPermissionsPresenterTest {
             presenter.present()
         }.test {
             val state = awaitUpdatedItem()
-            assertThat(state.currentPermissions?.roomName).isEqualTo(ADMIN.powerLevel)
+            assertThat(state.currentPermissions?.roomName).isEqualTo(Admin.powerLevel)
             assertThat(state.hasChanges).isFalse()
 
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, MODERATOR))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, Moderator))
 
             awaitItem().run {
-                assertThat(currentPermissions?.roomName).isEqualTo(MODERATOR.powerLevel)
+                assertThat(currentPermissions?.roomName).isEqualTo(Moderator.powerLevel)
                 assertThat(hasChanges).isTrue()
             }
         }
@@ -120,28 +120,28 @@ class ChangeBaseRoomPermissionsPresenterTest {
         }.test {
             val state = awaitUpdatedItem()
 
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.INVITE, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.KICK, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.BAN, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.SEND_EVENTS, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.REDACT_EVENTS, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_AVATAR, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_TOPIC, MODERATOR))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.INVITE, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.KICK, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.BAN, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.SEND_EVENTS, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.REDACT_EVENTS, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_AVATAR, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_TOPIC, Moderator))
 
             val items = cancelAndConsumeRemainingEvents()
 
             (items.last() as? Event.Item<ChangeRoomPermissionsState>)?.value?.run {
                 assertThat(currentPermissions).isEqualTo(
                     RoomPowerLevelsValues(
-                        invite = MODERATOR.powerLevel,
-                        kick = MODERATOR.powerLevel,
-                        ban = MODERATOR.powerLevel,
-                        redactEvents = MODERATOR.powerLevel,
-                        sendEvents = MODERATOR.powerLevel,
-                        roomName = MODERATOR.powerLevel,
-                        roomAvatar = MODERATOR.powerLevel,
-                        roomTopic = MODERATOR.powerLevel,
+                        invite = Moderator.powerLevel,
+                        kick = Moderator.powerLevel,
+                        ban = Moderator.powerLevel,
+                        redactEvents = Moderator.powerLevel,
+                        sendEvents = Moderator.powerLevel,
+                        roomName = Moderator.powerLevel,
+                        roomAvatar = Moderator.powerLevel,
+                        roomTopic = Moderator.powerLevel,
                     )
                 )
             }
@@ -162,17 +162,17 @@ class ChangeBaseRoomPermissionsPresenterTest {
             presenter.present()
         }.test {
             val state = awaitUpdatedItem()
-            assertThat(state.currentPermissions?.roomName).isEqualTo(ADMIN.powerLevel)
+            assertThat(state.currentPermissions?.roomName).isEqualTo(Admin.powerLevel)
             assertThat(state.hasChanges).isFalse()
 
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_AVATAR, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_TOPIC, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.SEND_EVENTS, MODERATOR))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.REDACT_EVENTS, USER))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.KICK, ADMIN))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.BAN, ADMIN))
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.INVITE, ADMIN))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_AVATAR, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_TOPIC, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.SEND_EVENTS, Moderator))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.REDACT_EVENTS, User))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.KICK, Admin))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.BAN, Admin))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.INVITE, Admin))
             skipItems(7)
             assertThat(awaitItem().hasChanges).isTrue()
 
@@ -181,7 +181,7 @@ class ChangeBaseRoomPermissionsPresenterTest {
             assertThat(awaitItem().saveAction).isEqualTo(AsyncAction.Loading)
             assertThat(awaitItem().hasChanges).isFalse()
             awaitItem().run {
-                assertThat(currentPermissions?.roomName).isEqualTo(MODERATOR.powerLevel)
+                assertThat(currentPermissions?.roomName).isEqualTo(Moderator.powerLevel)
                 assertThat(saveAction).isEqualTo(AsyncAction.Success(Unit))
             }
             assertThat(analyticsService.capturedEvents).containsExactlyElementsIn(
@@ -227,17 +227,17 @@ class ChangeBaseRoomPermissionsPresenterTest {
             presenter.present()
         }.test {
             val state = awaitUpdatedItem()
-            assertThat(state.currentPermissions?.roomName).isEqualTo(ADMIN.powerLevel)
+            assertThat(state.currentPermissions?.roomName).isEqualTo(Admin.powerLevel)
             assertThat(state.hasChanges).isFalse()
 
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, MODERATOR))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, Moderator))
             assertThat(awaitItem().hasChanges).isTrue()
 
             state.eventSink(ChangeRoomPermissionsEvent.Save)
 
             assertThat(awaitItem().saveAction).isEqualTo(AsyncAction.Loading)
             awaitItem().run {
-                assertThat(currentPermissions?.roomName).isEqualTo(MODERATOR.powerLevel)
+                assertThat(currentPermissions?.roomName).isEqualTo(Moderator.powerLevel)
                 // Couldn't save the changes, so they're still pending
                 assertThat(hasChanges).isTrue()
                 assertThat(saveAction).isInstanceOf(AsyncAction.Failure::class.java)
@@ -245,7 +245,7 @@ class ChangeBaseRoomPermissionsPresenterTest {
 
             state.eventSink(ChangeRoomPermissionsEvent.ResetPendingActions)
             awaitItem().run {
-                assertThat(currentPermissions?.roomName).isEqualTo(MODERATOR.powerLevel)
+                assertThat(currentPermissions?.roomName).isEqualTo(Moderator.powerLevel)
                 assertThat(saveAction).isEqualTo(AsyncAction.Uninitialized)
                 assertThat(hasChanges).isTrue()
             }
@@ -259,7 +259,7 @@ class ChangeBaseRoomPermissionsPresenterTest {
             presenter.present()
         }.test {
             val state = awaitUpdatedItem()
-            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, MODERATOR))
+            state.eventSink(ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, Moderator))
             assertThat(awaitItem().hasChanges).isTrue()
 
             state.eventSink(ChangeRoomPermissionsEvent.Exit)

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeBaseRoomPermissionsViewTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/rolesandpermissions/permissions/ChangeBaseRoomPermissionsViewTest.kt
@@ -115,9 +115,9 @@ class ChangeBaseRoomPermissionsViewTest {
         rule.onAllNodesWithText(users).onFirst().performClick()
         recorder.assertList(
             listOf(
-                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.ADMIN),
-                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.MODERATOR),
-                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.USER),
+                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.Admin),
+                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.Moderator),
+                ChangeRoomPermissionsEvent.ChangeMinimumRoleForAction(RoomPermissionType.ROOM_NAME, RoomMember.Role.User),
             )
         )
     }

--- a/features/roommembermoderation/impl/src/test/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenterTest.kt
+++ b/features/roommembermoderation/impl/src/test/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenterTest.kt
@@ -61,8 +61,8 @@ class RoomMemberModerationPresenterTest {
         val room = aJoinedRoom(
             canBan = false,
             canKick = false,
-            myUserRole = RoomMember.Role.USER,
-            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.USER.powerLevel)
+            myUserRole = RoomMember.Role.User,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.User.powerLevel)
         )
         createRoomMemberModerationPresenter(room = room).test {
             val initialState = awaitState()
@@ -81,7 +81,7 @@ class RoomMemberModerationPresenterTest {
         val room = aJoinedRoom(
             canBan = true,
             canKick = true,
-            myUserRole = RoomMember.Role.ADMIN,
+            myUserRole = RoomMember.Role.Admin,
             targetRoomMember = null
         )
         createRoomMemberModerationPresenter(room = room).test {
@@ -103,8 +103,8 @@ class RoomMemberModerationPresenterTest {
         val room = aJoinedRoom(
             canBan = true,
             canKick = true,
-            myUserRole = RoomMember.Role.ADMIN,
-            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.USER.powerLevel)
+            myUserRole = RoomMember.Role.Admin,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.User.powerLevel)
         )
         createRoomMemberModerationPresenter(room = room).test {
             val initialState = awaitState()
@@ -125,8 +125,8 @@ class RoomMemberModerationPresenterTest {
         val room = aJoinedRoom(
             canBan = true,
             canKick = true,
-            myUserRole = RoomMember.Role.MODERATOR,
-            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.ADMIN.powerLevel)
+            myUserRole = RoomMember.Role.Moderator,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.Admin.powerLevel)
         )
         createRoomMemberModerationPresenter(room = room).test {
             val initialState = awaitState()
@@ -147,7 +147,7 @@ class RoomMemberModerationPresenterTest {
         val room = aJoinedRoom(
             canBan = true,
             canKick = true,
-            myUserRole = RoomMember.Role.MODERATOR,
+            myUserRole = RoomMember.Role.Moderator,
             targetRoomMember = aRoomMember(userId = A_USER_ID, membership = RoomMembershipState.BAN)
         )
         createRoomMemberModerationPresenter(room = room).test {
@@ -321,7 +321,7 @@ class RoomMemberModerationPresenterTest {
     private fun aJoinedRoom(
         canKick: Boolean = false,
         canBan: Boolean = false,
-        myUserRole: RoomMember.Role = RoomMember.Role.USER,
+        myUserRole: RoomMember.Role = RoomMember.Role.User,
         kickUserResult: Result<Unit> = Result.success(Unit),
         banUserResult: Result<Unit> = Result.success(Unit),
         unBanUserResult: Result<Unit> = Result.success(Unit),

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomInfo.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomInfo.kt
@@ -83,7 +83,7 @@ data class RoomInfo(
      * Returns the list of users with the given [role] in this room.
      */
     fun usersWithRole(role: RoomMember.Role): List<UserId> {
-        return if (role == RoomMember.Role.CREATOR) {
+        return if (role is RoomMember.Role.Owner && role.isCreator) {
             this.creators
         } else {
             this.roomPowerLevels?.usersWithRole(role).orEmpty().toList()

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/powerlevels/RoomPowerLevels.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/powerlevels/RoomPowerLevels.kt
@@ -26,13 +26,22 @@ data class RoomPowerLevels(
     private val users: ImmutableMap<UserId, Long>,
 ) {
     /**
+     * Returns the power level of the user in the room.
+     *
+     * If the user is not found, returns 0.
+     */
+    fun powerLevelOf(userId: UserId): Long {
+        return users[userId] ?: 0L
+    }
+
+    /**
      * Returns the set of [UserId]s that have the given role in the room.
      *
-     * **WARNING**: This method must not be used with the [RoomMember.Role.CREATOR] role. It'll result in a runtime error.
+     * **WARNING**: This method must not be used with a creator role. It'll result in a runtime error.
      */
     fun usersWithRole(role: RoomMember.Role): Set<UserId> {
-        return if (role == RoomMember.Role.CREATOR) {
-            error("RoomPowerLevels.usersWithRole should not be used with CREATOR role, use roomInfo.creators instead")
+        return if (role is RoomMember.Role.Owner && role.isCreator) {
+            error("RoomPowerLevels.usersWithRole should not be used with a creator role, use roomInfo.creators instead")
         } else {
             users.filterValues { RoomMember.Role.forPowerLevel(it) == role }.keys
         }
@@ -42,7 +51,7 @@ data class RoomPowerLevels(
      * Returns the role of the user in the room based on their power level.
      * If the user is not found, returns null.
      *
-     * **WARNING**: This method must not be used with the [RoomMember.Role.CREATOR] role, as it won't return any results.
+     * **WARNING**: This method must not be used with a creator role, as it won't return any results.
      */
     fun roleOf(userId: UserId): RoomMember.Role? {
         return users[userId]?.let(RoomMember.Role::forPowerLevel)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -343,7 +343,7 @@ class RustMatrixClient(
                 powerLevelContentOverride = defaultRoomCreationPowerLevels.copy(
                     invite = if (createRoomParams.joinRuleOverride == JoinRule.Knock) {
                         // override the invite power level so it's the same as kick.
-                        RoomMember.Role.MODERATOR.powerLevel.toInt()
+                        RoomMember.Role.Moderator.powerLevel.toInt()
                     } else {
                         null
                     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustBaseRoom.kt
@@ -128,7 +128,11 @@ class RustBaseRoom(
 
     override suspend fun userRole(userId: UserId): Result<RoomMember.Role> = withContext(roomDispatcher) {
         runCatchingExceptions {
-            RoomMemberMapper.mapRole(innerRoom.suggestedRoleForUser(userId.value))
+            val powerLevel = roomInfoFlow.value.roomPowerLevels?.powerLevelOf(userId) ?: 0L
+            RoomMemberMapper.mapRole(
+                role = innerRoom.suggestedRoleForUser(userId.value),
+                powerLevel = powerLevel,
+            )
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapper.kt
@@ -16,25 +16,36 @@ import org.matrix.rustcomponents.sdk.MembershipState as RustMembershipState
 import org.matrix.rustcomponents.sdk.RoomMember as RustRoomMember
 
 object RoomMemberMapper {
-    fun map(roomMember: RustRoomMember): RoomMember = RoomMember(
-        userId = UserId(roomMember.userId),
-        displayName = roomMember.displayName,
-        avatarUrl = roomMember.avatarUrl,
-        membership = mapMembership(roomMember.membership),
-        isNameAmbiguous = roomMember.isNameAmbiguous,
-        powerLevel = roomMember.powerLevel.into(),
-        normalizedPowerLevel = roomMember.normalizedPowerLevel.into(),
-        isIgnored = roomMember.isIgnored,
-        role = mapRole(roomMember.suggestedRoleForPowerLevel),
-        membershipChangeReason = roomMember.membershipChangeReason
-    )
+    fun map(roomMember: RustRoomMember): RoomMember {
+        val powerLevel = roomMember.powerLevel.into()
+        return RoomMember(
+            userId = UserId(roomMember.userId),
+            displayName = roomMember.displayName,
+            avatarUrl = roomMember.avatarUrl,
+            membership = mapMembership(roomMember.membership),
+            isNameAmbiguous = roomMember.isNameAmbiguous,
+            powerLevel = powerLevel,
+            normalizedPowerLevel = roomMember.normalizedPowerLevel.into(),
+            isIgnored = roomMember.isIgnored,
+            role = mapRole(roomMember.suggestedRoleForPowerLevel, powerLevel),
+            membershipChangeReason = roomMember.membershipChangeReason
+        )
+    }
 
-    fun mapRole(role: RoomMemberRole): RoomMember.Role =
+    fun mapRole(role: RoomMemberRole, powerLevel: Long?): RoomMember.Role =
         when (role) {
-            RoomMemberRole.CREATOR -> RoomMember.Role.CREATOR
-            RoomMemberRole.ADMINISTRATOR -> RoomMember.Role.ADMIN
-            RoomMemberRole.MODERATOR -> RoomMember.Role.MODERATOR
-            RoomMemberRole.USER -> RoomMember.Role.USER
+            RoomMemberRole.CREATOR -> RoomMember.Role.Owner(isCreator = true)
+            RoomMemberRole.ADMINISTRATOR -> {
+                val superAdmin = RoomMember.Role.Owner(isCreator = false)
+                val powerLevelOrDefault = powerLevel ?: 0L
+                if (powerLevelOrDefault >= superAdmin.powerLevel) {
+                    superAdmin
+                } else {
+                    RoomMember.Role.Admin
+                }
+            }
+            RoomMemberRole.MODERATOR -> RoomMember.Role.Moderator
+            RoomMemberRole.USER -> RoomMember.Role.User
         }
 
     fun mapMembership(membershipState: RustMembershipState): RoomMembershipState =

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/powerlevels/RoomPowerLevelsValuesMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/powerlevels/RoomPowerLevelsValuesMapper.kt
@@ -28,6 +28,6 @@ object RoomPowerLevelsValuesMapper {
 }
 
 fun PowerLevel.into(): Long = when (this) {
-    PowerLevel.Infinite -> RoomMember.Role.CREATOR.powerLevel
+    PowerLevel.Infinite -> RoomMember.Role.Owner(isCreator = true).powerLevel
     is PowerLevel.Value -> this.value
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapperTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/member/RoomMemberMapperTest.kt
@@ -17,9 +17,19 @@ import org.matrix.rustcomponents.sdk.MembershipState as RustMembershipState
 class RoomMemberMapperTest {
     @Test
     fun mapRole() {
-        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.USER)).isEqualTo(RoomMember.Role.USER)
-        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.MODERATOR)).isEqualTo(RoomMember.Role.MODERATOR)
-        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.ADMINISTRATOR)).isEqualTo(RoomMember.Role.ADMIN)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.USER, 0L)).isEqualTo(RoomMember.Role.User)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.MODERATOR, 50L)).isEqualTo(RoomMember.Role.Moderator)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.ADMINISTRATOR, 100L)).isEqualTo(RoomMember.Role.Admin)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.ADMINISTRATOR, 150L)).isEqualTo(RoomMember.Role.Owner(isCreator = false))
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.CREATOR, Long.MAX_VALUE)).isEqualTo(RoomMember.Role.Owner(isCreator = true))
+
+        // `null` power level defaults to USER role
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.ADMINISTRATOR, null)).isEqualTo(RoomMember.Role.Admin)
+
+        // Power level is only taken into account for ADMINISTRATOR role
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.USER, 123L)).isEqualTo(RoomMember.Role.User)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.MODERATOR, 1L)).isEqualTo(RoomMember.Role.Moderator)
+        assertThat(RoomMemberMapper.mapRole(RoomMemberRole.CREATOR, 0L)).isEqualTo(RoomMember.Role.Owner(isCreator = true))
     }
 
     @Test

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomMemberFixture.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/RoomMemberFixture.kt
@@ -20,7 +20,7 @@ fun aRoomMember(
     powerLevel: Long = 0L,
     normalizedPowerLevel: Long = 0L,
     isIgnored: Boolean = false,
-    role: RoomMember.Role = RoomMember.Role.USER,
+    role: RoomMember.Role = RoomMember.Role.User,
     membershipChangeReason: String? = null,
 ) = RoomMember(
     userId = userId,

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/model/RoomInfoExtension.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/model/RoomInfoExtension.kt
@@ -22,14 +22,14 @@ fun RoomInfo.getAvatarData(size: AvatarSize) = AvatarData(
 
 /**
  * Returns the role of the user in the room.
- * If the user is a creator, returns [RoomMember.Role.CREATOR].
+ * If the user is a creator, returns [RoomMember.Role.Owner].
  * Otherwise, checks the power levels and returns the corresponding role.
- * If no specific power level is set for the user, defaults to [RoomMember.Role.USER].
+ * If no specific power level is set for the user, defaults to [RoomMember.Role.User].
  */
 fun RoomInfo.roleOf(userId: UserId): RoomMember.Role {
     return if (creators.contains(userId)) {
-        RoomMember.Role.CREATOR
+        RoomMember.Role.Owner(isCreator = true)
     } else {
-        roomPowerLevels?.roleOf(userId) ?: RoomMember.Role.USER
+        roomPowerLevels?.roleOf(userId) ?: RoomMember.Role.User
     }
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomState.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/room/MatrixRoomState.kt
@@ -99,7 +99,7 @@ fun BaseRoom.canHandleKnockRequestsAsState(updateKey: Long): State<Boolean> {
 fun BaseRoom.userPowerLevelAsState(updateKey: Long): State<Long> {
     return produceState(initialValue = 0, key1 = updateKey) {
         value = userRole(sessionId)
-            .getOrDefault(RoomMember.Role.USER)
+            .getOrDefault(RoomMember.Role.User)
             .powerLevel
     }
 }
@@ -108,7 +108,7 @@ fun BaseRoom.userPowerLevelAsState(updateKey: Long): State<Long> {
 fun BaseRoom.isOwnUserAdmin(): Boolean {
     val roomInfo by roomInfoFlow.collectAsState()
     val role = roomInfo.roleOf(sessionId)
-    return role == RoomMember.Role.ADMIN || role == RoomMember.Role.CREATOR
+    return role == RoomMember.Role.Admin || role is RoomMember.Role.Owner
 }
 
 @Composable


### PR DESCRIPTION
## Content

- Makes `RoomMember.Role` a sealed interface instead of an enum so it's not tied to a power level. Replace `RoomMember.Role.CREATOR` with `.Owner(isCreator: Boolean)`, which maps both creators and super admins.
- Adapt 'roles and permissions' screen to these changes, forbidding owners from demoting themselves and adjusting the admin member count to take into account owners too.
- Adapt 'change role' screen for owners: owners can't modify the roles of other owners (promote/demote) but can modify any other users with no need for confirmation.

## Motivation and context

https://github.com/element-hq/element-x-android/issues/5059 and https://github.com/element-hq/element-x-android/issues/5070.

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
