### PR TITLE
Media viewer: release the `ExoPlayers` when the hosting composables are disposed

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -281,6 +281,7 @@ private fun ExoPlayerLifecycleHelper(
         onDispose {
             Timber.d("Disposing exoplayer")
             if (!exoPlayer.isReleased) {
+                exoPlayer.removeListener(playerListener)
                 exoPlayer.release()
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

Should fix https://github.com/element-hq/element-x-android/issues/5346 (and maybe help with the OOM issues).

It seems like the lifecycle side effect handler wasn't enough to trigger this: the `DESTROY` case would only be used when the `MediaViewerView` itself was disposed.

## Tests

It's difficult to tell without logs: open a room with several videos in it, open one of it then navigate back and forth: you should see logs about the exo players being initialized and disposed, and when coming back to previous videos you should still be able to play them.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
