### PR TITLE
When a background SDK task fails, react in the client

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -66,7 +66,12 @@ class RustMatrixClientFactory(
     private val sqliteStoreBuilderProvider: SqliteStoreBuilderProvider,
     private val workManagerScheduler: WorkManagerScheduler,
 ) {
-    private val sessionDelegate = RustClientSessionDelegate(sessionStore, appCoroutineScope, coroutineDispatchers)
+    private val sessionDelegate = RustClientSessionDelegate(
+        sessionStore = sessionStore,
+        appCoroutineScope = appCoroutineScope,
+        analyticsService = analyticsService,
+        coroutineDispatchers = coroutineDispatchers
+    )
 
     suspend fun create(sessionData: SessionData): RustMatrixClient = withContext(coroutineDispatchers.io) {
         val client = getBaseClientBuilder(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/core/SdkBackgroundTaskError.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/core/SdkBackgroundTaskError.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.core
+
+import uniffi.matrix_sdk_common.BackgroundTaskFailureReason
+
+/**
+ * Error thrown when a background SDK task panics and can't recover.
+ * @param task The name of the task that failed.
+ * @param reason The cause of this error.
+ */
+class SdkBackgroundTaskError(
+    task: String,
+    reason: BackgroundTaskFailureReason,
+) : Error() {
+    override val message: String = run {
+        val message = when (reason) {
+            is BackgroundTaskFailureReason.EarlyTermination -> "Early termination"
+            is BackgroundTaskFailureReason.Error -> "Error: ${reason.error}"
+            is BackgroundTaskFailureReason.Panic -> buildString {
+                append("Panic (unrecoverable): ")
+                reason.message?.let { append(it) }
+                reason.panicBacktrace?.let {
+                    append("\n")
+                    append(it)
+                }
+            }
+        }
+        "SDK background task '$task' failure: \n$message"
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
@@ -9,16 +9,20 @@
 package io.element.android.libraries.matrix.impl
 
 import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.impl.core.SdkBackgroundTaskError
 import io.element.android.libraries.matrix.impl.fixtures.factories.aRustSession
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
 import io.element.android.libraries.sessionstorage.test.aSessionData
+import io.element.android.services.analytics.api.AnalyticsService
+import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import uniffi.matrix_sdk_common.BackgroundTaskFailureReason
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RustClientSessionDelegateTest {
@@ -44,12 +48,37 @@ class RustClientSessionDelegateTest {
         assertThat(result!!.accessToken).isEqualTo("at")
         assertThat(result.refreshToken).isEqualTo("rt")
     }
+
+    @Test
+    fun `onBackgroundTaskErrorReport reports the error to analytics if recoverable`() = runTest {
+        val analyticsService = FakeAnalyticsService(isEnabled = true)
+        val sut = aRustClientSessionDelegate(analyticsService = analyticsService)
+        sut.onBackgroundTaskErrorReport("Crasher", BackgroundTaskFailureReason.EarlyTermination)
+        sut.onBackgroundTaskErrorReport("Crasher", BackgroundTaskFailureReason.Error("BOOM"))
+
+        assertThat(analyticsService.trackedErrors).hasSize(2)
+        assertThat(analyticsService.trackedErrors[0].message).isEqualTo("SDK background task 'Crasher' failure: \nEarly termination")
+        assertThat(analyticsService.trackedErrors[1].message).isEqualTo("SDK background task 'Crasher' failure: \nError: BOOM")
+    }
+
+    @Test(expected = SdkBackgroundTaskError::class)
+    fun `onBackgroundTaskErrorReport reports the error to analytics and throws it if it's a panic`() = runTest {
+        val analyticsService = FakeAnalyticsService(isEnabled = true)
+        val sut = aRustClientSessionDelegate(analyticsService = analyticsService)
+        sut.onBackgroundTaskErrorReport("Crasher", BackgroundTaskFailureReason.Panic("BOOM", "Stacktrace"))
+
+        assertThat(analyticsService.trackedErrors).hasSize(1)
+        assertThat(analyticsService.trackedErrors[0].message)
+            .isEqualTo("SDK background task 'Crasher' failure: \nPanic (unrecoverable): BOOM\nStacktrace")
+    }
 }
 
 fun TestScope.aRustClientSessionDelegate(
     sessionStore: SessionStore = InMemorySessionStore(),
+    analyticsService: AnalyticsService = FakeAnalyticsService(),
 ) = RustClientSessionDelegate(
     sessionStore = sessionStore,
     appCoroutineScope = this,
+    analyticsService = analyticsService,
     coroutineDispatchers = testCoroutineDispatchers(),
 )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Implement `RustClientSessionDelegate.onBackgroundTaskErrorReport`:
- For initialization issues or errors, we just print and report them.
- For panics (unrecoverable errors) we also crash the app.

## Motivation and context

React to issues in the SDK, parity with iOS.

## Tests

You can't really test it unless you trigger one of those issues or modify the code to manually fail.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
