### PR TITLE
Prevent loop when exiting the attachments preview screen

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
@@ -66,7 +66,7 @@ fun AttachmentsPreviewView(
         state.eventSink(AttachmentsPreviewEvents.CancelAndClearSendState)
     }
 
-    BackHandler(enabled = state.sendActionState !is SendActionState.Sending.Uploading) {
+    BackHandler(enabled = state.sendActionState !is SendActionState.Sending.Uploading && state.sendActionState !is SendActionState.Done) {
         postCancel()
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Disable the custom `BackHandler` when the `sendState` is `Done`.

## Motivation and context

Otherwise, it can get into a loop in some cases where `postCancel()` calls the `OnDoneListener`, which triggers an up navigation, which then simulates a back press... and we end up in the custom `BackHandler` again.

## Tests

I couldn't reproduce the issue myself, and it seems to happen in several Android versions according to the Play Store reports:

- Android 11 (SDK 30)
- Android 14 (SDK 34)
- Android 15 (SDK 35)
- Android 16 Beta (SDK 36)

I could just take a guess at the issue given the stack trace:

<details>
<summary>Details</summary>
<pre>
at io.element.android.libraries.androidutils.file.DefaultTemporaryUriDeleter.delete (TemporaryUriDeleter.kt:36)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.dismiss (AttachmentsPreviewPresenter.java:219)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.present$handleEvents (AttachmentsPreviewPresenter.java:143)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.access$present$handleEvents (AttachmentsPreviewPresenter.java:50)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter$present$2$1.invoke (AttachmentsPreviewPresenter.java:171)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter$present$2$1.invoke (AttachmentsPreviewPresenter.java:171)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewViewKt.AttachmentsPreviewView$postCancel (AttachmentsPreviewView.kt:62)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewViewKt.AttachmentsPreviewView$lambda$1$lambda$0 (AttachmentsPreviewView.kt:70)
  at androidx.activity.compose.BackHandlerKt$BackHandler$backCallback$1$1.handleOnBackPressed (BackHandler.kt:89)
  at androidx.activity.OnBackPressedDispatcher.onBackPressed (OnBackPressedDispatcher.kt:260)
  at androidx.activity.ComponentActivity.onBackPressed (ComponentActivity.kt:588)
  at com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint.handleUpNavigation (ActivityIntegrationPoint.kt:43)
  at com.bumble.appyx.core.node.Node.navigateUp (Node.kt:221)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewNode.onDoneListener$lambda$0 (AttachmentsPreviewNode.java:37)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.dismiss (AttachmentsPreviewPresenter.java:227)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.present$handleEvents (AttachmentsPreviewPresenter.java:143)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter.access$present$handleEvents (AttachmentsPreviewPresenter.java:50)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter$present$2$1.invoke (AttachmentsPreviewPresenter.java:171)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewPresenter$present$2$1.invoke (AttachmentsPreviewPresenter.java:171)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewViewKt.AttachmentsPreviewView$postCancel (AttachmentsPreviewView.kt:62)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewViewKt.AttachmentsPreviewView$lambda$1$lambda$0 (AttachmentsPreviewView.kt:70)
  at androidx.activity.compose.BackHandlerKt$BackHandler$backCallback$1$1.handleOnBackPressed (BackHandler.kt:89)
  at androidx.activity.OnBackPressedDispatcher.onBackPressed (OnBackPressedDispatcher.kt:260)
  at androidx.activity.ComponentActivity.onBackPressed (ComponentActivity.kt:588)
  at com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint.handleUpNavigation (ActivityIntegrationPoint.kt:43)
  at com.bumble.appyx.core.node.Node.navigateUp (Node.kt:221)
  at io.element.android.features.messages.impl.attachments.preview.AttachmentsPreviewNode.onDoneListener$lambda$0 (AttachmentsPreviewNode.java:37)
...
</pre>
</details>

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
