### PR TITLE
Fix rendering notifications after receiving redundant push

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/RustNotificationService.kt
@@ -45,7 +45,7 @@ class RustNotificationService(
             }
             val items = notificationClient.getNotifications(requests)
             buildMap {
-                val eventIds = requests.flatMap { it.eventIds }
+                val eventIds = requests.flatMap { it.eventIds }.distinct()
                 for (rawEventId in eventIds) {
                     val roomId = RoomId(requests.find { it.eventIds.contains(rawEventId) }?.roomId!!)
                     val eventId = EventId(rawEventId)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Deduplicate event IDs before iterating them, to ensure we only ever look up (and thus destroy) any item at most once.

## Motivation and context

Since merging v25.11.2 into SchildiChat Next, notifications have often been failing with "Unable to resolve event: Unknown error: TimelineEvent object has already been destroyed".

I have not 100% confirmed that this patch fixes it yet, doing the PR now anyway so I don't forget later. I will keep using my app with this patch for a while to observe.

I can artificially reproduce the error by forcing the code to iterate over the same event ID twice, so it may be good to have either way. Last time I ran into this and looked at the logs, I also found two "elementx: Queueing notification: NotificationEventRequest" log lines for the event that eventually failed, which may also support this theory. But again, to be further observed.

## Tests

Use the app for a while and observe if notifications fail to render via "Unable to resolve event: Unknown error: TimelineEvent object has already been destroyed".

## Tested devices

- [x] Physical: (currently testing on SchildiChat Next on v25.11.2 base, to be observed in the long run)
- [ ] Emulator
- OS version(s): Android 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] You've made a self review of your PR
