### PR TITLE
Move dependencies block out of the android block.

### DIFF
--- a/libraries/compound/build.gradle.kts
+++ b/libraries/compound/build.gradle.kts
@@ -18,12 +18,12 @@ android {
     testOptions {
         unitTests.isIncludeAndroidResources = true
     }
+}
 
-    dependencies {
-        implementation(libs.showkase)
-        testCommonDependencies(libs)
-        testImplementation(libs.test.roborazzi)
-        testImplementation(libs.test.roborazzi.compose)
-        testImplementation(libs.test.roborazzi.junit)
-    }
+dependencies {
+    implementation(libs.showkase)
+    testCommonDependencies(libs)
+    testImplementation(libs.test.roborazzi)
+    testImplementation(libs.test.roborazzi.compose)
+    testImplementation(libs.test.roborazzi.junit)
 }

--- a/libraries/cryptography/test/build.gradle.kts
+++ b/libraries/cryptography/test/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.cryptography.test"
+}
 
-    dependencies {
-        api(projects.libraries.cryptography.api)
-    }
+dependencies {
+    api(projects.libraries.cryptography.api)
 }

--- a/libraries/dateformatter/api/build.gradle.kts
+++ b/libraries/dateformatter/api/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.dateformatter.api"
+}
 
-    dependencies {
-        testCommonDependencies(libs)
-    }
+dependencies {
+    testCommonDependencies(libs)
 }

--- a/libraries/dateformatter/impl/build.gradle.kts
+++ b/libraries/dateformatter/impl/build.gradle.kts
@@ -30,19 +30,19 @@ android {
             )
         }
     }
+}
 
-    dependencies {
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.designsystem)
-        implementation(projects.libraries.di)
-        implementation(projects.libraries.uiStrings)
-        implementation(projects.services.toolbox.api)
+dependencies {
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.designsystem)
+    implementation(projects.libraries.di)
+    implementation(projects.libraries.uiStrings)
+    implementation(projects.services.toolbox.api)
 
-        api(projects.libraries.dateformatter.api)
-        api(libs.datetime)
+    api(projects.libraries.dateformatter.api)
+    api(libs.datetime)
 
-        testCommonDependencies(libs, true)
-        testImplementation(projects.libraries.dateformatter.test)
-        testImplementation(projects.services.toolbox.test)
-    }
+    testCommonDependencies(libs, true)
+    testImplementation(projects.libraries.dateformatter.test)
+    testImplementation(projects.services.toolbox.test)
 }

--- a/libraries/dateformatter/test/build.gradle.kts
+++ b/libraries/dateformatter/test/build.gradle.kts
@@ -11,9 +11,9 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.dateformatter.test"
+}
 
-    dependencies {
-        api(projects.libraries.dateformatter.api)
-        api(libs.datetime)
-    }
+dependencies {
+    api(projects.libraries.dateformatter.api)
+    api(libs.datetime)
 }

--- a/libraries/designsystem/build.gradle.kts
+++ b/libraries/designsystem/build.gradle.kts
@@ -25,24 +25,24 @@ android {
             consumerProguardFiles("consumer-rules.pro")
         }
     }
+}
 
-    dependencies {
-        api(projects.libraries.compound)
+dependencies {
+    api(projects.libraries.compound)
 
-        implementation(libs.androidx.compose.material3.windowsizeclass)
-        implementation(libs.androidx.compose.material3.adaptive)
-        implementation(libs.coil.compose)
-        implementation(libs.vanniktech.blurhash)
-        implementation(projects.libraries.androidutils)
-        implementation(projects.libraries.architecture)
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.preferences.api)
-        implementation(projects.libraries.testtags)
-        implementation(projects.libraries.uiStrings)
+    implementation(libs.androidx.compose.material3.windowsizeclass)
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.coil.compose)
+    implementation(libs.vanniktech.blurhash)
+    implementation(projects.libraries.androidutils)
+    implementation(projects.libraries.architecture)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.preferences.api)
+    implementation(projects.libraries.testtags)
+    implementation(projects.libraries.uiStrings)
 
