### PR TITLE
Make sure we display errors when we create a recovery key and it fails

### DIFF
--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupState.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupState.kt
@@ -23,6 +23,7 @@ sealed interface SetupState {
     data object Creating : SetupState
     data class Created(val formattedRecoveryKey: String) : SetupState
     data class CreatedAndSaved(val formattedRecoveryKey: String) : SetupState
+    data class Error(val exception: Exception) : SetupState
 }
 
 fun SetupState.recoveryKey(): String? = when (this) {

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupStateProvider.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupStateProvider.kt
@@ -23,6 +23,7 @@ open class SecureBackupSetupStateProvider : PreviewParameterProvider<SecureBacku
                 setupState = SetupState.CreatedAndSaved(aFormattedRecoveryKey()),
                 showSaveConfirmationDialog = true,
             ),
+            aSecureBackupSetupState(setupState = SetupState.Error(Exception("Test error"))),
             // Add other states here
         )
 }

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupView.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/setup/SecureBackupSetupView.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.androidutils.system.startSharePlainTextInten
 import io.element.android.libraries.designsystem.atomic.pages.FlowStepPage
 import io.element.android.libraries.designsystem.components.BigIcon
 import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
+import io.element.android.libraries.designsystem.components.dialogs.ErrorDialog
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.Button
@@ -49,6 +50,16 @@ fun SecureBackupSetupView(
         Content(state = state)
     }
 
+    if (state.setupState is SetupState.Error) {
+        ErrorDialog(
+            title = stringResource(id = CommonStrings.common_something_went_wrong),
+            content = stringResource(id = CommonStrings.common_something_went_wrong_message),
+            onSubmit = {
+                state.eventSink.invoke(SecureBackupSetupEvents.DismissDialog)
+            },
+        )
+    }
+
     if (state.showSaveConfirmationDialog) {
         ConfirmationDialog(
             title = stringResource(id = R.string.screen_recovery_key_setup_confirmation_title),
@@ -70,7 +81,8 @@ private fun SecureBackupSetupState.canGoBack(): Boolean {
 private fun title(state: SecureBackupSetupState): String {
     return when (state.setupState) {
         SetupState.Init,
-        SetupState.Creating -> if (state.isChangeRecoveryKeyUserStory) {
+        SetupState.Creating,
+        is SetupState.Error -> if (state.isChangeRecoveryKeyUserStory) {
             stringResource(id = R.string.screen_recovery_key_change_title)
         } else {
             stringResource(id = R.string.screen_recovery_key_setup_title)
@@ -85,7 +97,8 @@ private fun title(state: SecureBackupSetupState): String {
 private fun subtitle(state: SecureBackupSetupState): String {
     return when (state.setupState) {
         SetupState.Init,
-        SetupState.Creating -> if (state.isChangeRecoveryKeyUserStory) {
+        SetupState.Creating,
+        is SetupState.Error -> if (state.isChangeRecoveryKeyUserStory) {
             stringResource(id = R.string.screen_recovery_key_change_description)
         } else {
             stringResource(id = R.string.screen_recovery_key_setup_description)
@@ -137,7 +150,8 @@ private fun ColumnScope.Buttons(
     val chooserTitle = stringResource(id = R.string.screen_recovery_key_save_action)
     when (state.setupState) {
         SetupState.Init,
-        SetupState.Creating -> {
+        SetupState.Creating,
+        is SetupState.Error -> {
             Button(
                 text = stringResource(id = CommonStrings.action_done),
                 enabled = false,

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
@@ -26,7 +26,8 @@ class FakeEncryptionService(
     private val pinUserIdentityResult: (UserId) -> Result<Unit> = { lambdaError() },
     private val isUserVerifiedResult: (UserId) -> Result<Boolean> = { lambdaError() },
     private val withdrawVerificationResult: (UserId) -> Result<Unit> = { lambdaError() },
-    private val getUserIdentityResult: (UserId) -> Result<IdentityState?> = { lambdaError() }
+    private val getUserIdentityResult: (UserId) -> Result<IdentityState?> = { lambdaError() },
+    private val enableRecoveryLambda: (Boolean) -> Result<Unit> = { lambdaError() },
 ) : EncryptionService {
     private var disableRecoveryFailure: Exception? = null
     override val backupStateStateFlow: MutableStateFlow<BackupState> = MutableStateFlow(BackupState.UNKNOWN)
@@ -87,7 +88,7 @@ class FakeEncryptionService(
     }
 
     override suspend fun enableRecovery(waitForBackupsToUpload: Boolean): Result<Unit> = simulateLongTask {
-        return Result.success(Unit)
+        return enableRecoveryLambda(waitForBackupsToUpload)
     }
 
     fun givenWaitForBackupUploadSteadyStateFlow(flow: Flow<BackupUploadState>) {

--- a/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupViewChange_Day_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupViewChange_Day_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d55e9236e761726e03742c6292ec3ced7af48b385da5a7be9eccc444a78ec312
+size 35886

--- a/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupViewChange_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupViewChange_Night_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bc9364efa8aa639f8989d74a5172665ee0fa8f4c9c354b584cfdabfd98d723c
+size 32964

--- a/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupView_Day_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupView_Day_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34272a001ad54175280dc251375cee45e2978cba78c7d4b08b10d59ae7093d93
+size 34340

--- a/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupView_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.securebackup.impl.setup_SecureBackupSetupView_Night_5_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86e9cbfe60551d6d7f052ad0a7f75eda029569d9d51cf63339e223df5332ec63
+size 31674


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When enabling the recovery key fails, display an error dialog and ask to retry.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5074.

## Screenshots / GIFs

In the PR.

## Tests

Follow the instructions in the issue, you should now get an error dialog if generating the key fails.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
