### PR TITLE
Remove all video metadata from externally shared videos

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
@@ -24,6 +24,7 @@ import androidx.media3.transformer.EditedMediaItem
 import androidx.media3.transformer.Effects
 import androidx.media3.transformer.ExportException
 import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.InAppMp4Muxer
 import androidx.media3.transformer.ProgressHolder
 import androidx.media3.transformer.TransformationRequest
 import androidx.media3.transformer.Transformer
@@ -88,6 +89,10 @@ class VideoCompressor(
         // If we need to resize the video, we also want to recalculate the bitrate
         val newBitrate = videoCompressorConfig.newBitRate
 
+        // Remove all video metadata
+        val removeMetadataMuxer = InAppMp4Muxer.Factory { metadataEntries ->
+            metadataEntries.removeAll { true }
+        }
         val inputMediaItem = MediaItem.fromUri(uri)
         val outputMediaItem = EditedMediaItem.Builder(inputMediaItem)
             .setFrameRate(newFrameRate)
@@ -109,6 +114,7 @@ class VideoCompressor(
             .setAudioMimeType(MimeTypes.AUDIO_AAC)
             .setPortraitEncodingEnabled(false)
             .setEncoderFactory(encoderFactory)
+            .setMuxerFactory(removeMetadataMuxer)
             .addListener(object : Transformer.Listener {
                 override fun onCompleted(composition: Composition, exportResult: ExportResult) {
                     trySend(VideoTranscodingEvent.Completed(tmpFile))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Use `InAppMp4Muxer` with a custom metadata provider that removes all metadata entries for the video files.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6186.

This was a mix of 2 issues:

1. The media picker added by google and which we use for the media selection in-app apparently already strips all metadata from the videos somehow, so we were under the illusion that transcoding was removing the metadata while it was not, it was the media picker.
2. Media3 Transformer purposefully keeps all metadata from the original video unless instructed otherwise (like we did in this PR). This doesn't seem to be documented anywhere and it's quite counter-intuitive.

## Tests

<!-- Explain how you tested your development -->

1. Take a video with GPS metadata like [this one](https://drive.google.com/file/d/1H_iNIEuTy_kZh9_TZ51w2KVR-Phi0usK/view?usp=sharing).
2. Download it to your test device and share it *from a external app* to a room in Element X with the share sheet.
3. Check on the other side that the video doesn't contain GPS metadata anymore with the command `exiftool <file> | grep GPS`.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
