### PR TITLE
Space : add view members entry

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
@@ -22,8 +22,6 @@ import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
 import io.element.android.appnav.di.RoomGraphFactory
 import io.element.android.appnav.room.RoomNavigationTarget
-import io.element.android.appnav.room.joined.JoinedRoomLoadedFlowNode.Inputs
-import io.element.android.appnav.room.joined.JoinedRoomLoadedFlowNode.NavTarget
 import io.element.android.features.messages.api.MessagesEntryPoint
 import io.element.android.features.roomdetails.api.RoomDetailsEntryPoint
 import io.element.android.features.space.api.SpaceEntryPoint
@@ -154,6 +152,9 @@ class JoinedRoomLoadedFlowNode(
             NavTarget.RoomNotificationSettings -> {
                 createRoomDetailsNode(buildContext, RoomDetailsEntryPoint.InitialTarget.RoomNotificationSettings)
             }
+            NavTarget.RoomMemberList -> {
+                createRoomDetailsNode(buildContext, RoomDetailsEntryPoint.InitialTarget.RoomMemberList)
+            }
             NavTarget.Space -> {
                 createSpaceNode(buildContext)
             }
@@ -168,6 +169,10 @@ class JoinedRoomLoadedFlowNode(
 
             override fun onOpenDetails() {
                 backstack.push(NavTarget.RoomDetails)
+            }
+
+            override fun onOpenMemberList() {
+                backstack.push(NavTarget.RoomMemberList)
             }
         }
         return spaceEntryPoint.nodeBuilder(this, buildContext)
@@ -217,6 +222,9 @@ class JoinedRoomLoadedFlowNode(
         data object RoomDetails : NavTarget
 
         @Parcelize
+        data object RoomMemberList : NavTarget
+
+        @Parcelize
         data class RoomMemberDetails(val userId: UserId) : NavTarget
 
         @Parcelize
@@ -229,17 +237,17 @@ class JoinedRoomLoadedFlowNode(
     }
 }
 
-private fun initialElement(plugins: List<Plugin>): NavTarget {
-    val input = plugins.filterIsInstance<Inputs>().single()
+private fun initialElement(plugins: List<Plugin>): JoinedRoomLoadedFlowNode.NavTarget {
+    val input = plugins.filterIsInstance<JoinedRoomLoadedFlowNode.Inputs>().single()
     return when (input.initialElement) {
         is RoomNavigationTarget.Root -> {
             if (input.room.roomInfoFlow.value.isSpace) {
-                NavTarget.Space
+                JoinedRoomLoadedFlowNode.NavTarget.Space
             } else {
-                NavTarget.Messages(input.initialElement.eventId)
+                JoinedRoomLoadedFlowNode.NavTarget.Messages(input.initialElement.eventId)
             }
         }
-        RoomNavigationTarget.Details -> NavTarget.RoomDetails
-        RoomNavigationTarget.NotificationSettings -> NavTarget.RoomNotificationSettings
+        RoomNavigationTarget.Details -> JoinedRoomLoadedFlowNode.NavTarget.RoomDetails
+        RoomNavigationTarget.NotificationSettings -> JoinedRoomLoadedFlowNode.NavTarget.RoomNotificationSettings
     }
 }

--- a/features/roomdetails/api/src/main/kotlin/io/element/android/features/roomdetails/api/RoomDetailsEntryPoint.kt
+++ b/features/roomdetails/api/src/main/kotlin/io/element/android/features/roomdetails/api/RoomDetailsEntryPoint.kt
@@ -24,6 +24,9 @@ interface RoomDetailsEntryPoint : FeatureEntryPoint {
         data object RoomDetails : InitialTarget
 
         @Parcelize
+        data object RoomMemberList : InitialTarget
+
+        @Parcelize
         data class RoomMemberDetails(val roomMemberId: UserId) : InitialTarget
 
         @Parcelize

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/DefaultRoomDetailsEntryPoint.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/DefaultRoomDetailsEntryPoint.kt
@@ -44,4 +44,5 @@ internal fun InitialTarget.toNavTarget() = when (this) {
     is InitialTarget.RoomDetails -> NavTarget.RoomDetails
     is InitialTarget.RoomMemberDetails -> NavTarget.RoomMemberDetails(roomMemberId)
     is InitialTarget.RoomNotificationSettings -> NavTarget.RoomNotificationSettings(showUserDefinedSettingStyle = true)
+    InitialTarget.RoomMemberList -> NavTarget.RoomMemberList
 }

--- a/features/space/api/src/main/kotlin/io/element/android/features/space/api/SpaceEntryPoint.kt
+++ b/features/space/api/src/main/kotlin/io/element/android/features/space/api/SpaceEntryPoint.kt
@@ -33,5 +33,7 @@ interface SpaceEntryPoint : FeatureEntryPoint {
     interface Callback : Plugin {
         fun onOpenRoom(roomId: RoomId, viaParameters: List<String>)
         fun onOpenDetails()
+
+        fun onOpenMemberList()
     }
 }

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/SpaceFlowNode.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/SpaceFlowNode.kt
@@ -88,6 +88,10 @@ class SpaceFlowNode(
                         callback.onOpenDetails()
                     }
 
+                    override fun onOpenMemberList() {
+                        callback.onOpenMemberList()
+                    }
+
                     override fun onLeaveSpace() {
                         backstack.push(NavTarget.Leave)
                     }

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceNode.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceNode.kt
@@ -42,6 +42,8 @@ class SpaceNode(
     interface Callback : Plugin {
         fun onOpenRoom(roomId: RoomId, viaParameters: List<String>)
         fun onOpenDetails()
+
+        fun onOpenMemberList()
         fun onLeaveSpace()
     }
 
@@ -82,6 +84,9 @@ class SpaceNode(
             },
             onShareSpace = {
                 onShareRoom(context)
+            },
+            onViewMembersClick = {
+                callback.onOpenMemberList()
             },
             acceptDeclineInviteView = {
                 acceptDeclineInviteView.Render(

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
@@ -78,6 +78,7 @@ fun SpaceView(
     onShareSpace: () -> Unit,
     onLeaveSpaceClick: () -> Unit,
     onDetailsClick: () -> Unit,
+    onViewMembersClick: () -> Unit,
     modifier: Modifier = Modifier,
     acceptDeclineInviteView: @Composable () -> Unit,
 ) {
@@ -89,7 +90,8 @@ fun SpaceView(
                 onBackClick = onBackClick,
                 onLeaveSpaceClick = onLeaveSpaceClick,
                 onShareSpace = onShareSpace,
-                onDetailsClick = onDetailsClick
+                onDetailsClick = onDetailsClick,
+                onViewMembersClick = onViewMembersClick,
             )
         },
         content = { padding ->
@@ -256,6 +258,7 @@ private fun SpaceViewTopBar(
     onLeaveSpaceClick: () -> Unit,
     onDetailsClick: () -> Unit,
     onShareSpace: () -> Unit,
+    onViewMembersClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TopAppBar(
@@ -307,6 +310,20 @@ private fun SpaceViewTopBar(
                 DropdownMenuItem(
                     onClick = {
                         showMenu = false
+                        onViewMembersClick()
+                    },
+                    text = { Text(stringResource(id = CommonStrings.screen_space_menu_action_members)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = CompoundIcons.User(),
+                            tint = ElementTheme.colors.iconSecondary,
+                            contentDescription = null,
+                        )
+                    }
+                )
+                DropdownMenuItem(
+                    onClick = {
+                        showMenu = false
                         onLeaveSpaceClick()
                     },
                     text = {
@@ -344,10 +361,10 @@ private fun SpaceAvatarAndNameRow(
         )
         Text(
             modifier = Modifier
-                    .padding(horizontal = 8.dp)
-                    .semantics {
-                        heading()
-                    },
+                .padding(horizontal = 8.dp)
+                .semantics {
+                    heading()
+                },
             text = name ?: stringResource(CommonStrings.common_no_space_name),
             style = ElementTheme.typography.fontBodyLgMedium,
             fontStyle = FontStyle.Italic.takeIf { name == null },
@@ -403,6 +420,7 @@ internal fun SpaceViewPreview(
         onLeaveSpaceClick = {},
         acceptDeclineInviteView = {},
         onDetailsClick = {},
+        onViewMembersClick = {},
         onBackClick = {},
     )
 }

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/DefaultSpaceEntryPointTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/DefaultSpaceEntryPointTest.kt
@@ -46,6 +46,7 @@ class DefaultSpaceEntryPointTest {
         val callback = object : SpaceEntryPoint.Callback {
             override fun onOpenRoom(roomId: RoomId, viaParameters: List<String>) = lambdaError()
             override fun onOpenDetails() = lambdaError()
+            override fun onOpenMemberList() = lambdaError()
         }
         val result = entryPoint.nodeBuilder(parentNode, BuildContext.root(null))
             .inputs(nodeInputs)

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/root/SpaceViewTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/root/SpaceViewTest.kt
@@ -140,6 +140,7 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setSpace
     onShareSpace: () -> Unit = EnsureNeverCalled(),
     onLeaveSpaceClick: () -> Unit = EnsureNeverCalled(),
     onDetailsClick: () -> Unit = EnsureNeverCalled(),
+    onViewMembersClick: () -> Unit = EnsureNeverCalled(),
     acceptDeclineInviteView: @Composable () -> Unit = {},
 ) {
     setContent {
@@ -150,6 +151,7 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setSpace
             onShareSpace = onShareSpace,
             onLeaveSpaceClick = onLeaveSpaceClick,
             onDetailsClick = onDetailsClick,
+            onViewMembersClick = onViewMembersClick,
             acceptDeclineInviteView = acceptDeclineInviteView,
         )
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Now that we can reuse the LoadedRoomFlowNode for space, introduce "View Members" action in the space screen.

## Motivation and context
Close https://github.com/element-hq/element-x-android/issues/5617
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No ui change.
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a space
- Click on the 3 dot menu and select "View members"' entry.
- You should now have access to the People screen as for room

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
