### PR TITLE
Fix `LinkifyHelper` index out of bounds with parenthesis

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
@@ -97,7 +97,7 @@ object LinkifyHelper {
             val closingParenthesisCount = linkifiedTextLastPath.count { it == ')' }
             val openingParenthesisCount = linkifiedTextLastPath.count { it == '(' }
             // If it's not part of a pair, remove it from the link span by adjusting the end index
-            end -= closingParenthesisCount - openingParenthesisCount
+            end -= (closingParenthesisCount - openingParenthesisCount).coerceAtLeast(0)
         }
         return end
     }

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
@@ -122,4 +122,22 @@ class LinkifierHelperTest {
         assertThat(urlSpans.size).isEqualTo(1)
         assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android/READ(ME)")
     }
+
+    @Test
+    fun `linkification handles mismatched opening parenthesis in URL`() {
+        val text = "A url: (https://github.com/element-hq/element-android/READ((((((ME))"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android/READ((((((ME))")
+    }
+
+    @Test
+    fun `linkification handles mismatched closing parenthesis in URL`() {
+        val text = "A url: (https://github.com/element-hq/element-android/READ(ME)))))"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android/READ(ME)")
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

When parenthesis were mismatched by having more opening parenthesis than closing ones, we could end up incorrectly making the URLSpan `end` value greater than the actual text length, causing an `IndexOutOfBoundsException`.

## Motivation and context

Fixes https://sentry.tools.element.io/organizations/element/issues/11226929/events/967262d3928a4d3d9c0eea4eb6cc43b3/

## Tests

Unit tests included in the PR.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
