### PR TITLE
feat: Add foreground MediaSessionService for background media playback

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,7 @@ androidx_media3_ui = { module = "androidx.media3:media3-ui", version.ref = "medi
 androidx_media3_transformer = { module = "androidx.media3:media3-transformer", version.ref = "media3" }
 androidx_media3_effect = { module = "androidx.media3:media3-effect", version.ref = "media3" }
 androidx_media3_common = { module = "androidx.media3:media3-common", version.ref = "media3" }
+androidx_media3_session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 androidx_biometric = "androidx.biometric:biometric-ktx:1.4.0-alpha02"
 
 androidx_activity_activity = { module = "androidx.activity:activity", version.ref = "activity" }

--- a/libraries/mediaviewer/impl/build.gradle.kts
+++ b/libraries/mediaviewer/impl/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.ui)
+    implementation(libs.androidx.media3.session)
     implementation(libs.telephoto.zoomableimage)
     implementation(libs.vanniktech.blurhash)
     implementation(libs.telephoto.flick)

--- a/libraries/mediaviewer/impl/src/main/AndroidManifest.xml
+++ b/libraries/mediaviewer/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 Element Creations Ltd.
+  ~
+  ~ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  ~ Please see LICENSE files in the repository root for full details.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
+    <application>
+        <service
+            android:name=".local.player.MediaPlaybackService"
+            android:enabled="true"
+            android:exported="true"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -43,12 +44,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
-import androidx.lifecycle.Lifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import io.element.android.compound.theme.ElementTheme
@@ -60,7 +59,6 @@ import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.toDp
 import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.Text
-import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.mediaviewer.api.MediaInfo
 import io.element.android.libraries.mediaviewer.api.helper.formatFileExtensionAndSize
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
@@ -68,7 +66,7 @@ import io.element.android.libraries.mediaviewer.impl.local.LocalMediaViewState
 import io.element.android.libraries.mediaviewer.impl.local.PlayableState
 import io.element.android.libraries.mediaviewer.impl.local.player.MediaPlayerControllerState
 import io.element.android.libraries.mediaviewer.impl.local.player.MediaPlayerControllerView
-import io.element.android.libraries.mediaviewer.impl.local.player.rememberExoPlayer
+import io.element.android.libraries.mediaviewer.impl.local.player.rememberMediaServicePlayer
 import io.element.android.libraries.mediaviewer.impl.local.player.seekToEnsurePlaying
 import io.element.android.libraries.mediaviewer.impl.local.player.togglePlay
 import io.element.android.libraries.mediaviewer.impl.local.rememberLocalMediaViewState
@@ -86,29 +84,29 @@ fun MediaAudioView(
     modifier: Modifier = Modifier,
     isDisplayed: Boolean = true,
 ) {
-    val exoPlayer = rememberExoPlayer()
-    ExoPlayerMediaAudioView(
-        isDisplayed = isDisplayed,
-        localMediaViewState = localMediaViewState,
-        bottomPaddingInPixels = bottomPaddingInPixels,
-        exoPlayer = exoPlayer,
-        localMedia = localMedia,
-        info = info,
-        audioFocus = audioFocus,
-        modifier = modifier,
-    )
+    val player = rememberMediaServicePlayer()
+    if (player != null) {
+        ServicePlayerMediaAudioView(
+            isDisplayed = isDisplayed,
+            localMediaViewState = localMediaViewState,
+            bottomPaddingInPixels = bottomPaddingInPixels,
+            player = player,
+            localMedia = localMedia,
+            info = info,
+            modifier = modifier,
+        )
+    }
 }
 
 @SuppressLint("UnsafeOptInUsageError")
 @Composable
