### PR TITLE
Fix error when attempting to verify with recovery key with missing backup key

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -44,8 +44,8 @@ import org.matrix.rustcomponents.sdk.Encryption
 import org.matrix.rustcomponents.sdk.UserIdentity
 import org.matrix.rustcomponents.sdk.BackupUploadState as RustBackupUploadState
 import org.matrix.rustcomponents.sdk.EnableRecoveryProgress as RustEnableRecoveryProgress
-import org.matrix.rustcomponents.sdk.SteadyStateException as RustSteadyStateException
 import org.matrix.rustcomponents.sdk.RecoveryException as RustRecoveryException
+import org.matrix.rustcomponents.sdk.SteadyStateException as RustSteadyStateException
 
 class RustEncryptionService(
     client: Client,


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/5647
 
## Content

Currently, if you verify using a recovery key, but the backup key is corrupt, it will fail, saying that you entered the incorrect recovery key, even if you entered the correct recovery key.  This PR ignores errors coming from importing secrets from secret storage, allowing those errors to be handle by the "key storage out of sync" detection.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5099

## Tests

<!-- Explain how you tested your development -->

- Step 1: follow the steps from https://github.com/element-hq/element-x-android/issues/5099
- Step 2: observe that the error in step 5 no longer occurs, and the user is able to enter the app normally

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): Android 16 (emulated Pixel 9)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
