### PR TITLE
Delegate the sending of call notifications to Element Call

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -248,9 +248,7 @@ class CallScreenPresenter @AssistedInject constructor(
                 Timber.d("Observing sync state in-call for sessionId: ${roomCallType.sessionId}")
                 client.syncService().syncState
                     .collect { state ->
-                        if (state == SyncState.Running) {
-                            client.notifyCallStartIfNeeded(callType.roomId)
-                        } else {
+                        if (state != SyncState.Running) {
                             appForegroundStateService.updateIsInCallState(true)
                         }
                     }
@@ -261,32 +259,6 @@ class CallScreenPresenter @AssistedInject constructor(
                 appForegroundStateService.updateIsInCallState(false)
             }
         }
-    }
-
-    private suspend fun MatrixClient.notifyCallStartIfNeeded(roomId: RoomId) {
-        if (notifiedCallStart) return
-
-        val activeRoomForSession = activeRoomsHolder.getActiveRoomMatching(sessionId, roomId)
-        val sendCallNotificationResult = if (activeRoomForSession != null) {
-            Timber.d("Notifying call start for room $roomId. Has room call: ${activeRoomForSession.info().hasRoomCall}")
-            activeRoomForSession.sendCallNotificationIfNeeded()
-        } else {
-            // Instantiate the room from the session and roomId and send the notification
-            getJoinedRoom(roomId)?.use { room ->
-                Timber.d("Notifying call start for room $roomId. Has room call: ${room.info().hasRoomCall}")
-                room.sendCallNotificationIfNeeded()
-            } ?: run {
-                Timber.w("No room found for session $sessionId and room $roomId, skipping call notification.")
-                return
-            }
-        }
-
-        sendCallNotificationResult.fold(
-            onSuccess = { notifiedCallStart = true },
-            onFailure = { error ->
-                Timber.e(error, "Failed to send call notification for room $roomId.")
-            }
-        )
     }
 
     private fun parseMessage(message: String): WidgetMessage? {

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
@@ -13,6 +13,7 @@ import io.element.android.libraries.di.AppScope
 import io.element.android.libraries.matrix.api.MatrixClientProvider
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.room.isDm
 import io.element.android.libraries.matrix.api.widget.CallWidgetSettingsProvider
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.services.appnavstate.api.ActiveRoomsHolder
@@ -44,7 +45,7 @@ class DefaultCallWidgetProvider @Inject constructor(
         val baseUrl = customBaseUrl ?: EMBEDDED_CALL_WIDGET_BASE_URL
 
         val isEncrypted = room.info().isEncrypted ?: room.getUpdatedIsEncrypted().getOrThrow()
-        val widgetSettings = callWidgetSettingsProvider.provide(baseUrl, encrypted = isEncrypted)
+        val widgetSettings = callWidgetSettingsProvider.provide(baseUrl, encrypted = isEncrypted, direct = room.isDm())
         val callUrl = room.generateWidgetWebViewUrl(
             widgetSettings = widgetSettings,
             clientId = clientId,

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
@@ -82,19 +82,12 @@ import kotlin.time.Duration.Companion.seconds
     }
 
     @Test
-    fun `present - with CallType RoomCall sets call as active, loads URL, runs WidgetDriver and notifies the other clients a call started`() = runTest {
-        val sendCallNotificationIfNeededLambda = lambdaRecorder<Result<Boolean>> { Result.success(true) }
-        val syncService = FakeSyncService(SyncState.Running)
-        val fakeRoom = FakeJoinedRoom(sendCallNotificationIfNeededResult = sendCallNotificationIfNeededLambda)
-        val client = FakeMatrixClient(syncService = syncService).apply {
-            givenGetRoomResult(A_ROOM_ID, fakeRoom)
-        }
+    fun `present - with CallType RoomCall sets call as active, loads URL and runs WidgetDriver`() = runTest {
         val widgetDriver = FakeMatrixWidgetDriver()
         val widgetProvider = FakeCallWidgetProvider(widgetDriver)
         val analyticsLambda = lambdaRecorder<MobileScreen.ScreenName, Unit> {}
         val joinedCallLambda = lambdaRecorder<CallType, Unit> {}
         val presenter = createCallScreenPresenter(
-            matrixClientsProvider = FakeMatrixClientProvider(getClient = { Result.success(client) }),
             callType = CallType.RoomCall(A_SESSION_ID, A_ROOM_ID),
             widgetDriver = widgetDriver,
             widgetProvider = widgetProvider,
@@ -116,7 +109,6 @@ import kotlin.time.Duration.Companion.seconds
             assertThat(widgetProvider.getWidgetCalled).isTrue()
             assertThat(widgetDriver.runCalledCount).isEqualTo(1)
             analyticsLambda.assertions().isCalledOnce().with(value(MobileScreen.ScreenName.RoomCall))
-            sendCallNotificationIfNeededLambda.assertions().isCalledOnce()
 
             // Wait until the WidgetDriver is loaded
             skipItems(1)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -215,7 +215,7 @@ anvil_compiler_api = { module = "dev.zacsweers.anvil:compiler-api", version.ref 
 anvil_compiler_utils = { module = "dev.zacsweers.anvil:compiler-utils", version.ref = "anvil" }
 
 # Element Call
-element_call_embedded = "io.element.android:element-call-embedded:0.13.1"
+element_call_embedded = "io.element.android:element-call-embedded:0.14.0"
 
 # Auto services
 google_autoservice = { module = "com.google.auto.service:auto-service", version.ref = "autoservice" }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/JoinedRoom.kt
@@ -156,11 +156,6 @@ interface JoinedRoom : BaseRoom {
      */
     fun getWidgetDriver(widgetSettings: MatrixWidgetSettings): Result<MatrixWidgetDriver>
 
-    /**
-     * Send an Element Call started notification if needed.
-     */
-    suspend fun sendCallNotificationIfNeeded(): Result<Boolean>
-
     suspend fun setSendQueueEnabled(enabled: Boolean)
 
     /**

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/widget/CallWidgetSettingsProvider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/widget/CallWidgetSettingsProvider.kt
@@ -14,5 +14,6 @@ interface CallWidgetSettingsProvider {
         baseUrl: String,
         widgetId: String = UUID.randomUUID().toString(),
         encrypted: Boolean,
+        direct: Boolean,
     ): MatrixWidgetSettings
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -428,12 +428,6 @@ class JoinedRustRoom(
         }
     }
 
-    override suspend fun sendCallNotificationIfNeeded(): Result<Boolean> = withContext(roomDispatcher) {
-        runCatchingExceptions {
-            innerRoom.sendCallNotificationIfNeeded()
-        }
-    }
-
     override suspend fun setSendQueueEnabled(enabled: Boolean) {
         withContext(roomDispatcher) {
             Timber.d("setSendQueuesEnabled: $enabled")

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/DefaultCallWidgetSettingsProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/widget/DefaultCallWidgetSettingsProvider.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.first
 import org.matrix.rustcomponents.sdk.newVirtualElementCallWidget
 import uniffi.matrix_sdk.EncryptionSystem
 import uniffi.matrix_sdk.HeaderStyle
+import uniffi.matrix_sdk.NotificationType
 import uniffi.matrix_sdk.VirtualElementCallWidgetOptions
 import javax.inject.Inject
 import uniffi.matrix_sdk.Intent as CallIntent
@@ -29,7 +30,7 @@ class DefaultCallWidgetSettingsProvider @Inject constructor(
     private val callAnalyticsCredentialsProvider: CallAnalyticCredentialsProvider,
     private val analyticsService: AnalyticsService,
 ) : CallWidgetSettingsProvider {
-    override suspend fun provide(baseUrl: String, widgetId: String, encrypted: Boolean): MatrixWidgetSettings {
+    override suspend fun provide(baseUrl: String, widgetId: String, encrypted: Boolean, direct: Boolean): MatrixWidgetSettings {
         val isAnalyticsEnabled = analyticsService.userConsentFlow.first()
         val options = VirtualElementCallWidgetOptions(
             elementCallUrl = baseUrl,
@@ -53,6 +54,7 @@ class DefaultCallWidgetSettingsProvider @Inject constructor(
             hideHeader = true,
             controlledMediaDevices = true,
             header = HeaderStyle.APP_BAR,
+            sendNotificationType = if (direct) NotificationType.RING else NotificationType.NOTIFICATION,
         )
         val rustWidgetSettings = newVirtualElementCallWidget(options)
         return MatrixWidgetSettings.fromRustWidgetSettings(rustWidgetSettings)

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeJoinedRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeJoinedRoom.kt
@@ -55,7 +55,6 @@ class FakeJoinedRoom(
     private val roomNotificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
     private var createTimelineResult: (CreateTimelineParams) -> Result<Timeline> = { lambdaError() },
     private val editMessageLambda: (EventId, String, String?, List<IntentionalMention>) -> Result<Unit> = { _, _, _, _ -> lambdaError() },
-    private val sendCallNotificationIfNeededResult: () -> Result<Boolean> = { lambdaError() },
     private val progressCallbackValues: List<Pair<Long, Long>> = emptyList(),
     private val generateWidgetWebViewUrlResult: (MatrixWidgetSettings, String, String?, String?) -> Result<String> = { _, _, _, _ -> lambdaError() },
     private val getWidgetDriverResult: (MatrixWidgetSettings) -> Result<MatrixWidgetDriver> = { lambdaError() },
@@ -205,10 +204,6 @@ class FakeJoinedRoom(
 
     override fun getWidgetDriver(widgetSettings: MatrixWidgetSettings): Result<MatrixWidgetDriver> {
         return getWidgetDriverResult(widgetSettings)
-    }
-
-    override suspend fun sendCallNotificationIfNeeded(): Result<Boolean> = simulateLongTask {
-        sendCallNotificationIfNeededResult()
     }
 
     override suspend fun setSendQueueEnabled(enabled: Boolean) = simulateLongTask {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

As of Element Call version 0.14.0, the widget is now capable of sending call notifications itself if we just request this with the `sendNotificationType` URL parameter. This will more reliably trigger a notification on the receiver side than what we were doing before with `Room::send_call_notification_if_needed`, since it always waits until the `m.call.member` state event has been sent before sending the notification event.

This change requires matrix-rust-sdk to be updated to https://github.com/matrix-org/matrix-rust-sdk/commit/feadfde1b54f2caf9d1dbbbd0208781b657b0c3f or later. I don't have permission to run the workflows on https://github.com/matrix-org/matrix-rust-components-kotlin, so I'll need your help to get this done.

I would also like to **backport this fix** to the RC if possible once reviewed.

## Motivation and context

Android implementation of https://github.com/element-hq/voip-internal/issues/381

## Tests

<!-- Explain how you tested your development -->

1. Open a receiving client on another device
2. On the phone, go to a non-DM room and start a call
3. Verify that the receiving client shows a visual notification
4. On the phone, go to your DM with the receiver and start a call
5. Verify that the receiving client plays a ringtone

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): LineageOS 22.2 (Android 15)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
