### PR TITLE
Hide the home navigation bar if the user is not a member of any Space.

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomePresenter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomePresenter.kt
@@ -74,6 +74,12 @@ class HomePresenter(
             }
         }
 
+        LaunchedEffect(homeSpacesState.spaceRooms.isEmpty()) {
+            // If the last space is left, ensure that the Chat view is rendered.
+            if (homeSpacesState.spaceRooms.isEmpty()) {
+                currentHomeNavigationBarItemOrdinal = HomeNavigationBarItem.Chats.ordinal
+            }
+        }
         val snackbarMessage by snackbarDispatcher.collectSnackbarMessageAsState()
         return HomeState(
             matrixUser = matrixUser.value,

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeState.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeState.kt
@@ -29,4 +29,5 @@ data class HomeState(
     val eventSink: (HomeEvents) -> Unit,
 ) {
     val displayActions = currentHomeNavigationBarItem == HomeNavigationBarItem.Chats
+    val showNavigationBar = isSpaceFeatureEnabled && homeSpacesState.spaceRooms.isNotEmpty()
 }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeStateProvider.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeStateProvider.kt
@@ -36,6 +36,8 @@ open class HomeStateProvider : PreviewParameterProvider<HomeState> {
                         summaries = generateRoomListRoomSummaryList(),
                     )
                 ),
+                // For the bottom nav bar to be visible in the preview, the user must be member of at least one space
+                homeSpacesState = aHomeSpacesState(),
             ),
             aHomeState(
                 isSpaceFeatureEnabled = true,

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -194,7 +194,7 @@ private fun HomeScaffold(
             )
         },
         bottomBar = {
-            if (state.isSpaceFeatureEnabled) {
+            if (state.showNavigationBar) {
                 NavigationBar(
                     containerColor = Color.Transparent,
                     modifier = Modifier

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/HomePresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/HomePresenterTest.kt
@@ -12,9 +12,11 @@ import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.impl.roomlist.aRoomListState
+import io.element.android.features.home.impl.spaces.HomeSpacesState
 import io.element.android.features.home.impl.spaces.aHomeSpacesState
 import io.element.android.features.logout.api.direct.aDirectLogoutState
 import io.element.android.features.rageshake.api.RageshakeFeatureAvailability
+import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
@@ -30,10 +32,10 @@ import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.A_USER_NAME
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
+import io.element.android.tests.testutils.MutablePresenter
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.test
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +67,7 @@ class HomePresenterTest {
             assertThat(withUserState.matrixUser.avatarUrl).isEqualTo(AN_AVATAR_URL)
             assertThat(withUserState.showAvatarIndicator).isFalse()
             assertThat(withUserState.isSpaceFeatureEnabled).isFalse()
+            assertThat(withUserState.showNavigationBar).isFalse()
         }
     }
 
@@ -145,13 +148,42 @@ class HomePresenterTest {
         }
     }
 
-    private fun TestScope.createHomePresenter(
+    @Test
+    fun `present - NavigationBar is hidden when the last space is left`() = runTest {
+        val homeSpacesPresenter = MutablePresenter(aHomeSpacesState())
+        val presenter = createHomePresenter(
+            featureFlagService = FakeFeatureFlagService(
+                initialState = mapOf(FeatureFlags.Space.key to true),
+            ),
+            homeSpacesPresenter = homeSpacesPresenter,
+        )
+        presenter.test {
+            skipItems(1)
+            val initialState = awaitItem()
+            assertThat(initialState.currentHomeNavigationBarItem).isEqualTo(HomeNavigationBarItem.Chats)
+            assertThat(initialState.showNavigationBar).isTrue()
+            // User navigate to Spaces
+            initialState.eventSink(HomeEvents.SelectHomeNavigationBarItem(HomeNavigationBarItem.Spaces))
+            val spaceState = awaitItem()
+            assertThat(spaceState.currentHomeNavigationBarItem).isEqualTo(HomeNavigationBarItem.Spaces)
+            // The last space is left
+            homeSpacesPresenter.updateState(aHomeSpacesState(spaceRooms = emptyList()))
+            skipItems(1)
+            val finalState = awaitItem()
+            // We are back to Chats
+            assertThat(finalState.currentHomeNavigationBarItem).isEqualTo(HomeNavigationBarItem.Chats)
+            assertThat(finalState.showNavigationBar).isFalse()
+        }
+    }
+
+    private fun createHomePresenter(
         client: MatrixClient = FakeMatrixClient(),
         syncService: SyncService = FakeSyncService(),
         snackbarDispatcher: SnackbarDispatcher = SnackbarDispatcher(),
         rageshakeFeatureAvailability: RageshakeFeatureAvailability = RageshakeFeatureAvailability { flowOf(false) },
         indicatorService: IndicatorService = FakeIndicatorService(),
-        featureFlagService: FeatureFlagService = FakeFeatureFlagService()
+        featureFlagService: FeatureFlagService = FakeFeatureFlagService(),
+        homeSpacesPresenter: Presenter<HomeSpacesState> = Presenter { aHomeSpacesState() },
     ) = HomePresenter(
         client = client,
         syncService = syncService,
@@ -159,7 +191,7 @@ class HomePresenterTest {
         indicatorService = indicatorService,
         logoutPresenter = { aDirectLogoutState() },
         roomListPresenter = { aRoomListState() },
-        homeSpacesPresenter = { aHomeSpacesState() },
+        homeSpacesPresenter = homeSpacesPresenter,
         rageshakeFeatureAvailability = rageshakeFeatureAvailability,
         featureFlagService = featureFlagService,
     )


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Hide the navigation bar if the user is not a member of any space.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Part of https://github.com/element-hq/element-meta/issues/2906:
`The tab bar with the option to view joined spaces is only shown when the user has at least one space that they have joined (because otherwise they have no clue what to do in here).`

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login using an account which is not in any space
- Enable the Space FF
- Observe that the navigation bar on the home screen is still not rendered
- From a client capable of doing this, join a space
- The navigation bar should become visible.
- Navigate to the space tab
- From a client capable of doing this, leave the space
- Observe that the room list is displayed again, and the navigation bar is not displayed anymore

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
