### PR TITLE
Fix stack overflow when quickly going back on a `Space` screen

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpaceView.kt
@@ -109,10 +109,12 @@ fun SpaceView(
     modifier: Modifier = Modifier,
     acceptDeclineInviteView: @Composable () -> Unit,
 ) {
-    BackHandler {
+    var handledBack by remember { mutableStateOf(false) }
+    BackHandler(enabled = !handledBack) {
         if (state.isManageMode) {
             state.eventSink(SpaceEvents.ExitManageMode)
         } else {
+            handledBack = true
             onBackClick()
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says.

## Motivation and context

Should fix [this Sentry issue](https://sentry.tools.element.io/organizations/element/issues/7813298/events/4151f1c086c14d398ddb34c7859cd9bd/).

## Tests

Open a space, then quickly click on the nav back button or use the back gesture 3-4 times. If the app is closed but you don't see a crash in the logs, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
