### PR TITLE
Fix 'test push loop back' notification check

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayDevice.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayDevice.kt
@@ -21,5 +21,14 @@ data class PushGatewayDevice(
      * Required. The pushkey given when the pusher was created.
      */
     @SerialName("pushkey")
-    val pushKey: String
+    val pushKey: String,
+    /** Optional. Additional pusher data. */
+    @SerialName("data")
+    val data: PusherData? = null,
+)
+
+@Serializable
+data class PusherData(
+    @SerialName("default_payload")
+    val defaultPayload: Map<String, String>,
 )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayNotification.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayNotification.kt
@@ -20,5 +20,5 @@ data class PushGatewayNotification(
      * Required. This is an array of devices that the notification should be sent to.
      */
     @SerialName("devices")
-    val devices: List<PushGatewayDevice>
+    val devices: List<PushGatewayDevice>,
 )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayNotifyRequest.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/pushgateway/PushGatewayNotifyRequest.kt
@@ -42,9 +42,12 @@ class DefaultPushGatewayNotifyRequest(
                     devices = listOf(
                         PushGatewayDevice(
                             params.appId,
-                            params.pushKey
+                            params.pushKey,
+                            PusherData(mapOf(
+                                "cs" to "A_FAKE_SECRET",
+                            ))
                         )
-                    )
+                    ),
                 )
             )
         )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says: we now include the client secret as the HS would do, since it's mandatory. Otherwise, the received push notification would not have it and we'd discard it, leading to the check failing.

## Motivation and context

Fix one of the issues mentioned in https://github.com/element-hq/element-x-android/issues/5530.

## Tests

Go to settings -> notifications -> troubleshoot and run the tests.

The test push loop back step should now work again.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
