### PR TITLE
When mapping an invalid notification event, only drop that one

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
@@ -53,7 +53,9 @@ class RustNotificationService(
                             is BatchNotificationResult.Ok -> {
                                 when (val status = result.status) {
                                     is NotificationStatus.Event -> {
-                                        put(eventId, Result.success(notificationMapper.map(sessionId, eventId, roomId, status.item)))
+                                        val result = notificationMapper.map(sessionId, eventId, roomId, status.item)
+                                        result.onFailure { Timber.e(it, "Could not map notification event $eventId") }
+                                        put(eventId, result)
                                     }
                                     is NotificationStatus.EventNotFound -> {
                                         Timber.e("Could not retrieve event for notification with $eventId - event not found")

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.impl.notification
 
+import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.CallNotifyType
@@ -21,10 +22,12 @@ import org.matrix.rustcomponents.sdk.TimelineEventType
 import org.matrix.rustcomponents.sdk.use
 
 class TimelineEventToNotificationContentMapper {
-    fun map(timelineEvent: TimelineEvent): NotificationContent {
-        return timelineEvent.use {
-            timelineEvent.eventType().use { eventType ->
-                eventType.toContent(senderId = UserId(timelineEvent.senderId()))
+    fun map(timelineEvent: TimelineEvent): Result<NotificationContent> {
+        return runCatchingExceptions {
+            timelineEvent.use {
+                timelineEvent.eventType().use { eventType ->
+                    eventType.toContent(senderId = UserId(timelineEvent.senderId()))
+                }
             }
         }
     }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiTimelineEvent.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiTimelineEvent.kt
@@ -14,7 +14,7 @@ import org.matrix.rustcomponents.sdk.NoPointer
 import org.matrix.rustcomponents.sdk.TimelineEvent
 import org.matrix.rustcomponents.sdk.TimelineEventType
 
-class FakeFfiTimelineEvent(
+open class FakeFfiTimelineEvent(
     val timestamp: ULong = A_FAKE_TIMESTAMP.toULong(),
     val timelineEventType: TimelineEventType = aRustTimelineEventTypeMessageLike(),
     val senderId: String = A_USER_ID_2.value,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. I added a regression test too.

## Motivation and context

Previously, this meant the code processing the whole notification batch result failed and other notifications would be lost too.

## Tests

If the new unit test passes, it should be fine.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
