### PR TITLE
Upgrade compose to 2025.12.01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ camera = "1.5.2"
 work = "2.11.0"
 
 # Compose
-compose_bom = "2025.12.00"
+compose_bom = "2025.12.01"
 
 # Coroutines
 coroutines = "1.10.2"


### PR DESCRIPTION
 Upgrade compose to 2025.12.01, not sure why Renovate does not handle this. 

Does not fix https://github.com/element-hq/element-x-android/issues/5944