### PR TITLE
Only offer to verify if a cross-signed device is available

### DIFF
--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModePresenter.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModePresenter.kt
@@ -26,7 +26,7 @@ class ChooseSelfVerificationModePresenter(
 ) : Presenter<ChooseSelfVerificationModeState> {
     @Composable
     override fun present(): ChooseSelfVerificationModeState {
-        val isLastDevice by encryptionService.isLastDevice.collectAsState()
+        val hasDevicesToVerifyAgainst by encryptionService.hasDevicesToVerifyAgainst.collectAsState()
         val recoveryState by encryptionService.recoveryStateStateFlow.collectAsState()
         val canEnterRecoveryKey by remember { derivedStateOf { recoveryState == RecoveryState.INCOMPLETE } }
 
@@ -39,7 +39,7 @@ class ChooseSelfVerificationModePresenter(
         }
 
         return ChooseSelfVerificationModeState(
-            isLastDevice = isLastDevice,
+            isLastDevice = !hasDevicesToVerifyAgainst,
             canEnterRecoveryKey = canEnterRecoveryKey,
             directLogoutState = directLogoutState,
             eventSink = ::eventHandler,

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModePresenter.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModePresenter.kt
@@ -39,7 +39,7 @@ class ChooseSelfVerificationModePresenter(
         }
 
         return ChooseSelfVerificationModeState(
-            isLastDevice = !hasDevicesToVerifyAgainst,
+            canUseAnotherDevice = hasDevicesToVerifyAgainst,
             canEnterRecoveryKey = canEnterRecoveryKey,
             directLogoutState = directLogoutState,
             eventSink = ::eventHandler,

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeState.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeState.kt
@@ -10,7 +10,7 @@ package io.element.android.features.ftue.impl.sessionverification.choosemode
 import io.element.android.features.logout.api.direct.DirectLogoutState
 
 data class ChooseSelfVerificationModeState(
-    val isLastDevice: Boolean,
+    val canUseAnotherDevice: Boolean,
     val canEnterRecoveryKey: Boolean,
     val directLogoutState: DirectLogoutState,
     val eventSink: (ChooseSelfVerificationModeEvent) -> Unit,

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeStateProvider.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeStateProvider.kt
@@ -13,18 +13,18 @@ import io.element.android.features.logout.api.direct.aDirectLogoutState
 class ChooseSelfVerificationModeStateProvider :
     PreviewParameterProvider<ChooseSelfVerificationModeState> {
     override val values = sequenceOf(
-        aChooseSelfVerificationModeState(isLastDevice = true, canEnterRecoveryKey = true),
-        aChooseSelfVerificationModeState(isLastDevice = true, canEnterRecoveryKey = false),
-        aChooseSelfVerificationModeState(isLastDevice = false, canEnterRecoveryKey = true),
-        aChooseSelfVerificationModeState(isLastDevice = false, canEnterRecoveryKey = false),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = true),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = false),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = false, canEnterRecoveryKey = true),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = false, canEnterRecoveryKey = false),
     )
 }
 
 fun aChooseSelfVerificationModeState(
-    isLastDevice: Boolean = false,
+    canUseAnotherDevice: Boolean = true,
     canEnterRecoveryKey: Boolean = true,
 ) = ChooseSelfVerificationModeState(
-    isLastDevice = isLastDevice,
+    canUseAnotherDevice = canUseAnotherDevice,
     canEnterRecoveryKey = canEnterRecoveryKey,
     directLogoutState = aDirectLogoutState(),
     eventSink = {},

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeStateProvider.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeStateProvider.kt
@@ -13,10 +13,10 @@ import io.element.android.features.logout.api.direct.aDirectLogoutState
 class ChooseSelfVerificationModeStateProvider :
     PreviewParameterProvider<ChooseSelfVerificationModeState> {
     override val values = sequenceOf(
-        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = true),
-        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = false),
         aChooseSelfVerificationModeState(canUseAnotherDevice = false, canEnterRecoveryKey = true),
         aChooseSelfVerificationModeState(canUseAnotherDevice = false, canEnterRecoveryKey = false),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = true),
+        aChooseSelfVerificationModeState(canUseAnotherDevice = true, canEnterRecoveryKey = false),
     )
 }
 

