### PR TITLE
Set shortcut ID on received notifications to make them appear as a Conversation

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -136,7 +136,10 @@ class DefaultNotificationCreator @Inject constructor(
                 // that can be displayed in not disturb mode if white listed (the later will need compat28.x)
                 .setCategory(NotificationCompat.CATEGORY_MESSAGE)
                 // ID of the corresponding shortcut, for conversation features under API 30+
-                .setShortcutId(roomInfo.roomId.value)
+                // Must match those created in the ShortcutInfoCompat.Builder()
+                // for the notification to appear as a "Conversation":
+                // https://developer.android.com/develop/ui/views/notifications/conversations
+                .setShortcutId("${roomInfo.sessionId.value}-${roomInfo.roomId.value}")
                 // Auto-bundling is enabled for 4 or more notifications on API 24+ (N+)
                 // devices and all Wear devices. But we want a custom grouping, so we specify the groupID
                 .setGroup(roomInfo.sessionId.value)


### PR DESCRIPTION
This is the missing piece for Android to treat a notification as a "conversation". Note that this requires shortcuts to have already been created prior to receiving the notification.

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Notifications should now show as "conversations" (provided a shortcut for that conversation has already been created by sending a message with #5180)

## Motivation and context

Partially resolves #1547 

## Screenshots / GIFs

Here the user `Steve` doesn't have a shortcut in the left image, but they do the right (as I sent a message to them). User `frebib ⚡` does in both for contrast. The main difference seems to be the size of the avatar and the positioning of the notification within the tray

|Before|After|
|-|-|
|<img width="1344" height="1037" alt="Screenshot_20250820-220930~2" src="https://github.com/user-attachments/assets/d553f135-4895-459a-887f-ccd85e2752c5" />|<img width="1343" height="777" alt="Screenshot_20250820-221007" src="https://github.com/user-attachments/assets/c6f0dbdb-e8ee-4550-bd4b-e9f608060b59" />|

<img width="360" alt="Screenshot_20250820-213700" src="https://github.com/user-attachments/assets/8036acb7-7a70-462d-9c71-836c20f5fb7f" /><img width="360" alt="Screenshot_20250820-213711" src="https://github.com/user-attachments/assets/41abc04e-9fad-42ef-b0cc-c93a5d523b86" />


## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
