### PR TITLE
Uris should take precedence in plain text intents

### DIFF
--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/ShareIntentHandler.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/ShareIntentHandler.kt
@@ -58,8 +58,9 @@ class DefaultShareIntentHandler(
         onPlainText: suspend (String) -> Boolean,
     ): Boolean {
         val type = intent.resolveType(context) ?: return false
+        val uris = getIncomingUris(intent, type)
         return when {
-            type == MimeTypes.PlainText -> handlePlainText(intent, onPlainText)
+            uris.isEmpty() && type == MimeTypes.PlainText -> handlePlainText(intent, onPlainText)
             type.isMimeTypeImage() ||
                 type.isMimeTypeVideo() ||
                 type.isMimeTypeAudio() ||
@@ -67,7 +68,6 @@ class DefaultShareIntentHandler(
                 type.isMimeTypeFile() ||
                 type.isMimeTypeText() ||
                 type.isMimeTypeAny() -> {
-                val uris = getIncomingUris(intent, type)
                 val result = onUris(uris)
                 revokeUriPermissions(uris.map { it.uri })
                 result


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When handling a plain text share intent, check if it contains Uris before handling its content.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5781.

## Tests

- Create a macro using MacroDroid.
- Share it in the app.

If the file is shared, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
