### PR TITLE
Remove `JoinRule.Private` from the codebase

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/JoinRuleItem.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/JoinRuleItem.kt
@@ -35,7 +35,7 @@ sealed interface JoinRuleItem {
      * Transforms a [JoinRuleItem] option into a [JoinRule].
      */
     fun toJoinRule(): JoinRule = when (this) {
-        Private -> JoinRule.Private
+        Private -> JoinRule.Invite
         PublicVisibility.Public -> JoinRule.Public
         PublicVisibility.AskToJoin -> JoinRule.Knock
         is PublicVisibility.Restricted -> JoinRule.Restricted(persistentListOf(AllowRule.RoomMembership(parentSpaceId)))

--- a/features/createroom/impl/src/test/kotlin/io/element/android/features/createroom/impl/JoinRuleItemTest.kt
+++ b/features/createroom/impl/src/test/kotlin/io/element/android/features/createroom/impl/JoinRuleItemTest.kt
@@ -18,7 +18,7 @@ import org.junit.Test
 class JoinRuleItemTest {
     @Test
     fun `toJoinRule works as expected`() {
-        assertThat(JoinRuleItem.Private.toJoinRule()).isEqualTo(JoinRule.Private)
+        assertThat(JoinRuleItem.Private.toJoinRule()).isEqualTo(JoinRule.Invite)
         assertThat(JoinRuleItem.PublicVisibility.Public.toJoinRule()).isEqualTo(JoinRule.Public)
         assertThat(JoinRuleItem.PublicVisibility.AskToJoin.toJoinRule()).isEqualTo(JoinRule.Knock)
         assertThat(JoinRuleItem.PublicVisibility.Restricted(A_ROOM_ID).toJoinRule())

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenter.kt
@@ -376,10 +376,9 @@ private fun JoinRule?.toJoinAuthorisationStatus(): JoinAuthorisationStatus {
     return when (this) {
         JoinRule.Knock,
         is JoinRule.KnockRestricted -> JoinAuthorisationStatus.CanKnock
-        JoinRule.Invite,
-        JoinRule.Private -> JoinAuthorisationStatus.NeedInvite
+        JoinRule.Invite -> JoinAuthorisationStatus.NeedInvite
         is JoinRule.Restricted -> JoinAuthorisationStatus.Restricted
         JoinRule.Public -> JoinAuthorisationStatus.CanJoin
-        else -> JoinAuthorisationStatus.Unknown
+        is JoinRule.Custom, null -> JoinAuthorisationStatus.Unknown
     }
 }

--- a/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
+++ b/features/joinroom/impl/src/test/kotlin/io/element/android/features/joinroom/impl/JoinRoomPresenterTest.kt
@@ -1036,34 +1036,6 @@ class JoinRoomPresenterTest {
     }
 
     @Test
-    fun `present - when room is not known RoomPreview is loaded as Private`() = runTest {
-        val client = FakeMatrixClient(
-            getNotJoinedRoomResult = { _, _ ->
-                Result.success(
-                    aRoomPreview(
-                        info = aRoomPreviewInfo(joinRule = JoinRule.Private),
-                        roomMembershipDetails = {
-                            Result.success(aRoomMembershipDetails())
-                        },
-                    )
-                )
-            },
-            spaceService = FakeSpaceService(
-                spaceRoomListResult = { FakeSpaceRoomList() },
-            ),
-        )
-        val presenter = createJoinRoomPresenter(
-            matrixClient = client
-        )
-        presenter.test {
-            skipItems(1)
-            awaitItem().also { state ->
-                assertThat(state.joinAuthorisationStatus).isEqualTo(JoinAuthorisationStatus.NeedInvite)
-            }
-        }
-    }
-
-    @Test
     fun `present - when room is not known RoomPreview is loaded as Custom`() = runTest {
         val client = FakeMatrixClient(
             getNotJoinedRoomResult = { _, _ ->

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
@@ -582,7 +582,7 @@ class RoomDetailsPresenterTest {
             assertThat(awaitItem().canShowKnockRequests).isFalse()
             featureFlagService.setFeatureEnabled(FeatureFlags.Knock, true)
             assertThat(awaitItem().canShowKnockRequests).isTrue()
-            room.givenRoomInfo(aRoomInfo(joinRule = JoinRule.Private))
+            room.givenRoomInfo(aRoomInfo(joinRule = JoinRule.Invite))
             assertThat(awaitItem().canShowKnockRequests).isFalse()
             cancelAndIgnoreRemainingEvents()
         }

--- a/features/securityandprivacy/impl/src/main/kotlin/io/element/android/features/securityandprivacy/impl/root/SecurityAndPrivacyPresenter.kt
+++ b/features/securityandprivacy/impl/src/main/kotlin/io/element/android/features/securityandprivacy/impl/root/SecurityAndPrivacyPresenter.kt
@@ -472,7 +472,6 @@ private fun JoinRule?.map(): SecurityAndPrivacyRoomAccess {
         JoinRule.Invite -> SecurityAndPrivacyRoomAccess.InviteOnly
         // All other cases are not supported so we default to InviteOnly
         is JoinRule.Custom,
-        JoinRule.Private,
         null -> SecurityAndPrivacyRoomAccess.InviteOnly
     }
 }
@@ -481,7 +480,7 @@ private fun SecurityAndPrivacyRoomAccess.map(): JoinRule? {
     return when (this) {
         SecurityAndPrivacyRoomAccess.Anyone -> JoinRule.Public
         SecurityAndPrivacyRoomAccess.AskToJoin -> JoinRule.Knock
-        SecurityAndPrivacyRoomAccess.InviteOnly -> JoinRule.Private
+        SecurityAndPrivacyRoomAccess.InviteOnly -> JoinRule.Invite
         is SecurityAndPrivacyRoomAccess.SpaceMember -> JoinRule.Restricted(
             rules = this.spaceIds.map { AllowRule.RoomMembership(it) }.toImmutableList()
         )

--- a/features/securityandprivacy/impl/src/test/kotlin/io/element/android/features/securityandprivacy/impl/root/SecurityAndPrivacyPresenterTest.kt
+++ b/features/securityandprivacy/impl/src/test/kotlin/io/element/android/features/securityandprivacy/impl/root/SecurityAndPrivacyPresenterTest.kt
@@ -309,7 +309,7 @@ class SecurityAndPrivacyPresenterTest {
             baseRoom = FakeBaseRoom(
                 roomPermissions = roomPermissions(),
                 getRoomVisibilityResult = { Result.success(RoomVisibility.Private) },
-                initialRoomInfo = aRoomInfo(historyVisibility = RoomHistoryVisibility.Shared, joinRule = JoinRule.Private)
+                initialRoomInfo = aRoomInfo(historyVisibility = RoomHistoryVisibility.Shared, joinRule = JoinRule.Invite)
             ),
             enableEncryptionResult = enableEncryptionLambda,
             updateJoinRuleResult = updateJoinRuleLambda,
@@ -1091,7 +1091,7 @@ class SecurityAndPrivacyPresenterTest {
             baseRoom = FakeBaseRoom(
                 roomPermissions = roomPermissions(),
                 getRoomVisibilityResult = { Result.success(RoomVisibility.Private) },
-                initialRoomInfo = aRoomInfo(historyVisibility = RoomHistoryVisibility.Shared, joinRule = JoinRule.Private)
+                initialRoomInfo = aRoomInfo(historyVisibility = RoomHistoryVisibility.Shared, joinRule = JoinRule.Invite)
             ),
         ),
         navigator: SecurityAndPrivacyNavigator = FakeSecurityAndPrivacyNavigator(),

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceStateProvider.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceStateProvider.kt
@@ -38,7 +38,7 @@ class LeaveSpaceStateProvider : PreviewParameterProvider<LeaveSpaceState> {
                         ),
                         aSelectableSpaceRoom(
                             spaceRoom = aSpaceRoom(
-                                joinRule = JoinRule.Private,
+                                joinRule = JoinRule.Invite,
                             ),
                             isSelected = false,
                         ),
@@ -56,7 +56,7 @@ class LeaveSpaceStateProvider : PreviewParameterProvider<LeaveSpaceState> {
                         ),
                         aSelectableSpaceRoom(
                             spaceRoom = aSpaceRoom(
-                                joinRule = JoinRule.Private,
+                                joinRule = JoinRule.Invite,
                             ),
                             isSelected = true,
                         ),

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceView.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/leave/LeaveSpaceView.kt
@@ -311,8 +311,8 @@ private fun SpaceItem(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (room.joinRule == JoinRule.Private) {
-                    // Picto for private
+                if (room.joinRule == JoinRule.Invite) {
+                    // Picto for invite only
                     Icon(
                         modifier = Modifier
                             .size(16.dp)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MediaPreviewValue.kt
@@ -37,7 +37,6 @@ fun MediaPreviewValue?.isPreviewEnabled(joinRule: JoinRule?): Boolean {
         null, On -> true
         Off -> false
         Private -> when (joinRule) {
-            is JoinRule.Private,
             is JoinRule.Knock,
             is JoinRule.Invite,
             is JoinRule.Restricted,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/join/JoinRule.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/join/JoinRule.kt
@@ -14,7 +14,6 @@ import kotlinx.collections.immutable.ImmutableList
 @Immutable
 sealed interface JoinRule {
     data object Public : JoinRule
-    data object Private : JoinRule
     data object Knock : JoinRule
     data object Invite : JoinRule
     data class Restricted(val rules: ImmutableList<AllowRule>) : JoinRule

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/JoinRule.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/JoinRule.kt
@@ -15,7 +15,8 @@ import org.matrix.rustcomponents.sdk.JoinRule as RustJoinRule
 fun RustJoinRule.map(): JoinRule {
     return when (this) {
         RustJoinRule.Public -> JoinRule.Public
-        RustJoinRule.Private -> JoinRule.Private
+        // Assume a private join rule is invite only instead. Private shouldn't be in use in Matrix.
+        RustJoinRule.Private -> JoinRule.Invite
         RustJoinRule.Knock -> JoinRule.Knock
         RustJoinRule.Invite -> JoinRule.Invite
         is RustJoinRule.Restricted -> JoinRule.Restricted(rules.map { it.map() }.toImmutableList())
@@ -27,7 +28,6 @@ fun RustJoinRule.map(): JoinRule {
 fun JoinRule.map(): RustJoinRule {
     return when (this) {
         JoinRule.Public -> RustJoinRule.Public
-        JoinRule.Private -> RustJoinRule.Private
         JoinRule.Knock -> RustJoinRule.Knock
         JoinRule.Invite -> RustJoinRule.Invite
         is JoinRule.Restricted -> RustJoinRule.Restricted(rules.map { it.map() })


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

It shouldn't be in use, since it was never properly defined:

- The `Private` values coming from the SDK are considered to be `Invite` instead.
- Remove any existing `JoinRule.Private` usages in our code.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6127#issuecomment-3839635135

## Screenshots / GIFs

There shouldn't be any changes in screenshots.

## Tests

Maybe test creating a room with a `private` access doesn't create a room with a private join rule?

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
