### PR TITLE
Add unit test on VideoCompressorHelper

### DIFF
--- a/libraries/androidutils/build.gradle.kts
+++ b/libraries/androidutils/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.test.junit)
     testImplementation(libs.test.truth)
     testImplementation(libs.test.robolectric)
+    testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.coroutines.core)
     testImplementation(libs.coroutines.test)
     testImplementation(projects.services.toolbox.test)

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelper.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelper.kt
@@ -27,7 +27,7 @@ class VideoCompressorHelper(
     fun getOutputSize(inputSize: Size): Size {
         val resultMajor = min(inputSize.major(), maxSize)
         val aspectRatio = inputSize.major().toFloat() / inputSize.minor().toFloat()
-        return if (inputSize.width >= inputSize.height) {
+        return if (inputSize.isLandscape()) {
             Size(resultMajor, (resultMajor / aspectRatio).roundToInt())
         } else {
             Size((resultMajor / aspectRatio).roundToInt(), resultMajor)
@@ -46,5 +46,6 @@ class VideoCompressorHelper(
     }
 }
 
-internal fun Size.major(): Int = if (width > height) width else height
-internal fun Size.minor(): Int = if (width < height) width else height
+private fun Size.isLandscape(): Boolean = width > height
+private fun Size.major(): Int = if (isLandscape()) width else height
+private fun Size.minor(): Int = if (isLandscape()) height else width

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelperTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelperTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.androidutils.media
+
+import android.util.Size
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class VideoCompressorHelperTest {
+    @Test
+    fun `test getOutputSize`() {
+        val helper = VideoCompressorHelper(maxSize = 720)
+
+        // Landscape input
+        var inputSize = Size(1920, 1080)
+        var outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(720, 405))
+
+        // Landscape input small height
+        inputSize = Size(1920, 200)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(720, 75))
+
+        // Portrait input
+        inputSize = Size(1080, 1920)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(405, 720))
+
+        // Portrait input small width
+        inputSize = Size(200, 1920)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(75, 720))
+
+        // Square input
+        inputSize = Size(1000, 1000)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(720, 720))
+
+        // Square input same size
+        inputSize = Size(720, 720)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(720, 720))
+
+        // Square input no downscaling
+        inputSize = Size(240, 240)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(240, 240))
+
+        // Small input landscape (no downscaling)
+        inputSize = Size(640, 480)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(640, 480))
+
+        // Small input portrait (no downscaling)
+        inputSize = Size(480, 640)
+        outputSize = helper.getOutputSize(inputSize)
+        assertThat(outputSize).isEqualTo(Size(480, 640))
+    }
+}

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelperTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/media/VideoCompressorHelperTest.kt
@@ -64,4 +64,16 @@ class VideoCompressorHelperTest {
         outputSize = helper.getOutputSize(inputSize)
         assertThat(outputSize).isEqualTo(Size(480, 640))
     }
+
+    @Test
+    fun `test calculateOptimalBitrate`() {
+        val helper = VideoCompressorHelper(maxSize = 720)
+        val inputSize = Size(1920, 1080)
+        var bitrate = helper.calculateOptimalBitrate(inputSize, frameRate = 30)
+        // Output size will be 720x405, so bitrate = 720*405*0.1*30 = 874800
+        assertThat(bitrate).isEqualTo(874800L)
+        // Half frame rate, half bitrate
+        bitrate = helper.calculateOptimalBitrate(inputSize, frameRate = 15)
+        assertThat(bitrate).isEqualTo(437400L)
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Add unit test on VideoCompressorHelper. Complement for #5223.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
More tests, less regression

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- This PR is adding unit tests.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
