### PR TITLE
Fix navigation issue once incoming share is handled

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/LoggedInFlowNode.kt
@@ -489,7 +489,7 @@ class LoggedInFlowNode(
                     params = ShareEntryPoint.Params(intent = navTarget.intent),
                     callback = object : ShareEntryPoint.Callback {
                         override fun onDone(roomIds: List<RoomId>) {
-                            navigateUp()
+                            backstack.pop()
                             roomIds.singleOrNull()?.let { roomId ->
                                 backstack.push(NavTarget.Room(roomId.toRoomIdOrAlias()))
                             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
When incoming share is handled (data is sent to a room), it was not possible to navigate back to the room list.
Pressing back was popping up the room, but the room was added again on the backstack.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix navigation issue. Fix stackOverflow error (EDIT: no, actually fixed by https://github.com/element-hq/element-x-android/pull/5724. EDIT 2: it actually does fix a back navigation issue too).

From the PlayStore report:
```
Exception java.lang.StackOverflowError: stack size 8188KB
  at com.bumble.appyx.core.node.Node.navigateUp (Node.kt:220)
  at io.element.android.appnav.LoggedInFlowNode$resolve$3.onDone (LoggedInFlowNode.kt:486)
  at io.element.android.features.share.impl.ShareNode$resolve$callback$1.onCancel (ShareNode.java:65)
  at io.element.android.libraries.roomselect.impl.RoomSelectNode$View$1$1.invoke (RoomSelectNode.kt:45)
  at io.element.android.libraries.roomselect.impl.RoomSelectNode$View$1$1.invoke (RoomSelectNode.kt:45)
  at io.element.android.libraries.roomselect.impl.RoomSelectViewKt.RoomSelectView$onBackButton (RoomSelectView.kt:87)
  at io.element.android.libraries.roomselect.impl.RoomSelectViewKt.RoomSelectView$lambda$1$0 (RoomSelectView.kt:91)
  at androidx.activity.compose.BackHandlerKt$BackHandler$backCallback$1$1.handleOnBackPressed (BackHandler.kt:89)
  at androidx.activity.OnBackPressedDispatcher.onBackPressed (OnBackPressedDispatcher.kt:260)
  at androidx.activity.ComponentActivity.onBackPressed (ComponentActivity.kt:588)
  at com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint.handleUpNavigation (ActivityIntegrationPoint.kt:43)
  at com.bumble.appyx.core.node.Node.navigateUp (Node.kt:221)
  at io.element.android.appnav.LoggedInFlowNode$resolve$3.onDone (LoggedInFlowNode.kt:486)
  ...
```

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Share content to Element X
- Pick a room
- Send content
- The timeline is opened
- Press back
- if the room list is displayed the bug is fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
