### PR TITLE
Increase Element Call audio init delay ensuring the right audio device is used

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
@@ -29,7 +29,7 @@ import kotlinx.serialization.json.Json
 import timber.log.Timber
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * This class manages the audio devices for a WebView.
@@ -246,7 +246,6 @@ class WebViewAudioManager(
     private fun registerWebViewDeviceSelectedCallback() {
         val webViewAudioDeviceSelectedCallback = AndroidWebViewAudioBridge(
             onAudioDeviceSelected = { selectedDeviceId ->
-                Timber.d("Audio device selected in webview, id: $selectedDeviceId")
                 previousSelectedDevice = listAudioDevices().find { it.id.toString() == selectedDeviceId }
                 audioManager.selectAudioDevice(selectedDeviceId)
             },
@@ -254,7 +253,7 @@ class WebViewAudioManager(
                 coroutineScope.launch(Dispatchers.Main) {
                     // Even with the callback, it seems like starting the audio takes a bit on the webview side,
                     // so we add an extra delay here to make sure it's ready
-                    delay(500.milliseconds)
+                    delay(2.seconds)
 
                     // Calling this ahead of time makes the default audio device to not use the right audio stream
                     setAvailableAudioDevices()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Increase the initial delay until we start managing audio for EC in the app from 0.5s to 2s.

## Motivation and context

Works around https://github.com/element-hq/element-x-android/issues/5269 (I hope). This fixed the wrong audio stream being used when starting a call when I tested this on my test device.

There is some kind of race condition between livekit in the EC webview and the Android audio system, and if we try to provide the available audio devices or select one too soon, we end up using the wrong audio stream. In the long term, either we finally figure out what's causing it and hook these changes to some callback, or we'll need to pivot to something more native-ish.

## Tests

In a room, start a call. If changing the 'in-call' volume modifies the audio volume, it's working. If it's the media volume that does it, it's still broken.

Do the same for joining an existing call, just in case.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
