### PR TITLE
Fix leaving the room not always dismissing the room screen

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
@@ -163,8 +163,7 @@ class RoomFlowNode @AssistedInject constructor(
                 else -> {
                     if (membership == CurrentUserMembership.LEFT && previousMembership == CurrentUserMembership.JOINED) {
                         // The user left the room in this device, remove the room from the backstack
-                        val lastLocalMembershipUpdate = membershipUpdateFlow.first()
-                        if (lastLocalMembershipUpdate.roomId == roomId && !lastLocalMembershipUpdate.isUserInRoom) {
+                        if (!membershipUpdateFlow.first().isUserInRoom) {
                             navigateUp()
                         }
                     } else {

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/Flow.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/coroutine/Flow.kt
@@ -8,11 +8,24 @@
 package io.element.android.libraries.core.coroutine
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.runningFold
 
 /**
  * Returns the first element of the flow that is an instance of [T], waiting for it if necessary.
  */
 suspend inline fun <reified T> Flow<*>.firstInstanceOf(): T {
     return first { it is T } as T
+}
+
+/**
+ * Returns a flow that emits pairs of the previous and current values.
+ * The first emission will be a pair of `null` and the first value emitted by the source flow.
+ */
+fun <T> Flow<T>.withPreviousValue(): Flow<Pair<T?, T>> {
+    return runningFold(null) { prev: Pair<T?, T>?, current ->
+        prev?.second to current
+    }
+        .filterNotNull()
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Use the existing `RoomInfo` membership check to dismiss the room instead of using `RoomMembershipObserver`.

As a side effect, the room screen will be dismissed too if the room is left on another client.

## Motivation and context

Fix issue observed in Maestro where leaving the room wouldn't dismiss the screen but transition to a 'not-joined' screen.

## Tests

Maestro passes again. I couldn't reproduce this locally, might be a race condition as @ganfra suggested.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
