### PR TITLE
Fix sending videos in Android 11 and lower

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -42,3 +42,12 @@
 }
 
 -keep class io.element.android.x.di.** { *; }
+
+
+# Keep LogSessionId class and related classes (https://github.com/androidx/media/issues/2535)
+-keep class android.media.metrics.LogSessionId { *; }
+-keep class android.media.metrics.** { *; }
+
+# Keep Media3 classes that use reflection (https://github.com/androidx/media/issues/2535)
+-keep class androidx.media3.** { *; }
+-dontwarn android.media.metrics.**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says, it fixes an error dismissing the send video screen, with the following stack trace:

```
Thread: DefaultDispatcher-worker-2, Exception: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/media/metrics/LogSessionId;
at coil3.ImageLoader$Builder.createAssetLoader(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:63)
at androidx.media3.transformer.DefaultAssetLoaderFactory.createAssetLoader(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:77)
at androidx.camera.core.SurfaceRequest$4.createAssetLoader(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:25)
at androidx.media3.transformer.SequenceAssetLoader.(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:75)
at androidx.media3.transformer.TransformerInternal.(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:182)
at androidx.media3.transformer.Transformer.startInternal(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:184)
at io.element.android.libraries.mediaupload.impl.VideoCompressor$compress$1$1.invokeSuspend(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:390)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:9)
at kotlinx.coroutines.DispatchedTask.run(r8-map-id-7700c5d5ea2efbf39986a72da7ed949880eeac9c56003bdcb4e494b8f83682ba:115)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:246)
at android.app.ActivityThread.main(ActivityThread.java:8653)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.platform.MotionDurationScaleImpl@9cc1d5e, androidx.compose.runtime.BroadcastFrameClock@18f553f, StandaloneCoroutine{Cancelling}@3baae0c, AndroidUiDispatcher@cbf355]
Caused by: java.lang.ClassNotFoundException: android.media.metrics.LogSessionId
... 16 more
```

Which is weird, because according to the docs, `LogSessionId` was added for API 31, so it would be normal for it to be missing on API 30 and lower. However, the added proguard rules fix this problem, so maybe the docs are wrong.

## Motivation and context

This is caused by a bug in the Media3 Transform library: https://github.com/androidx/media/issues/2535.

## Tests

Using an emulator or real device with API 30 (Android 11):

- Build and install the nightly/release version of the app.
- Try sending a video in a room.
- If the preview screen doesn't disappear automatically, it should be fixed.

Previously the attachment preview screen would be gone and you'd see the stack trace mentioned above instead.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
