### PR TITLE
[Release script] Ensure that the release version will match the next Monday date

### DIFF
--- a/tools/release/release.sh
+++ b/tools/release/release.sh
@@ -99,12 +99,12 @@ printf "\n======================================================================
 versionsFile="./plugins/src/main/kotlin/Versions.kt"
 # The version of the release must match the date of next monday, where the release is supposed to go live
 # The command below gets the date of next monday
-newtMondayDateCommand="date -v +1w -v -monday"
+nextMondayDateCommand="date -v +1w -v -monday"
 # Get release year on 2 digits
-versionYearCandidate=$(${newtMondayDateCommand} +%y)
+versionYearCandidate=$(${nextMondayDateCommand} +%y)
 currentVersionMonth=$(grep "val versionMonth" ${versionsFile} | cut  -d " " -f6)
 # Get release month on 2 digits
-versionMonthCandidate=$(${newtMondayDateCommand} +%m)
+versionMonthCandidate=$(${nextMondayDateCommand} +%m)
 versionMonthCandidateNoLeadingZero=${versionMonthCandidate/#0/}
 currentVersionReleaseNumber=$(grep "val versionReleaseNumber" ${versionsFile} | cut  -d " " -f6)
 # if the release month is the same as the current version, we increment the release number, else we reset it to 0


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that the release version will match the next Monday date, using the command `date -v +1w -v -monday`.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
This will ensure that release are aligned on iOS one. Previously release manager had to change the release candidate manually and it can be forgotten.

For instance we have just released EXA 26.01.2 and EXI is 26.02.0. EXI version is correct, EXA is not.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
NA

## Tests

<!-- Explain how you tested your development -->

I have tested the command locally and it behaves correctly on MacOS, so it should be fine. If you want perform more test, you can run locally the command `date -v +1w -v -DAY` by replacing `DAY` with day name (full or only 3 first chars).

## Tested devices

- MacOS

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
