### PR TITLE
Enable `SyncNotificationsWithWorkManager` by default in release mode apps too

### DIFF
--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -114,8 +114,7 @@ enum class FeatureFlags(
         title = "Sync notifications with WorkManager",
         description = "Use WorkManager to schedule notification sync tasks when a push is received." +
             " This should improve reliability and battery usage.",
-        // Enable by default on nightly and debug builds so we can get feedback before enabling it for everyone.
-        defaultValue = { meta -> meta.buildType != BuildType.RELEASE },
+        defaultValue = { true },
         isFinished = false,
     ),
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

This feature seems to work quite well in nightlies after the latest fixes, so we want to enable it for the next RC too.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
