### PR TITLE
When linkifying, adjust the `URLSpan`'s url too

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
@@ -16,8 +16,6 @@ import androidx.core.text.toSpannable
 import androidx.core.text.util.LinkifyCompat
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import timber.log.Timber
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 /**
  * Helper class to linkify text while preserving existing URL spans.
@@ -59,7 +57,8 @@ object LinkifyHelper {
 
                 // Adapt the url in the URL span to the new end index too if needed
                 if (end != newEnd) {
-                    val url = spannable.subSequence(start, newEnd).toString()
+                    val diff = end - newEnd
+                    val url = urlSpan.url.substring(0, urlSpan.url.length - diff)
                     spannable.removeSpan(urlSpan)
                     spannable.setSpan(URLSpan(url), start, newEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
                 } else {
@@ -87,12 +86,12 @@ object LinkifyHelper {
         var end = end
 
         // Trailing punctuation found, adjust the end index
-        while (spannable[end - 1] in sequenceOf('.', ',', ';', ':', '!', '?', '…') && end > start) {
+        while (end > start && spannable[end - 1] in sequenceOf('.', ',', ';', ':', '!', '?', '…')) {
             end--
         }
 
         // If the last character is a closing parenthesis, check if it's part of a pair
-        if (spannable[end - 1] == ')' && end > start) {
+        if (end > start && spannable[end - 1] == ')') {
             val linkifiedTextLastPath = spannable.substring(start, end).substringAfterLast('/')
             val closingParenthesisCount = linkifiedTextLastPath.count { it == ')' }
             val openingParenthesisCount = linkifiedTextLastPath.count { it == '(' }

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
@@ -10,7 +10,9 @@ package io.element.android.libraries.androidutils.text
 
 import android.telephony.TelephonyManager
 import android.text.style.URLSpan
+import androidx.core.text.buildSpannedString
 import androidx.core.text.getSpans
+import androidx.core.text.inSpans
 import androidx.core.text.toSpannable
 import com.google.common.truth.Truth.assertThat
 import io.element.android.tests.testutils.WarmUpRule
@@ -139,5 +141,28 @@ class LinkifierHelperTest {
         val urlSpans = result.toSpannable().getSpans<URLSpan>()
         assertThat(urlSpans.size).isEqualTo(1)
         assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android/READ(ME)")
+    }
+
+    @Test
+    fun `linkification handles trailing question marks`() {
+        val text = "A url: https://github.com/element-hq/element-android?"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android")
+    }
+
+    @Test
+    fun `linkification doesn't modify existing URLSpan`() {
+        val text = buildSpannedString {
+            append("A url: ")
+            inSpans(URLSpan("https://github.com/element-hq/element-android?")) {
+                append("here")
+            }
+        }
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("https://github.com/element-hq/element-android?")
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Instead of constructing the URL from the text, use the existing `URLSpan.url` value, adjusting its length.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6183

## Tests

- Send `example.com?` as a plain text message.
- EXA should linkify the `example.com` text, without the `?`.
- When clicked, it should open `http://example.com`.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
