### PR TITLE
Remove unused `TagSoup` proguard rule

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,9 +10,6 @@
 -keep class com.sun.jna.** { *; }
 -keep class * implements com.sun.jna.** { *; }
 
-# TagSoup, coming from the RTE library
--keep class org.ccil.cowan.tagsoup.** { *; }
-
 # kotlinx.serialization
 
 # Kotlin serialization looks up the generated serializer classes through a function on companion


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Remove this rule, which doesn't really do anything anymore AFAICT.

## Motivation and context

Does as much of https://github.com/element-hq/element-x-android/issues/5705 as we can.

## Tests

Build the app in release mode, it should keep working as expected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
