### PR TITLE
Catch exceptions when changing the audio communication device

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
@@ -18,6 +18,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
+import io.element.android.libraries.core.extensions.runCatchingExceptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -385,10 +386,18 @@ class WebViewAudioManager(
         currentDeviceId = device?.id
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (device != null) {
-                Timber.d("Setting communication device: ${device.id} - ${deviceName(device.type, device.productName.toString())}")
-                setCommunicationDevice(device)
+                runCatchingExceptions {
+                    Timber.d("Setting communication device: ${device.id} - ${deviceName(device.type, device.productName.toString())}")
+                    setCommunicationDevice(device)
+                }.onFailure {
+                    Timber.e(it, "Could not set communication device.")
+                }
             } else {
-                audioManager.clearCommunicationDevice()
+                runCatchingExceptions {
+                    clearCommunicationDevice()
+                }.onFailure {
+                    Timber.e(it, "Could not clear communication device.")
+                }
             }
         } else {
             // On Android 11 and lower, we don't have the concept of communication devices


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Catch exceptions when changing the audio communication device in Element Call, log the errors instead.

## Motivation and context

Fix https://sentry.tools.element.io/organizations/element/issues/11227938/events/894944cf6c414234972e7ff766d22a70/

```
java.lang.IllegalArgumentException: invalid portID 1743
    at android.os.Parcel.createExceptionOrNull(Parcel.java:3054)
    at android.os.Parcel.createException(Parcel.java:3034)
    at android.os.Parcel.readException(Parcel.java:3017)
    at android.os.Parcel.readException(Parcel.java:2959)
    at android.media.IAudioService$Stub$Proxy.setCommunicationDevice(IAudioService.java:5971)
    at android.media.AudioManager.setCommunicationDevice(AudioManager.java:7775)
    at io.element.android.features.call.impl.utils.WebViewAudioManager.selectAudioDevice(r8-map-id-d391da7e13318a6053c0090609941610e92b5b23e01c8fa22be3586faaa66eba:10)
    at io.element.android.features.call.impl.utils.WebViewAudioManager.selectDefaultAudioDevice(r8-map-id-d391da7e13318a6053c0090609941610e92b5b23e01c8fa22be3586faaa66eba:99)
    at io.element.android.features.call.impl.utils.WebViewAudioManager$audioDeviceCallback$1.onAudioDevicesAdded(r8-map-id-d391da7e13318a6053c0090609941610e92b5b23e01c8fa22be3586faaa66eba:149)
    at android.media.AudioManager$NativeEventHandlerDelegate$1.handleMessage(AudioManager.java:8637)
    at android.os.Handler.dispatchMessage(Handler.java:111)
    at android.os.Looper.loopOnce(Looper.java:238)
    at android.os.Looper.loop(Looper.java:357)
    at android.app.ActivityThread.main(ActivityThread.java:8149)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
```

## Tests

I don't think this one can be easily tested.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
