### PR TITLE
Revert "Stop overriding the homeserver when restoring a `Client`"

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -71,6 +71,7 @@ class RustMatrixClientFactory(
             passphrase = sessionData.passphrase,
             slidingSyncType = ClientBuilderSlidingSync.Restored,
         )
+            .homeserverUrl(sessionData.homeserverUrl)
             .username(sessionData.userId)
             .use { it.build() }
 


### PR DESCRIPTION
Reverts element-hq/element-x-android#5753

While the new Client setup fixed the issue of the server info not being refreshed after clearing the cache - or ever, if in the future we add some mechanism to periodically do so -, the new one forces us to perform a server discovery operation when the app starts, and will fail to restore the session if there is an error with this request, which is a way worse behaviour.

Instead of this, we need something in the SDK (+ the needed code to support that in the client) that allows us to keep both the server name and the homeserver url and avoid performing this discovery operation on every app restart.