### PR TITLE
Use the right video preset when sharing videos

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -37,6 +37,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.permalink.PermalinkBuilder
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaupload.api.MediaOptimizationConfig
+import io.element.android.libraries.mediaupload.api.MediaOptimizationConfigProvider
 import io.element.android.libraries.mediaupload.api.MediaSenderFactory
 import io.element.android.libraries.mediaupload.api.MediaUploadInfo
 import io.element.android.libraries.mediaupload.api.allFiles
@@ -62,6 +63,7 @@ class AttachmentsPreviewPresenter(
     private val mediaOptimizationSelectorPresenterFactory: MediaOptimizationSelectorPresenter.Factory,
     @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
+    private val mediaOptimizationConfigProvider: MediaOptimizationConfigProvider,
 ) : Presenter<AttachmentsPreviewState> {
     @AssistedFactory
     interface Factory {
@@ -107,13 +109,9 @@ class AttachmentsPreviewPresenter(
             // to prepare it for sending. This is done to avoid blocking the UI thread when the
             // user clicks on the send button.
             if (mediaOptimizationSelectorState.displayMediaSelectorViews == false) {
-                val mediaOptimizationConfig = MediaOptimizationConfig(
-                    compressImages = mediaOptimizationSelectorState.isImageOptimizationEnabled == true,
-                    videoCompressionPreset = mediaOptimizationSelectorState.selectedVideoPreset ?: VideoCompressionPreset.STANDARD,
-                )
                 preprocessMediaJob = preProcessAttachment(
                     attachment = attachment,
-                    mediaOptimizationConfig = mediaOptimizationConfig,
+                    mediaOptimizationConfig = mediaOptimizationConfigProvider.get(),
                     displayProgress = false,
                     sendActionState = sendActionState,
                 )

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -44,6 +44,7 @@ import io.element.android.libraries.mediaupload.api.MediaPreProcessor
 import io.element.android.libraries.mediaupload.api.MediaSenderFactory
 import io.element.android.libraries.mediaupload.api.MediaUploadInfo
 import io.element.android.libraries.mediaupload.impl.DefaultMediaSender
+import io.element.android.libraries.mediaupload.test.FakeMediaOptimizationConfigProvider
 import io.element.android.libraries.mediaupload.test.FakeMediaPreProcessor
 import io.element.android.libraries.mediaviewer.api.aVideoMediaInfo
 import io.element.android.libraries.mediaviewer.api.anApkMediaInfo
@@ -598,6 +599,7 @@ class AttachmentsPreviewPresenterTest {
                 )
             }
         ),
+        mediaOptimizationConfigProvider: FakeMediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(),
     ): AttachmentsPreviewPresenter {
         return AttachmentsPreviewPresenter(
             attachment = aMediaAttachment(localMedia),
@@ -619,6 +621,7 @@ class AttachmentsPreviewPresenterTest {
             mediaOptimizationSelectorPresenterFactory = mediaOptimizationSelectorPresenterFactory,
             timelineMode = timelineMode,
             inReplyToEventId = null,
+            mediaOptimizationConfigProvider = mediaOptimizationConfigProvider,
         )
     }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenterTest.kt
@@ -22,12 +22,12 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.mediaupload.api.MaxUploadSizeProvider
+import io.element.android.libraries.mediaupload.test.FakeMediaOptimizationConfigProvider
 import io.element.android.libraries.mediaviewer.api.aVideoMediaInfo
 import io.element.android.libraries.mediaviewer.api.anImageMediaInfo
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
 import io.element.android.libraries.mediaviewer.test.viewer.aLocalMedia
 import io.element.android.libraries.preferences.api.store.VideoCompressionPreset
-import io.element.android.libraries.preferences.test.InMemorySessionPreferencesStore
 import io.element.android.tests.testutils.WarmUpRule
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -233,16 +233,16 @@ class DefaultMediaOptimizationSelectorPresenterTest {
     private fun createDefaultMediaOptimizationSelectorPresenter(
         localMedia: LocalMedia = aLocalMedia(mockMediaUrl, aVideoMediaInfo()),
         maxUploadSizeProvider: MaxUploadSizeProvider = MaxUploadSizeProvider { Result.success(1_000L) },
-        sessionPreferencesStore: InMemorySessionPreferencesStore = InMemorySessionPreferencesStore(),
         featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(mapOf(FeatureFlags.SelectableMediaQuality.key to true)),
         mediaExtractorFactory: FakeVideoMetadataExtractorFactory = FakeVideoMetadataExtractorFactory(),
+        mediaOptimizationConfigProvider: FakeMediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(),
     ): DefaultMediaOptimizationSelectorPresenter {
         return DefaultMediaOptimizationSelectorPresenter(
             localMedia = localMedia,
             maxUploadSizeProvider = maxUploadSizeProvider,
-            sessionPreferencesStore = sessionPreferencesStore,
             featureFlagService = featureFlagService,
             mediaExtractorFactory = mediaExtractorFactory,
+            mediaOptimizationConfigProvider = mediaOptimizationConfigProvider,
         )
     }
 }

--- a/libraries/mediaupload/impl/build.gradle.kts
+++ b/libraries/mediaupload/impl/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(projects.libraries.androidutils)
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)
+    implementation(projects.libraries.featureflag.api)
     implementation(projects.libraries.matrix.api)
     implementation(projects.services.toolbox.api)
     implementation(libs.androidx.exifinterface)

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/DefaultMediaOptimizationConfigProvider.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/DefaultMediaOptimizationConfigProvider.kt
@@ -10,17 +10,28 @@ package io.element.android.libraries.mediaupload.impl
 
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.featureflag.api.FeatureFlagService
+import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.mediaupload.api.MediaOptimizationConfig
 import io.element.android.libraries.mediaupload.api.MediaOptimizationConfigProvider
 import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
+import io.element.android.libraries.preferences.api.store.VideoCompressionPreset
 import kotlinx.coroutines.flow.first
 
 @ContributesBinding(SessionScope::class)
 class DefaultMediaOptimizationConfigProvider(
     private val sessionPreferencesStore: SessionPreferencesStore,
+    private val featureFlagsService: FeatureFlagService,
 ) : MediaOptimizationConfigProvider {
-    override suspend fun get(): MediaOptimizationConfig = MediaOptimizationConfig(
-        compressImages = sessionPreferencesStore.doesOptimizeImages().first(),
-        videoCompressionPreset = sessionPreferencesStore.getVideoCompressionPreset().first(),
-    )
+    override suspend fun get(): MediaOptimizationConfig {
+        val compressImages = sessionPreferencesStore.doesOptimizeImages().first()
+        return MediaOptimizationConfig(
+            compressImages = compressImages,
+            videoCompressionPreset = if (featureFlagsService.isFeatureEnabled(FeatureFlags.SelectableMediaQuality)) {
+                sessionPreferencesStore.getVideoCompressionPreset().first()
+            } else {
+                if (compressImages) VideoCompressionPreset.STANDARD else VideoCompressionPreset.HIGH
+            },
+        )
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Makes `DefaultMediaOptimizationConfigProvider` take into account the feature flags to decide whether to use the separate video compression option or not, to select which video preset should be returned.
- Use this in several places instead of the raw `SessionPreferencesStore` to make sure the right preset is selected.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5873

## Tests

1. In Settings -> Advanced settings, disable media compression.
2. Then share a 1080p+ video in a room.
3. Check the video is 1080p, not 720p.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
