### PR TITLE
Fix: "Reset identity" flow leaves backup disabled #5075

### DIFF
--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowManager.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowManager.kt
@@ -11,15 +11,13 @@ package io.element.android.features.securebackup.impl.reset
 import dev.zacsweers.metro.Inject
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.matrix.api.encryption.BackupState
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
 import io.element.android.libraries.matrix.api.encryption.IdentityResetHandle
-import io.element.android.libraries.matrix.api.verification.SessionVerificationService
-import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -27,7 +25,6 @@ import kotlinx.coroutines.launch
 class ResetIdentityFlowManager(
     private val encryptionService: EncryptionService,
     @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
-    private val sessionVerificationService: SessionVerificationService,
 ) {
     private val resetHandleFlow: MutableStateFlow<AsyncData<IdentityResetHandle?>> = MutableStateFlow(AsyncData.Uninitialized)
     val currentHandleFlow: StateFlow<AsyncData<IdentityResetHandle?>> = resetHandleFlow
@@ -35,7 +32,7 @@ class ResetIdentityFlowManager(
 
     fun whenResetIsDone(block: () -> Unit) {
         whenResetIsDoneWaitingJob = sessionCoroutineScope.launch {
-            sessionVerificationService.sessionVerifiedStatus.filterIsInstance<SessionVerifiedStatus.Verified>().first()
+            encryptionService.backupStateStateFlow.first { it == BackupState.ENABLED }
             block()
         }
     }

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
@@ -40,9 +40,7 @@ import io.element.android.libraries.matrix.api.encryption.IdentityOidcResetHandl
 import io.element.android.libraries.matrix.api.encryption.IdentityPasswordResetHandle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -109,34 +107,33 @@ class ResetIdentityFlowNode(
     private fun CoroutineScope.startReset() = launch {
         // Instead of cancelling the reset job on every ON_START, we can do it before starting a new attempt
         cancelResetJob()
-        resetIdentityFlowManager.getResetHandle()
+
+        val handleResult = resetIdentityFlowManager.getResetHandle()
             // We're only interested in the success/failure case, and we need this flow to stop by itself
             // since each call to `startReset` will create a new one
-            .filter { it.isSuccess() || it.isFailure() }
-            .take(1)
-            .collectLatest { state ->
-                when (state) {
-                    is AsyncData.Failure -> {
-                        cancelResetJob()
-                        Timber.e(state.error, "Could not load the reset identity handle.")
+            .first { it.isSuccess() || it.isFailure() }
+
+        when (handleResult) {
+            is AsyncData.Failure -> {
+                cancelResetJob()
+                Timber.e(handleResult.error, "Could not load the reset identity handle.")
+            }
+            is AsyncData.Success -> {
+                when (val handle = handleResult.data) {
+                    null -> {
+                        Timber.d("No reset handle return, the reset is done.")
                     }
-                    is AsyncData.Success -> {
-                        when (val handle = state.data) {
-                            null -> {
-                                Timber.d("No reset handle return, the reset is done.")
-                            }
-                            is IdentityOidcResetHandle -> {
-                                Timber.d("Launching reset confirmation in MAS")
-                                activity.openUrlInChromeCustomTab(null, darkTheme, handle.url)
-                                Timber.d("Starting resetOidc")
-                                resetJob = launch { handle.resetOidc() }
-                                resetJob?.invokeOnCompletion { Timber.d("resetOidc ended") }
-                            }
-                            is IdentityPasswordResetHandle -> backstack.push(NavTarget.ResetPassword)
-                        }
+                    is IdentityOidcResetHandle -> {
+                        Timber.d("Launching reset confirmation in MAS")
+                        activity.openUrlInChromeCustomTab(null, darkTheme, handle.url)
+                        Timber.d("Starting resetOidc")
+                        resetJob = launch { handle.resetOidc() }
+                        resetJob?.invokeOnCompletion { Timber.d("resetOidc ended") }
                     }
-                    else -> Unit
+                    is IdentityPasswordResetHandle -> backstack.push(NavTarget.ResetPassword)
                 }
+            }
+            else -> Unit
         }
     }
 

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
@@ -16,8 +16,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.DialogProperties
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.Plugin
@@ -43,6 +41,8 @@ import io.element.android.libraries.matrix.api.encryption.IdentityPasswordResetH
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -81,15 +81,9 @@ class ResetIdentityFlowNode(
     override fun onBuilt() {
         super.onBuilt()
 
-        lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onStart(owner: LifecycleOwner) {
-                sessionCoroutineScope.launch {
-                    resetIdentityFlowManager.whenResetIsDone {
-                        callback.onDone()
-                    }
-                }
-            }
-        })
+        resetIdentityFlowManager.whenResetIsDone {
+            callback.onDone()
+        }
     }
 
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node {
@@ -113,7 +107,13 @@ class ResetIdentityFlowNode(
     }
 
     private fun CoroutineScope.startReset() = launch {
+        // Instead of cancelling the reset job on every ON_START, we can do it before starting a new attempt
+        cancelResetJob()
         resetIdentityFlowManager.getResetHandle()
+            // We're only interested in the success/failure case, and we need this flow to stop by itself
+            // since each call to `startReset` will create a new one
+            .filter { it.isSuccess() || it.isFailure() }
+            .take(1)
             .collectLatest { state ->
                 when (state) {
                     is AsyncData.Failure -> {
@@ -128,7 +128,6 @@ class ResetIdentityFlowNode(
                             is IdentityOidcResetHandle -> {
                                 Timber.d("Launching reset confirmation in MAS")
                                 activity.openUrlInChromeCustomTab(null, darkTheme, handle.url)
-
                                 Timber.d("Starting resetOidc")
                                 resetJob = launch { handle.resetOidc() }
                                 resetJob?.invokeOnCompletion { Timber.d("resetOidc ended") }
@@ -138,7 +137,18 @@ class ResetIdentityFlowNode(
                     }
                     else -> Unit
                 }
-            }
+        }
+    }
+
+    override fun performUpNavigation(): Boolean {
+        val navigatesUp = super.performUpNavigation()
+
+        // This intercepts the back navigation so we only cancel this job when the user actually navigates up
+        if (navigatesUp) {
+            sessionCoroutineScope.launch { cancelResetJob() }
+        }
+
+        return navigatesUp
     }
 
     private suspend fun cancelResetJob() {

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
@@ -83,20 +83,11 @@ class ResetIdentityFlowNode(
 
         lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onStart(owner: LifecycleOwner) {
-                // If the custom tab / Web browser was opened, we need to cancel the reset job
-                // when we come back to the node if the reset wasn't successful
                 sessionCoroutineScope.launch {
-                    cancelResetJob()
-
                     resetIdentityFlowManager.whenResetIsDone {
                         callback.onDone()
                     }
                 }
-            }
-
-            override fun onDestroy(owner: LifecycleOwner) {
-                // Make sure we cancel the reset job when the node is destroyed, just in case
-                sessionCoroutineScope.launch { cancelResetJob() }
             }
         })
     }

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
@@ -145,16 +145,16 @@ class ResetIdentityFlowNode(
 
         // This intercepts the back navigation so we only cancel this job when the user actually navigates up
         if (navigatesUp) {
-            sessionCoroutineScope.launch { cancelResetJob() }
+            sessionCoroutineScope.launch { resetIdentityFlowManager.cancel() }
+            cancelResetJob()
         }
 
         return navigatesUp
     }
 
-    private suspend fun cancelResetJob() {
+    private fun cancelResetJob() {
         resetJob?.cancel()
         resetJob = null
-        resetIdentityFlowManager.cancel()
     }
 
     @Composable

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowNode.kt
@@ -126,8 +126,12 @@ class ResetIdentityFlowNode(
                                 Timber.d("No reset handle return, the reset is done.")
                             }
                             is IdentityOidcResetHandle -> {
+                                Timber.d("Launching reset confirmation in MAS")
                                 activity.openUrlInChromeCustomTab(null, darkTheme, handle.url)
+
+                                Timber.d("Starting resetOidc")
                                 resetJob = launch { handle.resetOidc() }
+                                resetJob?.invokeOnCompletion { Timber.d("resetOidc ended") }
                             }
                             is IdentityPasswordResetHandle -> backstack.push(NavTarget.ResetPassword)
                         }

--- a/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowManagerTest.kt
+++ b/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/reset/ResetIdentityFlowManagerTest.kt
@@ -11,11 +11,10 @@ package io.element.android.features.securebackup.impl.reset
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.architecture.AsyncData
+import io.element.android.libraries.matrix.api.encryption.BackupState
 import io.element.android.libraries.matrix.api.encryption.IdentityResetHandle
-import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
 import io.element.android.libraries.matrix.test.encryption.FakeEncryptionService
 import io.element.android.libraries.matrix.test.encryption.FakeIdentityPasswordResetHandle
-import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -104,9 +103,9 @@ class ResetIdentityFlowManagerTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `whenResetIsDone - will trigger the lambda when verification status is verified`() = runTest {
-        val verificationService = FakeSessionVerificationService()
-        val flowManager = createFlowManager(sessionVerificationService = verificationService)
+    fun `whenResetIsDone - will trigger the lambda when key backup is enabled`() = runTest {
+        val encryptionService = FakeEncryptionService()
+        val flowManager = createFlowManager(encryptionService = encryptionService)
         var isDone = false
 
         flowManager.whenResetIsDone {
@@ -115,25 +114,31 @@ class ResetIdentityFlowManagerTest {
 
         assertThat(isDone).isFalse()
 
-        verificationService.emitVerifiedStatus(SessionVerifiedStatus.Unknown)
+        encryptionService.emitBackupState(BackupState.UNKNOWN)
         advanceUntilIdle()
         assertThat(isDone).isFalse()
 
-        verificationService.emitVerifiedStatus(SessionVerifiedStatus.NotVerified)
+        encryptionService.emitBackupState(BackupState.DISABLING)
         advanceUntilIdle()
         assertThat(isDone).isFalse()
 
-        verificationService.emitVerifiedStatus(SessionVerifiedStatus.Verified)
+        encryptionService.emitBackupState(BackupState.WAITING_FOR_SYNC)
+        advanceUntilIdle()
+        assertThat(isDone).isFalse()
+
+        encryptionService.emitBackupState(BackupState.ENABLING)
+        advanceUntilIdle()
+        assertThat(isDone).isFalse()
+
+        encryptionService.emitBackupState(BackupState.ENABLED)
         advanceUntilIdle()
         assertThat(isDone).isTrue()
     }
 
     private fun TestScope.createFlowManager(
         encryptionService: FakeEncryptionService = FakeEncryptionService(),
-        sessionVerificationService: FakeSessionVerificationService = FakeSessionVerificationService(),
     ) = ResetIdentityFlowManager(
         encryptionService = encryptionService,
         sessionCoroutineScope = this,
-        sessionVerificationService = sessionVerificationService,
     )
 }


### PR DESCRIPTION
Fix https://github.com/element-hq/element-x-android/issues/5075

Don't cancel the resetOidc job in onStart or onDestroy of ResetIdentityFlowNode

Sometimes, when using MAS to log in, then choosing to reset identity, the reset process was being cancelled mid-way, preventing the `resetOidc` job from turning on Key Storage.

In my investigation of this, I found that the `onStart` and `onDestroy` methods were _both_ sometimes called when the `resetOidc` job was still running.

So this change prevents us from cancelling the `resetOidc` job in `onStart` and `onDestroy` (and therefore removes `onDestroy` completely).

I am concerned that we might leave `resetOidc` running if the user does not choose "Finish Reset" in MAS, but I think the right fix for this is to do something inside `resetOidc` (in the Rust) because I don't think we have anything in the Android world where we know it's time to kill `resetOidc` rather than just wait a little longer for it to complete. If anyone knows better, please advise me.

## Tests

<!-- Explain how you tested your development -->

I followed the testcase in https://github.com/element-hq/element-x-android/issues/5075 and observed that "Key storage" in Settings was sometimes disabled after login and reset (1 out of 5 times for me).

After the fix I ran through the same test 10 times and it worked every time: log in, reset identity, check Key storage in settings: it is enabled.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 15

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [n/a] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
