### PR TITLE
Space : makes sure to use room heroes for avatar

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/spaces/SpaceRoom.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/spaces/SpaceRoom.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.libraries.matrix.api.spaces
 
+import androidx.compose.runtime.Immutable
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
@@ -14,6 +15,7 @@ import io.element.android.libraries.matrix.api.room.RoomType
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.user.MatrixUser
 
+@Immutable
 data class SpaceRoom(
     val rawName: String?,
     val displayName: String,

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
@@ -53,6 +53,8 @@ import io.element.android.libraries.matrix.ui.model.icon
 import io.element.android.libraries.matrix.ui.model.label
 import io.element.android.libraries.ui.strings.CommonPlurals
 import io.element.android.libraries.ui.strings.CommonStrings
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SpaceRoomItemView(
@@ -70,6 +72,9 @@ fun SpaceRoomItemView(
         avatarData = spaceRoom.getAvatarData(AvatarSize.SpaceListItem),
         isSpace = spaceRoom.isSpace,
         hideAvatars = hideAvatars,
+        heroes = spaceRoom.heroes
+            .map { hero -> hero.getAvatarData(AvatarSize.SpaceListItem) }
+            .toImmutableList(),
         onClick = onClick,
         onLongClick = onLongClick,
         trailingAction = trailingAction,
@@ -164,6 +169,7 @@ private fun NameAndIndicatorRow(
 private fun SpaceRoomItemScaffold(
     avatarData: AvatarData,
     isSpace: Boolean,
+    heroes: ImmutableList<AvatarData>,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     hideAvatars: Boolean,
@@ -189,7 +195,7 @@ private fun SpaceRoomItemScaffold(
     ) {
         Avatar(
             avatarData = avatarData,
-            avatarType = if (isSpace) AvatarType.Space() else AvatarType.Room(),
+            avatarType = if (isSpace) AvatarType.Space() else AvatarType.Room(heroes = heroes),
             hideImage = hideAvatars,
         )
         Spacer(modifier = Modifier.width(16.dp))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content
Space : makes sure to use room heroes for avatar.
Also mark SpaceRoom as Immutable to avoid useless recomposition.
<!-- Describe shortly what has been changed -->

## Motivation and context
Fix Avatar not showing for DMs 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui change.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Create a Space and add DM rooms on EW
- Open this Space on EX and check the DM rooms have avatar 

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
