### PR TITLE
Renovate: add a cooldown of 7 days for dependencies that we do not manage

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,15 @@
     "string:app_name",
     "gradle",
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
+    {
+      "matchPackageNames": [
+        "org.matrix.rustcomponents:sdk-android",
+        "/^io.element.android/",
+      ],
+      "minimumReleaseAge": null,
+    },
     {
       "groupName": "kotlin",
       "matchPackageNames": [
@@ -37,4 +45,3 @@
     },
   ],
 }
-


### PR DESCRIPTION
All is in the title.