### PR TITLE
Ensure Metro `@AssistedInject` is used.

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -36,7 +36,6 @@ import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.operation.replace
 import com.bumble.appyx.navmodel.backstack.operation.singleTop
-import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import im.vector.app.features.analytics.plan.JoinedRoom
@@ -65,6 +64,7 @@ import io.element.android.features.userprofile.api.UserProfileEntryPoint
 import io.element.android.features.verifysession.api.IncomingVerificationEntryPoint
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
+import io.element.android.libraries.architecture.appyx.LoadingNode
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.architecture.waitForNavTargetAttached
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarDispatcher
@@ -281,7 +281,7 @@ class LoggedInFlowNode(
 
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
         return when (navTarget) {
-            NavTarget.Placeholder -> createNode<PlaceholderNode>(buildContext)
+            NavTarget.Placeholder -> createNode<LoadingNode>(buildContext)
             NavTarget.LoggedInPermanent -> {
                 val callback = object : LoggedInNode.Callback {
                     override fun navigateToNotificationTroubleshoot() {
@@ -547,13 +547,6 @@ class LoggedInFlowNode(
         }
     }
 }
-
-@ContributesNode(AppScope::class)
-@AssistedInject
-class PlaceholderNode(
-    @Assisted buildContext: BuildContext,
-    @Assisted plugins: List<Plugin>,
-) : Node(buildContext, plugins = plugins)
 
 @Parcelize
 private class AttachRoomOperation(

--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -39,7 +39,6 @@ import com.bumble.appyx.navmodel.backstack.operation.singleTop
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.Inject
 import im.vector.app.features.analytics.plan.JoinedRoom
 import io.element.android.annotations.ContributesNode
 import io.element.android.appnav.loggedin.LoggedInNode
@@ -550,7 +549,7 @@ class LoggedInFlowNode(
 }
 
 @ContributesNode(AppScope::class)
-@Inject
+@AssistedInject
 class PlaceholderNode(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -9,15 +9,11 @@ package io.element.android.appnav
 
 import android.content.Intent
 import android.os.Parcelable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.core.node.node
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import com.bumble.appyx.navmodel.backstack.BackStack
@@ -41,11 +37,11 @@ import io.element.android.features.rageshake.api.reporter.BugReporter
 import io.element.android.features.signedout.api.SignedOutEntryPoint
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
+import io.element.android.libraries.architecture.appyx.LoadingNode
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.architecture.waitForChildAttached
 import io.element.android.libraries.core.uri.ensureProtocol
 import io.element.android.libraries.deeplink.api.DeeplinkData
-import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.toRoomIdOrAlias
 import io.element.android.libraries.matrix.api.permalink.PermalinkData
@@ -203,9 +199,10 @@ class RootFlowNode(
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
         return when (navTarget) {
             is NavTarget.LoggedInFlow -> {
-                val matrixClient = matrixSessionCache.getOrNull(navTarget.sessionId) ?: return splashNode(buildContext).also {
-                    Timber.w("Couldn't find any session, go through SplashScreen")
-                }
+                val matrixClient = matrixSessionCache.getOrNull(navTarget.sessionId)
+                    ?: return createNode<LoadingNode>(buildContext).also {
+                        Timber.w("Couldn't find any session, go through SplashScreen")
+                    }
                 val inputs = LoggedInAppScopeFlowNode.Inputs(matrixClient)
                 val callback = object : LoggedInAppScopeFlowNode.Callback {
                     override fun onOpenBugReport() {
@@ -234,7 +231,7 @@ class RootFlowNode(
                     )
                     .build()
             }
-            NavTarget.SplashScreen -> splashNode(buildContext)
+            NavTarget.SplashScreen -> createNode<LoadingNode>(buildContext)
             NavTarget.BugReport -> {
                 val callback = object : BugReportEntryPoint.Callback {
                     override fun onDone() {
@@ -246,12 +243,6 @@ class RootFlowNode(
                     .callback(callback)
                     .build()
             }
-        }
-    }
-
-    private fun splashNode(buildContext: BuildContext) = node(buildContext) {
-        Box(modifier = it.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
         }
     }
 

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
@@ -23,7 +23,6 @@ import com.bumble.appyx.navmodel.backstack.operation.replace
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.Inject
 import io.element.android.annotations.ContributesNode
 import io.element.android.features.analytics.api.AnalyticsEntryPoint
 import io.element.android.features.ftue.impl.notifications.NotificationsOptInNode
@@ -149,7 +148,7 @@ class FtueFlowNode(
 }
 
 @ContributesNode(AppScope::class)
-@Inject
+@AssistedInject
 class PlaceholderNode(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
@@ -8,10 +8,7 @@
 package io.element.android.features.ftue.impl
 
 import android.os.Parcelable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.bumble.appyx.core.modality.BuildContext
@@ -20,7 +17,6 @@ import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.newRoot
 import com.bumble.appyx.navmodel.backstack.operation.replace
-import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
@@ -33,8 +29,8 @@ import io.element.android.features.ftue.impl.state.InternalFtueState
 import io.element.android.features.lockscreen.api.LockScreenEntryPoint
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
+import io.element.android.libraries.architecture.appyx.LoadingNode
 import io.element.android.libraries.architecture.createNode
-import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
 import io.element.android.libraries.di.SessionScope
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
@@ -87,7 +83,7 @@ class FtueFlowNode(
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
         return when (navTarget) {
             NavTarget.Placeholder -> {
-                createNode<PlaceholderNode>(buildContext)
+                createNode<LoadingNode>(buildContext)
             }
             is NavTarget.SessionVerification -> {
                 val callback = object : FtueSessionVerificationFlowNode.Callback {
@@ -144,19 +140,5 @@ class FtueFlowNode(
     @Composable
     override fun View(modifier: Modifier) {
         BackstackView()
-    }
-}
-
-@ContributesNode(AppScope::class)
-@AssistedInject
-class PlaceholderNode(
-    @Assisted buildContext: BuildContext,
-    @Assisted plugins: List<Plugin>,
-) : Node(buildContext, plugins = plugins) {
-    @Composable
-    override fun View(modifier: Modifier) {
-        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
-        }
     }
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsFlowNode.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsFlowNode.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.lifecycleScope
 import com.bumble.appyx.core.lifecycle.subscribe
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.core.node.node
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.newRoot
@@ -28,6 +27,7 @@ import io.element.android.features.lockscreen.impl.setup.pin.SetupPinNode
 import io.element.android.features.lockscreen.impl.unlock.PinUnlockNode
 import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
+import io.element.android.libraries.architecture.appyx.LoadingNode
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.di.SessionScope
 import kotlinx.coroutines.flow.first
@@ -42,7 +42,7 @@ class LockScreenSettingsFlowNode(
     private val pinCodeManager: PinCodeManager,
 ) : BaseFlowNode<LockScreenSettingsFlowNode.NavTarget>(
     backstack = BackStack(
-        initialElement = NavTarget.Unknown,
+        initialElement = NavTarget.Loading,
         savedStateMap = buildContext.savedStateMap,
     ),
     buildContext = buildContext,
@@ -50,7 +50,7 @@ class LockScreenSettingsFlowNode(
 ) {
     sealed interface NavTarget : Parcelable {
         @Parcelize
-        data object Unknown : NavTarget
+        data object Loading : NavTarget
 
         @Parcelize
         data object Unlock : NavTarget
@@ -94,6 +94,9 @@ class LockScreenSettingsFlowNode(
 
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
         return when (navTarget) {
+            NavTarget.Loading -> {
+                createNode<LoadingNode>(buildContext)
+            }
             NavTarget.Unlock -> {
                 val callback = object : PinUnlockNode.Callback {
                     override fun onUnlock() {
@@ -113,7 +116,6 @@ class LockScreenSettingsFlowNode(
                 }
                 createNode<LockScreenSettingsNode>(buildContext, plugins = listOf(callback))
             }
-            NavTarget.Unknown -> node(buildContext) { }
         }
     }
 

--- a/libraries/architecture/build.gradle.kts
+++ b/libraries/architecture/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(libs.appyx.core)
     api(libs.androidx.lifecycle.runtime)
     api(libs.molecule.runtime)
+    implementation(projects.libraries.designsystem)
 
     testCommonDependencies(libs)
 }

--- a/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/appyx/LoadingNode.kt
+++ b/libraries/architecture/src/main/kotlin/io/element/android/libraries/architecture/appyx/LoadingNode.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.architecture.appyx
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.plugin.Plugin
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import io.element.android.annotations.ContributesNode
+import io.element.android.libraries.designsystem.theme.components.CircularProgressIndicator
+
+@ContributesNode(AppScope::class)
+@AssistedInject
+class LoadingNode(
+    @Assisted buildContext: BuildContext,
+    @Assisted plugins: List<Plugin>,
+) : Node(buildContext, plugins = plugins) {
+    @Composable
+    override fun View(modifier: Modifier) {
+        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistDiTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistDiTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.tests.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
+import com.lemonappdev.konsist.api.ext.list.withParameter
+import com.lemonappdev.konsist.api.verify.assertTrue
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.Inject
+import org.junit.Test
+
+class KonsistDiTest {
+    @Test
+    fun `class annotated with @Inject should not have constructors with @Assisted parameter`() {
+        Konsist
+            .scopeFromProject()
+            .classes()
+            .withAnnotationOf(Inject::class)
+            .assertTrue(
+                additionalMessage = "Class with @Assisted parameter in constructor should be annotated with @AssistedInject and not @Inject"
+            ) { classDeclaration ->
+                classDeclaration.constructors
+                    .withParameter { parameterDeclaration ->
+                        parameterDeclaration.hasAnnotationOf(Assisted::class)
+                    }
+                    .isEmpty()
+            }
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure Metro `@AssistedInject` is used.
Also create `LoadingNode` to avoid code duplication.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Clean code.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- No expected change, loading wheel may be displayed where that was an empty screen before, but user should hardly see it since it will vanish very fast.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
