### PR TITLE
Refresh a Space's room list after creating a room in it

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/SpaceFlowNode.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/SpaceFlowNode.kt
@@ -174,6 +174,8 @@ class SpaceFlowNode(
             is NavTarget.CreateRoom -> {
                 val callback = object : CreateRoomEntryPoint.Callback {
                     override fun onRoomCreated(roomId: RoomId) {
+                        // Reset the room list in the space so this new room is displayed
+                        lifecycleScope.launch { spaceRoomList.reset() }
                         callback.navigateToRoom(roomId, emptyList())
                     }
                 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. Thanks @ganfra for the tips to simplify this.

## Motivation and context

Fix this issue (I can't really find a GH issue for it 😅 ).

## Tests

- In a space screen, create a room.
- Go back from the room to the space screen.
- The new room should be displayed or will be displayed shortly after, once the room list is reloaded.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
