### PR TITLE
Clearing the room list search clears the search term too

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchView.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -33,7 +34,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -111,7 +111,11 @@ private fun RoomListSearchContent(
                 },
                 navigationIcon = { BackButton(onClick = ::onBackButtonClick) },
                 title = {
-                    var value by remember { mutableStateOf(TextFieldValue(state.query)) }
+                    // TODO replace `state.query` with TextFieldState when it's available for M3 TextField
+                    // The stateSaver will keep the selection state when returning to this UI
+                    var value by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+                        mutableStateOf(TextFieldValue(state.query))
+                    }
 
                     val focusRequester = remember { FocusRequester() }
                     FilledTextField(
@@ -137,6 +141,8 @@ private fun RoomListSearchContent(
                             if (value.text.isNotEmpty()) {
                                 IconButton(onClick = {
                                     state.eventSink(RoomListSearchEvents.ClearQuery)
+                                    // Clear local state too
+                                    value = value.copy(text = "")
                                 }) {
                                     Icon(
                                         imageVector = CompoundIcons.Close(),
@@ -148,7 +154,6 @@ private fun RoomListSearchContent(
                     )
 
                     LaunchedEffect(Unit) {
-                        value = value.copy(selection = TextRange(value.text.length))
                         if (!focusRequester.restoreFocusedChild()) {
                             focusRequester.requestFocus()
                         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Improves how the search query state is handled, adding a state saver to ensure the selection is preserved.
- When the clear button is tapped, the local UI state is cleared too.
- Added a reminder to replace it with `TextFieldState` when it's available in M3, which would simplify this code.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5601

## Tests

- Open the room list search, add some query.
- Open a room.
- Exit it: the text and selection should be preserved.
- Tap on the clear button, the query should now be gone, as well as the room list items.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
