### PR TITLE
feature (media send queue) : enable send queue by default

### DIFF
--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -140,9 +140,9 @@ enum class FeatureFlags(
     MediaUploadOnSendQueue(
         key = "feature.media_upload_through_send_queue",
         title = "Media upload through send queue",
-        description = "Experimental support for treating media uploads as regular events, with an improved retry and cancellation implementation.",
-        defaultValue = { buildMeta -> buildMeta.buildType != BuildType.RELEASE },
-        isFinished = false,
+        description = "Support for treating media uploads as regular events, with an improved retry and cancellation implementation.",
+        defaultValue = { true },
+        isFinished = true,
     ),
     MediaCaptionCreation(
         key = "feature.media_caption_creation",


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
Following discussions around https://github.com/element-hq/element-x-android/issues/4883, enable send queue by default and hide the feature flag from dev settings.
<!-- Describe shortly what has been changed -->

## Motivation and context
Improve sending media.
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
