### PR TITLE
Add max retry checks for `FetchNotificationsWorker`

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchNotificationsWorker.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchNotificationsWorker.kt
@@ -24,6 +24,8 @@ import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.di.annotations.ApplicationContext
 import io.element.android.libraries.matrix.api.auth.SessionRestorationException
 import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.exception.ClientException
+import io.element.android.libraries.matrix.api.exception.isNetworkError
 import io.element.android.libraries.push.api.push.NotificationEventRequest
 import io.element.android.libraries.push.api.push.SyncOnNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.NotifiableEventResolver
@@ -40,7 +42,8 @@ import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 
 private const val MAX_RETRY_ATTEMPTS = 3
-private const val TAG = "FetchNotificationsWorker"
+private val rescheduleDelay = 30.seconds
+private const val TAG = "NotificationsWorker"
 
 @AssistedInject
 class FetchNotificationsWorker(
@@ -57,29 +60,47 @@ class FetchNotificationsWorker(
 ) : CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result = withContext(coroutineDispatchers.io) {
         Timber.tag(TAG).d("FetchNotificationsWorker started")
+        val canRetry = workerParams.runAttemptCount < MAX_RETRY_ATTEMPTS
+
         val requests = workerDataConverter.deserialize(inputData) ?: return@withContext Result.failure()
         // Wait for network to be available, but not more than 10 seconds
         val hasNetwork = withTimeoutOrNull(10.seconds) {
             networkMonitor.connectivity.first { it == NetworkStatus.Connected }
         } != null
         if (!hasNetwork) {
-            if (workerParams.runAttemptCount < MAX_RETRY_ATTEMPTS) {
-                Timber.tag(TAG).w("No network, retrying later")
-                return@withContext Result.retry()
-            } else {
-                Timber.tag(TAG).w("No network available and reached max retry attempts (${workerParams.runAttemptCount}/$MAX_RETRY_ATTEMPTS)")
-                return@withContext Result.failure()
-            }
+            Timber.tag(TAG).w("No network, re-scheduling to retry later")
+            val sessionId = requests.first().sessionId
+            workManagerScheduler.submit(
+                SyncNotificationWorkManagerRequest(
+                    sessionId = sessionId,
+                    notificationEventRequests = requests,
+                    workerDataConverter = workerDataConverter,
+                    buildVersionSdkIntProvider = buildVersionSdkIntProvider,
+                    delay = rescheduleDelay,
+                )
+            )
+            return@withContext Result.failure()
         }
 
         val failedSyncForSessions = mutableMapOf<SessionId, Throwable>()
 
         val groupedRequests = requests.groupBy { it.sessionId }.toMutableMap()
+        val recoverableFailedRequests = mutableSetOf<NotificationEventRequest>()
         for ((sessionId, notificationRequests) in groupedRequests) {
             Timber.tag(TAG).d("Processing notification requests for session $sessionId")
             eventResolver.resolveEvents(sessionId, notificationRequests)
                 .fold(
                     onSuccess = { result ->
+                        // Store failed but recoverable requests
+                        recoverableFailedRequests.addAll(
+                            result
+                                .filter { (_, eventResult) ->
+                                    val exception = eventResult.exceptionOrNull()
+                                    exception is ClientException.Generic && exception.isNetworkError()
+                                }
+                                .map { it.key }
+                        )
+
                         // Update the resolved results in the queue
                         (queue.results as MutableSharedFlow).emit(requests to result)
                     },
@@ -90,8 +111,36 @@ class FetchNotificationsWorker(
                 )
         }
 
-        // If there were failures for whole sessions, we retry all their requests
-        if (failedSyncForSessions.isNotEmpty()) {
+        // Handle failures, re-schedule and retry/fail as needed
+        handleFailures(
+            canRetry = canRetry,
+            requests = requests,
+            recoverableFailedRequests = recoverableFailedRequests,
+            failedSyncForSessions = failedSyncForSessions,
+        )?.let { result ->
+            return@withContext result
+        }
+
+        Timber.tag(TAG).d("Notifications processed successfully")
+
+        performOpportunisticSyncIfNeeded(groupedRequests)
+
+        Result.success()
+    }
+
+    private fun handleFailures(
+        canRetry: Boolean,
+        requests: List<NotificationEventRequest>,
+        recoverableFailedRequests: Set<NotificationEventRequest>,
+        failedSyncForSessions: Map<SessionId, Throwable>,
+    ): Result? {
+        val allRequestsFailed = recoverableFailedRequests == requests.toSet()
+        if (allRequestsFailed) {
+            return if (canRetry) Result.retry() else Result.failure()
+        } else if (!canRetry) {
+            return Result.failure()
+        } else if (failedSyncForSessions.isNotEmpty()) {
+            val groupedRequests = requests.groupBy { it.sessionId }.toMutableMap()
             @Suppress("LoopWithTooManyJumpStatements")
             for ((failedSessionId, exception) in failedSyncForSessions) {
                 if (exception.cause is SessionRestorationException) {
@@ -100,25 +149,34 @@ class FetchNotificationsWorker(
                     continue
                 }
                 val requestsToRetry = groupedRequests[failedSessionId] ?: continue
-                if (workerParams.runAttemptCount < MAX_RETRY_ATTEMPTS) {
-                    Timber.tag(TAG).d("Re-scheduling ${requestsToRetry.size} failed notification requests for session $failedSessionId")
-                    workManagerScheduler.submit(
-                        SyncNotificationWorkManagerRequest(
-                            sessionId = failedSessionId,
-                            notificationEventRequests = requestsToRetry,
-                            workerDataConverter = workerDataConverter,
-                            buildVersionSdkIntProvider = buildVersionSdkIntProvider,
-                        )
+                Timber.tag(TAG).d("Re-scheduling ${requestsToRetry.size} failed notification requests for session $failedSessionId")
+                workManagerScheduler.submit(
+                    SyncNotificationWorkManagerRequest(
+                        sessionId = failedSessionId,
+                        notificationEventRequests = requestsToRetry,
+                        workerDataConverter = workerDataConverter,
+                        buildVersionSdkIntProvider = buildVersionSdkIntProvider,
+                        delay = rescheduleDelay,
                     )
-                }
+                )
+            }
+        } else if (recoverableFailedRequests.isNotEmpty()) {
+            val bySessionId = recoverableFailedRequests.groupBy { it.sessionId }
+            for ((sessionId, failedRequests) in bySessionId) {
+                Timber.tag(TAG).d("Re-scheduling ${recoverableFailedRequests.size} recoverable failed notification requests for $sessionId")
+                workManagerScheduler.submit(
+                    SyncNotificationWorkManagerRequest(
+                        sessionId = sessionId,
+                        notificationEventRequests = failedRequests,
+                        workerDataConverter = workerDataConverter,
+                        buildVersionSdkIntProvider = buildVersionSdkIntProvider,
+                        delay = rescheduleDelay,
+                    )
+                )
             }
         }
 
-        Timber.tag(TAG).d("Notifications processed successfully")
-
-        performOpportunisticSyncIfNeeded(groupedRequests)
-
-        Result.success()
+        return null
     }
 
     private suspend fun performOpportunisticSyncIfNeeded(

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncNotificationWorkManagerRequest.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncNotificationWorkManagerRequest.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import timber.log.Timber
 import java.security.InvalidParameterException
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -31,6 +32,7 @@ class SyncNotificationWorkManagerRequest(
     private val notificationEventRequests: List<NotificationEventRequest>,
     private val workerDataConverter: SyncNotificationsWorkerDataConverter,
     private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
+    private val delay: Duration? = null,
 ) : WorkManagerRequest {
     override fun build(): Result<List<WorkRequest>> {
         if (notificationEventRequests.isEmpty()) {
@@ -47,6 +49,10 @@ class SyncNotificationWorkManagerRequest(
                         // See https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work#backwards-compat
                         if (buildVersionSdkIntProvider.isAtLeast(Build.VERSION_CODES.TIRAMISU)) {
                             setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        }
+
+                        if (delay != null) {
+                            setInitialDelay(delay.toJavaDuration())
                         }
                     }
                     .setBackoffCriteria(BackoffPolicy.LINEAR, 30.seconds.toJavaDuration())

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchNotificationWorkerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchNotificationWorkerTest.kt
@@ -125,7 +125,7 @@ class FetchNotificationWorkerTest {
         advanceTimeBy(10.seconds)
 
         // The process failed due to a timeout in getting the network connectivity, a retry is scheduled
-        assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
     }
 
     @Test
@@ -166,7 +166,7 @@ class FetchNotificationWorkerTest {
         queue: NotificationResolverQueue = FakeNotificationResolverQueue(
             processingLambda = { Result.success(ResolvedPushEvent.Event(aNotifiableMessageEvent())) }
         ),
-        workManagerScheduler: FakeWorkManagerScheduler = FakeWorkManagerScheduler(),
+        workManagerScheduler: FakeWorkManagerScheduler = FakeWorkManagerScheduler(submitLambda = {}),
         syncOnNotifiableEvent: SyncOnNotifiableEvent = SyncOnNotifiableEvent {},
     ) = FetchNotificationsWorker(
         workerParams = createWorkerParams(workDataOf("requests" to input)),


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Add a maximum of 3 retries for fetching notifications with `WorkManager`.

## Motivation and context

Not having this can potentially result in a work request being re-scheduled indefinitely.

Part of https://github.com/element-hq/element-x-android/issues/6209

## Tests

I don't think this can be easily tested.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
