### PR TITLE
Stop overriding the homeserver when restoring a `Client`

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -66,7 +66,6 @@ class RustMatrixClientFactory(
             passphrase = sessionData.passphrase,
             slidingSyncType = ClientBuilderSlidingSync.Restored,
         )
-            .homeserverUrl(sessionData.homeserverUrl)
             .username(sessionData.userId)
             .use { it.build() }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Removes the `setHomeserverUrl` call when restoring a `Client` from its `SessionData`.

## Motivation and context

This call isn't necessary and overrides the existing data previously saved by the SDK, resulting in losing data such as the `Client::server` (the discovery server URL).

In turn, this caused the app to be unable to refresh the server info in some homeservers. Sadly, this means users that are already logged in will be affected by this issue since their configured URLs would have been overridden after the first `Client` restoration, so they won't be able to refresh their server info until they log out and in again.

## Tests

- Freshly log into `element.io` or some other HS whose server URL doesn't match their HS URL (the host for the `/.well-known/matrix/client` doesn't match the actual HS).
- Then clear the cache from the developer settings. You should not see this messages in the logs anymore:

```
matrix_sdk::client: Failed to fetch client well-known: the server returned an error: [404] <non-json bytes> | crates/matrix-sdk/src/client/mod.rs:1994
```

Also, if right after restoring the `Client` you add a log containing the `Client.server()` value, it should display the server URL instead of null.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
