### PR TITLE
Room list: enable latest event sorter.

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListExtensions.kt
@@ -66,7 +66,11 @@ internal fun RoomListInterface.entriesFlow(
                 trySendBlocking(roomEntriesUpdate)
             }
         }
-        val result = entriesWithDynamicAdapters(pageSize.toUInt(), listener)
+        val result = entriesWithDynamicAdaptersWith(
+            pageSize = pageSize.toUInt(),
+            enableLatestEventSorter = true,
+            listener = listener,
+        )
         val controller = result.controller()
         controller.setFilter(initialFilterKind)
         roomListDynamicEvents.onEach { controllerEvents ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Room list: enable latest event sorter.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_ui/room_list_service/sorters/fn.new_sorter_latest_event.html

> Create a new sorter that will sort two RoomListItem by their latest events’ state: latest events representing a local event (LatestEventValue::LocalIsSending or LatestEventValue::LocalCannotBeSent) come first, and latest event representing a remote event (LatestEventValue::Remote) come last.


## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open the app
- enter airplane mode
- from a room not displayed at the first position send an event
- on the room list, the room where the event is sending is displayed first

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
