### PR TITLE
Fallback to the default push gateway on error

### DIFF
--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayResolver.kt
@@ -63,8 +63,9 @@ class DefaultUnifiedPushGatewayResolver(
                         UnifiedPushGatewayResolverResult.NoMatrixGateway
                     }
                 } catch (throwable: Throwable) {
-                    if ((throwable as? HttpException)?.code() == HttpURLConnection.HTTP_NOT_FOUND) {
-                        Timber.tag(loggerTag.value).i("Checking for UnifiedPush endpoint yielded 404, using fallback")
+                    val code = (throwable as? HttpException)?.code()
+                    if (code in NoMatrixGatewayResp) {
+                        Timber.tag(loggerTag.value).i("Checking for UnifiedPush endpoint yielded $code, using fallback")
                         UnifiedPushGatewayResolverResult.NoMatrixGateway
                     } else {
                         Timber.tag(loggerTag.value).e(throwable, "Error checking for UnifiedPush endpoint")
@@ -73,5 +74,15 @@ class DefaultUnifiedPushGatewayResolver(
                 }
             }
         }
+    }
+
+    companion object {
+        private val NoMatrixGatewayResp = listOf<Int>(
+            HttpURLConnection.HTTP_UNAUTHORIZED,
+            HttpURLConnection.HTTP_FORBIDDEN,
+            HttpURLConnection.HTTP_NOT_FOUND,
+            HttpURLConnection.HTTP_BAD_METHOD,
+            HttpURLConnection.HTTP_NOT_ACCEPTABLE
+        )
     }
 }

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayUrlResolver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushGatewayUrlResolver.kt
@@ -28,8 +28,9 @@ class DefaultUnifiedPushGatewayUrlResolver(
     ): String {
         return when (gatewayResult) {
             is UnifiedPushGatewayResolverResult.Error -> {
-                // Use previous gateway if any, or the provided one
-                unifiedPushStore.getPushGateway(instance) ?: gatewayResult.gateway
+                // Use previous gateway if any, or the default one
+                unifiedPushStore.getPushGateway(instance)
+                    ?: defaultPushGatewayHttpUrlProvider.provide()
             }
             UnifiedPushGatewayResolverResult.ErrorInvalidUrl,
             UnifiedPushGatewayResolverResult.NoMatrixGateway -> {

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayResolverTest.kt
@@ -118,10 +118,40 @@ class DefaultUnifiedPushGatewayResolverTest {
     }
 
     @Test
-    fun `when a custom url is forbidden (403), Error is returned`() = runTest {
+    fun `when a custom url is forbidden (403), NoMatrixGateway is returned`() = runTest {
         val unifiedPushApiFactory = FakeUnifiedPushApiFactory(
             discoveryResponse = {
                 throw HttpException(Response.error<Unit>(HttpURLConnection.HTTP_FORBIDDEN, "".toResponseBody()))
+            }
+        )
+        val sut = createDefaultUnifiedPushGatewayResolver(
+            unifiedPushApiFactory = unifiedPushApiFactory
+        )
+        val result = sut.getGateway("http://custom.url")
+        assertThat(unifiedPushApiFactory.baseUrlParameter).isEqualTo("http://custom.url")
+        assertThat(result).isEqualTo(UnifiedPushGatewayResolverResult.NoMatrixGateway)
+    }
+
+    @Test
+    fun `when a custom url is not acceptable (406), NoMatrixGateway is returned`() = runTest {
+        val unifiedPushApiFactory = FakeUnifiedPushApiFactory(
+            discoveryResponse = {
+                throw HttpException(Response.error<Unit>(HttpURLConnection.HTTP_NOT_ACCEPTABLE, "".toResponseBody()))
+            }
+        )
+        val sut = createDefaultUnifiedPushGatewayResolver(
+            unifiedPushApiFactory = unifiedPushApiFactory
+        )
+        val result = sut.getGateway("http://custom.url")
+        assertThat(unifiedPushApiFactory.baseUrlParameter).isEqualTo("http://custom.url")
+        assertThat(result).isEqualTo(UnifiedPushGatewayResolverResult.NoMatrixGateway)
+    }
+
+    @Test
+    fun `when a custom url is internal error (500), Error is returned`() = runTest {
+        val unifiedPushApiFactory = FakeUnifiedPushApiFactory(
+            discoveryResponse = {
+                throw HttpException(Response.error<Unit>(HttpURLConnection.HTTP_INTERNAL_ERROR, "".toResponseBody()))
             }
         )
         val sut = createDefaultUnifiedPushGatewayResolver(

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayUrlResolverTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultUnifiedPushGatewayUrlResolverTest.kt
@@ -59,7 +59,7 @@ class DefaultUnifiedPushGatewayUrlResolverTest {
     }
 
     @Test
-    fun `resolve Error returns the url if no current url is available`() {
+    fun `resolve Error returns the default gateway url if no current url is available`() {
         val sut = createDefaultUnifiedPushGatewayUrlResolver(
             unifiedPushStore = FakeUnifiedPushStore(
                 getPushGatewayResult = { instance ->
@@ -72,7 +72,7 @@ class DefaultUnifiedPushGatewayUrlResolverTest {
             gatewayResult = UnifiedPushGatewayResolverResult.Error("aUrl"),
             instance = "instance",
         )
-        assertThat(result).isEqualTo("aUrl")
+        assertThat(result).isEqualTo(FakeDefaultPushGatewayHttpUrlProvider().provide())
     }
 
     private fun createDefaultUnifiedPushGatewayUrlResolver(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->

Based on #5741.

Fallback to the default gateway if the discovery request returns an error and no gateway was recorded for the push server yet.

## Motivation and context

We have the issue #5723 because the gateway resolver uses the custom gateway by default, when the request fails and the push server doesn't have any gateway yet. This exact issue is fixed with #5741 because 406 is included in valid responses showing no gateway is available. But we wouldn't have that issue if the fallback was to the default gateway.

I have split the 2 patchs in 2 PR, because I may not be aware of a need that let you choose to fallback to the custom gateway instead of the default, and I don't want to block the other patch.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Tests

<!-- Explain how you tested your development -->

- Install Sunup
- Enable UnifiedPush and selection Sunup
- Go to notification troubleshooting list
- Observe the nonexistent gateway being used

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
