### PR TITLE
Fix media seeking flicker

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
@@ -121,6 +121,7 @@ private fun ExoPlayerMediaAudioView(
                 durationInMillis = 0,
                 canMute = false,
                 isMuted = false,
+                seekingToMillis = null,
             )
         )
     }
@@ -171,15 +172,21 @@ private fun ExoPlayerMediaAudioView(
     LaunchedEffect(exoPlayer.isPlaying) {
         if (exoPlayer.isPlaying) {
             while (true) {
+                val position = exoPlayer.currentPosition
+                val seekingTo = mediaPlayerControllerState.seekingToMillis
                 mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                    progressInMillis = exoPlayer.currentPosition,
+                    progressInMillis = position,
+                    seekingToMillis = if (seekingTo != null && position >= seekingTo) null else seekingTo,
                 )
                 delay(200)
             }
         } else {
             // Ensure we render the final state
+            val position = exoPlayer.currentPosition
+            val seekingTo = mediaPlayerControllerState.seekingToMillis
             mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                progressInMillis = exoPlayer.currentPosition,
+                progressInMillis = position,
+                seekingToMillis = if (seekingTo != null && position >= seekingTo) null else seekingTo,
             )
         }
     }
@@ -294,6 +301,9 @@ private fun ExoPlayerMediaAudioView(
                 exoPlayer.togglePlay()
             },
             onSeekChange = {
+                mediaPlayerControllerState = mediaPlayerControllerState.copy(
+                    seekingToMillis = it.toLong(),
+                )
                 exoPlayer.seekToEnsurePlaying(it.toLong())
             },
             onToggleMute = {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerState.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerState.kt
@@ -18,7 +18,16 @@ data class MediaPlayerControllerState(
     val durationInMillis: Long,
     val canMute: Boolean,
     val isMuted: Boolean,
+    val seekingToMillis: Long?,
 ) {
+    /**
+     * The progress in milliseconds to display. When [seekingToMillis] is non-null (during a seek operation),
+     * this returns the target seek position. Once the player catches up to the seek position,
+     * [seekingToMillis] is cleared (set to null) and this returns [progressInMillis] again.
+     */
+    val displayProgressInMillis: Long
+        get() = seekingToMillis ?: progressInMillis
+
     @FloatRange(from = 0.0, to = 1.0)
-    val progressAsFloat = (progressInMillis.toFloat() / durationInMillis.toFloat()).coerceIn(0f, 1f)
+    val progressAsFloat = (displayProgressInMillis.toFloat() / durationInMillis.toFloat()).coerceIn(0f, 1f)
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerStateProvider.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerStateProvider.kt
@@ -34,6 +34,7 @@ private fun aMediaPlayerControllerState(
     durationInMillis: Long = 83_000,
     canMute: Boolean = true,
     isMuted: Boolean = false,
+    seekingToMillis: Long? = null,
 ) = MediaPlayerControllerState(
     isVisible = isVisible,
     isPlaying = isPlaying,
@@ -42,4 +43,5 @@ private fun aMediaPlayerControllerState(
     durationInMillis = durationInMillis,
     canMute = canMute,
     isMuted = isMuted,
+    seekingToMillis = seekingToMillis,
 )

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/player/MediaPlayerControllerView.kt
@@ -126,7 +126,7 @@ fun MediaPlayerControllerView(
                     modifier = Modifier
                         .widthIn(min = 48.dp)
                         .padding(horizontal = 8.dp),
-                    text = state.progressInMillis.toHumanReadableDuration(),
+                    text = state.displayProgressInMillis.toHumanReadableDuration(),
                     textAlign = TextAlign.Center,
                     color = ElementTheme.colors.textPrimary,
                     style = ElementTheme.typography.fontBodyXsMedium,
@@ -135,7 +135,9 @@ fun MediaPlayerControllerView(
                 Slider(
                     modifier = Modifier.weight(1f),
                     valueRange = 0f..state.durationInMillis.toFloat(),
-                    value = lastSelectedValue.takeIf { it >= 0 } ?: state.progressInMillis.toFloat(),
+                    value = lastSelectedValue.takeIf { it >= 0 }
+                        ?: state.seekingToMillis?.toFloat()
+                        ?: state.progressInMillis.toFloat(),
                     onValueChange = {
                         lastSelectedValue = it
                     },

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -108,6 +108,7 @@ private fun ExoPlayerMediaVideoView(
                 durationInMillis = 0,
                 canMute = true,
                 isMuted = false,
+                seekingToMillis = null,
             )
         )
     }
@@ -225,6 +226,9 @@ private fun ExoPlayerMediaVideoView(
             },
             onSeekChange = {
                 autoHideController++
+                mediaPlayerControllerState = mediaPlayerControllerState.copy(
+                    seekingToMillis = it.toLong(),
+                )
                 exoPlayer.seekToEnsurePlaying(it.toLong())
             },
             onToggleMute = {
@@ -242,15 +246,21 @@ private fun ExoPlayerMediaVideoView(
     LaunchedEffect(exoPlayer.isPlaying) {
         if (exoPlayer.isPlaying) {
             while (true) {
+                val position = exoPlayer.currentPosition
+                val seekingTo = mediaPlayerControllerState.seekingToMillis
                 mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                    progressInMillis = exoPlayer.currentPosition,
+                    progressInMillis = position,
+                    seekingToMillis = if (seekingTo != null && position >= seekingTo) null else seekingTo,
                 )
                 delay(200)
             }
         } else {
             // Ensure we render the final state
+            val position = exoPlayer.currentPosition
+            val seekingTo = mediaPlayerControllerState.seekingToMillis
             mediaPlayerControllerState = mediaPlayerControllerState.copy(
-                progressInMillis = exoPlayer.currentPosition,
+                progressInMillis = position,
+                seekingToMillis = if (seekingTo != null && position >= seekingTo) null else seekingTo,
             )
         }
     }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Fix media player cursor flickering

## Motivation and context

When seeking media, the player cursor will flicker to the previous position, and then seek.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Try to seek media

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
