### PR TITLE
Update Compose bom to 2025.07.00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ camera = "1.4.2"
 
 # Compose
 compose_bom = "2025.07.00"
-composecompiler = "1.5.15"
 
 # Coroutines
 coroutines = "1.10.2"
@@ -222,10 +221,6 @@ google_autoservice = { module = "com.google.auto.service:auto-service", version.
 google_autoservice_annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoservice" }
 
 # Miscellaneous
-# Add unused dependency to androidx.compose.compiler:compiler to let Renovate create PR to change the
-# value of `composecompiler` (which is used to set composeOptions.kotlinCompilerExtensionVersion.
-# See https://github.com/renovatebot/renovate/issues/18354
-android_composeCompiler = { module = "androidx.compose.compiler:compiler", version.ref = "composecompiler" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 
 [bundles]


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Update Compose bom to 2025.07.00

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Same issue than #4970, except that that dependency dashboard do not mention it, Renovate did not create a PR, so I do it manually.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Smoke tests (in progress)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
