### PR TITLE
Keep the cursor position in room list search when going back

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -84,7 +84,6 @@ import io.element.android.libraries.designsystem.text.toAnnotatedString
 import io.element.android.libraries.designsystem.theme.components.BottomSheetDragHandle
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.Text
-import io.element.android.libraries.designsystem.utils.HideKeyboardWhenDisposed
 import io.element.android.libraries.designsystem.utils.KeepScreenOn
 import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarHost
@@ -123,8 +122,6 @@ fun MessagesView(
     }
 
     KeepScreenOn(state.voiceMessageComposerState.keepScreenOn)
-
-    HideKeyboardWhenDisposed()
 
     val snackbarHostState = rememberSnackbarHostState(snackbarMessage = state.snackbarMessage)
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. Also, make sure disposing a `MessagesView` doesn't accidentally hide the keyboard once the transition animation is done.

This was caused by `HideKeyboardWhenDisposed`, which ran once the transition animation was complete and the keyboard had been restored in the previous screen. If we want to implement something like this we might have to do it at the node level and being able to intercept the transition state somehow.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5461.

## Screenshots / GIFs

| Before | After |
|-|-|
| <video src=https://github.com/user-attachments/assets/dab02d0d-7023-44f3-8a23-e58b544dd047 /> | <video src=https://github.com/user-attachments/assets/48e1121f-f558-4127-94cc-9e0ed1e5c568 /> |

## Tests

1. Go to the room list, add some term to search.
2. Open a room. Tap on the composer so the keyboard is displayed. Try navigating to several screens from it, it should always hide the keyboard even without `HideKeyboardWhenDisposed`.
3. Go back to the room list search: the search term should still be there, the cursor should be at the end and the keyboard should remain visible.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
