### PR TITLE
Introduce a11y screenshot test

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.hazeEffect
@@ -300,6 +301,25 @@ internal fun RoomListRoomSummary.contentType() = displayType.ordinal
 internal fun HomeViewPreview(@PreviewParameter(HomeStateProvider::class) state: HomeState) = ElementPreview {
     HomeView(
         homeState = state,
+        onRoomClick = {},
+        onSettingsClick = {},
+        onSetUpRecoveryClick = {},
+        onConfirmRecoveryKeyClick = {},
+        onStartChatClick = {},
+        onRoomSettingsClick = {},
+        onReportRoomClick = {},
+        onMenuActionClick = {},
+        onDeclineInviteAndBlockUser = {},
+        acceptDeclineInviteView = {},
+        leaveRoomView = {}
+    )
+}
+
+@Preview
+@Composable
+internal fun HomeViewA11yPreview() = ElementPreview {
+    HomeView(
+        homeState = aHomeState(),
         onRoomClick = {},
         onSettingsClick = {},
         onSetUpRecoveryClick = {},

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
@@ -12,6 +12,7 @@ import com.google.common.truth.Truth.assertThat
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
 import com.lemonappdev.konsist.api.ext.list.withName
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
 import com.lemonappdev.konsist.api.ext.list.withoutName
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertTrue
@@ -29,6 +30,26 @@ class KonsistPreviewTest {
                 it.hasNameEndingWith("Preview") &&
                     it.hasNameEndingWith("LightPreview").not() &&
                     it.hasNameEndingWith("DarkPreview").not()
+            }
+    }
+
+    @Test
+    fun `Check functions with 'A11yPreview'`() {
+        Konsist
+            .scopeFromProject()
+            .functions()
+            .withNameEndingWith("A11yPreview")
+            .assertTrue(
+                additionalMessage = "Functions with 'A11yPreview' suffix should have '@Previews' annotation and not '@PreviewsDayNight'," +
+                    " should contain 'ElementPreview' composable," +
+                    " should contain the tested view" +
+                    " and should be internal"
+            ) {
+                val testedView = it.name.removeSuffix("A11yPreview")
+                it.text.contains("$testedView(") &&
+                    it.hasAllAnnotationsOf(PreviewsDayNight::class).not() &&
+                    it.text.contains("ElementPreview") &&
+                    it.hasInternalModifier
             }
     }
 

--- a/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
+++ b/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
@@ -29,11 +29,24 @@ object ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
         AndroidComposablePreviewScanner()
             .scanPackageTrees(*PACKAGE_TREES)
             .getPreviews()
+            .filter { composablePreview -> composablePreview.methodName.endsWith("A11yPreview").not() }
             .withIndex()
             .toList()
     }
 
     override fun provideValues(): List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> = values
+}
+
+object ComposableA11yPreviewProvider : TestParameter.TestParameterValuesProvider {
+    private val values: List<ComposablePreview<AndroidPreviewInfo>> by lazy {
+        AndroidComposablePreviewScanner()
+            .scanPackageTrees(*PACKAGE_TREES)
+            .getPreviews()
+            .filter { composablePreview -> composablePreview.methodName.endsWith("A11yPreview") }
+            .toList()
+    }
+
+    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> = values
 }
 
 object Shard1ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {

--- a/tests/uitests/src/test/kotlin/base/ScreenshotTest.kt
+++ b/tests/uitests/src/test/kotlin/base/ScreenshotTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Density
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.RenderExtension
 import app.cash.paparazzi.TestName
 import com.android.resources.NightMode
 import io.element.android.compound.theme.ElementTheme
@@ -112,7 +113,12 @@ fun createScreenshotIdFor(preview: ComposablePreview<AndroidPreviewInfo>) = buil
 }.joinToString("_")
 
 object PaparazziPreviewRule {
-    fun createFor(preview: ComposablePreview<AndroidPreviewInfo>, locale: String, deviceConfig: DeviceConfig = ScreenshotTest.defaultDeviceConfig): Paparazzi {
+    fun createFor(
+        preview: ComposablePreview<AndroidPreviewInfo>,
+        locale: String,
+        deviceConfig: DeviceConfig = ScreenshotTest.defaultDeviceConfig,
+        renderExtensions: Set<RenderExtension> = setOf(),
+    ): Paparazzi {
         val densityScale = deviceConfig.density.dpiValue / 160f
         val customScreenHeight = preview.previewInfo.heightDp.takeIf { it >= 0 }?.let { it * densityScale }?.toInt()
         return Paparazzi(
@@ -125,7 +131,8 @@ object PaparazziPreviewRule {
                 softButtons = false,
                 screenHeight = customScreenHeight ?: deviceConfig.screenHeight,
             ),
-            maxPercentDifference = 0.01
+            maxPercentDifference = 0.01,
+            renderExtensions = renderExtensions,
         )
     }
 }

--- a/tests/uitests/src/test/kotlin/ui/PreviewA11yTest.kt
+++ b/tests/uitests/src/test/kotlin/ui/PreviewA11yTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package ui
+
+import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
+import base.ComposableA11yPreviewProvider
+import base.PaparazziPreviewRule
+import base.ScreenshotTest
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
+import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
+
+/**
+ * Test that takes a preview and runs a screenshot test on it.
+ * It uses [ComposableA11yPreviewProvider] to test only previews that ends with "A11yPreview".
+ */
+@RunWith(TestParameterInjector::class)
+class PreviewA11yTest(
+    @TestParameter(valuesProvider = ComposableA11yPreviewProvider::class)
+    val preview: ComposablePreview<AndroidPreviewInfo>,
+) {
+    @get:Rule
+    val paparazziRule = PaparazziPreviewRule.createFor(
+        preview = preview,
+        locale = "en",
+        renderExtensions = setOf(AccessibilityRenderExtension()),
+    )
+
+    @Test
+    fun snapshot() {
+        ScreenshotTest.runTest(paparazzi = paparazziRule, preview = preview, localeStr = "en")
+    }
+}

--- a/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21c09cac237b2b4823dbb945161c6d6d574dc2c8ffb37088696d09736d8e782a
+size 124636


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add a new test about a11y content and add a first preview (and then) screenshot with a11y information displayed.

See https://cashapp.github.io/paparazzi/accessibility/ for the used solution.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Be able to detect regression on a11y content

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Check the new recorded screenshot. It should contain a11y information.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
