### PR TITLE
Create `AppMigration09` to remove the cached `well-known` config from the SDK

### DIFF
--- a/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration09.kt
+++ b/features/migration/impl/src/main/kotlin/io/element/android/features/migration/impl/migrations/AppMigration09.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.migration.impl.migrations
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.Inject
+import io.element.android.libraries.matrix.api.MatrixClientProvider
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.sessionstorage.api.SessionStore
+
+/**
+ * Ensure we clear the well-known cached config, since it could be invalid due to an SDK issue.
+ */
+@ContributesIntoSet(AppScope::class)
+@Inject
+class AppMigration09(
+    private val sessionStore: SessionStore,
+    private val matrixClientProvider: MatrixClientProvider,
+) : AppMigration {
+    override val order: Int = 9
+
+    override suspend fun migrate(isFreshInstall: Boolean) {
+        if (isFreshInstall) return
+
+        val sessions = sessionStore.getAllSessions()
+
+        for (session in sessions) {
+            val client = matrixClientProvider.getOrRestore(SessionId(session.userId)).getOrNull() ?: continue
+            client.resetWellKnownConfig()
+        }
+    }
+}

--- a/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration09Test.kt
+++ b/features/migration/impl/src/test/kotlin/io/element/android/features/migration/impl/migrations/AppMigration09Test.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.migration.impl.migrations
+
+import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.FakeMatrixClientProvider
+import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
+import io.element.android.libraries.sessionstorage.test.aSessionData
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AppMigration09Test {
+    @Test
+    fun `migration on fresh install does nothing`() = runTest {
+        val sessionStore = InMemorySessionStore(initialList = listOf(aSessionData()))
+        val getClientLambda = lambdaRecorder<SessionId, Result<MatrixClient>> { Result.success(FakeMatrixClient()) }
+        val clientProvider = FakeMatrixClientProvider(getClient = getClientLambda)
+        val migration = AppMigration09(sessionStore, clientProvider)
+        migration.migrate(isFreshInstall = true)
+
+        getClientLambda.assertions().isNeverCalled()
+    }
+
+    @Test
+    fun `migration on upgrade should invoke the resetWellKnownConfig method`() = runTest {
+        val sessionStore = InMemorySessionStore(initialList = listOf(aSessionData()))
+        val resetWellKnownLambda = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val getClientLambda = lambdaRecorder<SessionId, Result<MatrixClient>> {
+            Result.success(FakeMatrixClient(resetWellKnownConfigLambda = resetWellKnownLambda))
+        }
+        val clientProvider = FakeMatrixClientProvider(getClient = getClientLambda)
+        val migration = AppMigration09(sessionStore, clientProvider)
+        migration.migrate(isFreshInstall = false)
+
+        getClientLambda.assertions().isCalledOnce()
+        resetWellKnownLambda.assertions().isCalledOnce()
+    }
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -214,7 +214,15 @@ interface MatrixClient {
      */
     fun createLinkDesktopHandler(): Result<LinkDesktopHandler>
 
+    /**
+     * Performs a database optimization that should flush cached data and improve performance.
+     */
     suspend fun performDatabaseVacuum(): Result<Unit>
+
+    /**
+     * Resets the cached client `well-known` config by the SDK.
+     */
+    suspend fun resetWellKnownConfig(): Result<Unit>
 }
 
 /**

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -791,6 +791,13 @@ class RustMatrixClient(
         }
     }
 
+    override suspend fun resetWellKnownConfig(): Result<Unit> {
+        return runCatchingExceptions {
+            Timber.d("Resetting well-known config for session $sessionId")
+            innerClient.resetWellKnown()
+        }
+    }
+
     private suspend fun getCacheSize(
         includeCryptoDb: Boolean = false,
     ): Long = withContext(sessionDispatcher) {

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -112,6 +112,7 @@ class FakeMatrixClient(
     private val markRoomAsFullyReadResult: (RoomId, EventId) -> Result<Unit> = { _, _ -> lambdaError() },
     private val performDatabaseVacuumLambda: () -> Result<Unit> = { lambdaError() },
     private val getDatabaseSizesLambda: () -> Result<SdkStoreSizes> = { lambdaError() },
+    private val resetWellKnownConfigLambda: () -> Result<Unit> = { lambdaError() },
 ) : MatrixClient {
     var setDisplayNameCalled: Boolean = false
         private set
@@ -378,5 +379,9 @@ class FakeMatrixClient(
 
     override fun createLinkMobileHandler(): Result<LinkMobileHandler> {
         return createLinkMobileHandlerResult()
+    }
+
+    override suspend fun resetWellKnownConfig(): Result<Unit> {
+        return resetWellKnownConfigLambda()
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Adds also a new `MatrixClient.resetWellKnownConfig` method.

## Motivation and context

This `well-known` value was most likely incorrectly cached due to a previous issue in the SDK

## Tests

You'll need to build Element Pro to test this.

1. Install the app.
2. Attach a logcat instance.
3. Run the app. You should see a 'resetting well-known config for session...' log.
4. Open some room. The well-known file request should appear in the logs.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
