### PR TITLE
Provide `ConfigureRoomState.availableVisibilityOptions` in presenter

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -124,6 +124,14 @@ class ConfigureRoomPresenter(
         val localCoroutineScope = rememberCoroutineScope()
         val createRoomAction: MutableState<AsyncAction<RoomId>> = remember { mutableStateOf(AsyncAction.Uninitialized) }
 
+        val availableVisibilityOptions = remember(isSpace, isKnockFeatureEnabled) {
+            listOfNotNull(
+                RoomVisibilityItem.Public,
+                RoomVisibilityItem.AskToJoin.takeIf { !isSpace && isKnockFeatureEnabled },
+                RoomVisibilityItem.Private,
+            ).toImmutableList()
+        }
+
         fun createRoom(config: CreateRoomConfig) {
             createRoomAction.value = AsyncAction.Uninitialized
             localCoroutineScope.createRoom(config, createRoomAction)
@@ -155,13 +163,13 @@ class ConfigureRoomPresenter(
         }
 
         return ConfigureRoomState(
-            isKnockFeatureEnabled = isKnockFeatureEnabled,
             config = createRoomConfig,
             avatarActions = avatarActions,
             createRoomAction = createRoomAction.value,
             cameraPermissionState = cameraPermissionState,
             homeserverName = homeserverName,
             roomAddressValidity = roomAddressValidity.value,
+            availableVisibilityOptions = availableVisibilityOptions,
             eventSink = ::handleEvent,
         )
     }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
@@ -16,13 +16,13 @@ import io.element.android.libraries.permissions.api.PermissionsState
 import kotlinx.collections.immutable.ImmutableList
 
 data class ConfigureRoomState(
-    val isKnockFeatureEnabled: Boolean,
     val config: CreateRoomConfig,
     val avatarActions: ImmutableList<AvatarAction>,
     val createRoomAction: AsyncAction<RoomId>,
     val cameraPermissionState: PermissionsState,
     val roomAddressValidity: RoomAddressValidity,
     val homeserverName: String,
+    val availableVisibilityOptions: ImmutableList<RoomVisibilityItem>,
     val eventSink: (ConfigureRoomEvents) -> Unit
 ) {
     val isValid: Boolean = config.roomName?.isNotEmpty() == true &&

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomStateProvider.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomStateProvider.kt
@@ -101,14 +101,17 @@ fun aConfigureRoomState(
     cameraPermissionState: PermissionsState = aPermissionsState(showDialog = false),
     homeserverName: String = "matrix.org",
     roomAddressValidity: RoomAddressValidity = RoomAddressValidity.Valid,
+    availableVisibilityOptions: List<RoomVisibilityItem> = RoomVisibilityItem.entries.filter {
+        if (!isKnockFeatureEnabled) it != RoomVisibilityItem.AskToJoin else true
+    },
     eventSink: (ConfigureRoomEvents) -> Unit = { },
 ) = ConfigureRoomState(
     config = config,
-    isKnockFeatureEnabled = isKnockFeatureEnabled,
     avatarActions = avatarActions.toImmutableList(),
     createRoomAction = createRoomAction,
     cameraPermissionState = cameraPermissionState,
     homeserverName = homeserverName,
     roomAddressValidity = roomAddressValidity,
+    availableVisibilityOptions = availableVisibilityOptions.toImmutableList(),
     eventSink = eventSink,
 )

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -65,6 +65,7 @@ import io.element.android.libraries.matrix.ui.components.AvatarPickerView
 import io.element.android.libraries.matrix.ui.room.address.RoomAddressField
 import io.element.android.libraries.permissions.api.PermissionsView
 import io.element.android.libraries.ui.strings.CommonStrings
+import kotlinx.collections.immutable.ImmutableList
 import kotlin.jvm.optionals.getOrNull
 
 @Composable
@@ -120,6 +121,7 @@ fun ConfigureRoomView(
             )
 
             RoomVisibilityAndAccessOptions(
+                options = state.availableVisibilityOptions,
                 selected = when (state.config.roomVisibility) {
                     is RoomVisibilityState.Private -> RoomVisibilityItem.Private
                     is RoomVisibilityState.Public -> when (state.config.roomVisibility.roomAccess) {
@@ -127,7 +129,6 @@ fun ConfigureRoomView(
                         RoomAccess.Anyone -> RoomVisibilityItem.Public
                     }
                 },
-                isKnockingEnabled = state.isKnockFeatureEnabled,
                 onOptionClick = {
                     focusManager.clearFocus()
                     state.eventSink(ConfigureRoomEvents.RoomVisibilityChanged(it))
@@ -279,8 +280,8 @@ private fun ConfigureRoomOptions(
 
 @Composable
 private fun RoomVisibilityAndAccessOptions(
+    options: ImmutableList<RoomVisibilityItem>,
     selected: RoomVisibilityItem,
-    isKnockingEnabled: Boolean,
     onOptionClick: (RoomVisibilityItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -288,11 +289,7 @@ private fun RoomVisibilityAndAccessOptions(
         title = stringResource(R.string.screen_create_room_room_access_section_title),
         modifier = modifier,
     ) {
-        RoomVisibilityItem.entries.forEach { item ->
-            if (item == RoomVisibilityItem.AskToJoin && !isKnockingEnabled) {
-                return@forEach
-            }
-
+        options.forEach { item ->
             val isSelected = item == selected
             ListItem(
                 leadingContent = ListItemContent.Custom {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. 

Besides this, hide knocking for spaces even if the knocking feature is enabled. We don't want to have knocking in spaces yet.

## Motivation and context

It seems better to handle the filtering logic there than on the view.

## Screenshots / GIFs

There *shouldn't be* any UI changes.

## Tests

Enter the create room/space screens, everything should work as before, expect for the knocking option not being available for spaces.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