-private fun ExoPlayerMediaAudioView(
+private fun ServicePlayerMediaAudioView(
     isDisplayed: Boolean,
     localMediaViewState: LocalMediaViewState,
     bottomPaddingInPixels: Int,
-    exoPlayer: ExoPlayer,
+    player: Player,
     localMedia: LocalMedia?,
     info: MediaInfo?,
-    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -153,7 +151,7 @@ private fun ExoPlayerMediaAudioView(
 
             override fun onTimelineChanged(timeline: Timeline, reason: Int) {
                 if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
-                    exoPlayer.duration.takeIf { it >= 0 }
+                    player.duration.takeIf { it >= 0 }
                         ?.let {
                             mediaPlayerControllerState = mediaPlayerControllerState.copy(
                                 durationInMillis = it,
@@ -168,34 +166,37 @@ private fun ExoPlayerMediaAudioView(
         }
     }
 
-    LaunchedEffect(exoPlayer.isPlaying) {
-        if (exoPlayer.isPlaying) {
+    LaunchedEffect(player.isPlaying) {
+        if (player.isPlaying) {
             while (true) {
                 mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                    progressInMillis = exoPlayer.currentPosition,
+                    progressInMillis = player.currentPosition,
                 )
                 delay(200)
             }
         } else {
             // Ensure we render the final state
             mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                progressInMillis = exoPlayer.currentPosition,
+                progressInMillis = player.currentPosition,
             )
         }
     }
     LaunchedEffect(isDisplayed) {
         // If not displayed, make sure to pause the audio
         if (!isDisplayed) {
-            exoPlayer.pause()
+            player.pause()
         }
     }
-    if (localMedia?.uri != null) {
+    if (localMedia?.uri != null && isDisplayed) {
         LaunchedEffect(localMedia.uri) {
             val mediaItem = MediaItem.fromUri(localMedia.uri)
-            exoPlayer.setMediaItem(mediaItem)
+            player.setMediaItem(mediaItem)
+            player.prepare()
         }
+    } else if (!isDisplayed) {
+        // Don't clear media items when not displayed
     } else {
-        exoPlayer.setMediaItems(emptyList())
+        player.setMediaItems(emptyList())
     }
     val context = LocalContext.current
     val waveform = info?.waveform
@@ -233,7 +234,7 @@ private fun ExoPlayerMediaAudioView(
                             .width(240.dp),
                         factory = {
                             PlayerView(context).apply {
-                                player = exoPlayer
+                                this.player = player
                                 resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                                 layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
                                 useController = false
@@ -255,7 +256,7 @@ private fun ExoPlayerMediaAudioView(
                         showCursor = true,
                         waveform = waveform.toImmutableList(),
                         onSeek = {
-                            exoPlayer.seekToEnsurePlaying((it * exoPlayer.duration).toLong())
+                            player.seekToEnsurePlaying((it * player.duration).toLong())
                         },
                         seekEnabled = true,
                     )
@@ -291,15 +292,15 @@ private fun ExoPlayerMediaAudioView(
         MediaPlayerControllerView(
             state = mediaPlayerControllerState,
             onTogglePlay = {
-                exoPlayer.togglePlay()
+                player.togglePlay()
             },
             onSeekChange = {
-                exoPlayer.seekToEnsurePlaying(it.toLong())
+                player.seekToEnsurePlaying(it.toLong())
             },
             onToggleMute = {
                 // Cannot happen for audio files
             },
-            audioFocus = audioFocus,
+            audioFocus = null,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
@@ -307,16 +308,12 @@ private fun ExoPlayerMediaAudioView(
         )
     }
 
-    OnLifecycleEvent { _, event ->
-        when (event) {
-            Lifecycle.Event.ON_CREATE -> exoPlayer.addListener(playerListener)
-            Lifecycle.Event.ON_RESUME -> exoPlayer.prepare()
-            Lifecycle.Event.ON_PAUSE -> exoPlayer.pause()
-            Lifecycle.Event.ON_DESTROY -> {
-                exoPlayer.release()
-                exoPlayer.removeListener(playerListener)
-            }
-            else -> Unit
+    // Add and remove listener with the composable lifecycle
+    DisposableEffect(Unit) {
+        player.addListener(playerListener)
+
+        onDispose {
+            player.removeListener(playerListener)
         }
     }
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/ExoPlayerExtensions.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/ExoPlayerExtensions.kt
@@ -9,9 +9,8 @@
 package io.element.android.libraries.mediaviewer.impl.local.player
 
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
 
-fun ExoPlayer.togglePlay() {
+fun Player.togglePlay() {
     if (isPlaying) {
         pause()
     } else {
@@ -23,7 +22,7 @@ fun ExoPlayer.togglePlay() {
     }
 }
 
-fun ExoPlayer.seekToEnsurePlaying(positionMs: Long) {
+fun Player.seekToEnsurePlaying(positionMs: Long) {
     if (isPlaying.not()) {
         play()
     }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlaybackService.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlaybackService.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.mediaviewer.impl.local.player
+
+import android.content.Intent
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+
+class MediaPlaybackService : MediaSessionService() {
+    private var mediaSession: MediaSession? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        val player = ExoPlayer.Builder(this)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(),
+                /* handleAudioFocus= */ true
+            )
+            .setHandleAudioBecomingNoisy(true)
+            .build()
+
+        mediaSession = MediaSession.Builder(this, player).build()
+
+        player.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playbackState == Player.STATE_ENDED) {
+                    stopSelf()
+                }
+            }
+        })
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        val player = mediaSession?.player
+        if (player == null || !player.playWhenReady) {
+            stopSelf()
+        }
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onDestroy() {
+        mediaSession?.run {
+            player.release()
+            release()
+        }
+        mediaSession = null
+        super.onDestroy()
+    }
+}

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlaybackServiceConnection.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlaybackServiceConnection.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.mediaviewer.impl.local.player
+
+import android.content.ComponentName
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.google.common.util.concurrent.MoreExecutors
+
+@Composable
+fun rememberMediaServicePlayer(): Player? {
+    if (LocalInspectionMode.current) {
+        return remember { ExoPlayerForPreview() }
+    }
+    val context = LocalContext.current
+    var player: Player? by remember { mutableStateOf(null) }
+    DisposableEffect(Unit) {
+        val sessionToken = SessionToken(context, ComponentName(context, MediaPlaybackService::class.java))
+        val future = MediaController.Builder(context, sessionToken).buildAsync()
+        future.addListener({ player = future.get() }, MoreExecutors.directExecutor())
+        onDispose {
+            MediaController.releaseFuture(future)
+            player = null
+        }
+    }
+    return player
+}

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -11,7 +11,6 @@ package io.element.android.libraries.mediaviewer.impl.local.video
 import android.annotation.SuppressLint
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
-import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,13 +30,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.Lifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Player.STATE_READY
 import androidx.media3.common.Timeline
-import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import io.element.android.compound.theme.ElementTheme
@@ -47,13 +43,12 @@ import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.toDp
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.utils.KeepScreenOn
-import io.element.android.libraries.designsystem.utils.OnLifecycleEvent
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
 import io.element.android.libraries.mediaviewer.impl.local.LocalMediaViewState
 import io.element.android.libraries.mediaviewer.impl.local.PlayableState
 import io.element.android.libraries.mediaviewer.impl.local.player.MediaPlayerControllerState
 import io.element.android.libraries.mediaviewer.impl.local.player.MediaPlayerControllerView
-import io.element.android.libraries.mediaviewer.impl.local.player.rememberExoPlayer
+import io.element.android.libraries.mediaviewer.impl.local.player.rememberMediaServicePlayer
 import io.element.android.libraries.mediaviewer.impl.local.player.seekToEnsurePlaying
 import io.element.android.libraries.mediaviewer.impl.local.player.togglePlay
 import io.element.android.libraries.mediaviewer.impl.local.rememberLocalMediaViewState
@@ -73,29 +68,29 @@ fun MediaVideoView(
     audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
-    val exoPlayer = rememberExoPlayer()
-    ExoPlayerMediaVideoView(
-        isDisplayed = isDisplayed,
-        localMediaViewState = localMediaViewState,
-        bottomPaddingInPixels = bottomPaddingInPixels,
-        exoPlayer = exoPlayer,
-        localMedia = localMedia,
-        autoplay = autoplay,
-        audioFocus = audioFocus,
-        modifier = modifier,
-    )
+    val player = rememberMediaServicePlayer()
+    if (player != null) {
+        ServicePlayerMediaVideoView(
+            isDisplayed = isDisplayed,
+            localMediaViewState = localMediaViewState,
+            bottomPaddingInPixels = bottomPaddingInPixels,
+            player = player,
+            localMedia = localMedia,
+            autoplay = autoplay,
+            modifier = modifier,
+        )
+    }
 }
 
 @SuppressLint("UnsafeOptInUsageError")
 @Composable
-private fun ExoPlayerMediaVideoView(
+private fun ServicePlayerMediaVideoView(
     isDisplayed: Boolean,
     localMediaViewState: LocalMediaViewState,
     bottomPaddingInPixels: Int,
-    exoPlayer: ExoPlayer,
+    player: Player,
     localMedia: LocalMedia?,
     autoplay: Boolean,
-    audioFocus: AudioFocus?,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -142,7 +137,7 @@ private fun ExoPlayerMediaVideoView(
 
             override fun onTimelineChanged(timeline: Timeline, reason: Int) {
                 if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
-                    exoPlayer.duration.takeIf { it >= 0 }
+                    player.duration.takeIf { it >= 0 }
                         ?.let {
                             mediaPlayerControllerState = mediaPlayerControllerState.copy(
                                 durationInMillis = it,
@@ -163,20 +158,23 @@ private fun ExoPlayerMediaVideoView(
 
     LaunchedEffect(autoHideController) {
         delay(5.seconds)
-        if (exoPlayer.isPlaying) {
+        if (player.isPlaying) {
             mediaPlayerControllerState = mediaPlayerControllerState.copy(
                 isVisible = false,
             )
         }
     }
 
-    if (localMedia?.uri != null) {
+    if (localMedia?.uri != null && isDisplayed) {
         LaunchedEffect(localMedia.uri) {
             val mediaItem = MediaItem.fromUri(localMedia.uri)
-            exoPlayer.setMediaItem(mediaItem)
+            player.setMediaItem(mediaItem)
+            player.prepare()
         }
+    } else if (!isDisplayed) {
+        // Don't clear media items when not displayed - just don't set new ones
     } else {
-        exoPlayer.setMediaItems(emptyList())
+        player.setMediaItems(emptyList())
     }
     KeepScreenOn(mediaPlayerControllerState.isPlaying)
     Box(
@@ -206,7 +204,7 @@ private fun ExoPlayerMediaVideoView(
                     ),
                 factory = {
                     PlayerView(context).apply {
-                        player = exoPlayer
+                        this.player = player
                         resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
                         useController = false
@@ -221,17 +219,17 @@ private fun ExoPlayerMediaVideoView(
             state = mediaPlayerControllerState,
             onTogglePlay = {
                 autoHideController++
-                exoPlayer.togglePlay()
+                player.togglePlay()
             },
             onSeekChange = {
                 autoHideController++
-                exoPlayer.seekToEnsurePlaying(it.toLong())
+                player.seekToEnsurePlaying(it.toLong())
             },
             onToggleMute = {
                 autoHideController++
-                exoPlayer.volume = if (exoPlayer.volume == 1f) 0f else 1f
+                player.volume = if (player.volume == 1f) 0f else 1f
             },
-            audioFocus = audioFocus,
+            audioFocus = null,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
@@ -239,24 +237,24 @@ private fun ExoPlayerMediaVideoView(
         )
     }
 
-    LaunchedEffect(exoPlayer.isPlaying) {
-        if (exoPlayer.isPlaying) {
+    LaunchedEffect(player.isPlaying) {
+        if (player.isPlaying) {
             while (true) {
                 mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                    progressInMillis = exoPlayer.currentPosition,
+                    progressInMillis = player.currentPosition,
                 )
                 delay(200)
             }
         } else {
             // Ensure we render the final state
             mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                progressInMillis = exoPlayer.currentPosition,
+                progressInMillis = player.currentPosition,
             )
         }
     }
 
-    ExoPlayerLifecycleHelper(
-        exoPlayer = exoPlayer,
+    PlayerLifecycleHelper(
+        player = player,
         autoplay = autoplay,
         isDisplayed = isDisplayed,
         playerListener = playerListener,
@@ -264,27 +262,22 @@ private fun ExoPlayerMediaVideoView(
     )
 }
 
-@OptIn(UnstableApi::class)
 @Composable
-private fun ExoPlayerLifecycleHelper(
-    exoPlayer: ExoPlayer,
+private fun PlayerLifecycleHelper(
+    player: Player,
     autoplay: Boolean,
     isDisplayed: Boolean,
     playerListener: Player.Listener,
     mediaPlayerControllerState: MediaPlayerControllerState,
 ) {
-    // Prepare and release the exoPlayer with the composable lifecycle
+    // Add and remove listener with the composable lifecycle
     DisposableEffect(Unit) {
-        Timber.d("ExoPlayerMediaVideoView DisposableEffect: initializing exoPlayer")
-        exoPlayer.addListener(playerListener)
-        exoPlayer.prepare()
+        Timber.d("ServicePlayerMediaVideoView DisposableEffect: adding listener")
+        player.addListener(playerListener)
 
         onDispose {
-            Timber.d("Disposing exoplayer")
-            if (!exoPlayer.isReleased) {
-                exoPlayer.removeListener(playerListener)
-                exoPlayer.release()
-            }
+            Timber.d("Disposing player listener")
+            player.removeListener(playerListener)
         }
     }
 
@@ -293,18 +286,11 @@ private fun ExoPlayerLifecycleHelper(
         val isReadyAndNotPlaying = mediaPlayerControllerState.isReady && !mediaPlayerControllerState.isPlaying
         if (needsAutoPlay && isDisplayed && isReadyAndNotPlaying) {
             // When displayed, start autoplaying
-            exoPlayer.play()
+            player.play()
             needsAutoPlay = false
         } else if (!isDisplayed && mediaPlayerControllerState.isPlaying) {
             // If not displayed, make sure to pause the video
-            exoPlayer.pause()
-        }
-    }
-
-    // Pause playback when lifecycle is paused
-    OnLifecycleEvent { _, event ->
-        if (event == Lifecycle.Event.ON_PAUSE && exoPlayer.isPlaying) {
-            exoPlayer.pause()
+            player.pause()
         }
     }
 }


### PR DESCRIPTION
## Content

Add a foreground `MediaSessionService` that owns the ExoPlayer instance, so media playback (audio and video) continues when the app goes to background. Voice messages are completely unaffected — they use a separate pipeline (`DefaultMediaPlayer` / `SimplePlayer`).

### Changes:
- **New `MediaPlaybackService`** — A `MediaSessionService` subclass that owns ExoPlayer + `MediaSession`. Handles audio focus, headphone unplug, and auto-stops when playback ends.
- **New `rememberMediaServicePlayer()`** — Composable that connects to the service via `MediaController`, returning a `Player?` (null while connecting).
- **Modified `MediaVideoView` / `MediaAudioView`** — Use service-backed player instead of composition-scoped ExoPlayer. Removed `ON_PAUSE` lifecycle handlers that killed background playback. Added `isDisplayed` guards for HorizontalPager pre-loading.
- **Modified `ExoPlayerExtensions`** — Changed receivers from `ExoPlayer` to `Player` interface.
- **Added `media3-session` dependency**.

## Motivation and context

Media playback stops when the app goes to background because `MediaVideoView` and `MediaAudioView` explicitly pause/release ExoPlayer on `ON_PAUSE`/`ON_DESTROY` lifecycle events. Users expect audio to continue playing when they switch apps.

## Tests

- Play audio file in media viewer → press Home → verify playback continues with notification visible
- Play video → press Home → verify audio track continues
- Play a voice message → verify no foreground service, same behavior as before
- Play media → let it finish naturally → verify service stops and notification dismissed
- While playing → swipe app from recents → verify playback continues
- While paused → swipe app from recents → verify service stops
- Swipe between media items in pager → only current item plays
- Play/pause, seek, mute controls all work through MediaController

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR