### PR TITLE
Fix navigation stack overflow when sharing media

### DIFF
--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
@@ -89,7 +89,7 @@ fun RoomSelectView(
     fun onBackButton(state: RoomSelectState) {
         if (state.isSearchActive) {
             state.eventSink(RoomSelectEvents.ToggleSearchActive)
-        } else {
+        } else if (canHandleBack) {
             canHandleBack = false
             onDismiss()
         }
@@ -109,7 +109,10 @@ fun RoomSelectView(
                     RoomSelectMode.Share -> stringResource(CommonStrings.common_send_to)
                 },
                 navigationIcon = {
-                    BackButton(onClick = { onBackButton(state) })
+                    BackButton(
+                        enabled = canHandleBack,
+                        onClick = { onBackButton(state) }
+                    )
                 },
                 actions = {
                     TextButton(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Makes sure the `BackHandler` can only navigate up once in the `RoomSelectView` component.

This screen is a good candidate for the `SafeBackHandler` we previously talked about @bmarty .

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5688.

## Tests

<!-- Explain how you tested your development -->

- From another app, share some file or media.
- When cancelling or actually sending the file, you should navigate to the room and see the file being sent.

Previously, this would get in a stack overflow where `navigateUp` triggered a back event that got caught by `BackHandler`, which in turn navigated up, and ended up looping in that logic.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
