### PR TITLE
Make sure we destroy rooms removed from the a `ActiveRoomsHolder`

### DIFF
--- a/services/appnavstate/api/src/main/kotlin/io/element/android/services/appnavstate/api/ActiveRoomsHolder.kt
+++ b/services/appnavstate/api/src/main/kotlin/io/element/android/services/appnavstate/api/ActiveRoomsHolder.kt
@@ -53,8 +53,11 @@ class ActiveRoomsHolder {
      */
     fun removeRoom(sessionId: SessionId, roomId: RoomId) {
         val roomsForSessionId = rooms[sessionId] ?: return
-        roomsForSessionId.find { it.roomId == roomId }?.destroy()
-        roomsForSessionId.removeIf { it.roomId == roomId }
+        roomsForSessionId.find { it.roomId == roomId }?.let { room ->
+            // Destroy the room to reset the live timeline
+            room.destroy()
+            roomsForSessionId.remove(room)
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

This is needed to clear their timeline cache so their timeline creation is faster when they're re-opened. This would also happen after a GC, but that can take time to happen so if the room is re-opened shortly after closing it, this cache clear might not have happened.

It's probably what caused https://github.com/element-hq/element-x-android/issues/5580.

## Tests

- Open a room, and back paginate a lot. You can also open its gallery and let it back paginate on its own.
- Close the room.
- Open it again.

The opening time should be the same as when you first opened it. Previously, this could take 10-20s or more, depending on how much you had back paginated and how many timeline items the timeline had cached on the Rust side.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
