### PR TITLE
Do not use the bestDescription but the caption for images, when available

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -431,27 +431,37 @@ class DefaultNotificationCreator(
                     senderPerson
                 )
                 else -> {
-                    val message = MessagingStyle.Message(
-                        event.body?.annotateForDebug(71),
-                        event.timestamp,
-                        senderPerson
-                    ).also { message ->
-                        event.imageUri?.let {
-                            message.setData(event.imageMimeType ?: "image/", it)
-                        }
-                        message.extras.putString(MESSAGE_EVENT_ID, event.eventId.value)
-                    }
-                    addMessage(message)
-
-                    // Add additional message for captions
-                    if (event.imageUri != null && event.body != null) {
-                        addMessage(
-                            MessagingStyle.Message(
-                                event.body,
-                                event.timestamp,
-                                senderPerson,
-                            )
+                    if (event.imageMimeType != null && event.imageUri != null) {
+                        // Image case
+                        val message = MessagingStyle.Message(
+                            // This text will not be rendered, but some systems does not render the image
+                            // if the text is null
+                            stringProvider.getString(CommonStrings.common_image),
+                            event.timestamp,
+                            senderPerson,
                         )
+                            .setData(event.imageMimeType, event.imageUri)
+                        message.extras.putString(MESSAGE_EVENT_ID, event.eventId.value)
+                        addMessage(message)
+                        // Add additional message for captions
+                        if (event.body != null) {
+                            addMessage(
+                                MessagingStyle.Message(
+                                    event.body.annotateForDebug(72),
+                                    event.timestamp,
+                                    senderPerson,
+                                )
+                            )
+                        }
+                    } else {
+                        // Text case
+                        val message = MessagingStyle.Message(
+                            event.body?.annotateForDebug(71),
+                            event.timestamp,
+                            senderPerson
+                        )
+                        message.extras.putString(MESSAGE_EVENT_ID, event.eventId.value)
+                        addMessage(message)
                     }
                 }
             }


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Do not use the bestDescription but the caption for images because else the filename will be rendered in the notification and for image / gif / png we do not want that since the filename can be quite ugly and does not bring much.  Example:

<img width="401" height="244" alt="image" src="https://github.com/user-attachments/assets/6e8080e7-6535-44f9-a694-574b50f2d232" />

Also fixes the issue when images is not rendered on some system and so they can be empty notification.


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Avoid having random filename to be rendered in the notification below the images.
Also closes #3945, which was less visible since a text message was always rendered below the image, but with this change, it's not the case anymore

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Receive images with caption: the images and the captions should be displayed in the notification drawer
- Receive images without caption: only the image should be displayed. If the image cannot be displayed, the filename will be displayed

## Tested devices

- [ ] Physical
- [x] Emulator, in particular Pixel 9A with API 36 which can repro #3945. It's now possible to have only images rendered in the notification.
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