-        ksp(libs.showkase.processor)
-        implementation(libs.showkase)
+    ksp(libs.showkase.processor)
+    implementation(libs.showkase)
 
-        testCommonDependencies(libs)
-    }
+    testCommonDependencies(libs)
 }

--- a/libraries/featureflag/test/build.gradle.kts
+++ b/libraries/featureflag/test/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.featureflag.test"
+}
 
-    dependencies {
-        api(projects.libraries.featureflag.api)
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.matrix.test)
-        implementation(libs.coroutines.core)
-    }
+dependencies {
+    api(projects.libraries.featureflag.api)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.matrix.test)
+    implementation(libs.coroutines.core)
 }

--- a/libraries/mediapickers/api/build.gradle.kts
+++ b/libraries/mediapickers/api/build.gradle.kts
@@ -13,12 +13,12 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.mediapickers.api"
+}
 
-    dependencies {
-        implementation(projects.libraries.uiStrings)
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.di)
+dependencies {
+    implementation(projects.libraries.uiStrings)
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
 
-        testCommonDependencies(libs)
-    }
+    testCommonDependencies(libs)
 }

--- a/libraries/mediapickers/test/build.gradle.kts
+++ b/libraries/mediapickers/test/build.gradle.kts
@@ -15,10 +15,10 @@ setupDependencyInjection()
 
 android {
     namespace = "io.element.android.libraries.mediapickers.test"
+}
 
-    dependencies {
-        implementation(projects.libraries.core)
-        implementation(projects.libraries.di)
-        api(projects.libraries.mediapickers.api)
-    }
+dependencies {
+    implementation(projects.libraries.core)
+    implementation(projects.libraries.di)
+    api(projects.libraries.mediapickers.api)
 }

--- a/libraries/preferences/test/build.gradle.kts
+++ b/libraries/preferences/test/build.gradle.kts
@@ -11,12 +11,12 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.preferences.test"
+}
 
-    dependencies {
-        api(projects.libraries.preferences.api)
-        implementation(projects.libraries.matrix.api)
-        implementation(projects.tests.testutils)
-        implementation(libs.coroutines.core)
-        implementation(libs.androidx.datastore.preferences)
-    }
+dependencies {
+    api(projects.libraries.preferences.api)
+    implementation(projects.libraries.matrix.api)
+    implementation(projects.tests.testutils)
+    implementation(libs.coroutines.core)
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/libraries/previewutils/build.gradle.kts
+++ b/libraries/previewutils/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.previewutils"
+}
 
-    dependencies {
-        implementation(projects.libraries.designsystem)
-        implementation(projects.libraries.matrix.api)
+dependencies {
+    implementation(projects.libraries.designsystem)
+    implementation(projects.libraries.matrix.api)
 
-        implementation(libs.kotlinx.collections.immutable)
-    }
+    implementation(libs.kotlinx.collections.immutable)
 }

--- a/libraries/ui-utils/build.gradle.kts
+++ b/libraries/ui-utils/build.gradle.kts
@@ -13,11 +13,11 @@ plugins {
 
 android {
     namespace = "io.element.android.libraries.ui.utils"
+}
 
-    dependencies {
-        implementation(projects.libraries.androidutils)
-        implementation(projects.services.toolbox.impl)
+dependencies {
+    implementation(projects.libraries.androidutils)
+    implementation(projects.services.toolbox.impl)
 
-        testCommonDependencies(libs)
-    }
+    testCommonDependencies(libs)
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Move dependencies block out of the android block.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Ensure consistency between all our module configuration.
Follow Android guidelines (see https://developer.android.com/build/dependencies)

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
No expected impact

## Tests

<!-- Explain how you tested your development -->
No expected impact

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
