### PR TITLE
Fix keyboard not auto-opening when editing a message

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -706,14 +706,14 @@ class MessageComposerPresenter(
                     val draft = createDraftFromState(markdownTextEditorState, richTextEditorState)
                     updateDraft(draft, isVolatile = true).join()
                 }
-                setText(newComposerMode.content, markdownTextEditorState, richTextEditorState)
+                setText(newComposerMode.content, markdownTextEditorState, richTextEditorState, requestFocus = true)
             }
             is MessageComposerMode.EditCaption -> {
                 if (currentComposerMode.isEditing.not()) {
                     val draft = createDraftFromState(markdownTextEditorState, richTextEditorState)
                     updateDraft(draft, isVolatile = true).join()
                 }
-                setText(newComposerMode.content, markdownTextEditorState, richTextEditorState)
+                setText(newComposerMode.content, markdownTextEditorState, richTextEditorState, requestFocus = true)
             }
             else -> {
                 // When coming from edit, just clear the composer as it'd be weird to reset a volatile draft in this scenario.

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/SoftKeyboardEffect.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/SoftKeyboardEffect.kt
@@ -41,11 +41,16 @@ internal fun <T> SoftKeyboardEffect(
             // Await window focus in case returning from a dialog
             view.awaitWindowFocus()
 
-            // Show the keyboard, temporarily using the root view for focus
-            view.showKeyboard(andRequestFocus = true)
-
-            // Refocus to the correct view
+            // First, focus the correct editor view
             latestOnRequestFocus()
+
+            // Show keyboard on the focused editor view rather than the root view,
+            // as some devices require showSoftInput on the actual input view.
+            // Using post to run after the current focus pass completes.
+            view.post {
+                val focusedView = view.findFocus() ?: view
+                focusedView.showKeyboard()
+            }
         }
     }
 }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/SoftKeyboardEffect.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/SoftKeyboardEffect.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
 import io.element.android.libraries.androidutils.ui.awaitWindowFocus
-import io.element.android.libraries.androidutils.ui.isKeyboardVisible
 import io.element.android.libraries.androidutils.ui.showKeyboard
 
 /**
@@ -42,13 +41,11 @@ internal fun <T> SoftKeyboardEffect(
             // Await window focus in case returning from a dialog
             view.awaitWindowFocus()
 
-            if (!view.isKeyboardVisible()) {
-                // Show the keyboard, temporarily using the root view for focus
-                view.showKeyboard(andRequestFocus = true)
+            // Show the keyboard, temporarily using the root view for focus
+            view.showKeyboard(andRequestFocus = true)
 
-                // Refocus to the correct view
-                latestOnRequestFocus()
-            }
+            // Refocus to the correct view
+            latestOnRequestFocus()
         }
     }
 }


### PR DESCRIPTION
## Content

Remove the unreliable isKeyboardVisible() guard in SoftKeyboardEffect so the keyboard always opens when entering a special composer mode. Also request focus explicitly when setting text in edit mode.

## Motivation and context

When a user selects "Edit" on a message, the composer enters edit mode and the text is populated correctly, but the soft keyboard does not open automatically and the user has to manually tap the input field. The root cause was InputMethodManager.isAcceptingText returning true after the action sheet dismissed (even though the keyboard wasn't visible), causing showKeyboard() and onRequestFocus() to be skipped entirely.

## Screenshots / GIFs

None 

## Tests

1.  Send a text message in a room
2.  Long-press the message and select "Edit"
3. Verify the keyboard opens automatically without needing to tap the input field                                                                                                   
4. Send an image with a caption
5. Long-press the image and select "Edit caption"                                                                                                                                   
6. Verify the keyboard opens automatically                                                                       
7. Reply to any message and verify the keyboard opens automatically

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
