### PR TITLE
Add `MediaSource.safeUrl` for removing invalid fragment part from URLs

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemStickerContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemStickerContent.kt
@@ -30,5 +30,5 @@ data class TimelineItemStickerContent(
 
     /* Stickers are supposed to be small images so
        we allow using the mediaSource (unless the url is empty) */
-    val preferredMediaSource = if (mediaSource.url.isEmpty()) thumbnailSource else mediaSource
+    val preferredMediaSource = if (mediaSource.safeUrl.isEmpty()) thumbnailSource else mediaSource
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaSource.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaSource.kt
@@ -9,7 +9,7 @@
 package io.element.android.libraries.matrix.api.media
 
 import android.os.Parcelable
-import androidx.core.net.toUri
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -17,31 +17,20 @@ data class MediaSource(
     /**
      * Url of the media.
      */
-    val url: String,
+    private val url: String,
     /**
      * This is used to hold data for encrypted media.
      */
     val json: String? = null,
-) : Parcelable
-
-/**
- * Returns a new [MediaSource] with a valid URL.
- */
-fun MediaSource.withCleanUrl(): MediaSource {
-    val uri = this.url.toUri()
-    if (uri.scheme != "mxc") return this
-
-    // We've seen some MXC urls in the wild having some `mxc://foo/bar#auto` fragment suffix, which is invalid
-    val cleanedUrl = buildString {
-        append(uri.scheme)
-        if (!this.endsWith("://")) {
-            append("://")
-        }
-        append(uri.host)
-        if (uri.path != null) {
-            append(uri.path)
-        }
+) : Parcelable {
+    /**
+     * A URL with invalid parts (like `#fragment`, if it's an MXC url) removed.
+     */
+    @IgnoredOnParcel
+    val safeUrl = if (url.startsWith("mxc")) {
+        // We've seen some MXC urls in the wild having some `mxc://foo/bar#auto` fragment suffix, which is invalid
+        url.substringBefore("#")
+    } else {
+        url
     }
-
-    return this.copy(url = cleanedUrl)
 }

--- a/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/media/MediaSourceTest.kt
+++ b/libraries/matrix/api/src/test/kotlin/io/element/android/libraries/matrix/api/media/MediaSourceTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.media
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.media.aMediaSource
+import org.junit.Test
+
+class MediaSourceTest {
+    @Test
+    fun `safeUrl removes the fragment part in MXC urls`() {
+        val mediaSource = aMediaSource(url = "mxc://matrix.org/url#fragment")
+        assertThat(mediaSource.safeUrl).isEqualTo("mxc://matrix.org/url")
+    }
+
+    @Test
+    fun `safeUrl keeps the fragment part in a non-MXC url`() {
+        val mediaSource = aMediaSource(url = "https://matrix.org/url#fragment")
+        assertThat(mediaSource.safeUrl).isEqualTo("https://matrix.org/url#fragment")
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
@@ -14,7 +14,6 @@ import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaFile
 import io.element.android.libraries.matrix.api.media.MediaSource
-import io.element.android.libraries.matrix.api.media.withCleanUrl
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.use
@@ -92,7 +91,7 @@ class RustMediaLoader(
         return if (json != null) {
             RustMediaSource.fromJson(json)
         } else {
-            RustMediaSource.fromUrl(withCleanUrl().url)
+            RustMediaSource.fromUrl(safeUrl)
         }
     }
 }

--- a/libraries/matrixmedia/impl/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
+++ b/libraries/matrixmedia/impl/src/main/kotlin/io/element/android/libraries/matrix/ui/media/CoilMediaFetcher.kt
@@ -16,7 +16,6 @@ import coil3.fetch.SourceFetchResult
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.media.toFile
-import io.element.android.libraries.matrix.api.media.withCleanUrl
 import okio.Buffer
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -28,14 +27,10 @@ internal class CoilMediaFetcher(
     private val mediaData: MediaRequestData,
 ) : Fetcher {
     override suspend fun fetch(): FetchResult? {
-        val source = mediaData.source
-        val mediaSource = when {
-            source == null -> {
-                Timber.e("MediaData source is null")
-                return null
-            }
-            source.url.startsWith("mxc:") -> source.withCleanUrl()
-            else -> source
+        val mediaSource = mediaData.source
+        if (mediaSource == null) {
+            Timber.e("MediaData source is null")
+            return null
         }
         return when (val kind = mediaData.kind) {
             is MediaRequestData.Kind.Content -> fetchContent(mediaSource)

--- a/libraries/matrixmedia/impl/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataKeyer.kt
+++ b/libraries/matrixmedia/impl/src/main/kotlin/io/element/android/libraries/matrix/ui/media/MediaRequestDataKeyer.kt
@@ -25,5 +25,5 @@ internal class MediaRequestDataKeyer : Keyer<MediaRequestData> {
 }
 
 private fun MediaRequestData.toKey(): String? {
-    return source?.let { "${it.url}_$kind" }
+    return source?.let { "${it.safeUrl}_$kind" }
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -126,7 +126,7 @@ class MediaViewerDataSource(
             when (mediaItem) {
                 is MediaItem.DateSeparator -> Unit
                 is MediaItem.Event -> {
-                    val sourceUrl = mediaItem.mediaSource().url
+                    val sourceUrl = mediaItem.mediaSource().safeUrl
                     val localMedia = localMediaStates.getOrPut(sourceUrl) {
                         mutableStateOf(AsyncData.Uninitialized)
                     }
@@ -153,7 +153,7 @@ class MediaViewerDataSource(
     }.toImmutableList()
 
     fun clearLoadingError(data: MediaViewerPageData.MediaViewerData) {
-        localMediaStates[data.mediaSource.url]?.value = AsyncData.Uninitialized
+        localMediaStates[data.mediaSource.safeUrl]?.value = AsyncData.Uninitialized
     }
 
     suspend fun loadMore(direction: Timeline.PaginationDirection) {
@@ -162,7 +162,7 @@ class MediaViewerDataSource(
 
     suspend fun loadMedia(data: MediaViewerPageData.MediaViewerData) {
         Timber.d("loadMedia for ${data.eventId}")
-        val localMediaState = localMediaStates.getOrPut(data.mediaSource.url) {
+        val localMediaState = localMediaStates.getOrPut(data.mediaSource.safeUrl) {
             mutableStateOf(AsyncData.Uninitialized)
         }
         localMediaState.value = AsyncData.Loading()

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationMediaRepo.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationMediaRepo.kt
@@ -101,7 +101,7 @@ class DefaultNotificationMediaRepo(
         }
     }
 
-    private fun MediaSource.cachedFile(): File? = mxcTools.mxcUri2FilePath(url)?.let {
+    private fun MediaSource.cachedFile(): File? = mxcTools.mxcUri2FilePath(safeUrl)?.let {
         File("${cacheDir.path}/$CACHE_NOTIFICATION_SUBDIR/$it")
     }
 }

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessageMediaRepo.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessageMediaRepo.kt
@@ -95,7 +95,7 @@ class DefaultVoiceMessageMediaRepo(
         }
     }
 
-    private val cachedFile: File? = mxcTools.mxcUri2FilePath(mediaSource.url)?.let {
+    private val cachedFile: File? = mxcTools.mxcUri2FilePath(mediaSource.safeUrl)?.let {
         File("${cacheDir.path}/$CACHE_VOICE_SUBDIR/$it")
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add `MediaSource.safeUrl` which returns a valid MXC url without a fragment part or the original URL if it's not MXC.

## Motivation and context

We've seen some MXC urls in the wild having some `mxc://foo/bar#auto` fragment suffix, which is invalid, but the URL before that fragment part is valid and can be displayed.

## Tests

The only way I think we could test this is manually editing/sending some custom media event and adding the `#fragment` part to the MXC url.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
