### PR TITLE
Filter empty days

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
@@ -16,6 +16,7 @@ import io.element.android.features.messages.impl.timeline.factories.event.Timeli
 import io.element.android.features.messages.impl.timeline.factories.virtual.TimelineItemVirtualFactory
 import io.element.android.features.messages.impl.timeline.groups.TimelineItemGrouper
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemDaySeparatorModel
 import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
@@ -96,7 +97,8 @@ class TimelineItemsFactory(
             }
         }
         val result = timelineItemGrouper.group(newTimelineItemStates).toImmutableList()
-        this._timelineItems.emit(result)
+        val filteredResult = filterEmptyDaySeparators(result).toImmutableList()
+        this._timelineItems.emit(filteredResult)
     }
 
     private suspend fun buildAndCacheItem(
@@ -112,5 +114,43 @@ class TimelineItemsFactory(
             }
         diffCache[index] = timelineItem
         return timelineItem
+    }
+
+    private fun filterEmptyDaySeparators(items: List<TimelineItem>): List<TimelineItem> {
+        val result = ArrayList<TimelineItem>()
+        var i = 0
+        while (i < items.size) {
+            val current = items[i]
+            if (isDaySeparator(current)) {
+                val hasEventsForDay = hasEventsForDaySeparator(items, i)
+                if (hasEventsForDay) {
+                    result.add(current)
+                }
+                i++
+            } else {
+                result.add(current)
+                i++
+            }
+        }
+        return result
+    }
+
+    private fun hasEventsForDaySeparator(items: List<TimelineItem>, daySeparatorIndex: Int): Boolean {
+        var j = daySeparatorIndex - 1
+        while (j >= 0) {
+            if (isEventItem(items[j])) {
+                return true
+            }
+            j--
+        }
+        return false
+    }
+
+    private fun isEventItem(item: TimelineItem): Boolean {
+        return item is TimelineItem.Event || item is TimelineItem.GroupedEvents
+    }
+
+    private fun isDaySeparator(item: TimelineItem): Boolean {
+        return item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
@@ -16,6 +16,7 @@ import io.element.android.features.messages.impl.timeline.factories.event.Timeli
 import io.element.android.features.messages.impl.timeline.factories.virtual.TimelineItemVirtualFactory
 import io.element.android.features.messages.impl.timeline.groups.TimelineItemGrouper
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemDaySeparatorModel
 import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
@@ -96,7 +97,8 @@ class TimelineItemsFactory(
             }
         }
         val result = timelineItemGrouper.group(newTimelineItemStates).toImmutableList()
