### PR TITLE
Update state in runUpdatingState when CancellationException occurs

### DIFF
--- a/libraries/architecture/src/test/kotlin/io/element/android/libraries/architecture/AsyncActionTest.kt
+++ b/libraries/architecture/src/test/kotlin/io/element/android/libraries/architecture/AsyncActionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.architecture
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+class AsyncActionTest {
+    @Test
+    fun `updates state on timeout`() = runTest {
+        val state: MutableState<AsyncAction<Int>> = mutableStateOf(AsyncAction.Uninitialized)
+        val timeoutMillis = 500L
+        val operationTimeMillis = 1000L
+
+        try {
+            runUpdatingState(state = state) {
+                withTimeout(timeoutMillis.milliseconds) {
+                    delay(operationTimeMillis)
+                }
+                Result.success(0)
+            }
+            fail("Expected TimeoutCancellationException, but nothing was thrown")
+        } catch (e: TimeoutCancellationException) {
+            assertTrue(state.value.isFailure())
+            assertSame(e, state.value.errorOrNull())
+        }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomContentForwarder.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomContentForwarder.kt
@@ -14,7 +14,6 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.ForwardEventException
 import io.element.android.libraries.matrix.impl.roomlist.roomOrNull
 import io.element.android.libraries.matrix.impl.timeline.runWithTimelineListenerRegistered
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeout
 import org.matrix.rustcomponents.sdk.MsgLikeKind
 import org.matrix.rustcomponents.sdk.RoomListService
@@ -63,9 +62,6 @@ class RoomContentForwarder(
                 }
             }.onFailure {
                 failedForwardingTo.add(RoomId(room.id()))
-                if (it is CancellationException) {
-                    throw it
-                }
             }
         }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

`AsyncAction` > `runUpdatingState` wasn't updating the state when `CancellationException` occurs. This kind of exception happens, for example, when a timeout occurs. The state was remaining stuck in loading forever.

## Motivation and context

Issue
https://github.com/element-hq/element-x-android/issues/5242

## Tests

- A unit test was added to cover this scenario.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android API 33 (Samsung A32)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
