### PR TITLE
Fix read receipts not appearing in threaded timelines

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/JoinedRustRoom.kt
@@ -229,8 +229,11 @@ class JoinedRustRoom(
             is CreateTimelineParams.Threaded -> DateDividerMode.DAILY
         }
 
-        // Track read receipts only for focused timeline for performance optimization
-        val trackReadReceipts = createTimelineParams is CreateTimelineParams.Focused
+        // Track read receipts only for focused and threaded timelines for performance optimization
+        val trackReadReceipts = when (createTimelineParams) {
+            is CreateTimelineParams.Focused, is CreateTimelineParams.Threaded -> true
+            is CreateTimelineParams.MediaOnly, is CreateTimelineParams.MediaOnlyFocused, CreateTimelineParams.PinnedOnly -> false
+        }
 
         runCatchingExceptions {
             innerRoom.timelineWithConfiguration(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

What the title says. This check predates threads and somehow went unnoticed while testing. It's now part of a `when` statement, so any newly added timeline types will have to explicitly say if they want read receipt computation enabled or not.

## Motivation and context

Fixes the issue @bnjbvr reported, about read receipts not appearing in threads in EXA while they worked fine on EXI.

## Tests

With the threads lab flag enabled, open a thread with several messages and read receipts.

Check the read receipts appear and are updated when they change.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
