### PR TITLE
Replace navigation bar with floating toolbar on room list

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeState.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeState.kt
@@ -31,7 +31,6 @@ data class HomeState(
     val directLogoutState: DirectLogoutState,
     val eventSink: (HomeEvents) -> Unit,
 ) {
-    val displayActions = currentHomeNavigationBarItem == HomeNavigationBarItem.Chats
     val displayRoomListFilters = currentHomeNavigationBarItem == HomeNavigationBarItem.Chats && roomListState.displayFilters
     val showNavigationBar = homeSpacesState.spaceRooms.isNotEmpty()
 }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -13,6 +13,7 @@ package io.element.android.features.home.impl
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -21,19 +22,25 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingToolbarDefaults.ScreenOffset
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -56,14 +63,11 @@ import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.FloatingActionButton
 import io.element.android.libraries.designsystem.theme.components.Icon
-import io.element.android.libraries.designsystem.theme.components.NavigationBar
-import io.element.android.libraries.designsystem.theme.components.NavigationBarIcon
-import io.element.android.libraries.designsystem.theme.components.NavigationBarItem
-import io.element.android.libraries.designsystem.theme.components.NavigationBarText
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarHost
 import io.element.android.libraries.designsystem.utils.snackbar.rememberSnackbarHostState
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.launch
 
 @Composable
@@ -190,7 +194,7 @@ private fun HomeScaffold(
                 )
             )
         },
-        bottomBar = {
+        floatingActionButton = {
             if (state.showNavigationBar) {
                 val coroutineScope = rememberCoroutineScope()
                 HomeBottomBar(
@@ -214,13 +218,16 @@ private fun HomeScaffold(
                             state.eventSink(HomeEvents.SelectHomeNavigationBarItem(item))
                         }
                     },
-                    modifier = Modifier.hazeEffect(
-                        state = hazeState,
-                        style = HazeMaterials.thick(),
-                    )
+                    floatingActionButton = {
+                        when (state.currentHomeNavigationBarItem) {
+                            HomeNavigationBarItem.Chats -> HomeFloatingActionButton(onStartChatClick, CommonStrings.action_create_a_room)
+                            HomeNavigationBarItem.Spaces -> HomeFloatingActionButton(onCreateSpaceClick, CommonStrings.action_create_space)
+                        }
+                    }
                 )
             }
         },
+        floatingActionButtonPosition = FabPosition.Center,
         content = { padding ->
             when (state.currentHomeNavigationBarItem) {
                 HomeNavigationBarItem.Chats -> {
@@ -273,50 +280,51 @@ private fun HomeScaffold(
                 }
             }
         },
-        floatingActionButton = {
-            if (state.displayActions) {
-                FloatingActionButton(
-                    onClick = onStartChatClick,
-                ) {
-                    Icon(
-                        imageVector = CompoundIcons.Plus(),
-                        contentDescription = stringResource(id = R.string.screen_roomlist_a11y_create_message),
-                    )
-                }
-            }
-        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     )
 }
 
 @Composable
+private fun HomeFloatingActionButton(
+    onClick: () -> Unit,
+    contentDescription: Int,
+    modifier: Modifier = Modifier,
+) {
+    FloatingActionButton(onClick = onClick, modifier = modifier) {
+        Icon(
+            imageVector = CompoundIcons.Plus(),
+            contentDescription = stringResource(id = contentDescription),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@Composable
 private fun HomeBottomBar(
     currentHomeNavigationBarItem: HomeNavigationBarItem,
     onItemClick: (HomeNavigationBarItem) -> Unit,
+    floatingActionButton: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    NavigationBar(
-        containerColor = Color.Transparent,
+    HorizontalFloatingToolbar(
+        expanded = true,
+        floatingActionButton = floatingActionButton,
         modifier = modifier
+            .padding(bottom = ScreenOffset)
+            .zIndex(1f),
     ) {
         HomeNavigationBarItem.entries.forEach { item ->
             val isSelected = currentHomeNavigationBarItem == item
-            NavigationBarItem(
-                selected = isSelected,
-                onClick = {
-                    onItemClick(item)
-                },
-                icon = {
-                    NavigationBarIcon(
+            IconButton(
+                onClick = { onItemClick(item) },
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
                         imageVector = item.icon(isSelected),
-                    )
-                },
-                label = {
-                    NavigationBarText(
-                        text = stringResource(item.labelRes),
+                        contentDescription = stringResource(item.labelRes),
                     )
                 }
-            )
+            }
         }
     }
 }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/HomeTopBar.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/HomeTopBar.kt
@@ -120,15 +120,11 @@ fun HomeTopBar(
                 )
             },
             actions = {
-                when (selectedNavigationItem) {
-                    HomeNavigationBarItem.Chats -> RoomListMenuItems(
+                if (selectedNavigationItem == HomeNavigationBarItem.Chats) {
+                    RoomListMenuItems(
                         onToggleSearch = onToggleSearch,
                         onMenuActionClick = onMenuActionClick,
                         canReportBug = canReportBug
-                    )
-                    HomeNavigationBarItem.Spaces -> SpacesMenuItems(
-                        canCreateSpaces = canCreateSpaces,
-                        onCreateSpace = onCreateSpace
                     )
                 }
             },
@@ -209,21 +205,6 @@ private fun RoomListMenuItems(
                     }
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun SpacesMenuItems(
-    canCreateSpaces: Boolean,
-    onCreateSpace: () -> Unit
-) {
-    if (canCreateSpaces) {
-        IconButton(onClick = onCreateSpace) {
-            Icon(
-                imageVector = CompoundIcons.Plus(),
-                contentDescription = stringResource(CommonStrings.action_create_space)
-            )
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,7 +118,7 @@ androidx_preference = "androidx.preference:preference:1.2.1"
 androidx_webkit = "androidx.webkit:webkit:1.15.0"
 
 androidx_compose_bom = { module = "androidx.compose:compose-bom", version.ref = "compose_bom" }
-androidx_compose_material3 = { module = "androidx.compose.material3:material3" }
+androidx_compose_material3 = { module = "androidx.compose.material3:material3", version = '1.5.0-alpha11' }
 androidx_compose_material3_windowsizeclass = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx_compose_material3_adaptive = "androidx.compose.material3:material3-adaptive-android:1.0.0-alpha06"
 androidx_compose_ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
## Content

For discussion @ganfra @amshakal. Might not be applicable until `material3` version `1.5.0` is stable.

cc: @frebib (inspired the change)

## Motivation and context

According to the [Material 3 guidelines for the navigation bar](https://m3.material.io/components/navigation-bar/guidelines):
> Navigation bars provide access to three to five destinations.

As this page contained only two, it did not meet the spec. Additionally, since the expressive update, [its use is no longer recommended](https://m3.material.io/components/toolbars/overview):
> The bottom app bar is no longer recommended and should be replaced with the docked toolbar, which functions similarly, but is shorter and has more flexibility. 

## Screenshots / GIFs

| Chats | Spaces |
| --- | --- |
| <img width="1080" height="2410" alt="Screenshot_20260126-200726" src="https://github.com/user-attachments/assets/8d1d511c-1618-447f-9153-dfd4801365fa" /> | <img width="1080" height="2410" alt="Screenshot_20260126-200734" src="https://github.com/user-attachments/assets/fecb5ac1-e532-4d1d-9509-70cb65a623c7" /> |


## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
