### PR TITLE
Try fixing 'Timeline Event object has already been destroyed'

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
@@ -39,6 +39,7 @@ class NotificationMapper(
                     isDirect = item.roomInfo.isDirect,
                     activeMembersCount = item.roomInfo.joinedMembersCount.toInt(),
                 )
+                val timestamp = item.timestamp() ?: clock.epochMillis()
                 NotificationData(
                     sessionId = sessionId,
                     eventId = eventId,
@@ -53,8 +54,8 @@ class NotificationMapper(
                     isDm = isDm,
                     isEncrypted = item.roomInfo.isEncrypted.orFalse(),
                     isNoisy = item.isNoisy.orFalse(),
-                    timestamp = item.timestamp() ?: clock.epochMillis(),
-                    content = item.event.use { notificationContentMapper.map(it) }.getOrThrow(),
+                    timestamp = timestamp,
+                    content = notificationContentMapper.map(item.event).getOrThrow(),
                     hasMention = item.hasMention.orFalse(),
                 )
             }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -25,8 +25,9 @@ class TimelineEventToNotificationContentMapper {
     fun map(timelineEvent: TimelineEvent): Result<NotificationContent> {
         return runCatchingExceptions {
             timelineEvent.use {
+                val senderId = UserId(timelineEvent.senderId())
                 timelineEvent.eventType().use { eventType ->
-                    eventType.toContent(senderId = UserId(timelineEvent.senderId()))
+                    eventType.toContent(senderId = senderId)
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Avoid nested `use { ... }` blocks for the same object, compute `timestamp` ahead of time, just in case.

## Motivation and context

I've seen this in some rageshakes and locally:

```
Unable to resolve event: Unknown error: TimelineEvent object has already been destroyed - Showing fallback notification
```

Coming from the notification mapping code. The only `TimelineEvent` object I see is the one in `NotificationEvent.Timeline`, so it seems like the mapping is occasionally failing for some weird reason.

## Tests

I'm not sure how to test this other than keeping the test apk installed for a while and checking there are no fallback notifications with this cause.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 14

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
