### PR TITLE
Add 'Create room' option to menu in space screen

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
@@ -147,6 +147,7 @@ fun SpaceView(
                         onViewMembersClick = onViewMembersClick,
                         onManageRoomsClick = { state.eventSink(SpaceEvents.EnterManageMode) },
                         onAddRoomClick = onAddRoomClick,
+                        onCreateRoomClick = onCreateRoomClick,
                     )
                 }
             }
@@ -383,6 +384,7 @@ private fun SpaceViewTopBar(
     onViewMembersClick: () -> Unit,
     onManageRoomsClick: () -> Unit,
     onAddRoomClick: () -> Unit,
+    onCreateRoomClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TopAppBar(
@@ -415,6 +417,14 @@ private fun SpaceViewTopBar(
                 onDismissRequest = { showMenu = false }
             ) {
                 if (showManageRoomsAction) {
+                    SpaceMenuItem(
+                        titleRes = CommonStrings.action_create_room,
+                        icon = CompoundIcons.Plus(),
+                        onClick = {
+                            showMenu = false
+                            onCreateRoomClick()
+                        }
+                    )
                     SpaceMenuItem(
                         titleRes = CommonStrings.action_add_existing_rooms,
                         icon = CompoundIcons.Room(),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. This should be present only for users who can add/remove rooms from the space.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/5654.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

1. Open a space where you can modify its rooms.
2. Tap on the overflow menu.
3. Select 'create room'.
4. A create room screen should be displayed with the parent space pre-selected.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
