### PR TITLE
Make `relatedTo` in `RoomSendQueueUpdate.MediaUpload` a transaction id

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/SendQueueUpdate.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/SendQueueUpdate.kt
@@ -18,5 +18,5 @@ sealed interface SendQueueUpdate {
     data class SendError(val transactionId: TransactionId) : SendQueueUpdate
     data class RetrySendingEvent(val transactionId: TransactionId) : SendQueueUpdate
     data class SentEvent(val transactionId: TransactionId, val eventId: EventId) : SendQueueUpdate
-    data class MediaUpload(val relatedTo: EventId, val file: MediaSource?, val index: Long, val progress: Float) : SendQueueUpdate
+    data class MediaUpload(val relatedTo: TransactionId, val file: MediaSource?, val index: Long, val progress: Float) : SendQueueUpdate
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/SendQueueUpdatesExt.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/SendQueueUpdatesExt.kt
@@ -17,7 +17,7 @@ fun RoomSendQueueUpdate.map(): SendQueueUpdate = when (this) {
     is RoomSendQueueUpdate.NewLocalEvent -> SendQueueUpdate.NewLocalEvent(TransactionId(transactionId))
     is RoomSendQueueUpdate.CancelledLocalEvent -> SendQueueUpdate.CancelledLocalEvent(TransactionId(transactionId))
     is RoomSendQueueUpdate.MediaUpload -> SendQueueUpdate.MediaUpload(
-        relatedTo = EventId(relatedTo),
+        relatedTo = TransactionId(relatedTo),
         file = file?.map(),
         index = index.toLong(),
         progress = progress.current.toFloat() / progress.total.toFloat(),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Change the value to be mapped to a `TransactionId`.

## Motivation and context

It was being incorrectly mapped to an event id. This didn't break anything in prod because the check is only enforced in debug builds.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
