### PR TITLE
Send read receipts using the current timeline, not the live timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -389,13 +389,17 @@ class TimelinePresenter(
     ) = launch(dispatchers.computation) {
         // If we are at the bottom of timeline, we mark the room as read.
         if (firstVisibleIndex == 0) {
-            room.liveTimeline.markAsRead(receiptType = readReceiptType)
+            timelineController.invokeOnCurrentTimeline {
+                markAsRead(receiptType = readReceiptType)
+            }
         } else {
             // Get last valid EventId seen by the user, as the first index might refer to a Virtual item
             val eventId = getLastEventIdBeforeOrAt(firstVisibleIndex, timelineItems)
             if (eventId != null && eventId != lastReadReceiptId.value) {
                 lastReadReceiptId.value = eventId
-                room.liveTimeline.sendReadReceipt(eventId = eventId, receiptType = readReceiptType)
+                timelineController.invokeOnCurrentTimeline {
+                    sendReadReceipt(eventId = eventId, receiptType = readReceiptType)
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

This fixes sending read receipts in threads.

cc @frebib 

## Motivation and context

If you opened a thread, previously the app would try to send read receipts for it using the live timeline. As those events aren't really in the live timeline, this would be rejected by the homeserver.

## Tests

You'll need 2 clients (EX/EW) with the same account and one with a different account to test it. With threads enabled:

- From another account, send a message in a thread that this client will receive and take as an unread.
- With this client, open such thread.
- From the other client with the same account, check the read receipt is now gone.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
