### PR TITLE
Use `VerificationState.VERIFIED` as soon as it's available

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/verification/RustSessionVerificationService.kt
@@ -72,7 +72,8 @@ class RustSessionVerificationService(
     // Listen for changes in verification status and update accordingly
     private val verificationStateListenerTaskHandle = encryptionService.verificationStateListener(object : VerificationStateListener {
         override fun onUpdate(status: VerificationState) {
-            if (!isInitialized.get()) {
+            // If the status is verified, just use it. It can't be a false positive like unknown or unverified
+            if (!isInitialized.get() && status != VerificationState.VERIFIED) {
                 Timber.d("Discarding new verifications state: $status. E2EE is not initialised yet")
                 return
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Avoids discarding the verified state if the encryption layer is not fully loaded.

This can't be a false positive like `VerificationState.UNKNOWN` or `VerificationState.UNVERIFIED`, so it makes sense to return it as fast as possible.

## Motivation and context

Fixes an issue that caused long room list UI loading times.

## Tests

Open the app in a cold start. It should display the contents almost immediately, or at least way faster than before, specially with bad network connectivity.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