-        this._timelineItems.emit(result)
+        val filteredResult = filterEmptyDaySeparators(result).toImmutableList()
+        this._timelineItems.emit(filteredResult)
     }
 
     private suspend fun buildAndCacheItem(
@@ -113,4 +115,44 @@ class TimelineItemsFactory(
         diffCache[index] = timelineItem
         return timelineItem
     }
+}
+
+internal fun filterEmptyDaySeparators(items: List<TimelineItem>): List<TimelineItem> {
+    val result = ArrayList<TimelineItem>()
+    var i = 0
+    while (i < items.size) {
+        val current = items[i]
+        if (isDaySeparator(current)) {
+            val hasEventsForDay = hasEventsForDaySeparator(items, i)
+            if (hasEventsForDay) {
+                result.add(current)
+            }
+            i++
+        } else {
+            result.add(current)
+            i++
+        }
+    }
+    return result
+}
+
+internal fun hasEventsForDaySeparator(items: List<TimelineItem>, daySeparatorIndex: Int): Boolean {
+    var j = daySeparatorIndex + 1
+    while (j < items.size) {
+        val item = items[j]
+        when {
+            isEventItem(item) -> return true
+            isDaySeparator(item) -> return false
+        }
+        j++
+    }
+    return false
+}
+
+internal fun isEventItem(item: TimelineItem): Boolean {
+    return item is TimelineItem.Event || item is TimelineItem.GroupedEvents
+}
+
+internal fun isDaySeparator(item: TimelineItem): Boolean {
+    return item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2023-2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.timeline.factories
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.messages.impl.fixtures.aMessageEvent
+import io.element.android.features.messages.impl.timeline.aTimelineItemDebugInfo
+import io.element.android.features.messages.impl.timeline.aTimelineItemReactions
+import io.element.android.features.messages.impl.timeline.model.ReadReceiptData
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.TimelineItemReadReceipts
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemDaySeparatorModel
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemReadMarkerModel
+import io.element.android.features.messages.impl.timeline.model.virtual.aTimelineItemDaySeparatorModel
+import io.element.android.libraries.designsystem.components.avatar.anAvatarData
+import io.element.android.libraries.matrix.api.core.UniqueId
+import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
+import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.core.FakeSendHandle
+import io.element.android.libraries.matrix.ui.messages.reply.aProfileTimelineDetailsReady
+import kotlinx.collections.immutable.toImmutableList
+import org.junit.Test
+
+class TimelineItemsFactoryTest {
+    private val anEvent = TimelineItem.Event(
+        id = UniqueId("event"),
+        eventId = AN_EVENT_ID,
+        senderId = A_USER_ID,
+        senderAvatar = anAvatarData(),
+        senderProfile = aProfileTimelineDetailsReady(displayName = "User"),
+        content = aMessageEvent().content,
+        reactionsState = aTimelineItemReactions(count = 0),
+        readReceiptState = TimelineItemReadReceipts(emptyList<ReadReceiptData>().toImmutableList()),
+        localSendState = LocalEventSendState.Sent(AN_EVENT_ID),
+        isEditable = false,
+        canBeRepliedTo = false,
+        inReplyTo = null,
+        threadInfo = null,
+        origin = null,
+        timelineItemDebugInfoProvider = { aTimelineItemDebugInfo() },
+        messageShieldProvider = { null },
+        sendHandleProvider = { FakeSendHandle() },
+        forwarder = null,
+        forwarderProfile = null,
+    )
+
+    private fun aDaySeparator(date: String) = TimelineItem.Virtual(
+        id = UniqueId("day_$date"),
+        model = aTimelineItemDaySeparatorModel(date)
+    )
+
+    @Test
+    fun `filterEmptyDaySeparators keeps day separator with events after it`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            anEvent,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator with no events after it`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            aDaySeparator("Yesterday"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator at end with no events`() {
+        val items = listOf(
+            anEvent,
+            aDaySeparator("Today"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps first day separator and removes second when only first has events`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            anEvent,
+            aDaySeparator("Yesterday"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators handles multiple day separators in a row with no events`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            aDaySeparator("Yesterday"),
+            aDaySeparator("Last week"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps all items when no day separators`() {
+        val items = listOf(
+            anEvent,
+            anEvent.copy(id = UniqueId("event2")),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators handles grouped events after day separator`() {
+        val groupedEvents = TimelineItem.GroupedEvents(
+            id = UniqueId("grouped"),
+            events = listOf(anEvent).toImmutableList(),
+            aggregatedReadReceipts = emptyList<ReadReceiptData>().toImmutableList(),
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            groupedEvents,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(groupedEvents)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator followed by non-event virtual item`() {
+        val readMarker = TimelineItem.Virtual(
+            id = UniqueId("readMarker"),
+            model = io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemReadMarkerModel
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            readMarker,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(readMarker)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps day separator when non-event virtual items are between separator and event`() {
+        val readMarker = TimelineItem.Virtual(
+            id = UniqueId("readMarker"),
+            model = TimelineItemReadMarkerModel
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            readMarker,
+            anEvent,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(3)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+    }
+
+    private fun filterEmptyDaySeparators(items: List<TimelineItem>): List<TimelineItem> {
+        val result = ArrayList<TimelineItem>()
+        var i = 0
+        while (i < items.size) {
+            val current = items[i]
+            if (current is TimelineItem.Virtual && current.model is TimelineItemDaySeparatorModel) {
+                val hasEventsForDay = hasEventsForDaySeparator(items, i)
+                if (hasEventsForDay) {
+                    result.add(current)
+                }
+                i++
+            } else {
+                result.add(current)
+                i++
+            }
+        }
+        return result
+    }
+
+    private fun hasEventsForDaySeparator(items: List<TimelineItem>, daySeparatorIndex: Int): Boolean {
+        var j = daySeparatorIndex + 1
+        while (j < items.size) {
+            val item = items[j]
+            when {
+                isEventItem(item) -> return true
+                isDaySeparator(item) -> return false
+            }
+            j++
+        }
+        return false
+    }
+
+    private fun isEventItem(item: TimelineItem): Boolean {
+        return item is TimelineItem.Event || item is TimelineItem.GroupedEvents
+    }
+
+    private fun isDaySeparator(item: TimelineItem): Boolean {
+        return item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel
+    }
+}

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2023-2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.timeline.factories
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.messages.impl.fixtures.aMessageEvent
+import io.element.android.features.messages.impl.timeline.aTimelineItemDebugInfo
+import io.element.android.features.messages.impl.timeline.aTimelineItemReactions
+import io.element.android.features.messages.impl.timeline.model.ReadReceiptData
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.TimelineItemReadReceipts
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemReadMarkerModel
+import io.element.android.features.messages.impl.timeline.model.virtual.aTimelineItemDaySeparatorModel
+import io.element.android.libraries.designsystem.components.avatar.anAvatarData
+import io.element.android.libraries.matrix.api.core.UniqueId
+import io.element.android.libraries.matrix.api.timeline.item.event.LocalEventSendState
+import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.core.FakeSendHandle
+import io.element.android.libraries.matrix.ui.messages.reply.aProfileTimelineDetailsReady
+import kotlinx.collections.immutable.toImmutableList
+import org.junit.Test
+
+class TimelineItemsFactoryTest {
+    private val anEvent = TimelineItem.Event(
+        id = UniqueId("event"),
+        eventId = AN_EVENT_ID,
+        senderId = A_USER_ID,
+        senderAvatar = anAvatarData(),
+        senderProfile = aProfileTimelineDetailsReady(displayName = "User"),
+        content = aMessageEvent().content,
+        reactionsState = aTimelineItemReactions(count = 0),
+        readReceiptState = TimelineItemReadReceipts(emptyList<ReadReceiptData>().toImmutableList()),
+        localSendState = LocalEventSendState.Sent(AN_EVENT_ID),
+        isEditable = false,
+        canBeRepliedTo = false,
+        inReplyTo = null,
+        threadInfo = null,
+        origin = null,
+        timelineItemDebugInfoProvider = { aTimelineItemDebugInfo() },
+        messageShieldProvider = { null },
+        sendHandleProvider = { FakeSendHandle() },
+        forwarder = null,
+        forwarderProfile = null,
+    )
+
+    private fun aDaySeparator(date: String) = TimelineItem.Virtual(
+        id = UniqueId("day_$date"),
+        model = aTimelineItemDaySeparatorModel(date)
+    )
+
+    @Test
+    fun `filterEmptyDaySeparators keeps day separator with events after it`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            anEvent,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator with no events after it`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            aDaySeparator("Yesterday"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator at end with no events`() {
+        val items = listOf(
+            anEvent,
+            aDaySeparator("Today"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps first day separator and removes second when only first has events`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            anEvent,
+            aDaySeparator("Yesterday"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(anEvent)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators handles multiple day separators in a row with no events`() {
+        val items = listOf(
+            aDaySeparator("Today"),
+            aDaySeparator("Yesterday"),
+            aDaySeparator("Last week"),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps all items when no day separators`() {
+        val items = listOf(
+            anEvent,
+            anEvent.copy(id = UniqueId("event2")),
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators handles grouped events after day separator`() {
+        val groupedEvents = TimelineItem.GroupedEvents(
+            id = UniqueId("grouped"),
+            events = listOf(anEvent).toImmutableList(),
+            aggregatedReadReceipts = emptyList<ReadReceiptData>().toImmutableList(),
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            groupedEvents,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+        assertThat(result[1]).isEqualTo(groupedEvents)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators removes day separator followed by non-event virtual item`() {
+        val readMarker = TimelineItem.Virtual(
+            id = UniqueId("readMarker"),
+            model = io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemReadMarkerModel
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            readMarker,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(readMarker)
+    }
+
+    @Test
+    fun `filterEmptyDaySeparators keeps day separator when non-event virtual items are between separator and event`() {
+        val readMarker = TimelineItem.Virtual(
+            id = UniqueId("readMarker"),
+            model = TimelineItemReadMarkerModel
+        )
+        val items = listOf(
+            aDaySeparator("Today"),
+            readMarker,
+            anEvent,
+        )
+        val result = filterEmptyDaySeparators(items)
+        assertThat(result).hasSize(3)
+        assertThat(result[0]).isEqualTo(aDaySeparator("Today"))
+    }
+
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

There may be day dividers that include only filtered events. This change will eliminate those empty day dividers.

## Motivation and context

See #6360 "Tests"

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See a day that only has filtered events

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
