### PR TITLE
Tweak the power levels when creating a space

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -370,13 +370,8 @@ class RustMatrixClient(
 
     override suspend fun createRoom(createRoomParams: CreateRoomParameters): Result<RoomId> = withContext(sessionDispatcher) {
         runCatchingExceptions {
-            val powerLevels = if (createRoomParams.isSpace) {
-                defaultRoomCreationSpacePowerLevels(
-                    isPublic = createRoomParams.preset == RoomPreset.PUBLIC_CHAT || createRoomParams.joinRuleOverride == JoinRule.Public,
-                )
-            } else {
-                defaultRoomCreationPowerLevels
-            }
+            val hasPublicAccess = createRoomParams.preset == RoomPreset.PUBLIC_CHAT || createRoomParams.joinRuleOverride == JoinRule.Public
+            val powerLevels = defaultRoomCreationPowerLevels(isSpace = createRoomParams.isSpace, isPublic = hasPublicAccess)
 
             val rustParams = RustCreateRoomParameters(
                 name = createRoomParams.name,
@@ -841,33 +836,23 @@ class RustMatrixClient(
     }
 }
 
-private val defaultRoomCreationPowerLevels = PowerLevels(
-    usersDefault = null,
-    eventsDefault = null,
-    stateDefault = null,
-    ban = null,
-    kick = null,
-    redact = null,
-    invite = null,
-    notifications = null,
-    users = mapOf(),
-    events = mapOf(
-        "m.call.member" to 0,
-        "org.matrix.msc3401.call.member" to 0,
-    )
-)
-
-private fun defaultRoomCreationSpacePowerLevels(isPublic: Boolean) = PowerLevels(
+private fun defaultRoomCreationPowerLevels(isPublic: Boolean, isSpace: Boolean) = PowerLevels(
     usersDefault = null,
     // Only admins should be able to send events in general
-    eventsDefault = 100,
+    eventsDefault = if (isSpace) 100 else null,
     stateDefault = null,
     ban = null,
     kick = null,
     redact = null,
-    // If the space is public, anyone can invite other users, if it's private only moderators and admins can
     invite = if (isPublic) 0 else 50,
     notifications = null,
     users = mapOf(),
-    events = mapOf(),
+    events = if (!isSpace) {
+        mapOf(
+            "m.call.member" to 0,
+            "org.matrix.msc3401.call.member" to 0,
+        )
+    } else {
+        mapOf()
+    }
 )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When creating a space, these power levels should be overridden:
- `invite` should be `0` (user level) for rooms or spaces with a public join rule, or `50` (moderator) for the rest.
- `eventsDefault` should always be `100` (admin level) so only admins can send events to the spaces.

## Motivation and context

Follow the proposed spec:

> Space properties besides for the corresponding join rule when creating a new space.
> 
> | | public | others |
> |-|-|-|
> | Visibility (in directory) | public | private |
> | E2EE | off | on |
> | History Visibility | shared | invited |
> | Guest Access | - | - |
> | Permissions (override of defaults) | events_default=100, invite=0 | events_default=100, invite=50 |

Note knocking wasn't taken into account in this spec yet.

## Tests

Create public and private spaces, check they have the expected power levels.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
