### PR TITLE
`interface TestParameterValuesProvider` is deprecated.

### DIFF
--- a/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
+++ b/tests/uitests/src/test/kotlin/base/ComposablePreviewProvider.kt
@@ -9,7 +9,7 @@
 
 package base
 
-import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
@@ -24,8 +24,8 @@ private val PACKAGE_TREES = arrayOf(
     "io.element.android.x",
 )
 
-object ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
-    private val values: List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> by lazy {
+object ComposablePreviewProvider : TestParameterValuesProvider() {
+    val values: List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> by lazy {
         AndroidComposablePreviewScanner()
             .scanPackageTrees(*PACKAGE_TREES)
             .getPreviews()
@@ -34,10 +34,10 @@ object ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
             .toList()
     }
 
-    override fun provideValues(): List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> = values
+    override fun provideValues(context: Context): List<IndexedValue<ComposablePreview<AndroidPreviewInfo>>> = values
 }
 
-object ComposableA11yPreviewProvider : TestParameter.TestParameterValuesProvider {
+object ComposableA11yPreviewProvider : TestParameterValuesProvider() {
     private val values: List<ComposablePreview<AndroidPreviewInfo>> by lazy {
         AndroidComposablePreviewScanner()
             .scanPackageTrees(*PACKAGE_TREES)
@@ -46,25 +46,25 @@ object ComposableA11yPreviewProvider : TestParameter.TestParameterValuesProvider
             .toList()
     }
 
-    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> = values
+    override fun provideValues(context: Context): List<ComposablePreview<AndroidPreviewInfo>> = values
 }
 
-object Shard1ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
-    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> =
-        ComposablePreviewProvider.provideValues().filter { it.index % 4 == 0 }.map { it.value }
+object Shard1ComposablePreviewProvider : TestParameterValuesProvider() {
+    override fun provideValues(context: Context): List<ComposablePreview<AndroidPreviewInfo>> =
+        ComposablePreviewProvider.values.filter { it.index % 4 == 0 }.map { it.value }
 }
 
-object Shard2ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
-    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> =
-        ComposablePreviewProvider.provideValues().filter { it.index % 4 == 1 }.map { it.value }
+object Shard2ComposablePreviewProvider : TestParameterValuesProvider() {
+    override fun provideValues(context: Context): List<ComposablePreview<AndroidPreviewInfo>> =
+        ComposablePreviewProvider.values.filter { it.index % 4 == 1 }.map { it.value }
 }
 
-object Shard3ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
-    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> =
-        ComposablePreviewProvider.provideValues().filter { it.index % 4 == 2 }.map { it.value }
+object Shard3ComposablePreviewProvider : TestParameterValuesProvider() {
+    override fun provideValues(context: Context): List<ComposablePreview<AndroidPreviewInfo>> =
+        ComposablePreviewProvider.values.filter { it.index % 4 == 2 }.map { it.value }
 }
 
-object Shard4ComposablePreviewProvider : TestParameter.TestParameterValuesProvider {
-    override fun provideValues(): List<ComposablePreview<AndroidPreviewInfo>> =
-        ComposablePreviewProvider.provideValues().filter { it.index % 4 == 3 }.map { it.value }
+object Shard4ComposablePreviewProvider : TestParameterValuesProvider() {
+    override fun provideValues(context: Context): List<ComposablePreview<AndroidPreviewInfo>> =
+        ComposablePreviewProvider.values.filter { it.index % 4 == 3 }.map { it.value }
 }


### PR DESCRIPTION
Fix a deprecated api usage.

No expected change.