### PR TITLE
Disable avatar cluster for now

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/internal/RoomAvatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/internal/RoomAvatar.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.Dp
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarType
 import io.element.android.libraries.designsystem.components.avatar.avatarShape
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 internal fun RoomAvatar(
@@ -44,8 +45,9 @@ internal fun RoomAvatar(
         }
         else -> {
             AvatarCluster(
-                avatars = avatarType.heroes,
-                // Note: even for a room avatar, we use UserAvatarType here to display the avatar of heroes
+                // Keep only the first hero for now
+                avatars = avatarType.heroes.take(1).toImmutableList(),
+                // Note: even for a room avatar, we use AvatarType.User here to display the avatar of heroes
                 avatarType = AvatarType.User,
                 modifier = modifier,
                 hideAvatarImages = hideAvatarImage,

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
@@ -120,8 +120,8 @@ private fun SubtitleRow(
         if (visibilityIcon != null) {
             Icon(
                 modifier = Modifier
-                        .size(16.dp)
-                        .padding(end = 4.dp),
+                    .size(16.dp)
+                    .padding(end = 4.dp),
                 imageVector = visibilityIcon,
                 contentDescription = null,
                 tint = ElementTheme.colors.iconTertiary,
@@ -178,20 +178,20 @@ private fun SpaceRoomItemScaffold(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val clickModifier = Modifier
-            .combinedClickable(
-                    onClick = onClick,
-                    onLongClick = onLongClick,
-                    onLongClickLabel = stringResource(CommonStrings.action_open_context_menu),
-                    indication = ripple(),
-                    interactionSource = remember { MutableInteractionSource() }
-            )
-            .onKeyboardContextMenuAction { onLongClick }
+        .combinedClickable(
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onLongClickLabel = stringResource(CommonStrings.action_open_context_menu),
+            indication = ripple(),
+            interactionSource = remember { MutableInteractionSource() }
+        )
+        .onKeyboardContextMenuAction { onLongClick }
     Row(
         modifier = modifier
-                .fillMaxWidth()
-                .then(clickModifier)
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .height(IntrinsicSize.Min),
+            .fillMaxWidth()
+            .then(clickModifier)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .height(IntrinsicSize.Min),
     ) {
         Avatar(
             avatarData = avatarData,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Disable avatar cluster for now

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Prevent avatar cluster to be displayed for SpaceRoom.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
