### PR TITLE
Fix media viewer not being dismissed with reduced motion enabled

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/Accessibility.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/system/Accessibility.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.androidutils.system
+
+import android.content.Context
+import android.provider.Settings
+
+fun Context.getAnimationScale(): Float {
+    return Settings.Global.getFloat(contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f)
+}
+
+fun Context.areAnimationsEnabled(): Boolean {
+    return getAnimationScale() > 0f
+}

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerFlickToDismiss.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerFlickToDismiss.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import io.element.android.compound.theme.ElementTheme
+import io.element.android.libraries.androidutils.system.areAnimationsEnabled
 import kotlinx.coroutines.delay
 import me.saket.telephoto.ExperimentalTelephotoApi
 import me.saket.telephoto.flick.FlickToDismiss
@@ -34,10 +36,14 @@ fun MediaViewerFlickToDismiss(
     content: @Composable BoxScope.() -> Unit,
 ) {
     val flickState = rememberFlickToDismissState(dismissThresholdRatio = 0.1f, rotateOnDrag = false)
+    val context = LocalContext.current
     DismissFlickEffects(
         flickState = flickState,
         onDismissing = { animationDuration ->
-            delay(animationDuration / 3)
+            // Only add the delay if an animation should be played, otherwise `onDismiss` will never be called
+            if (context.areAnimationsEnabled()) {
+                delay(animationDuration / 3)
+            }
             onDismiss()
         },
         onDragging = onDragging,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This is also called 'remove animations' in some Android versions. It seems like the associated coroutine dispatcher never allows the `delay` calls to complete, or maybe they take too long and the coroutine is cancelled before they finish.

## Motivation and context

Fixes #5347.

## Tests

In the OS settings, enable 'remove animations' or 'reduce motion', then in the app open an image from the timeline/gallery.

Without this patch, the image (or the page) was dismissed, but not the media viewer so you could not tap on the content behind and could still navigate to previous/next items in the media viewer by scrolling.

With the patch it should just dismiss as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
