### PR TITLE
Try fixing performance metrics

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
@@ -214,6 +214,10 @@ class RoomFlowNode(
                 )
             }
             is NavTarget.JoinRoom -> {
+                // Clear analytics transactions for opening a joined room, since we're display a non-joined one
+                analyticsService.removeLongRunningTransaction(LoadJoinedRoomFlow)
+                analyticsService.removeLongRunningTransaction(OpenRoom)
+
                 val inputs = JoinRoomEntryPoint.Inputs(
                     roomId = navTarget.roomId,
                     roomIdOrAlias = inputs.roomIdOrAlias,

--- a/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomFlowNode.kt
@@ -41,6 +41,10 @@ import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.ui.room.LoadingRoomState
 import io.element.android.libraries.matrix.ui.room.LoadingRoomStateFlowFactory
+import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.LoadJoinedRoomFlow
+import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.NotificationToMessage
+import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.OpenRoom
+import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -53,6 +57,7 @@ class JoinedRoomFlowNode(
     @Assisted val buildContext: BuildContext,
     @Assisted plugins: List<Plugin>,
     loadingRoomStateFlowFactory: LoadingRoomStateFlowFactory,
+    private val analyticsService: AnalyticsService,
 ) :
     BaseFlowNode<JoinedRoomFlowNode.NavTarget>(
         backstack = BackStack(
@@ -81,6 +86,11 @@ class JoinedRoomFlowNode(
 
     override fun onBuilt() {
         super.onBuilt()
+
+        val parentTransaction = analyticsService.getLongRunningTransaction(NotificationToMessage)
+        val openRoomTransaction = analyticsService.startLongRunningTransaction(OpenRoom, parentTransaction)
+        analyticsService.startLongRunningTransaction(LoadJoinedRoomFlow, openRoomTransaction)
+
         loadingRoomStateStateFlow
             .map {
                 it is LoadingRoomState.Loaded

--- a/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/joined/JoinedRoomLoadedFlowNode.kt
@@ -48,8 +48,6 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.LoadJoinedRoomFlow
-import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.LoadMessagesUi
-import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.OpenRoom
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.api.finishLongRunningTransaction
 import io.element.android.services.appnavstate.api.ActiveRoomsHolder
@@ -106,8 +104,6 @@ class JoinedRoomLoadedFlowNode(
     init {
         lifecycle.subscribe(
             onCreate = {
-                val parent = analyticsService.getLongRunningTransaction(OpenRoom)
-                analyticsService.startLongRunningTransaction(LoadMessagesUi, parent)
                 Timber.v("OnCreate => ${inputs.room.roomId}")
                 appNavigationStateService.onNavigateToRoom(id, inputs.room.roomId)
                 activeRoomsHolder.addRoom(inputs.room)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Try making sure we remove stale long running transactions for `CatchUp` and we only track performance while opening joined rooms, not *any* room.

## Motivation and context

We've detected outliers in the `Up-to-date room list` and `Open a room` transactions in Sentry.

These changes try to make sure we're starting/stopping the long running transactions when needed.

## Tests

Perform the actions, check Sentry? 😅 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
