### PR TITLE
Do not show "Not Encrypted" badge for public rooms

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -87,7 +87,7 @@ class AttachmentsPreviewPresenter(
 
         val markdownTextEditorState = rememberMarkdownTextEditorState(initialText = null, initialFocus = false)
         val textEditorState by rememberUpdatedState(
-            TextEditorState.Markdown(markdownTextEditorState, isRoomEncrypted = null)
+            TextEditorState.Markdown(markdownTextEditorState, isRoomEncrypted = null, isRoomPublic = null)
         )
 
         val ongoingSendAttachmentJob = remember { mutableStateOf<Job?>(null) }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -212,9 +212,9 @@ class MessageComposerPresenter(
 
         val textEditorState by rememberUpdatedState(
             if (showTextFormatting) {
-                TextEditorState.Rich(richTextEditorState, roomInfo.isEncrypted == true)
+                TextEditorState.Rich(richTextEditorState, roomInfo.isEncrypted == true, roomInfo.isPublic == true)
             } else {
-                TextEditorState.Markdown(markdownTextEditorState, roomInfo.isEncrypted == true)
+                TextEditorState.Markdown(markdownTextEditorState, roomInfo.isEncrypted == true, roomInfo.isPublic == true)
             }
         )
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -373,6 +373,7 @@ fun TextComposer(
         TextFormattingLayout(
             modifier = layoutModifier,
             isRoomEncrypted = state.isRoomEncrypted,
+            isRoomPublic = state.isRoomPublic,
             textInput = textInput,
             dismissTextFormattingButton = {
                 IconColorButton(
@@ -390,6 +391,7 @@ fun TextComposer(
             composerMode = composerMode,
             voiceMessageState = voiceMessageState,
             isRoomEncrypted = state.isRoomEncrypted,
+            isRoomPublic = state.isRoomPublic,
             modifier = layoutModifier,
             textInput = textInput,
             endButtonParams = endButtonParams,
@@ -431,6 +433,7 @@ private fun StandardLayout(
     composerMode: MessageComposerMode,
     voiceMessageState: VoiceMessageState,
     isRoomEncrypted: Boolean?,
+    isRoomPublic: Boolean?,
     textInput: @Composable () -> Unit,
     voiceRecording: @Composable () -> Unit,
     endButtonParams: EndButtonParams,
@@ -440,7 +443,7 @@ private fun StandardLayout(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        if (isRoomEncrypted == false) {
+        if (isRoomEncrypted == false && isRoomPublic == false) {
             Spacer(Modifier.height(16.dp))
             NotEncryptedBadge()
             Spacer(Modifier.height(4.dp))
@@ -549,6 +552,7 @@ private fun NotEncryptedBadge() {
 @Composable
 private fun TextFormattingLayout(
     isRoomEncrypted: Boolean?,
+    isRoomPublic: Boolean?,
     textInput: @Composable () -> Unit,
     dismissTextFormattingButton: @Composable () -> Unit,
     textFormatting: @Composable () -> Unit,
@@ -559,7 +563,7 @@ private fun TextFormattingLayout(
         modifier = modifier.padding(vertical = 4.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        if (isRoomEncrypted == false) {
+        if (isRoomEncrypted == false && isRoomPublic == false) {
             NotEncryptedBadge()
             Spacer(Modifier.height(8.dp))
         }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/Fixtures.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/Fixtures.kt
@@ -14,6 +14,7 @@ fun aTextEditorStateMarkdown(
     initialText: String? = "",
     initialFocus: Boolean = false,
     isRoomEncrypted: Boolean? = null,
+    isRoomPublic: Boolean? = null,
 ): TextEditorState {
     return TextEditorState.Markdown(
         aMarkdownTextEditorState(
@@ -21,6 +22,7 @@ fun aTextEditorStateMarkdown(
             initialFocus = initialFocus,
         ),
         isRoomEncrypted = isRoomEncrypted,
+        isRoomPublic = isRoomPublic,
     )
 }
 
@@ -40,6 +42,7 @@ fun aTextEditorStateRich(
     initialMarkdown: String = initialText,
     initialFocus: Boolean = false,
     isRoomEncrypted: Boolean? = null,
+    isRoomPublic: Boolean? = null,
 ): TextEditorState {
     return TextEditorState.Rich(
         aRichTextEditorState(
@@ -49,6 +52,7 @@ fun aTextEditorStateRich(
             initialFocus = initialFocus,
         ),
         isRoomEncrypted = isRoomEncrypted,
+        isRoomPublic = isRoomPublic,
     )
 }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/TextEditorState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/TextEditorState.kt
@@ -15,15 +15,18 @@ import io.element.android.wysiwyg.compose.RichTextEditorState
 @Immutable
 sealed interface TextEditorState {
     val isRoomEncrypted: Boolean?
+    val isRoomPublic: Boolean?
 
     data class Markdown(
         val state: MarkdownTextEditorState,
         override val isRoomEncrypted: Boolean?,
+        override val isRoomPublic: Boolean? = null,
     ) : TextEditorState
 
     data class Rich(
         val richTextEditorState: RichTextEditorState,
         override val isRoomEncrypted: Boolean?,
+        override val isRoomPublic: Boolean? = null,
     ) : TextEditorState
 
     fun messageHtml(): String? = when (this) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Do not show "Not Encrypted" badge for public rooms

## Motivation and context

There's no point in warning that a public room isn't encrypted, because anyone can still join it and view the messages, even if encryption is in place.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

- See a public room
- It shouldn't show "Not Encrypted" badge above the message composer

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
