### PR TITLE
Ensure the thread summary sender's display name won't wrap to the next line

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemEventRow.kt
@@ -352,6 +352,8 @@ private fun ThreadSummaryView(
                     text = latestEvent.senderProfile.getDisambiguatedDisplayName(latestEvent.senderId),
                     style = ElementTheme.typography.fontBodySmMedium,
                     color = ElementTheme.colors.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
 
                 Spacer(modifier = Modifier.width(4.dp))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Make sure the display name only uses a single line and has an ellipsis at the end instead of wrapping to a new line.

## Motivation and context

Design issues detected.

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="317" height="64" alt="image" src="https://github.com/user-attachments/assets/ae6c8397-867c-4ef1-a500-bd70d1b51846" />|<img width="318" height="54" alt="image" src="https://github.com/user-attachments/assets/6c2f78b1-43eb-4234-bf97-63982475eef7" />|

## Tests

If you have thread summaries written by users with ambiguous names you can check a single line is used for it.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
