### PR TITLE
Add a way to configure value of useLegacyPackaging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -199,6 +199,10 @@ android {
         resources.pickFirsts += setOf(
             "META-INF/versions/9/OSGI-INF/MANIFEST.MF",
         )
+
+        jniLibs {
+            useLegacyPackaging = project.findProperty("useLegacyPackaging")?.toString()?.toBoolean()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
 Add a way to configure value of android.packaging.jniLibs.useLegacyPackaging from command line.


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Be able to generate smaller APKs when necessary.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
No expected change on FOSS.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
