### PR TITLE
Fix crash when `Shortcut` labels are empty

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
@@ -91,12 +91,13 @@ class DefaultNotificationConversationService(
 
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return
         val imageLoader = imageLoaderHolder.get(client)
+        val label = roomName.takeIf { it.isNotBlank() } ?: roomId.value
 
         val defaultShortcutIconSize = ShortcutManagerCompat.getIconMaxWidth(context)
         val icon = bitmapLoader.getRoomBitmap(
             avatarData = AvatarData(
                 id = roomId.value,
-                name = roomName,
+                name = label,
                 url = roomAvatarUrl,
                 size = AvatarSize.RoomDetailsHeader,
             ),
@@ -105,7 +106,7 @@ class DefaultNotificationConversationService(
         )?.let(IconCompat::createWithBitmap)
 
         val shortcutInfo = ShortcutInfoCompat.Builder(context, createShortcutId(sessionId, roomId))
-            .setShortLabel(roomName)
+            .setShortLabel(label)
             .setIcon(icon)
             .setIntent(intentProvider.getViewRoomIntent(sessionId, roomId, threadId = null, eventId = null))
             .setCategories(categories)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. If a room name is empty and we try to use that room name as a label for a shortcut, it will throw an exception that's not caught.

## Motivation and context

Fix a crash:

```
Exception java.lang.IllegalArgumentException: Shortcut must have a non-empty label
  at androidx.core.content.pm.ShortcutInfoCompat$Builder.build (ShortcutInfoCompat.java:919)
  at io.element.android.libraries.push.impl.notifications.conversations.DefaultNotificationConversationService.onSendMessage-L2ILk2A (DefaultNotificationConversationService.kt:119)
  at io.element.android.libraries.push.impl.notifications.conversations.DefaultNotificationConversationService$onSendMessage$1.invokeSuspend (DefaultNotificationConversationService.kt:18)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.internal.ScopeCoroutine.afterResume (Scopes.kt:35)
  at kotlinx.coroutines.AbstractCoroutine.resumeWith (AbstractCoroutine.kt:101)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:47)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:100)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:224)
  at android.os.Looper.loop (Looper.java:318)
  at android.app.ActivityThread.main (ActivityThread.java:8772)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:561)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1013)
  ```

## Tests

To be honest, I'm not sure how to reproduce it: this needs the room to have no name and not auto-create one from existing users. I thought an empty room where you're the only user present would be enough, but in the debugger I see 'Empty room' being the room display name, so I don't really know how you can get in a state where the room name isn't automatically generated and it's just empty.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
