### PR TITLE
Use `MediaPreviewValue.Private` to check if media should be displayed in notifications

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
@@ -14,6 +14,7 @@ import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageType
 
 data class NotificationData(
@@ -36,7 +37,7 @@ data class NotificationData(
     val timestamp: Long,
     val content: NotificationContent,
     val hasMention: Boolean,
-    val isPublicRoom: Boolean,
+    val roomJoinRule: JoinRule?,
 ) {
     fun getDisambiguatedDisplayName(userId: UserId): String = when {
         senderDisplayName.isNullOrBlank() -> userId.value

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/NotificationMapper.kt
@@ -18,8 +18,8 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.room.isDm
+import io.element.android.libraries.matrix.impl.room.join.map
 import io.element.android.services.toolbox.api.systemclock.SystemClock
-import org.matrix.rustcomponents.sdk.JoinRule
 import org.matrix.rustcomponents.sdk.NotificationEvent
 import org.matrix.rustcomponents.sdk.NotificationItem
 import org.matrix.rustcomponents.sdk.use
@@ -60,7 +60,7 @@ class NotificationMapper(
                     timestamp = timestamp,
                     content = notificationContentMapper.map(item.event).getOrThrow(),
                     hasMention = item.hasMention.orFalse(),
-                    isPublicRoom = item.roomInfo.joinRule == JoinRule.Public,
+                    roomJoinRule = item.roomInfo.joinRule?.map(),
                 )
             }
         }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notification/NotificationData.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notification/NotificationData.kt
@@ -11,6 +11,7 @@ package io.element.android.libraries.matrix.test.notification
 import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
@@ -28,7 +29,7 @@ fun aNotificationData(
     senderDisplayName: String? = A_USER_NAME_2,
     senderIsNameAmbiguous: Boolean = false,
     roomDisplayName: String? = A_ROOM_NAME,
-    isPublicRoom: Boolean = true,
+    roomJoinRule: JoinRule? = null,
 ): NotificationData {
     return NotificationData(
         sessionId = A_SESSION_ID,
@@ -48,6 +49,6 @@ fun aNotificationData(
         timestamp = timestamp,
         content = content,
         hasMention = hasMention,
-        isPublicRoom = isPublicRoom,
+        roomJoinRule = roomJoinRule,
     )
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -31,11 +31,12 @@ import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.exception.NotificationResolverException
-import io.element.android.libraries.matrix.api.media.MediaPreviewValue
 import io.element.android.libraries.matrix.api.media.getMediaPreviewValue
+import io.element.android.libraries.matrix.api.media.isPreviewEnabled
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EmoteMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EventType
@@ -140,11 +141,7 @@ class DefaultNotifiableEventResolver(
     ): Result<ResolvedPushEvent> = runCatchingExceptions {
         when (val content = this.content) {
             is NotificationContent.MessageLike.RoomMessage -> {
-                val showMediaPreview = when (client.mediaPreviewService.getMediaPreviewValue()) {
-                    MediaPreviewValue.On -> true
-                    MediaPreviewValue.Private -> !isPublicRoom
-                    MediaPreviewValue.Off -> false
-                }
+                val showMediaPreview = client.mediaPreviewService.getMediaPreviewValue().isPreviewEnabled(roomJoinRule)
                 val senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId)
                 val imageMimeType = content.getImageMimetype()
                 val imageUriString = if (showMediaPreview && imageMimeType != null) {
@@ -153,7 +150,8 @@ class DefaultNotifiableEventResolver(
                     null
                 }
 
-                if (content.getImageMimetype() != null && !showMediaPreview && isPublicRoom) {
+                val isPublicRoom = roomJoinRule == null || roomJoinRule == JoinRule.Public
+                if (imageMimeType != null && !showMediaPreview && isPublicRoom) {
                     Timber.tag(loggerTag.value)
                         .d("We should only display media previews for private rooms and the current room is public. Ignoring image uri.")
                 } else if (showMediaPreview && content.messageType is ImageMessageType && imageUriString == null) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says, we now take that option into account, inside a `when` so if a new option is added we'll also have to support it.

Also added `NotificationData.isPublicRoom` so we can use it to check if the room is public or not.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/5901.

## Tests

1. Go to Settings -> Advanced Settings -> Set 'Show media in timeline' to 'In private rooms'.
2. Backround the app.
3. From another device, in a private room, send an image. A notification should appear with a preview of the image.
4. From another device, in a public room, send an image. A caption or the filename of the image should be displayed instead.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
