### PR TITLE
Add free disk space action to CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: true
-          # all of these default to true, but we should only need the 'android' one (and maybe swap-storage?)
+          # All of these default to true, but we should only need the 'android' one (and maybe swap-storage?)
           android: false
           dotnet: true
           haskell: true
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/build_enterprise.yml
+++ b/.github/workflows/build_enterprise.yml
@@ -36,8 +36,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -31,8 +31,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/nightlyReports.yml
+++ b/.github/workflows/nightlyReports.yml
@@ -26,8 +26,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,8 +26,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/recordScreenshots.yml
+++ b/.github/workflows/recordScreenshots.yml
@@ -26,8 +26,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 
@@ -111,8 +111,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -31,8 +31,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,8 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          # This takes way too long to run
-          large-packages: true
+          # This takes way too long to run (~2 minutes) and it saves only ~5.5GB
+          large-packages: false
           docker-images: true
           swap-storage: false
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add `jlumbroso/free-disk-space` action to free up space.

- With `large-packages` enabled (removal of these enabled), 14GB of disk space are saved, but this can take 1-2 minutes to run in every GH flow.
- With `large-packages` disabled, we save 8.7GB of disk space, which seems good enough and this takes ~10s.

In the end we went with option 2 for speed, 8.7 extra free GB seem good enough for now.

## Motivation and context

I don't want to see another 'no space left on device' message ever again.

## Tests

Tested with everything but Android and Swap removed and it worked, but was slow. Then tried with `large-packages` and it seemed good enough.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
