### PR TITLE
Use variable bitrate mode when transcoding to ensure compatibility with old devices

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelper.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelper.kt
@@ -27,7 +27,11 @@ class VideoCompressorHelper(
     fun getOutputSize(inputSize: Size): Size {
         val resultMajor = min(inputSize.major(), maxSize)
         val aspectRatio = inputSize.major().toFloat() / inputSize.minor().toFloat()
-        return Size(resultMajor, (resultMajor / aspectRatio).roundToInt())
+        return if (inputSize.width >= inputSize.height) {
+            Size(resultMajor, (resultMajor / aspectRatio).roundToInt())
+        } else {
+            Size((resultMajor / aspectRatio).roundToInt(), resultMajor)
+        }
     }
 
     /**

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ThumbnailFactory.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/ThumbnailFactory.kt
@@ -123,8 +123,8 @@ class ThumbnailFactory @Inject constructor(
         val thumbnailResult = ThumbnailResult(
             file = thumbnailFile,
             info = ThumbnailInfo(
-                height = bitmapThumbnail.height.toLong(),
                 width = bitmapThumbnail.width.toLong(),
+                height = bitmapThumbnail.height.toLong(),
                 mimetype = mimeTypeToThumbnailMimeType(mimeType),
                 size = thumbnailFile.length()
             ),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This should be compatible with more old devices that may lack the needed codecs to properly encode using constant bitrate mode (CBR).

Also, rework the output size computation again. It seems to work fine now with both landscape and portrait videos, unless there's some unknown corner case I haven't found.

## Motivation and context

Fix https://github.com/element-hq/element-x-android/issues/4857.

## Tests

I had to use an old phone (OnePlus 8 I think) with Android 10 to reproduce the issue and test the fix.

- Using the stable version of the app, try sending a normal H264 video. If it gets sent as a file, the transcoding failed because of this issue.
- Then build and install this branch, send the same video. It should now be transcoded and sent as a video, not a file.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
