### PR TITLE
Filter out MSC4171 service_members for DM rooms

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceStateProvider.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceStateProvider.kt
@@ -119,6 +119,7 @@ private fun aSpaceInfo(
         activeMembersCount = 5,
         invitedMembersCount = 0,
         joinedMembersCount = 5,
+        serviceMembers = persistentListOf(),
         roomPowerLevels = null,
         highlightCount = 0,
         notificationCount = 0,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomInfo.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomInfo.kt
@@ -47,6 +47,7 @@ data class RoomInfo(
     val activeMembersCount: Long,
     val invitedMembersCount: Long,
     val joinedMembersCount: Long,
+    val serviceMembers: ImmutableList<UserId>,
     val roomPowerLevels: RoomPowerLevels?,
     val highlightCount: Long,
     val notificationCount: Long,

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomIsDmCheck.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomIsDmCheck.kt
@@ -29,4 +29,4 @@ suspend fun BaseRoom.isDm() = roomInfoFlow.first().isDm
 /**
  * Returns whether the [RoomInfo] is from a DM.
  */
-val RoomInfo.isDm get() = isDm(isDirect, activeMembersCount.toInt())
+val RoomInfo.isDm get() = isDm(isDirect, activeMembersCount.toInt() - serviceMembers.size)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMembersState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/room/RoomMembersState.kt
@@ -40,5 +40,5 @@ fun RoomMembersState.activeRoomMembers(): List<RoomMember> {
 fun RoomMembersState.getDirectRoomMember(roomInfo: RoomInfo, sessionId: SessionId): RoomMember? {
     return roomMembers()
         ?.takeIf { roomInfo.isDm }
-        ?.find { it.userId != sessionId && it.membership.isActive() }
+        ?.find { it.userId != sessionId && it.membership.isActive() && !roomInfo.serviceMembers.contains(it.userId) }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoExt.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoExt.kt
@@ -18,7 +18,8 @@ import org.matrix.rustcomponents.sdk.RoomInfo
  */
 fun RoomInfo.elementHeroes(): List<MatrixUser> {
     return heroes
-        .takeIf { isDirect && activeMembersCount.toLong() == 2L }
+        .takeIf { isDirect && (activeMembersCount - serviceMembers.size.toULong()) == 2UL }
+        ?.filter { !serviceMembers.contains(it.userId) }
         ?.takeIf { it.size == 1 }
         ?.map { it.map() }
         .orEmpty()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
@@ -58,6 +58,7 @@ class RoomInfoMapper {
             activeMembersCount = it.activeMembersCount.toLong(),
             invitedMembersCount = it.invitedMembersCount.toLong(),
             joinedMembersCount = it.joinedMembersCount.toLong(),
+            serviceMembers = it.serviceMembers.map(::UserId).toImmutableList(),
             roomPowerLevels = it.powerLevels?.let(::mapPowerLevels),
             highlightCount = it.highlightCount.toLong(),
             notificationCount = it.notificationCount.toLong(),


### PR DESCRIPTION
Fixes avatars for DM rooms with a 3rd user that is marked as a service member. Also fixes avatars for shortcuts to bridge rooms.

Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/6159
 
## Content

FIXME

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/4034

## Screenshots / GIFs

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
