### PR TITLE
Improve error displayed when .well-known file is malformed

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/AuthenticationException.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/AuthenticationException.kt
@@ -22,7 +22,10 @@ fun Throwable.mapAuthenticationException(): AuthenticationException {
             is ClientBuildException.Sdk -> AuthenticationException.Generic(message)
             is ClientBuildException.ServerUnreachable -> AuthenticationException.ServerUnreachable(message)
             is ClientBuildException.SlidingSync -> AuthenticationException.Generic(message)
-            is ClientBuildException.WellKnownDeserializationException -> AuthenticationException.Generic(message)
+            is ClientBuildException.WellKnownDeserializationException -> {
+                // Can happen if the .well-known URL has a redirection to an HTML page for instance
+                AuthenticationException.InvalidServerName(message)
+            }
             is ClientBuildException.WellKnownLookupFailed -> AuthenticationException.Generic(message)
             is ClientBuildException.EventCache -> AuthenticationException.Generic(message)
         }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/AuthenticationExceptionMappingTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/AuthenticationExceptionMappingTest.kt
@@ -31,6 +31,13 @@ class AuthenticationExceptionMappingTest {
     }
 
     @Test
+    fun `mapping a WellKnownDeserializationException returns a InvalidServerName AuthenticationException`() {
+        val exception = ClientBuildException.WellKnownDeserializationException("WellKnown Deserialization")
+        val mappedException = exception.mapAuthenticationException()
+        assertThat(mappedException).isException<AuthenticationException.InvalidServerName>("WellKnown Deserialization")
+    }
+
+    @Test
     fun `mapping specific exceptions map to their kotlin counterparts`() {
         assertThat(ClientBuildException.Generic("Unknown error").mapAuthenticationException())
             .isException<AuthenticationException.Generic>("Unknown error")
@@ -50,8 +57,6 @@ class AuthenticationExceptionMappingTest {
             .isException<AuthenticationException.ServerUnreachable>("Server unreachable")
         assertThat(ClientBuildException.SlidingSync("Sliding Sync").mapAuthenticationException())
             .isException<AuthenticationException.Generic>("Sliding Sync")
-        assertThat(ClientBuildException.WellKnownDeserializationException("WellKnown Deserialization").mapAuthenticationException())
-            .isException<AuthenticationException.Generic>("WellKnown Deserialization")
         assertThat(ClientBuildException.WellKnownLookupFailed("WellKnown Lookup Failed").mapAuthenticationException())
             .isException<AuthenticationException.Generic>("WellKnown Lookup Failed")
         assertThat(ClientBuildException.EventCache("EventCache error").mapAuthenticationException())


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

<!-- Describe shortly what has been changed -->
Map ClientBuildException.WellKnownDeserializationException to AuthenticationException.InvalidServerName, so that the error displayed to the user is more explicit.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6368

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|


 -->

|Before|After|
|-|-|
|<img width="822" height="463" alt="image" src="https://github.com/user-attachments/assets/9a80ee57-21d8-4f87-975a-6818b5ffcdbb" />|<img width="402" height="296" alt="image" src="https://github.com/user-attachments/assets/24b43287-2569-461e-8bf3-159c914d93ef" />|

## Tests

<!-- Explain how you tested your development -->

- Try to sign in to `debian.social`
- observe the updated error

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
