### PR TITLE
Add a foreground service with a wakelock for fetching push notifications

### DIFF
--- a/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
+++ b/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
@@ -15,6 +15,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Build
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -83,7 +84,9 @@ class DefaultNetworkMonitor(
                 if (network.networkHandle == connectivityManager.activeNetwork?.networkHandle) {
                     // If the network doesn't have the NET_CAPABILITY_VALIDATED capability, it means that the network is not able to reach the internet
                     // (according to Google), which is a common case in air-gapped environments.
-                    isInAirGappedEnvironment.value = !networkCapabilities.capabilities.contains(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        isInAirGappedEnvironment.value = !networkCapabilities.capabilities.contains(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    }
                 }
             }
 

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/PushHandlingWakeLock.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/PushHandlingWakeLock.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.api.push
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Abstraction over wakelocks used for push handling to ensure the device stays awake while we handle the push and schedule and run the work.
+ */
+interface PushHandlingWakeLock {
+    /**
+     * Acquire a wakelock for the given [key]. The wakelock will be held for the given [time] or until [unlock] is called, whichever happens first.
+     */
+    fun lock(key: String, time: Duration = 1.minutes)
+
+    /**
+     * Release the wakelock associated with the given [key]. If no wakelock is associated with the key, this method does nothing.
+     */
+    fun unlock(key: String)
+}

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/PushHandlingWakeLock.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/PushHandlingWakeLock.kt
@@ -15,12 +15,12 @@ import kotlin.time.Duration.Companion.minutes
  */
 interface PushHandlingWakeLock {
     /**
-     * Acquire a wakelock for the given [key]. The wakelock will be held for the given [time] or until [unlock] is called, whichever happens first.
+     * Acquire a wakelock. The wakelock will be held for the given [time] or until [unlock] is called, whichever happens first.
      */
-    fun lock(key: String, time: Duration = 1.minutes)
+    fun lock(time: Duration = 1.minutes)
 
     /**
-     * Release the wakelock associated with the given [key]. If no wakelock is associated with the key, this method does nothing.
+     * Release the wakelock. If no wakelock is associated with the key, this method does nothing.
      */
-    fun unlock(key: String)
+    fun unlock()
 }

--- a/libraries/push/impl/src/main/AndroidManifest.xml
+++ b/libraries/push/impl/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application>
+        <service android:name=".push.FetchPushForegroundService"
+            android:foregroundServiceType="shortService"
+            android:exported="false"
+            android:enabled="true" />
+
         <receiver
             android:name=".notifications.TestNotificationReceiver"
             android:exported="false" />

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/di/PushBindings.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/di/PushBindings.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.impl.di
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import io.element.android.libraries.push.impl.push.FetchPushForegroundService
+
+@ContributesTo(AppScope::class)
+interface PushBindings {
+    fun inject(fetchPushForegroundService: FetchPushForegroundService)
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/channels/NotificationChannels.kt
@@ -58,6 +58,8 @@ interface NotificationChannels {
      * Get the channel for test notifications.
      */
     fun getChannelIdForTest(): String
+
+    fun getSilentChannelId(): String = SILENT_NOTIFICATION_CHANNEL_ID
 }
 
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
@@ -142,7 +142,7 @@ class DefaultPushHandler(
 
             if (!workManagerScheduler.hasPendingWork(userId, WorkManagerRequestType.NOTIFICATION_SYNC)) {
                 Timber.d("No pending worker for push notifications found")
-                workManagerScheduler.submit(syncPendingNotificationsRequestFactory.create(userId, pushData.clientSecret))
+                workManagerScheduler.submit(syncPendingNotificationsRequestFactory.create(userId))
             }
         } catch (e: Exception) {
             Timber.tag(loggerTag.value).e(e, "## handleInternal() failed")

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandler.kt
@@ -31,7 +31,10 @@ import io.element.android.libraries.workmanager.api.WorkManagerScheduler
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.toolbox.api.systemclock.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 private val loggerTag = LoggerTag("PushHandler", LoggerTag.PushLoggerTag)
@@ -71,7 +74,12 @@ class DefaultPushHandler(
         if (buildMeta.lowPrivacyLoggingEnabled) {
             Timber.tag(loggerTag.value).d("## pushData: $pushData")
         }
-        incrementPushDataStore.incrementPushCounter()
+
+        // Update the push counter without blocking the coroutine execution, as it is not critical to be updated before handling the push
+        CoroutineScope(currentCoroutineContext()).launch {
+            incrementPushDataStore.incrementPushCounter()
+        }
+
         // Diagnostic Push
         if (pushData.eventId == DefaultTestPush.TEST_EVENT_ID) {
             pushHistoryService.onDiagnosticPush(providerInfo)
@@ -130,10 +138,11 @@ class DefaultPushHandler(
 
             Timber.d("Queueing notification: $pushRequest")
             pushHistoryService.insertOrUpdatePushRequest(pushRequest)
+            Timber.d("Queueing notification finished")
 
             if (!workManagerScheduler.hasPendingWork(userId, WorkManagerRequestType.NOTIFICATION_SYNC)) {
                 Timber.d("No pending worker for push notifications found")
-                workManagerScheduler.submit(syncPendingNotificationsRequestFactory.create(userId))
+                workManagerScheduler.submit(syncPendingNotificationsRequestFactory.create(userId, pushData.clientSecret))
             }
         } catch (e: Exception) {
             Timber.tag(loggerTag.value).e(e, "## handleInternal() failed")

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
@@ -8,15 +8,13 @@
 package io.element.android.libraries.push.impl.push
 
 import android.content.Context
-import android.os.PowerManager
-import androidx.core.content.getSystemService
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.di.annotations.ApplicationContext
 import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import timber.log.Timber
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 
 @ContributesBinding(AppScope::class)
@@ -24,30 +22,24 @@ import kotlin.time.Duration
 class DefaultPushHandlingWakeLock(
     @ApplicationContext private val context: Context,
 ) : PushHandlingWakeLock {
-    private val wakeLocks = ConcurrentHashMap<String, PowerManager.WakeLock>()
+    private val count = AtomicInteger(0)
 
-    override fun lock(key: String, time: Duration) {
-        Timber.d("Acquiring wakelock for push handling, key: $key.")
-        // Get or create a wakelock for this instance to ensure the device stays awake while we handle the push and schedule and run the work
-        val wakeLock = wakeLocks.getOrPut(key) {
-            val powerManager = context.getSystemService<PowerManager>()!!
-            powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag(key)).apply {
-                setReferenceCounted(false)
-            }
-        }
+    override fun lock(time: Duration) {
+        Timber.d("Acquiring wakelock for push handling, starting service.")
+        FetchPushForegroundService.startIfNeeded(context)
 
-        if (wakeLock.isHeld) {
-            // If the wakelock is already held, we need to release it before acquiring it again with a new timeout
-            wakeLock.release()
-        }
-
-        wakeLock.acquire(time.inWholeMilliseconds)
+        count.incrementAndGet()
     }
 
-    override fun unlock(key: String) {
-        Timber.d("Releasing wakelock used for push handling, key: $key.")
-        wakeLocks[key]?.release()
+    override fun unlock() {
+        Timber.d("Releasing wakelock used for push handling.")
+        FetchPushForegroundService.stop(context)
+        if (count.decrementAndGet() <= 0) {
+            Timber.d("No more wakelock needed for push handling, stopping service.")
+            count.set(0)
+        } else {
+            Timber.d("Wakelock still needed for push handling, restarting service | count: ${count.get()}.")
+            FetchPushForegroundService.startIfNeeded(context)
+        }
     }
-
-    private fun tag(key: String) = "push:wakelock:$key"
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.impl.push
+
+import android.content.Context
+import android.os.PowerManager
+import androidx.core.content.getSystemService
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.di.annotations.ApplicationContext
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
+
+@ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
+class DefaultPushHandlingWakeLock(
+    @ApplicationContext private val context: Context,
+) : PushHandlingWakeLock {
+    private val wakeLocks = ConcurrentHashMap<String, PowerManager.WakeLock>()
+
+    override fun lock(key: String, time: Duration) {
+        Timber.d("Acquiring wakelock for push handling, key: $key.")
+        // Get or create a wakelock for this instance to ensure the device stays awake while we handle the push and schedule and run the work
+        val wakeLock = wakeLocks.getOrPut(key) {
+            val powerManager = context.getSystemService<PowerManager>()!!
+            powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag(key)).apply {
+                setReferenceCounted(false)
+            }
+        }
+
+        if (wakeLock.isHeld) {
+            // If the wakelock is already held, we need to release it before acquiring it again with a new timeout
+            wakeLock.release()
+        }
+
+        wakeLock.acquire(time.inWholeMilliseconds)
+    }
+
+    override fun unlock(key: String) {
+        Timber.d("Releasing wakelock used for push handling, key: $key.")
+        wakeLocks[key]?.release()
+    }
+
+    private fun tag(key: String) = "push:wakelock:$key"
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/FetchPushForegroundService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/FetchPushForegroundService.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.impl.push
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+import dev.zacsweers.metro.Inject
+import io.element.android.libraries.architecture.bindings
+import io.element.android.libraries.designsystem.utils.CommonDrawables
+import io.element.android.libraries.di.annotations.AppCoroutineScope
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
+import io.element.android.libraries.push.impl.di.PushBindings
+import io.element.android.libraries.push.impl.notifications.channels.NotificationChannels
+import io.element.android.libraries.ui.strings.CommonStrings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.minutes
+
+private const val NOTIFICATION_ID = 1001
+
+// This kind of foreground service can only last up to 3 minutes before onTimeout is called
+private val wakelockTimeout = 3.minutes.inWholeMilliseconds
+
+/**
+ * Foreground service used to ensure the device stays awake while we handle the pushes and schedule and run the work to fetch the notification content.
+ */
+class FetchPushForegroundService : Service() {
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    @Inject lateinit var notificationChannels: NotificationChannels
+    @Inject lateinit var pushHandlingWakeLock: PushHandlingWakeLock
+    @Inject @AppCoroutineScope lateinit var coroutineScope: CoroutineScope
+
+    private val wakelock: PowerManager.WakeLock by lazy {
+        val powerManager = getSystemService(POWER_SERVICE) as PowerManager
+        powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "FetchPushService:WakeLock").apply {
+            setReferenceCounted(false)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        bindings<PushBindings>().inject(this)
+
+        wakelock.acquire(wakelockTimeout)
+
+        val notificationCompat = NotificationCompat.Builder(this, notificationChannels.getSilentChannelId())
+            .setSmallIcon(CommonDrawables.ic_notification)
+            .setContentTitle(getString(CommonStrings.common_android_fetching_notifications_title))
+            .setProgress(0, 0, true)
+            .setVibrate(longArrayOf(0))
+            .setSound(null)
+            .build()
+        startForeground(NOTIFICATION_ID, notificationCompat)
+
+        // The timeout is not automatic before Android 15, so we need to schedule it ourselves
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            coroutineScope.launch {
+                delay(wakelockTimeout)
+                onTimeout(startId)
+            }
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun stopService(intent: Intent?): Boolean {
+        wakelock.release()
+
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        return super.stopService(intent)
+    }
+
+    override fun onTimeout(startId: Int) {
+        super.onTimeout(startId)
+
+        pushHandlingWakeLock.unlock()
+    }
+
+    companion object {
+        fun startIfNeeded(context: Context) {
+            // Don't start the foreground service if the device is already awake
+            val powerManager = context.getSystemService(POWER_SERVICE) as PowerManager
+            if (powerManager.isInteractive) return
+
+            start(context)
+        }
+
+        fun start(context: Context) {
+            val intent = Intent(context, FetchPushForegroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, FetchPushForegroundService::class.java)
+            context.stopService(intent)
+        }
+    }
+}

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
@@ -25,6 +25,7 @@ import io.element.android.libraries.matrix.api.auth.SessionRestorationException
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.exception.ClientException
 import io.element.android.libraries.matrix.api.exception.isNetworkError
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import io.element.android.libraries.push.impl.db.PushRequest
 import io.element.android.libraries.push.impl.history.PushHistoryService
 import io.element.android.libraries.push.impl.notifications.NotifiableEventResolver
@@ -57,6 +58,7 @@ class FetchPendingNotificationsWorker(
     private val resultProcessor: NotificationResultProcessor,
     private val analyticsService: AnalyticsService,
     private val systemClock: SystemClock,
+    private val pushHandlingWakeLock: PushHandlingWakeLock,
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
         Timber.d("FetchNotificationsWorker started")
@@ -64,6 +66,8 @@ class FetchPendingNotificationsWorker(
         val sessionId = runCatchingExceptions {
             inputData.getString(SyncPendingNotificationsRequestBuilder.SESSION_ID)?.let(::SessionId)
         }.getOrNull() ?: return Result.failure()
+
+        val wakeLockKey = inputData.getString(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)
 
         // Fetch pending requests in the last 24 hours
         val fetchSince = Instant.fromEpochMilliseconds(systemClock.epochMillis()).minus(1.days)
@@ -78,7 +82,10 @@ class FetchPendingNotificationsWorker(
             return Result.success()
         }
 
-        checkNetworkConnection(requests)?.let { failure -> return failure }
+        checkNetworkConnection(requests)?.let { failure ->
+            wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
+            return failure
+        }
 
         Timber.d("Fetching ${requests.size} push requests")
 
@@ -101,9 +108,11 @@ class FetchPendingNotificationsWorker(
 
                     results
                 },
-                onFailure = {
+                onFailure = { throwable ->
                     // This is a failure at the fetch notification setup, not a failure for a single fetch notification operation
-                    return handleSetupError(sessionId, requests, pendingAnalyticTransactions, it)
+                    return handleSetupError(sessionId, requests, pendingAnalyticTransactions, throwable).also {
+                        wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
+                    }
                 }
             )
 
@@ -130,6 +139,9 @@ class FetchPendingNotificationsWorker(
         analyticsService.recordTransaction("Opportunistic sync", "opportunistic_sync") {
             performOpportunisticSyncIfNeeded(mapOf(sessionId to requests))
         }
+
+        // Unlock the associated wakelock ahead of time
+        wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
 
         return if (updatedRequests.any { it.status == PushRequestStatus.PENDING.value }) Result.retry() else Result.success()
     }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
@@ -67,7 +67,7 @@ class FetchPendingNotificationsWorker(
             inputData.getString(SyncPendingNotificationsRequestBuilder.SESSION_ID)?.let(::SessionId)
         }.getOrNull() ?: return Result.failure()
 
-        val wakeLockKey = inputData.getString(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)
+        pushHandlingWakeLock.unlock()
 
         // Fetch pending requests in the last 24 hours
         val fetchSince = Instant.fromEpochMilliseconds(systemClock.epochMillis()).minus(1.days)
@@ -82,10 +82,7 @@ class FetchPendingNotificationsWorker(
             return Result.success()
         }
 
-        checkNetworkConnection(requests)?.let { failure ->
-            wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
-            return failure
-        }
+        checkNetworkConnection(requests)?.let { failure -> return failure }
 
         Timber.d("Fetching ${requests.size} push requests")
 
@@ -110,9 +107,7 @@ class FetchPendingNotificationsWorker(
                 },
                 onFailure = { throwable ->
                     // This is a failure at the fetch notification setup, not a failure for a single fetch notification operation
-                    return handleSetupError(sessionId, requests, pendingAnalyticTransactions, throwable).also {
-                        wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
-                    }
+                    return handleSetupError(sessionId, requests, pendingAnalyticTransactions, throwable)
                 }
             )
 
@@ -139,9 +134,6 @@ class FetchPendingNotificationsWorker(
         analyticsService.recordTransaction("Opportunistic sync", "opportunistic_sync") {
             performOpportunisticSyncIfNeeded(mapOf(sessionId to requests))
         }
-
-        // Unlock the associated wakelock ahead of time
-        wakeLockKey?.let { pushHandlingWakeLock.unlock(it) }
 
         return if (updatedRequests.any { it.status == PushRequestStatus.PENDING.value }) Result.retry() else Result.success()
     }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
@@ -27,7 +27,6 @@ import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.push.impl.workmanager.SyncPendingNotificationsRequestBuilder.Companion.SESSION_ID
-import io.element.android.libraries.push.impl.workmanager.SyncPendingNotificationsRequestBuilder.Companion.WAKELOCK_KEY
 import io.element.android.libraries.workmanager.api.WorkManagerRequestBuilder
 import io.element.android.libraries.workmanager.api.WorkManagerRequestType
 import io.element.android.libraries.workmanager.api.WorkManagerRequestWrapper
@@ -39,19 +38,17 @@ import timber.log.Timber
 
 interface SyncPendingNotificationsRequestBuilder : WorkManagerRequestBuilder {
     fun interface Factory {
-        fun create(sessionId: SessionId, wakeLockKey: String): SyncPendingNotificationsRequestBuilder
+        fun create(sessionId: SessionId): SyncPendingNotificationsRequestBuilder
     }
 
     companion object {
         const val SESSION_ID = "session_id"
-        const val WAKELOCK_KEY = "wakelock_key"
     }
 }
 
 @AssistedInject
 class DefaultSyncPendingNotificationsRequestBuilder(
     @Assisted private val sessionId: SessionId,
-    @Assisted private val wakeLockKey: String,
     private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
     private val networkMonitor: NetworkMonitor,
     private val featureFlagService: FeatureFlagService,
@@ -59,7 +56,7 @@ class DefaultSyncPendingNotificationsRequestBuilder(
     @AssistedFactory
     @ContributesBinding(AppScope::class)
     interface Factory : SyncPendingNotificationsRequestBuilder.Factory {
-        override fun create(sessionId: SessionId, wakeLockKey: String): DefaultSyncPendingNotificationsRequestBuilder
+        override fun create(sessionId: SessionId): DefaultSyncPendingNotificationsRequestBuilder
     }
 
     override suspend fun build(): Result<List<WorkManagerRequestWrapper>> {
@@ -93,7 +90,7 @@ class DefaultSyncPendingNotificationsRequestBuilder(
             .build()
 
         val request = OneTimeWorkRequestBuilder<FetchPendingNotificationsWorker>()
-            .setInputData(workDataOf(SESSION_ID to sessionId.value, WAKELOCK_KEY to wakeLockKey))
+            .setInputData(workDataOf(SESSION_ID to sessionId.value))
             .apply {
                 // Expedited workers aren't needed on Android 12 or lower:
                 // They force displaying a foreground sync notification for no good reason, since they sync almost immediately anyway

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
@@ -27,6 +27,7 @@ import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.push.impl.workmanager.SyncPendingNotificationsRequestBuilder.Companion.SESSION_ID
+import io.element.android.libraries.push.impl.workmanager.SyncPendingNotificationsRequestBuilder.Companion.WAKELOCK_KEY
 import io.element.android.libraries.workmanager.api.WorkManagerRequestBuilder
 import io.element.android.libraries.workmanager.api.WorkManagerRequestType
 import io.element.android.libraries.workmanager.api.WorkManagerRequestWrapper
@@ -38,17 +39,19 @@ import timber.log.Timber
 
 interface SyncPendingNotificationsRequestBuilder : WorkManagerRequestBuilder {
     fun interface Factory {
-        fun create(sessionId: SessionId): SyncPendingNotificationsRequestBuilder
+        fun create(sessionId: SessionId, wakeLockKey: String): SyncPendingNotificationsRequestBuilder
     }
 
     companion object {
         const val SESSION_ID = "session_id"
+        const val WAKELOCK_KEY = "wakelock_key"
     }
 }
 
 @AssistedInject
 class DefaultSyncPendingNotificationsRequestBuilder(
     @Assisted private val sessionId: SessionId,
+    @Assisted private val wakeLockKey: String,
     private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
     private val networkMonitor: NetworkMonitor,
     private val featureFlagService: FeatureFlagService,
@@ -56,7 +59,7 @@ class DefaultSyncPendingNotificationsRequestBuilder(
     @AssistedFactory
     @ContributesBinding(AppScope::class)
     interface Factory : SyncPendingNotificationsRequestBuilder.Factory {
-        override fun create(sessionId: SessionId): DefaultSyncPendingNotificationsRequestBuilder
+        override fun create(sessionId: SessionId, wakeLockKey: String): DefaultSyncPendingNotificationsRequestBuilder
     }
 
     override suspend fun build(): Result<List<WorkManagerRequestWrapper>> {
@@ -90,7 +93,7 @@ class DefaultSyncPendingNotificationsRequestBuilder(
             .build()
 
         val request = OneTimeWorkRequestBuilder<FetchPendingNotificationsWorker>()
-            .setInputData(workDataOf(SESSION_ID to sessionId.value))
+            .setInputData(workDataOf(SESSION_ID to sessionId.value, WAKELOCK_KEY to wakeLockKey))
             .apply {
                 // Expedited workers aren't needed on Android 12 or lower:
                 // They force displaying a foreground sync notification for no good reason, since they sync almost immediately anyway

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
@@ -42,6 +42,7 @@ import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.lambda.value
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -173,6 +174,10 @@ class DefaultPushHandlerTest {
                 workManagerScheduler = workManagerScheduler,
             )
             defaultPushHandler.handle(aPushData, A_PUSHER_INFO)
+
+            // Give it enough time to increment the push counter
+            runCurrent()
+
             submitWorkLambda.assertions()
                 .isNeverCalled()
             incrementPushCounterResult.assertions()
@@ -239,7 +244,7 @@ class DefaultPushHandlerTest {
             systemClock = systemClock,
             workManagerScheduler = workManagerScheduler,
             resultProcessor = resultProcessor,
-            syncPendingNotificationsRequestFactory = SyncPendingNotificationsRequestBuilder.Factory {
+            syncPendingNotificationsRequestFactory = SyncPendingNotificationsRequestBuilder.Factory { _, _ ->
                 FakeSyncPendingNotificationsRequestBuilder()
             }
         )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlerTest.kt
@@ -244,7 +244,7 @@ class DefaultPushHandlerTest {
             systemClock = systemClock,
             workManagerScheduler = workManagerScheduler,
             resultProcessor = resultProcessor,
-            syncPendingNotificationsRequestFactory = SyncPendingNotificationsRequestBuilder.Factory { _, _ ->
+            syncPendingNotificationsRequestFactory = SyncPendingNotificationsRequestBuilder.Factory {
                 FakeSyncPendingNotificationsRequestBuilder()
             }
         )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
@@ -43,7 +43,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             result.request.run {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
-                assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
                 // True in API 33+
                 assertThat(workSpec.expedited).isTrue()
@@ -67,7 +66,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             result.request.run {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
-                assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
                 // False before API 33
                 assertThat(workSpec.expedited).isFalse()
@@ -145,11 +143,9 @@ private fun createSyncPendingNotificationsRequestBuilder(
     sdkVersion: Int = 33,
     isInAirGapEnvironment: Boolean = false,
     featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(),
-    wakeLockKey: String = "a_wake_lock_key",
 ) = DefaultSyncPendingNotificationsRequestBuilder(
     sessionId = sessionId,
     buildVersionSdkIntProvider = FakeBuildVersionSdkIntProvider(sdkVersion),
     networkMonitor = FakeNetworkMonitor().apply { givenIsInAirGappedEnvironment(isInAirGapEnvironment) },
     featureFlagService = featureFlagService,
-    wakeLockKey = wakeLockKey,
 )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
@@ -26,10 +26,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
 @RunWith(AndroidJUnit4::class)
 class DefaultSyncPendingNotificationsRequestBuilderTest {
     @Test
-    @Config(sdk = [33])
     fun `build - success API 33`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -53,7 +53,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
-    @Config(sdk = [32])
     fun `build - success API 32 and lower`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -78,7 +77,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
-    @Config(sdk = [33])
     fun `build - has NET_CAPABILITY_VALIDATED constraint if not in air-gapped env`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -99,7 +97,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
-    @Config(sdk = [33])
     fun `build - does not have NET_CAPABILITY_VALIDATED constraint if in air-gapped env`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -120,7 +117,6 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
-    @Config(sdk = [33])
     fun `build - does not have NET_CAPABILITY_VALIDATED constraint if feature flag is disabled`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
@@ -24,10 +24,12 @@ import io.element.android.services.toolbox.test.sdk.FakeBuildVersionSdkIntProvid
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class DefaultSyncPendingNotificationsRequestBuilderTest {
     @Test
+    @Config(sdk = [33])
     fun `build - success API 33`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -41,6 +43,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             result.request.run {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
+                assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
                 // True in API 33+
                 assertThat(workSpec.expedited).isTrue()
@@ -50,6 +53,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
+    @Config(sdk = [32])
     fun `build - success API 32 and lower`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -64,6 +68,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             result.request.run {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
+                assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.WAKELOCK_KEY)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
                 // False before API 33
                 assertThat(workSpec.expedited).isFalse()
@@ -73,6 +78,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
+    @Config(sdk = [33])
     fun `build - has NET_CAPABILITY_VALIDATED constraint if not in air-gapped env`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -93,6 +99,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
+    @Config(sdk = [33])
     fun `build - does not have NET_CAPABILITY_VALIDATED constraint if in air-gapped env`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -113,6 +120,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
     }
 
     @Test
+    @Config(sdk = [33])
     fun `build - does not have NET_CAPABILITY_VALIDATED constraint if feature flag is disabled`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
@@ -141,9 +149,11 @@ private fun createSyncPendingNotificationsRequestBuilder(
     sdkVersion: Int = 33,
     isInAirGapEnvironment: Boolean = false,
     featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(),
+    wakeLockKey: String = "a_wake_lock_key",
 ) = DefaultSyncPendingNotificationsRequestBuilder(
     sessionId = sessionId,
     buildVersionSdkIntProvider = FakeBuildVersionSdkIntProvider(sdkVersion),
     networkMonitor = FakeNetworkMonitor().apply { givenIsInAirGappedEnvironment(isInAirGapEnvironment) },
     featureFlagService = featureFlagService,
+    wakeLockKey = wakeLockKey,
 )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
@@ -28,6 +28,7 @@ import io.element.android.libraries.push.impl.notifications.FakeNotificationResu
 import io.element.android.libraries.push.impl.notifications.fixtures.aPushRequest
 import io.element.android.libraries.push.impl.notifications.model.ResolvedPushEvent
 import io.element.android.libraries.push.impl.push.SyncOnNotifiableEvent
+import io.element.android.libraries.push.test.push.FakePushHandlingWakeLock
 import io.element.android.libraries.workmanager.api.WorkManagerRequestBuilder
 import io.element.android.libraries.workmanager.api.di.MetroWorkerFactory
 import io.element.android.services.analytics.test.FakeAnalyticsService
@@ -238,6 +239,7 @@ class FetchPendingNotificationWorkerTest {
         pushHistoryService: FakePushHistoryService = FakePushHistoryService(),
         resultProcessor: FakeNotificationResultProcessor = FakeNotificationResultProcessor(),
         systemClock: FakeSystemClock = FakeSystemClock(),
+        pushHandlingWakeLock: FakePushHandlingWakeLock = FakePushHandlingWakeLock(),
     ) = FetchPendingNotificationsWorker(
         params = createWorkerParams(workDataOf("session_id" to input)),
         context = InstrumentationRegistry.getInstrumentation().context,
@@ -248,6 +250,7 @@ class FetchPendingNotificationWorkerTest {
         pushHistoryService = pushHistoryService,
         resultProcessor = resultProcessor,
         systemClock = systemClock,
+        pushHandlingWakeLock = pushHandlingWakeLock,
     )
 
     private fun TestScope.createWorkerParams(

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/push/FakePushHandlingWakeLock.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/push/FakePushHandlingWakeLock.kt
@@ -11,14 +11,14 @@ import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import kotlin.time.Duration
 
 class FakePushHandlingWakeLock(
-    private val lock: (key: String, time: Duration) -> Unit = { _, _ -> },
-    private val unlock: (key: String) -> Unit = { _ -> },
+    private val lock: (time: Duration) -> Unit = {},
+    private val unlock: () -> Unit = {},
 ) : PushHandlingWakeLock {
-    override fun lock(key: String, time: Duration) {
-        lock.invoke(key, time)
+    override fun lock(time: Duration) {
+        lock.invoke(time)
     }
 
-    override fun unlock(key: String) {
-        unlock.invoke(key)
+    override fun unlock() {
+        unlock.invoke()
     }
 }

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/push/FakePushHandlingWakeLock.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/push/FakePushHandlingWakeLock.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.push.test.push
+
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
+import kotlin.time.Duration
+
+class FakePushHandlingWakeLock(
+    private val lock: (key: String, time: Duration) -> Unit = { _, _ -> },
+    private val unlock: (key: String) -> Unit = { _ -> },
+) : PushHandlingWakeLock {
+    override fun lock(key: String, time: Duration) {
+        lock.invoke(key, time)
+    }
+
+    override fun unlock(key: String) {
+        unlock.invoke(key)
+    }
+}

--- a/libraries/pushproviders/firebase/build.gradle.kts
+++ b/libraries/pushproviders/firebase/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(projects.libraries.core)
     implementation(projects.libraries.di)
     implementation(projects.libraries.matrix.api)
+    implementation(projects.libraries.push.api)
     implementation(projects.libraries.uiStrings)
     implementation(projects.libraries.troubleshoot.api)
     implementation(projects.services.toolbox.api)

--- a/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingService.kt
+++ b/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingService.kt
@@ -44,12 +44,12 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         Timber.tag(loggerTag.value).w("New Firebase message. Priority: ${message.priority}/${message.originalPriority}")
-        val pushData = pushParser.parse(message.data)
 
         // Acquire wakelock to ensure the device stays awake while we handle the push and schedule and run the work
-        pushData?.clientSecret?.let { pushHandlingWakeLock.lock(it) }
+        pushHandlingWakeLock.lock()
 
         coroutineScope.launch {
+            val pushData = pushParser.parse(message.data)
             if (pushData == null) {
                 Timber.tag(loggerTag.value).w("Invalid data received from Firebase")
                 pushHandler.handleInvalid(

--- a/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingService.kt
+++ b/libraries/pushproviders/firebase/src/main/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingService.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.Inject
 import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.di.annotations.AppCoroutineScope
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import io.element.android.libraries.pushproviders.api.PushHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -25,6 +26,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
     @Inject lateinit var firebaseNewTokenHandler: FirebaseNewTokenHandler
     @Inject lateinit var pushParser: FirebasePushParser
     @Inject lateinit var pushHandler: PushHandler
+    @Inject lateinit var pushHandlingWakeLock: PushHandlingWakeLock
     @AppCoroutineScope
     @Inject lateinit var coroutineScope: CoroutineScope
 
@@ -42,8 +44,12 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         Timber.tag(loggerTag.value).w("New Firebase message. Priority: ${message.priority}/${message.originalPriority}")
+        val pushData = pushParser.parse(message.data)
+
+        // Acquire wakelock to ensure the device stays awake while we handle the push and schedule and run the work
+        pushData?.clientSecret?.let { pushHandlingWakeLock.lock(it) }
+
         coroutineScope.launch {
-            val pushData = pushParser.parse(message.data)
             if (pushData == null) {
                 Timber.tag(loggerTag.value).w("Invalid data received from Firebase")
                 pushHandler.handleInvalid(

--- a/libraries/pushproviders/firebase/src/test/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingServiceTest.kt
+++ b/libraries/pushproviders/firebase/src/test/kotlin/io/element/android/libraries/pushproviders/firebase/VectorFirebaseMessagingServiceTest.kt
@@ -15,6 +15,7 @@ import com.google.firebase.messaging.RemoteMessage
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SECRET
+import io.element.android.libraries.push.test.push.FakePushHandlingWakeLock
 import io.element.android.libraries.push.test.test.FakePushHandler
 import io.element.android.libraries.pushproviders.api.PushData
 import io.element.android.libraries.pushproviders.api.PushHandler
@@ -93,12 +94,14 @@ class VectorFirebaseMessagingServiceTest {
     private fun TestScope.createVectorFirebaseMessagingService(
         firebaseNewTokenHandler: FirebaseNewTokenHandler = FakeFirebaseNewTokenHandler(),
         pushHandler: PushHandler = FakePushHandler(),
+        pushHandlingWakeLock: FakePushHandlingWakeLock = FakePushHandlingWakeLock(),
     ): VectorFirebaseMessagingService {
         return VectorFirebaseMessagingService().apply {
             this.firebaseNewTokenHandler = firebaseNewTokenHandler
             this.pushParser = FirebasePushParser()
             this.pushHandler = pushHandler
             this.coroutineScope = this@createVectorFirebaseMessagingService
+            this.pushHandlingWakeLock = pushHandlingWakeLock
         }
     }
 }

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiver.kt
@@ -60,7 +60,7 @@ class VectorUnifiedPushMessagingReceiver : MessagingReceiver() {
      */
     override fun onMessage(context: Context, message: PushMessage, instance: String) {
         // Acquire wakelock to ensure the device stays awake while we handle the push and schedule and run the work
-        pushHandlingWakeLock.lock(instance)
+        pushHandlingWakeLock.lock()
 
         Timber.tag(loggerTag.value).d("New message, decrypted: ${message.decrypted}")
         coroutineScope.launch {

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiver.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiver.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.Inject
 import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.di.annotations.AppCoroutineScope
+import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import io.element.android.libraries.pushproviders.api.PushHandler
 import io.element.android.libraries.pushproviders.unifiedpush.registration.EndpointRegistrationHandler
 import io.element.android.libraries.pushproviders.unifiedpush.registration.RegistrationResult
@@ -37,12 +38,16 @@ class VectorUnifiedPushMessagingReceiver : MessagingReceiver() {
     @Inject lateinit var newGatewayHandler: UnifiedPushNewGatewayHandler
     @Inject lateinit var removedGatewayHandler: UnifiedPushRemovedGatewayHandler
     @Inject lateinit var endpointRegistrationHandler: EndpointRegistrationHandler
+    @Inject lateinit var pushHandlingWakeLock: PushHandlingWakeLock
 
     @AppCoroutineScope
     @Inject lateinit var coroutineScope: CoroutineScope
 
     override fun onReceive(context: Context, intent: Intent) {
-        context.bindings<VectorUnifiedPushMessagingReceiverBindings>().inject(this)
+        // We only need to inject this object once
+        if (!this::pushParser.isInitialized) {
+            context.bindings<VectorUnifiedPushMessagingReceiverBindings>().inject(this)
+        }
         super.onReceive(context, intent)
     }
 
@@ -54,6 +59,9 @@ class VectorUnifiedPushMessagingReceiver : MessagingReceiver() {
      * @param instance connection, for multi-account
      */
     override fun onMessage(context: Context, message: PushMessage, instance: String) {
+        // Acquire wakelock to ensure the device stays awake while we handle the push and schedule and run the work
+        pushHandlingWakeLock.lock(instance)
+
         Timber.tag(loggerTag.value).d("New message, decrypted: ${message.decrypted}")
         coroutineScope.launch {
             val pushData = pushParser.parse(message.content, instance)

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiverTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/VectorUnifiedPushMessagingReceiverTest.kt
@@ -18,6 +18,7 @@ import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SECRET
+import io.element.android.libraries.push.test.push.FakePushHandlingWakeLock
 import io.element.android.libraries.push.test.test.FakePushHandler
 import io.element.android.libraries.pushproviders.api.PushData
 import io.element.android.libraries.pushproviders.api.PushHandler
@@ -44,7 +45,7 @@ class VectorUnifiedPushMessagingReceiverTest {
     @Test
     fun `onReceive does the binding`() = runTest {
         val context = InstrumentationRegistry.getInstrumentation().context
-        val vectorUnifiedPushMessagingReceiver = createVectorUnifiedPushMessagingReceiver()
+        val vectorUnifiedPushMessagingReceiver = VectorUnifiedPushMessagingReceiver()
         // The binding is not found in the test env.
         assertThrows(IllegalStateException::class.java) {
             vectorUnifiedPushMessagingReceiver.onReceive(context, Intent())
@@ -208,6 +209,7 @@ class VectorUnifiedPushMessagingReceiverTest {
         unifiedPushNewGatewayHandler: UnifiedPushNewGatewayHandler = FakeUnifiedPushNewGatewayHandler(),
         endpointRegistrationHandler: EndpointRegistrationHandler = EndpointRegistrationHandler(),
         removedGatewayHandler: UnifiedPushRemovedGatewayHandler = UnifiedPushRemovedGatewayHandler { lambdaError() },
+        pushHandlingWakeLock: FakePushHandlingWakeLock = FakePushHandlingWakeLock(),
     ): VectorUnifiedPushMessagingReceiver {
         return VectorUnifiedPushMessagingReceiver().apply {
             this.pushParser = unifiedPushParser
@@ -220,6 +222,7 @@ class VectorUnifiedPushMessagingReceiverTest {
             this.removedGatewayHandler = removedGatewayHandler
             this.endpointRegistrationHandler = endpointRegistrationHandler
             this.coroutineScope = this@createVectorUnifiedPushMessagingReceiver
+            this.pushHandlingWakeLock = pushHandlingWakeLock
         }
     }
 }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -190,6 +190,7 @@
   <string name="common_advanced_settings">"Advanced settings"</string>
   <string name="common_an_image">"an image"</string>
   <string name="common_analytics">"Analytics"</string>
+  <string name="common_android_fetching_notifications_title">"Syncing notifications…"</string>
   <string name="common_android_shortcuts_remove_reason_left_room">"You left the room"</string>
   <string name="common_android_shortcuts_remove_reason_session_logged_out">"You were logged out of the session"</string>
   <string name="common_appearance">"Appearance"</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

- Creates `PushHandlingWakeLock` to centralise how wake locks for push notification handling are used: it'll control when we start the foreground service that will keep the device awake when scheduling push notification resolving. This foreground service will only be started if the device is not in 'interactive' mode, which means the CPU can enter deep sleep at any time.
- Acquire this wakelock for 3 minutes as soon as we receive a push notification in this service. The 3 minute limit comes from the type of foreground service, which has a matching timeout value.
- When we're starting processing the notifications for a session, stop the service and release the wakelock early if possible.
- When we try to stop the service, if there are still pending operations, restart the service so those are also processed without the CPU going into deep sleep.

## Motivation and context

This ensures the notification fetching is done as soon as possible when the device is locked/idle:

1. The async code that would previously skip some extra time while waiting for continuations (i.e. 10s timeout turning into 1-2 min) will behave as expected.
2. Same for coroutines launched with the wakelock enabled.
3. The expedited workers scheduled with the wakelock acquired should execute immediately: previously this could take several seconds, or even 10-20s.

## Tests

Everything should still work as expected, but notifications should be displayed earlier.

I tested this both with Firebase and UnifiedPush and could notice how pushes that could take 10-20s to display before when the device was locked displayed in at most 5s now.

If you want to test it yourself, just disconnect and lock your device so it can go into deep sleep, wait for 10-20s, then trigger some action that will make you receive a push notification. Having a EW session open can be useful too, to verify the timing: if you have another device to compare to, you'll see the one using this branch will display a notification at most 1-2s after EW does, if not simultaneously, while the one using the current `develop` can take >10s if it's hit with a particularly bad deep sleep state. Using UnifiedPush makes the tests more reliable as they don't have the FCM wakelock to prevent deep sleep, although using Firebase does not always prevent this behaviour, it's way more unlikely, but it can still happen if we don't start the wakelock/foreground service.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
