### PR TITLE
Misc : destroy SpaceRoomList

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/DefaultRoomGraphFactory.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/DefaultRoomGraphFactory.kt
@@ -9,15 +9,15 @@ package io.element.android.x.di
 
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import io.element.android.appnav.di.RoomComponentFactory
+import io.element.android.appnav.di.RoomGraphFactory
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 
 @ContributesBinding(SessionScope::class)
 @Inject
-class DefaultRoomComponentFactory(
+class DefaultRoomGraphFactory(
     private val sessionGraph: SessionGraph,
-) : RoomComponentFactory {
+) : RoomGraphFactory {
     override fun create(room: JoinedRoom): Any {
         return sessionGraph.roomGraphFactory
             .create(room, room)

--- a/app/src/main/kotlin/io/element/android/x/di/RoomGraph.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/RoomGraph.kt
@@ -7,18 +7,15 @@
 
 package io.element.android.x.di
 
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.GraphExtension
 import dev.zacsweers.metro.Provides
 import io.element.android.libraries.architecture.NodeFactoriesBindings
 import io.element.android.libraries.di.RoomScope
-import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 
 @GraphExtension(RoomScope::class)
 interface RoomGraph : NodeFactoriesBindings {
-    @ContributesTo(SessionScope::class)
     @GraphExtension.Factory
     interface Factory {
         fun create(

--- a/app/src/main/kotlin/io/element/android/x/di/SessionGraph.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/SessionGraph.kt
@@ -7,8 +7,6 @@
 
 package io.element.android.x.di
 
-import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.GraphExtension
 import dev.zacsweers.metro.Provides
 import io.element.android.libraries.architecture.NodeFactoriesBindings
@@ -19,7 +17,6 @@ import io.element.android.libraries.matrix.api.MatrixClient
 interface SessionGraph : NodeFactoriesBindings {
     val roomGraphFactory: RoomGraph.Factory
 
-    @ContributesTo(AppScope::class)
     @GraphExtension.Factory
     interface Factory {
         fun create(@Provides matrixClient: MatrixClient): SessionGraph

--- a/appnav/src/main/kotlin/io/element/android/appnav/di/RoomGraphFactory.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/RoomGraphFactory.kt
@@ -9,6 +9,6 @@ package io.element.android.appnav.di
 
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 
-fun interface RoomComponentFactory {
+fun interface RoomGraphFactory {
     fun create(room: JoinedRoom): Any
 }

--- a/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
@@ -20,7 +20,7 @@ import com.bumble.appyx.navmodel.backstack.operation.push
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
-import io.element.android.appnav.di.RoomComponentFactory
+import io.element.android.appnav.di.RoomGraphFactory
 import io.element.android.appnav.room.RoomNavigationTarget
 import io.element.android.features.messages.api.MessagesEntryPoint
 import io.element.android.features.roomdetails.api.RoomDetailsEntryPoint
@@ -56,7 +56,7 @@ class JoinedRoomLoadedFlowNode(
     private val sessionCoroutineScope: CoroutineScope,
     private val matrixClient: MatrixClient,
     private val activeRoomsHolder: ActiveRoomsHolder,
-    roomComponentFactory: RoomComponentFactory,
+    roomGraphFactory: RoomGraphFactory,
 ) : BaseFlowNode<JoinedRoomLoadedFlowNode.NavTarget>(
     backstack = BackStack(
         initialElement = when (val input = plugins.filterIsInstance<Inputs>().first().initialElement) {
@@ -83,7 +83,7 @@ class JoinedRoomLoadedFlowNode(
 
     private val inputs: Inputs = inputs()
     private val callbacks = plugins.filterIsInstance<Callback>()
-    override val graph = roomComponentFactory.create(inputs.room)
+    override val graph = roomGraphFactory.create(inputs.room)
 
     init {
         lifecycle.subscribe(

--- a/appnav/src/test/kotlin/io/element/android/appnav/JoinedRoomLoadedFlowNodeTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/JoinedRoomLoadedFlowNodeTest.kt
@@ -17,7 +17,7 @@ import com.bumble.appyx.navmodel.backstack.activeElement
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
 import com.bumble.appyx.testing.unit.common.helper.parentNodeTestHelper
 import com.google.common.truth.Truth.assertThat
-import io.element.android.appnav.di.RoomComponentFactory
+import io.element.android.appnav.di.RoomGraphFactory
 import io.element.android.appnav.room.RoomNavigationTarget
 import io.element.android.appnav.room.joined.JoinedRoomLoadedFlowNode
 import io.element.android.features.messages.api.MessagesEntryPoint
@@ -70,7 +70,7 @@ class JoinedRoomLoadedFlowNodeTest {
         }
     }
 
-    private class FakeRoomComponentFactory : RoomComponentFactory {
+    private class FakeRoomGraphFactory : RoomGraphFactory {
         override fun create(room: JoinedRoom): Any {
             return Unit
         }
@@ -110,7 +110,7 @@ class JoinedRoomLoadedFlowNodeTest {
         roomDetailsEntryPoint = roomDetailsEntryPoint,
         appNavigationStateService = FakeAppNavigationStateService(),
         sessionCoroutineScope = this,
-        roomComponentFactory = FakeRoomComponentFactory(),
+        roomGraphFactory = FakeRoomGraphFactory(),
         matrixClient = FakeMatrixClient(),
         activeRoomsHolder = activeRoomsHolder,
     )

--- a/features/changeroommemberroles/impl/src/main/kotlin/io/element/android/features/changeroommemberroles/impl/ChangeRoomMemberRolesRootNode.kt
+++ b/features/changeroommemberroles/impl/src/main/kotlin/io/element/android/features/changeroommemberroles/impl/ChangeRoomMemberRolesRootNode.kt
@@ -19,7 +19,7 @@ import com.bumble.appyx.core.plugin.Plugin
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
-import io.element.android.appnav.di.RoomComponentFactory
+import io.element.android.appnav.di.RoomGraphFactory
 import io.element.android.features.changeroommemberroes.api.ChangeRoomMemberRolesEntryPoint
 import io.element.android.features.changeroommemberroes.api.ChangeRoomMemberRolesListType
 import io.element.android.libraries.architecture.NodeInputs
@@ -36,7 +36,7 @@ import kotlinx.parcelize.Parcelize
 class ChangeRoomMemberRolesRootNode(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
-    roomComponentFactory: RoomComponentFactory,
+    roomGraphFactory: RoomGraphFactory,
 ) : ParentNode<ChangeRoomMemberRolesRootNode.NavTarget>(
     navModel = PermanentNavModel(
         navTargets = setOf(NavTarget),
@@ -54,7 +54,7 @@ class ChangeRoomMemberRolesRootNode(
 
     private val inputs = inputs<Inputs>()
 
-    override val graph = roomComponentFactory.create(inputs.joinedRoom)
+    override val graph = roomGraphFactory.create(inputs.joinedRoom)
 
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
         return createNode<ChangeRolesNode>(

--- a/features/changeroommemberroles/impl/src/test/kotlin/io/element/android/features/changeroommemberroles/impl/DefaultChangeRoomMemberRolesEntyPointTest.kt
+++ b/features/changeroommemberroles/impl/src/test/kotlin/io/element/android/features/changeroommemberroles/impl/DefaultChangeRoomMemberRolesEntyPointTest.kt
@@ -26,7 +26,7 @@ class DefaultChangeRoomMemberRolesEntyPointTest {
             ChangeRoomMemberRolesRootNode(
                 buildContext = buildContext,
                 plugins = plugins,
-                roomComponentFactory = { },
+                roomGraphFactory = { },
             )
         }
         val room = FakeJoinedRoom()

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/di/SpaceFlowGraph.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/di/SpaceFlowGraph.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.space.impl.di
+
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Provides
+import io.element.android.libraries.architecture.NodeFactoriesBindings
+import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
+
+@GraphExtension(SpaceFlowScope::class)
+interface SpaceFlowGraph : NodeFactoriesBindings {
+    @ContributesTo(SessionScope::class)
+    @GraphExtension.Factory
+    interface Factory {
+        fun create(@Provides spaceRoomList: SpaceRoomList): SpaceFlowGraph
+    }
+}

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/di/SpaceFlowScope.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/di/SpaceFlowScope.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.space.impl.di
+
+abstract class SpaceFlowScope private constructor()

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceNode.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceNode.kt
@@ -15,20 +15,15 @@ import com.bumble.appyx.core.plugin.Plugin
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
-import io.element.android.features.space.api.SpaceEntryPoint
-import io.element.android.libraries.architecture.inputs
-import io.element.android.libraries.di.SessionScope
+import io.element.android.features.space.impl.di.SpaceFlowScope
 
-@ContributesNode(SessionScope::class)
+@ContributesNode(SpaceFlowScope::class)
 @AssistedInject
 class LeaveSpaceNode(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
-    presenterFactory: LeaveSpacePresenter.Factory,
+    private val presenter: LeaveSpacePresenter,
 ) : Node(buildContext, plugins = plugins) {
-    private val inputs: SpaceEntryPoint.Inputs = inputs()
-    private val presenter = presenterFactory.create(inputs)
-
     @Composable
     override fun View(modifier: Modifier) {
         val state = presenter.present()

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpacePresenter.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpacePresenter.kt
@@ -15,17 +15,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
-import dev.zacsweers.metro.AssistedInject
-import io.element.android.features.space.api.SpaceEntryPoint
+import dev.zacsweers.metro.Inject
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.architecture.runUpdatingState
-import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.spaces.SpaceRoom
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
@@ -35,18 +32,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.jvm.optionals.getOrNull
 
-@AssistedInject
+@Inject
 class LeaveSpacePresenter(
-    @Assisted private val inputs: SpaceEntryPoint.Inputs,
-    matrixClient: MatrixClient,
+    private val spaceRoomList: SpaceRoomList,
 ) : Presenter<LeaveSpaceState> {
-    @AssistedFactory
-    fun interface Factory {
-        fun create(inputs: SpaceEntryPoint.Inputs): LeaveSpacePresenter
-    }
-
-    private val spaceRoomList = matrixClient.spaceService.spaceRoomList(inputs.roomId)
-
     @Composable
     override fun present(): LeaveSpaceState {
         val coroutineScope = rememberCoroutineScope()

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceNode.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceNode.kt
@@ -18,36 +18,33 @@ import com.bumble.appyx.core.plugin.Plugin
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
-import io.element.android.features.space.api.SpaceEntryPoint
+import io.element.android.features.space.impl.di.SpaceFlowScope
 import io.element.android.libraries.androidutils.R
 import io.element.android.libraries.androidutils.system.startSharePlainTextIntent
-import io.element.android.libraries.architecture.inputs
-import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-@ContributesNode(SessionScope::class)
+@ContributesNode(SpaceFlowScope::class)
 @AssistedInject
 class SpaceNode(
     @Assisted buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
-    presenterFactory: SpacePresenter.Factory,
+    private val presenter: SpacePresenter,
     private val matrixClient: MatrixClient,
+    private val spaceRoomList: SpaceRoomList,
 ) : Node(buildContext, plugins = plugins) {
     interface Callback : Plugin {
         fun onOpenRoom(roomId: RoomId, viaParameters: List<String>)
         fun onLeaveSpace()
     }
-
-    private val inputs: SpaceEntryPoint.Inputs = inputs()
     private val callback = plugins.filterIsInstance<Callback>().single()
-    private val presenter = presenterFactory.create(inputs)
 
     private fun onShareRoom(context: Context) = lifecycleScope.launch {
-        matrixClient.getRoom(inputs.roomId)?.use { room ->
+        matrixClient.getRoom(spaceRoomList.roomId)?.use { room ->
             room.getPermalink()
                 .onSuccess { permalink ->
                     context.startSharePlainTextIntent(

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpacePresenter.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpacePresenter.kt
@@ -13,11 +13,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
-import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.Inject
 import io.element.android.features.invite.api.SeenInvitesStore
-import io.element.android.features.space.api.SpaceEntryPoint
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.mapState
 import io.element.android.libraries.matrix.api.MatrixClient
@@ -31,19 +28,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.jvm.optionals.getOrNull
 
-@AssistedInject
+@Inject
 class SpacePresenter(
-    @Assisted private val inputs: SpaceEntryPoint.Inputs,
+    private val spaceRoomList: SpaceRoomList,
     private val client: MatrixClient,
     private val seenInvitesStore: SeenInvitesStore,
 ) : Presenter<SpaceState> {
-    @AssistedFactory
-    fun interface Factory {
-        fun create(inputs: SpaceEntryPoint.Inputs): SpacePresenter
-    }
-
-    private val spaceRoomList = client.spaceService.spaceRoomList(inputs.roomId)
-
     @Composable
     override fun present(): SpaceState {
         LaunchedEffect(Unit) {

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/DefaultSpaceEntryPointTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/DefaultSpaceEntryPointTest.kt
@@ -12,8 +12,12 @@ import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.space.api.SpaceEntryPoint
+import io.element.android.features.space.impl.di.FakeSpaceFlowGraph
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.spaces.FakeSpaceRoomList
+import io.element.android.libraries.matrix.test.spaces.FakeSpaceService
 import io.element.android.tests.testutils.lambda.lambdaError
 import io.element.android.tests.testutils.node.TestParentNode
 import org.junit.Rule
@@ -34,6 +38,12 @@ class DefaultSpaceEntryPointTest {
             SpaceFlowNode(
                 buildContext = buildContext,
                 plugins = plugins,
+                matrixClient = FakeMatrixClient(
+                    spaceService = FakeSpaceService(
+                        spaceRoomListResult = { _: RoomId -> FakeSpaceRoomList(A_ROOM_ID) }
+                    )
+                ),
+                graphFactory = FakeSpaceFlowGraph.Factory
             )
         }
         val callback = object : SpaceEntryPoint.Callback {

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/di/FakeSpaceFlowGraph.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/di/FakeSpaceFlowGraph.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.space.impl.di
+
+import com.bumble.appyx.core.node.Node
+import io.element.android.libraries.architecture.AssistedNodeFactory
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
+import kotlin.reflect.KClass
+
+class FakeSpaceFlowGraph : SpaceFlowGraph {
+    object Factory : SpaceFlowGraph.Factory {
+        override fun create(spaceRoomList: SpaceRoomList): SpaceFlowGraph {
+            return FakeSpaceFlowGraph()
+        }
+    }
+
+    override fun nodeFactories(): Map<KClass<out Node>, AssistedNodeFactory<*>> {
+        return emptyMap()
+    }
+}

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/leave/LeaveSpacePresenterTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/leave/LeaveSpacePresenterTest.kt
@@ -10,15 +10,11 @@
 package io.element.android.features.space.impl.leave
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.space.api.SpaceEntryPoint
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.AsyncData
-import io.element.android.libraries.matrix.api.MatrixClient
-import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import io.element.android.libraries.matrix.test.A_SPACE_NAME
-import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.spaces.FakeSpaceRoomList
-import io.element.android.libraries.matrix.test.spaces.FakeSpaceService
 import io.element.android.libraries.previewutils.room.aSpaceRoom
 import io.element.android.tests.testutils.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,15 +25,7 @@ import org.junit.Test
 class LeaveSpacePresenterTest {
     @Test
     fun `present - initial state`() = runTest {
-        val presenter = createLeaveSpacePresenter(
-            matrixClient = FakeMatrixClient(
-                spaceService = FakeSpaceService(
-                    spaceRoomListResult = {
-                        FakeSpaceRoomList()
-                    },
-                ),
-            ),
-        )
+        val presenter = createLeaveSpacePresenter()
         presenter.test {
             val state = awaitItem()
             assertThat(state.spaceName).isNull()
@@ -51,11 +39,7 @@ class LeaveSpacePresenterTest {
     fun `present - current space name`() = runTest {
         val fakeSpaceRoomList = FakeSpaceRoomList()
         val presenter = createLeaveSpacePresenter(
-            matrixClient = FakeMatrixClient(
-                spaceService = FakeSpaceService(
-                    spaceRoomListResult = { fakeSpaceRoomList },
-                ),
-            ),
+            spaceRoomList = fakeSpaceRoomList,
         )
         presenter.test {
             val state = awaitItem()
@@ -71,12 +55,10 @@ class LeaveSpacePresenterTest {
     }
 
     private fun createLeaveSpacePresenter(
-        inputs: SpaceEntryPoint.Inputs = SpaceEntryPoint.Inputs(A_ROOM_ID),
-        matrixClient: MatrixClient = FakeMatrixClient(),
+        spaceRoomList: SpaceRoomList = FakeSpaceRoomList(),
     ): LeaveSpacePresenter {
         return LeaveSpacePresenter(
-            inputs = inputs,
-            matrixClient = matrixClient,
+            spaceRoomList = spaceRoomList,
         )
     }
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/spaces/SpaceRoomList.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/spaces/SpaceRoomList.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.api.spaces
 
+import io.element.android.libraries.matrix.api.core.RoomId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Optional
@@ -17,9 +18,13 @@ interface SpaceRoomList {
         data class Idle(val hasMoreToLoad: Boolean) : PaginationStatus
     }
 
+    val roomId: RoomId
+
     val currentSpaceFlow: StateFlow<Optional<SpaceRoom>>
 
     val spaceRoomsFlow: Flow<List<SpaceRoom>>
     val paginationStatusFlow: StateFlow<PaginationStatus>
     suspend fun paginate(): Result<Unit>
+
+    fun destroy()
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceRoomList.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceRoomList.kt
@@ -8,26 +8,31 @@
 package io.element.android.libraries.matrix.impl.spaces
 
 import io.element.android.libraries.core.extensions.runCatchingExceptions
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.spaces.SpaceRoom
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import uniffi.matrix_sdk_ui.SpaceRoomListPaginationState
 import java.util.Optional
 import org.matrix.rustcomponents.sdk.SpaceRoomList as InnerSpaceRoomList
 
 class RustSpaceRoomList(
+    override val roomId: RoomId,
     private val innerProvider: suspend () -> InnerSpaceRoomList,
-    sessionCoroutineScope: CoroutineScope,
+    private val coroutineScope: CoroutineScope,
     spaceRoomMapper: SpaceRoomMapper,
 ) : SpaceRoomList {
-    private val inner = CompletableDeferred<InnerSpaceRoomList>()
+    private val innerCompletable = CompletableDeferred<InnerSpaceRoomList>()
 
     override val currentSpaceFlow = MutableStateFlow<Optional<SpaceRoom>>(Optional.empty())
 
@@ -41,37 +46,45 @@ class RustSpaceRoomList(
     )
 
     init {
-        sessionCoroutineScope.launch {
-            inner.complete(innerProvider())
-        }
-        sessionCoroutineScope.launch {
-            inner.await().paginationStateFlow()
+        coroutineScope.launch {
+            val inner = innerProvider()
+            innerCompletable.complete(inner)
+
+            inner.paginationStateFlow()
                 .onEach { paginationStatus ->
                     paginationStatusFlow.emit(paginationStatus.into())
                 }
-                .collect()
-        }
+                .launchIn(this)
 
-        sessionCoroutineScope.launch {
-            inner.await().spaceListUpdateFlow()
+            inner.spaceListUpdateFlow()
                 .onEach { updates ->
                     spaceListUpdateProcessor.postUpdates(updates)
                 }
-                .collect()
-        }
-        sessionCoroutineScope.launch {
-            inner.await().spaceUpdateFlow()
+                .launchIn(this)
+
+            inner.spaceUpdateFlow()
                 .map { space -> space.map(spaceRoomMapper::map) }
                 .onEach { space ->
                     currentSpaceFlow.emit(space)
                 }
-                .collect()
+                .launchIn(this)
         }
     }
 
     override suspend fun paginate(): Result<Unit> {
         return runCatchingExceptions {
-            inner.await().paginate()
+            innerCompletable.await().paginate()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun destroy() {
+        Timber.d("Destroying SpaceRoomList $roomId")
+        coroutineScope.cancel()
+        try {
+            innerCompletable.getCompleted().destroy()
+        } catch (_: Exception) {
+            // Ignore, we just want to make sure it's completed
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceService.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.impl.spaces
 
+import io.element.android.libraries.core.coroutine.childScope
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.spaces.SpaceRoom
@@ -54,9 +55,11 @@ class RustSpaceService(
     }
 
     override fun spaceRoomList(id: RoomId): SpaceRoomList {
+        val childCoroutineScope = sessionCoroutineScope.childScope(sessionDispatcher, "SpaceRoomListScope-$this")
         return RustSpaceRoomList(
+            roomId = id,
             innerProvider = { innerSpaceService.spaceRoomList(id.value) },
-            sessionCoroutineScope = sessionCoroutineScope,
+            coroutineScope = childCoroutineScope,
             spaceRoomMapper = spaceRoomMapper,
         )
     }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceRoomListTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/spaces/RustSpaceRoomListTest.kt
@@ -11,9 +11,11 @@ package io.element.android.libraries.matrix.impl.spaces
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import io.element.android.libraries.matrix.impl.fixtures.factories.aRustSpaceRoom
 import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeFfiSpaceRoomList
+import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -84,13 +86,15 @@ class RustSpaceRoomListTest {
     }
 
     private fun TestScope.createRustSpaceRoomList(
+        roomId: RoomId = A_ROOM_ID,
         innerSpaceRoomList: InnerSpaceRoomList = FakeFfiSpaceRoomList(),
         innerProvider: suspend () -> InnerSpaceRoomList = { innerSpaceRoomList },
         spaceRoomMapper: SpaceRoomMapper = SpaceRoomMapper(),
     ): RustSpaceRoomList {
         return RustSpaceRoomList(
+            roomId = roomId,
             innerProvider = innerProvider,
-            sessionCoroutineScope = backgroundScope,
+            coroutineScope = backgroundScope,
             spaceRoomMapper = spaceRoomMapper,
         )
     }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/spaces/FakeSpaceRoomList.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/spaces/FakeSpaceRoomList.kt
@@ -7,8 +7,10 @@
 
 package io.element.android.libraries.matrix.test.spaces
 
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.spaces.SpaceRoom
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
+import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.tests.testutils.lambda.lambdaError
 import io.element.android.tests.testutils.simulateLongTask
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import java.util.Optional
 
 class FakeSpaceRoomList(
+    override val roomId: RoomId = A_ROOM_ID,
     initialSpaceFlowValue: SpaceRoom? = null,
     initialSpaceRoomsValue: List<SpaceRoom> = emptyList(),
     initialSpaceRoomList: SpaceRoomList.PaginationStatus = SpaceRoomList.PaginationStatus.Loading,
@@ -46,5 +49,9 @@ class FakeSpaceRoomList(
 
     override suspend fun paginate(): Result<Unit> = simulateLongTask {
         paginateResult()
+    }
+
+    override fun destroy() {
+        // No op
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
This PR has 2 commits : 
1. Clean up some existing DI code (after metro migration)
2. Adds a new `SpaceFlowGraph` to handle `SpaceRoomList`, and ensure it's destroyed when the `SpaceFlowNode` is destroyed.
<!-- Describe shortly what has been changed -->

## Motivation and context
Avoid memory leak and waste of resources.
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui change.

## Tests

Just open/close spaces and check logs.

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
