### PR TITLE
Keep the child state in `AttachmentsPreviewPresenter` up to date

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -98,7 +98,7 @@ class AttachmentsPreviewPresenter(
         val mediaOptimizationSelectorPresenter = remember {
             mediaOptimizationSelectorPresenterFactory.create(mediaAttachment.localMedia)
         }
-        val mediaOptimizationSelectorState = mediaOptimizationSelectorPresenter.present()
+        val mediaOptimizationSelectorState by rememberUpdatedState(mediaOptimizationSelectorPresenter.present())
 
         val observableSendState = snapshotFlow { sendActionState.value }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Wrap `mediaOptimizationSelectorState` in `AttachmentsPreviewPresenter` in a `rememberUpdatedState` call so it's now a `State<*>` value and the lambdas / functions that use it can access the updated state.

## Motivation and context

This makes the `handleEvents` function capture the reference and be able to check the updated state, unblocking the media sending flow.

Fixes https://github.com/element-hq/element-x-android/issues/6029

## Screenshots / GIFs


https://github.com/user-attachments/assets/b0130832-062e-464d-9026-5da7b268024a



## Tests

1. In developer settings, enable 'select media quality per upload'.
2. In any room, send an image.
3. If the preview screen actually processes and sends the image, it's working.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
