### PR TITLE
Attempt to fix flaky test.

### DIFF
--- a/features/login/impl/build.gradle.kts
+++ b/features/login/impl/build.gradle.kts
@@ -60,4 +60,6 @@ dependencies {
     testImplementation(projects.libraries.permissions.test)
     testImplementation(projects.libraries.sessionStorage.test)
     testImplementation(projects.libraries.wellknown.test)
+    testImplementation(libs.androidx.camera.camera2)
+    testImplementation(libs.androidx.camera.lifecycle)
 }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanViewTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanViewTest.kt
@@ -9,9 +9,11 @@
 package io.element.android.features.login.impl.screens.qrcode.scan
 
 import androidx.activity.ComponentActivity
+import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.matrix.api.auth.qrlogin.MatrixQrCodeLoginData
 import io.element.android.libraries.matrix.test.auth.qrlogin.FakeMatrixQrCodeLoginData
@@ -20,6 +22,8 @@ import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.ensureCalledOnce
 import io.element.android.tests.testutils.ensureCalledOnceWithParam
 import io.element.android.tests.testutils.pressBackKey
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -29,6 +33,19 @@ import org.junit.runner.RunWith
 class QrCodeScanViewTest {
     @get:Rule
     val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private var provider: ProcessCameraProvider? = null
+
+    @Before
+    fun setup() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        provider = ProcessCameraProvider.getInstance(context).get()
+    }
+
+    @After
+    fun teardown() {
+        provider?.unbindAll()
+    }
 
     @Test
     fun `on back pressed - calls the expected callback`() {


### PR DESCRIPTION
The test `on QR code data ready - calls the expected callback` sometimes fails on the CI with the following error:

> androidx.concurrent.futures.CallbackToFutureAdapter$FutureGarbageCollectedException: The completer object was garbage collected - this future would otherwise never complete. The tag was: CameraX initInternal