### PR TITLE
Improve element gallery header

### DIFF
--- a/screenshots/html/screenshots.css
+++ b/screenshots/html/screenshots.css
@@ -238,3 +238,16 @@ a {
     margin-left: 16px;
     white-space: nowrap;
 }
+
+.copy-message {
+    position: absolute;
+    bottom: 60px;
+    right: 20px;
+    background-color: #0DBD8B;
+    color: white;
+    padding: 10px 20px;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    font-size: 16px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}

--- a/screenshots/html/script.js
+++ b/screenshots/html/script.js
@@ -232,6 +232,34 @@ function createImageElement(fullFile, modifiedDayTime) {
     return img;
 }
 
+function updateUrlAndScrollTo(id) {
+    // If the current URL already contains the fragment id, remove it, otherwise add it
+    if (window.location.hash === id) {
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+    } else {
+        history.replaceState(null, '', `${window.location.pathname}${window.location.search}#${id}`);
+    }
+    const element = document.getElementById(id);
+    if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+    }
+    // Also copy the URL to the clipboard
+    navigator.clipboard.writeText(window.location.href);
+    // And show a message that the URL has been copied to the clipboard
+    // First check if there is already a message, if so, remove it, or the shadow will accumulate.
+    const existingMessage = document.querySelector('.copy-message');
+    if (existingMessage) {
+        document.body.removeChild(existingMessage);
+    }
+    const message = document.createElement('div');
+    message.className = 'copy-message';
+    message.textContent = 'URL copied to clipboard!';
+    document.body.appendChild(message);
+    setTimeout(() => {
+        document.body.removeChild(message);
+    }, 2000);
+}
+
 function addTable() {
   var linesCounter = 0;
   // Remove any previous table
@@ -265,6 +293,9 @@ function addTable() {
     }
     const tr = document.createElement('tr');
     tr.id = niceName + screenshotCounter;
+    tr.onclick = () => {
+        updateUrlAndScrollTo(tr.id);
+    }
     let hasTranslatedFiles = false;
     for (let languageIndex = 0; languageIndex < dataLanguages.length; languageIndex++) {
       if (visibleLanguages[languageIndex] == 0) {
@@ -305,6 +336,9 @@ function addTable() {
         currentHeaderValue = niceName;
         const trHead = document.createElement('tr');
         trHead.id = niceName;
+        trHead.onclick = () => {
+            updateUrlAndScrollTo(trHead.id);
+        }
         const tdHead = document.createElement('td');
         tdHead.colSpan = numVisibleLanguages;
         tdHead.className = "view-header";


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Improve element gallery header.

Now that we have many supported languages, the header is not rendering nicely, see how https://element-hq.github.io/element-x-android is rendering now:

<img width="1287" height="134" alt="image" src="https://github.com/user-attachments/assets/965b0df1-35fb-4fda-a4d1-50c22b53dd8a" />

This PR groups the language into a dropbox, as per below:

<img width="1282" height="158" alt="image" src="https://github.com/user-attachments/assets/c6baf27f-1e84-464d-ba2b-7f3c5a12a5ce" />

<img width="1283" height="238" alt="image" src="https://github.com/user-attachments/assets/17320bd7-d854-4f3b-9bb7-2ccdba20c81a" />

Also this PR add a click to copy URL to ease sharing element from the gallery per URL.

Node: code change with the help of Gemini.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Give a little bit of love to Element Gallery

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->
See above

## Tests

<!-- Explain how you tested your development -->

- Open ./screenshots/index.html and see the change on the header
- Click on an image and observe that the url is copied
- Click on an image name (header) and observe that the url is copied

Hopefully the effect will be more visible on the next full element gallery generation 

## Tested devices

- [x] Firefox

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
