### PR TITLE
Add `NIGHTLY` env for Sentry

### DIFF
--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryAnalyticsProvider.kt
@@ -97,6 +97,6 @@ class SentryAnalyticsProvider(
 
 private fun BuildType.toSentryEnv() = when (this) {
     BuildType.RELEASE -> SentryConfig.ENV_RELEASE
-    BuildType.NIGHTLY,
+    BuildType.NIGHTLY -> SentryConfig.ENV_NIGHTLY
     BuildType.DEBUG -> SentryConfig.ENV_DEBUG
 }

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
@@ -12,5 +12,6 @@ object SentryConfig {
     const val NAME = "Sentry"
     const val DSN = BuildConfig.SENTRY_DSN
     const val ENV_DEBUG = "DEBUG"
+    const val ENV_NIGHTLY = "NIGHTLY"
     const val ENV_RELEASE = "RELEASE"
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

Previously, nightly issue reports and performance transactions were uploaded to 'DEBUG', which may make sense for issues, but not for performance traces.

## Tests

If you build a nightly build of the app, you should see events being uploaded to `NIGHTLY` in sentry.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