--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeView.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSelfVerificationModeView.kt
@@ -76,7 +76,7 @@ fun ChooseSelfVerificationModeView(
             ButtonColumnMolecule(
                 modifier = Modifier.padding(bottom = 16.dp)
             ) {
-                if (state.isLastDevice.not()) {
+                if (state.canUseAnotherDevice) {
                     Button(
                         modifier = Modifier.fillMaxWidth(),
                         text = stringResource(R.string.screen_identity_use_another_device),

--- a/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModePresenterTest.kt
+++ b/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModePresenterTest.kt
@@ -24,8 +24,8 @@ class ChooseSessionVerificationModePresenterTest {
     @Test
     fun `initial state - is relayed from EncryptionService`() = runTest {
         val encryptionService = FakeEncryptionService().apply {
-            // Is last device
-            emitIsLastDevice(true)
+            // Has device to verify against
+            emitHasDevicesToVerifyAgainst(false)
             // Can enter recovery key
             emitRecoveryState(RecoveryState.INCOMPLETE)
         }

--- a/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModePresenterTest.kt
+++ b/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModePresenterTest.kt
@@ -32,7 +32,7 @@ class ChooseSessionVerificationModePresenterTest {
         val presenter = createPresenter(encryptionService = encryptionService)
         presenter.test {
             awaitItem().run {
-                assertThat(isLastDevice).isTrue()
+                assertThat(canUseAnotherDevice).isFalse()
                 assertThat(canEnterRecoveryKey).isTrue()
                 assertThat(directLogoutState.logoutAction.isUninitialized()).isTrue()
             }

--- a/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModeViewTest.kt
+++ b/features/ftue/impl/src/test/kotlin/io/element/android/features/ftue/impl/sessionverification/choosemode/ChooseSessionVerificationModeViewTest.kt
@@ -43,7 +43,7 @@ class ChooseSessionVerificationModeViewTest {
     fun `clicking on use another device calls the callback`() {
         ensureCalledOnce { callback ->
             rule.setChooseSelfVerificationModeView(
-                aChooseSelfVerificationModeState(isLastDevice = false),
+                aChooseSelfVerificationModeState(canUseAnotherDevice = true),
                 onUseAnotherDevice = callback,
             )
             rule.clickOn(R.string.screen_identity_use_another_device)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/EncryptionService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/encryption/EncryptionService.kt
@@ -17,6 +17,7 @@ interface EncryptionService {
     val recoveryStateStateFlow: StateFlow<RecoveryState>
     val enableRecoveryProgressStateFlow: StateFlow<EnableRecoveryProgress>
     val isLastDevice: StateFlow<Boolean>
+    val hasDevicesToVerifyAgainst: StateFlow<Boolean>
 
     suspend fun enableBackups(): Result<Unit>
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -97,6 +97,11 @@ internal class RustEncryptionService(
     }
         .stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
 
+    /**
+     * Check if the user has any devices available to verify against every 5 seconds.
+     * TODO This is a temporary workaround, when we will have a way to observe
+     * the sessions, this code will have to be updated.
+     */
     override val hasDevicesToVerifyAgainst: StateFlow<Boolean> = flow {
         while (currentCoroutineContext().isActive) {
             val result = hasDevicesToVerifyAgainst().getOrDefault(false)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -96,6 +96,15 @@ internal class RustEncryptionService(
     }
         .stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
 
+    override val hasDevicesToVerifyAgainst: StateFlow<Boolean> = flow {
+        while (currentCoroutineContext().isActive) {
+            val result = hasDevicesToVerifyAgainst().getOrDefault(false)
+            emit(result)
+            delay(5_000)
+        }
+    }
+        .stateIn(sessionCoroutineScope, SharingStarted.Eagerly, false)
+
     override suspend fun enableBackups(): Result<Unit> = withContext(dispatchers.io) {
         runCatchingExceptions {
             service.enableBackups()
@@ -166,6 +175,14 @@ internal class RustEncryptionService(
     private suspend fun isLastDevice(): Result<Boolean> = withContext(dispatchers.io) {
         runCatchingExceptions {
             service.isLastDevice()
+        }.mapFailure {
+            it.mapRecoveryException()
+        }
+    }
+
+    private suspend fun hasDevicesToVerifyAgainst(): Result<Boolean> = withContext(dispatchers.io) {
+        runCatchingExceptions {
+            service.hasDevicesToVerifyAgainst()
         }.mapFailure {
             it.mapRecoveryException()
         }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.matrix.api.encryption.IdentityResetHandle
 import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityState
 import io.element.android.libraries.matrix.api.sync.SyncState
+import io.element.android.libraries.matrix.impl.exception.mapClientException
 import io.element.android.libraries.matrix.impl.sync.RustSyncService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
@@ -184,7 +185,7 @@ internal class RustEncryptionService(
         runCatchingExceptions {
             service.hasDevicesToVerifyAgainst()
         }.mapFailure {
-            it.mapRecoveryException()
+            it.mapClientException()
         }
     }
 

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiEncryption.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiEncryption.kt
@@ -32,6 +32,10 @@ class FakeFfiEncryption : Encryption(NoPointer) {
         return false
     }
 
+    override suspend fun hasDevicesToVerifyAgainst(): Boolean {
+        return true
+    }
+
     override fun backupState(): BackupState {
         return BackupState.ENABLED
     }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/encryption/FakeEncryptionService.kt
@@ -34,6 +34,7 @@ class FakeEncryptionService(
     override val recoveryStateStateFlow: MutableStateFlow<RecoveryState> = MutableStateFlow(RecoveryState.UNKNOWN)
     override val enableRecoveryProgressStateFlow: MutableStateFlow<EnableRecoveryProgress> = MutableStateFlow(EnableRecoveryProgress.Starting)
     override val isLastDevice: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val hasDevicesToVerifyAgainst: MutableStateFlow<Boolean> = MutableStateFlow(true)
     private var waitForBackupUploadSteadyStateFlow: Flow<BackupUploadState> = flowOf()
 
     private var recoverFailure: Exception? = null
@@ -81,6 +82,10 @@ class FakeEncryptionService(
 
     fun emitIsLastDevice(isLastDevice: Boolean) {
         this.isLastDevice.value = isLastDevice
+    }
+
+    fun emitHasDevicesToVerifyAgainst(hasDevicesToVerifyAgainst: Boolean) {
+        this.hasDevicesToVerifyAgainst.value = hasDevicesToVerifyAgainst
     }
 
     override suspend fun resetRecoveryKey(): Result<String> = simulateLongTask {


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-x-android/issues/4864

## Content

Currently, on logging in, it will offer to verify against another device if the user has any other devices, even if they are not cross-signed. This change uses the function introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/5699 to check whether the user has any cross-signed devices, and will only offer to verify if one is available.

## Motivation and context

https://github.com/element-hq/element-x-android/issues/4864

## Screenshots / GIFs

<img width="434" height="914" alt="image" src="https://github.com/user-attachments/assets/f1bddacf-9a63-4961-bbdf-1a0516daae85" />

No "Use another device" button

## Tests

<!-- Explain how you tested your development -->

- Signed in a test user with Element Web, but did not verify
- Ensured that the user had no other devices
- Signed in to Element X, and check that "Confirm your dentity" screen did not offer to "Use another device"
- Signed out of Element X
- Reset cross-signing in Element Web
- Signed in to Element X, and check that "Confirm your identity" screen now offers to "Use another device"

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 16 (API 36.0)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
