### PR TITLE
Revert "fix(deps): update dependency com.posthog:posthog-android to v3.27.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -216,7 +216,7 @@ haze_materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = 
 color_picker = "io.mhssn:colorpicker:1.0.0"
 
 # Analytics
-posthog = "com.posthog:posthog-android:3.27.0"
+posthog = "com.posthog:posthog-android:3.26.0"
 sentry = "io.sentry:sentry-android:8.27.1"
 # main branch can be tested replacing the version with main-SNAPSHOT
 matrix_analytics_events = "com.github.matrix-org:matrix-analytics-events:0.29.2"


### PR DESCRIPTION
Reverts element-hq/element-x-android#5834

It's causing an issue with proguard:

```
java.lang.NoSuchMethodError: No direct method <init>(Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V in class Lcom/posthog/PostHogConfig; or its super classes (declaration of 'com.posthog.PostHogConfig' appears in /data/app/~~4LlP1IO_wyIYkvZSek-imA==/io.element.android.x.debug-p3D7fDUnBwGgSQB5EXDp2A==/base.apk!classes27.dex)
                                                                             	at com.posthog.android.PostHogAndroidConfig.<init>(PostHogAndroidConfig.kt:22)
                                                                             	at com.posthog.android.PostHogAndroidConfig.<init>(PostHogAndroidConfig.kt:15)
                                                                             	at io.element.android.services.analyticsproviders.posthog.PostHogFactory.createPosthog(PostHogFactory.kt:29)
                                                                             	at io.element.android.services.analyticsproviders.posthog.PosthogAnalyticsProvider.init(PosthogAnalyticsProvider.kt:44)
                                                                             	at io.element.android.services.analytics.impl.DefaultAnalyticsService.initOrStop(DefaultAnalyticsService.kt:106)
...
```