### PR TITLE
[a11y] Add content descriptions to room list item indicators

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.home.impl.R
@@ -288,7 +289,10 @@ private fun MessagePreviewAndIndicatorRow(
 
         // Call and unread
         Row(
-            modifier = Modifier.height(16.dp),
+            modifier = Modifier
+                .height(16.dp)
+                // Used to force this line to be read aloud earlier than the latest event when using Talkback
+                .zIndex(-1f),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
@@ -285,6 +285,7 @@ private fun MessagePreviewAndIndicatorRow(
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
+
         // Call and unread
         Row(
             modifier = Modifier.height(16.dp),
@@ -371,7 +372,7 @@ private fun OnGoingCallIcon(
     Icon(
         modifier = Modifier.size(16.dp),
         imageVector = CompoundIcons.VideoCallSolid(),
-        contentDescription = null,
+        contentDescription = stringResource(CommonStrings.a11y_notifications_ongoing_call),
         tint = color,
     )
 }
@@ -380,7 +381,7 @@ private fun OnGoingCallIcon(
 private fun NotificationOffIndicatorAtom() {
     Icon(
         modifier = Modifier.size(16.dp),
-        contentDescription = null,
+        contentDescription = stringResource(CommonStrings.a11y_notifications_muted),
         imageVector = CompoundIcons.NotificationsOffSolid(),
         tint = ElementTheme.colors.iconQuaternary,
     )
@@ -390,7 +391,7 @@ private fun NotificationOffIndicatorAtom() {
 private fun MentionIndicatorAtom() {
     Icon(
         modifier = Modifier.size(16.dp),
-        contentDescription = null,
+        contentDescription = stringResource(CommonStrings.a11y_notifications_new_mentions),
         imageVector = CompoundIcons.Mention(),
         tint = ElementTheme.colors.unreadIndicator,
     )

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
@@ -304,8 +304,10 @@ private fun MessagePreviewAndIndicatorRow(
                 MentionIndicatorAtom()
             }
             if (room.hasNewContent) {
+                val contentDescription = stringResource(CommonStrings.a11y_notifications_new_messages)
                 UnreadIndicatorAtom(
-                    color = tint
+                    color = tint,
+                    contentDescription = contentDescription,
                 )
             }
         }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/UnreadIndicatorAtom.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/UnreadIndicatorAtom.kt
@@ -15,12 +15,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.unreadIndicator
+import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun UnreadIndicatorAtom(
@@ -29,8 +33,10 @@ fun UnreadIndicatorAtom(
     color: Color = ElementTheme.colors.unreadIndicator,
     isVisible: Boolean = true,
 ) {
+    val contentDescription = stringResource(CommonStrings.a11y_notifications_new_messages)
     Box(
         modifier = modifier
+            .semantics { this.contentDescription = contentDescription }
             .size(size)
             .clip(CircleShape)
             .background(if (isVisible) color else Color.Transparent)

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/UnreadIndicatorAtom.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/atoms/UnreadIndicatorAtom.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -24,7 +23,6 @@ import io.element.android.compound.theme.ElementTheme
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.unreadIndicator
-import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun UnreadIndicatorAtom(
@@ -32,11 +30,13 @@ fun UnreadIndicatorAtom(
     size: Dp = 12.dp,
     color: Color = ElementTheme.colors.unreadIndicator,
     isVisible: Boolean = true,
+    contentDescription: String? = null,
 ) {
-    val contentDescription = stringResource(CommonStrings.a11y_notifications_new_messages)
     Box(
         modifier = modifier
-            .semantics { this.contentDescription = contentDescription }
+            .semantics {
+                contentDescription?.let { this.contentDescription = it }
+            }
             .size(size)
             .clip(CircleShape)
             .background(if (isVisible) color else Color.Transparent)

--- a/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e0b4675b0b6de0d9efe12c8d7ec3c37de2761010f614e8bc609fc6de48c7b17
-size 127404
+oid sha256:a666f932d1a595763b3c88b31ffbe3d195ec0d986ca5f2c0173e8e25a6115317
+size 126085

--- a/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.home.impl_HomeViewA11y_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21c09cac237b2b4823dbb945161c6d6d574dc2c8ffb37088696d09736d8e782a
-size 124636
+oid sha256:6e0b4675b0b6de0d9efe12c8d7ec3c37de2761010f614e8bc609fc6de48c7b17
+size 127404


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. These can now be read aloud as 'ongoing call', 'new messages', 'new mentions'.

## Motivation and context

Closes https://github.com/element-hq/customer-success/issues/573.

## Tests

Enable a TTS solution like Talkback, then tap on different room list items/summaries.

- Tap on one without indicators: it should read just the room, timestamp and last message.
- Tap on one with an ongoing call: it should say also 'ongoing call'.
- Tap on one with mentions: it should say 'mentions', possible also 'new messages'.
- Tap on one with new messages: it should say 'new messages'.
- Tap on a muted one: it should say 'muted'.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
