### PR TITLE
Display 'join anyway' button on room preview when the state can't be loaded

### DIFF
--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -39,8 +39,6 @@ import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
-import io.element.android.libraries.matrix.api.exception.ClientException
-import io.element.android.libraries.matrix.api.exception.ErrorKind
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.RoomInfo
 import io.element.android.libraries.matrix.api.room.RoomMembershipDetails
@@ -141,11 +139,7 @@ class JoinRoomPresenter(
                             preview.previewInfo.toContentState(membershipDetails)
                         },
                         onFailure = { throwable ->
-                            if (throwable is ClientException.MatrixApi && (throwable.kind == ErrorKind.NotFound || throwable.kind == ErrorKind.Forbidden)) {
-                                ContentState.UnknownRoom
-                            } else {
-                                ContentState.Failure(throwable)
-                            }
+                            ContentState.UnknownRoom
                         }
                     )
                 }

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -1193,46 +1193,8 @@ class JoinRoomPresenterTest {
             skipItems(1)
             awaitItem().also { state ->
                 assertThat(state.contentState).isEqualTo(
-                    ContentState.Failure(error = AN_EXCEPTION)
+                    ContentState.UnknownRoom
                 )
-                state.eventSink(JoinRoomEvents.RetryFetchingContent)
-            }
-            skipItems(1)
-            awaitItem().also { state ->
-                assertThat(state.contentState).isEqualTo(ContentState.Loading)
-            }
-            awaitItem().also { state ->
-                assertThat(state.contentState).isEqualTo(
-                    ContentState.Failure(error = AN_EXCEPTION)
-                )
-            }
-        }
-    }
-
-    @Test
-    fun `present - when room is not known RoomPreview is loaded with error - dismiss`() = runTest {
-        val client = FakeMatrixClient(
-            getNotJoinedRoomResult = { _, _ ->
-                Result.failure(AN_EXCEPTION)
-            },
-            spaceService = FakeSpaceService(
-                spaceRoomListResult = { FakeSpaceRoomList() },
-            ),
-        )
-        val presenter = createJoinRoomPresenter(
-            matrixClient = client
-        )
-        presenter.test {
-            skipItems(1)
-            awaitItem().also { state ->
-                assertThat(state.contentState).isEqualTo(
-                    ContentState.Failure(error = AN_EXCEPTION)
-                )
-                state.eventSink(JoinRoomEvents.DismissErrorAndHideContent)
-            }
-            skipItems(1)
-            awaitItem().also { state ->
-                assertThat(state.contentState).isEqualTo(ContentState.Dismissing)
             }
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

## Content

Remove unknown room display condition.

## Motivation and context

The current logic for when to display unknown room screen doesn't work:

> So to explain, Element X Android had a condition of showing the Join Anyway button: https://github.com/element-hq/element-x-android/blob/b6e2208ccb6abccd1d4037ef9e00dda37607d17d/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt#L144-L148
> (State `ContentState.UnknownRoom` is the state that will ask the view layer to present an unknown room content in `JoinRoomView`)
>
> EXA calls [`matrix_sdk_ffi::Client::get_room_preview_from_room_alias`](https://github.com/matrix-org/matrix-rust-sdk/blob/588d6046533a9657bcb2eb98d2e886437e7964e4/bindings/matrix-sdk-ffi/src/client.rs#L1435-L1450) (in the room alias case) which eventually calls the code in https://github.com/matrix-org/matrix-rust-sdk/blob/588d6046533a9657bcb2eb98d2e886437e7964e4/crates/matrix-sdk/src/room_preview.rs#L142-L175
>
> The only error that can be returned at this point is `matrix_sdk::Error::InsufficientData`, then converted to `matrix_sdk_ffi::ClientError::Generic`, and then sent back to EXA as Kotlin exception

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login to EXA with a server that doesn't have room summary enabled (should be optional)
- Find a room that can't preview and join before this PR, and try to join with this PR applied

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 14 / 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
