### PR TITLE
Fix key storage if it's broken

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -214,7 +214,7 @@ class RustEncryptionService(
 
     override suspend fun recover(recoveryKey: String): Result<Unit> = withContext(dispatchers.io) {
         runCatchingExceptions {
-            service.recover(recoveryKey)
+            service.recoverAndFixBackup(recoveryKey)
         }.recoverCatching {
             when (it) {
                 // We ignore import errors because the user will be notified about them via the "Key storage out of sync" detection.


### PR DESCRIPTION
## Content

When recovering from Recovery, use the new `recoverAndFixBackup` method that fixes key storage if the public and private keys are out of sync.

(Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/6252)

## Motivation and context

For https://github.com/element-hq/element-meta/issues/3059 we want to detect when the key storage keys are inconsistent, and automatically fix the problem by creating a new backup. This change does that using the functionality recently added to matrix-rust-sdk.

## Screenshots / GIFs

Nothing changes visually, except after the "Key Storage Out Of Sync" banner appears and we choose "Enter Recovery Key" and enter it, the banner disappears. Previously, if backup keys were out of sync, it would remain.

## Tests

No tests were changed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 16.0

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
