### PR TITLE
Leave spave: iteration on string value.

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceView.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceView.kt
@@ -155,9 +155,8 @@ private fun LeaveSpaceHeader(
             ),
             subTitle =
                 if (state.selectableSpaceRooms is AsyncData.Success && state.selectableSpaceRooms.data.isNotEmpty()) {
-                    val count = state.selectableSpaceRooms.data.size
                     if (state.hasOnlyLastAdminRoom) {
-                        pluralStringResource(R.plurals.screen_leave_space_subtitle_only_last_admin, count, count)
+                        stringResource(R.string.screen_leave_space_subtitle_only_last_admin)
                     } else {
                         stringResource(R.string.screen_leave_space_subtitle)
                     }

--- a/features/space/impl/src/main/res/values/localazy.xml
+++ b/features/space/impl/src/main/res/values/localazy.xml
@@ -6,9 +6,6 @@
     <item quantity="other">"Leave %1$d rooms and space"</item>
   </plurals>
   <string name="screen_leave_space_subtitle">"Select the rooms you’d like to leave which you\'re not the only administrator for:"</string>
-  <plurals name="screen_leave_space_subtitle_only_last_admin">
-    <item quantity="one">"You will not be removed from the following room because you\'re the only administrator:"</item>
-    <item quantity="other">"You will not be removed from the following rooms because you\'re the only administrator:"</item>
-  </plurals>
+  <string name="screen_leave_space_subtitle_only_last_admin">"You will not be removed from the following room(s) because you\'re the only administrator:"</string>
   <string name="screen_leave_space_title">"Leave %1$s?"</string>
 </resources>

--- a/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Day_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Day_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16b86605705dbe40f359cb93eba19efcd5b119b2da38eadf2636bfb26458e838
-size 35844
+oid sha256:aa05867ac79a3bfb9f59bf1dafb02185274b46e9a5fbf27415a0e907780a0493
+size 36393

--- a/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Day_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Day_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:251c739a4d2f4b553d192bdfaf4565a0d2ac45938ce32c53205500b8ef347f19
-size 42540
+oid sha256:e74abc389c25fa9a5d33ade6d0f8a2242aeb5150fe81a26e26e9b561c46bb802
+size 43010

--- a/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Night_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Night_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09903fc1e3e5adf5b165acbd4cf504c5d570da9ad3ea8a7cc90c17e72e491fe4
-size 34953
+oid sha256:6465f03be41ae02635cbdc94f521059bdd6476c5b2ccfca6f28ccd8898112cea
+size 35530

--- a/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.space.impl.leave_LeaveSpaceView_Night_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e4ca33fcc750bbdea7e25aaed5f9ac7fef377ae44e9015576362af873da99af
-size 41658
+oid sha256:af017745220027708f5a84ca639c9990fe7e474a38aaeecc3cba82011d195360
+size 42080


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Do not use plurals in this case since it can lead to lint issues since there is no %d in the value for `one` and this triggers a warning in some languages.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix warning when syncing translations (see lint result in #5424)

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
See recorded ones.

## Tests

<!-- Explain how you tested your development -->

- Nothing to tests

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
