### PR TITLE
Fix: use the right `BuildTimeConfig` field for the SDK DSN

### DIFF
--- a/plugins/src/main/kotlin/config/BuildTimeConfig.kt
+++ b/plugins/src/main/kotlin/config/BuildTimeConfig.kt
@@ -29,7 +29,7 @@ object BuildTimeConfig {
     val SERVICES_POSTHOG_HOST: String? = null
     val SERVICES_POSTHOG_APIKEY: String? = null
     val SERVICES_SENTRY_DSN: String? = null
-    val SERVICES_SENTRY_SDK_DSN: String? = null
+    val SERVICES_SENTRY_DSN_RUST: String? = null
     val BUG_REPORT_URL: String? = null
     val BUG_REPORT_APP_NAME: String? = null
 

--- a/services/analyticsproviders/sentry/build.gradle.kts
+++ b/services/analyticsproviders/sentry/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         buildConfigFieldStr(
             name = "SDK_SENTRY_DSN",
             value = if (isEnterpriseBuild) {
-                BuildTimeConfig.SERVICES_SENTRY_SDK_DSN
+                BuildTimeConfig.SERVICES_SENTRY_DSN_RUST
             } else {
                 System.getenv("ELEMENT_SDK_SENTRY_DSN")
                     ?: readLocalProperty("services.analyticsproviders.sdk.sentry.dsn")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

We were using `SERVICES_SENTRY_SDK_DSN`, but the enterprise template uses `SERVICES_SENTRY_DSN_RUST`.

## Motivation and context

Fix build issue in the enterprise version of the app.

## Tests

Build the enterprise version of the app with the generated pkl templates.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
