### PR TITLE
Fix voice recording being interrupted by notifications sounds

### DIFF
--- a/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
+++ b/libraries/audio/impl/src/main/kotlin/io/element/android/libraries/audio/impl/DefaultAudioFocus.kt
@@ -39,10 +39,17 @@ class DefaultAudioFocus(
                 AudioManager.AUDIOFOCUS_GAIN -> {
                     // Do nothing
                 }
-                AudioManager.AUDIOFOCUS_LOSS,
+                AudioManager.AUDIOFOCUS_LOSS -> {
+                    // Permanent focus loss (e.g., phone call) — always stop/pause.
+                    onFocusLost()
+                }
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
-                    onFocusLost()
+                    // For recording, ignore transient focus losses (e.g., notification sounds).
+                    // The AudioRecord API keeps capturing regardless.
+                    if (requester != AudioFocusRequester.RecordVoiceMessage) {
+                        onFocusLost()
+                    }
                 }
             }
         }
@@ -51,7 +58,12 @@ class DefaultAudioFocus(
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(requester.toAudioUsage())
                 .build()
-            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+            val focusGain = if (requester == AudioFocusRequester.RecordVoiceMessage) {
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
+            } else {
+                AudioManager.AUDIOFOCUS_GAIN
+            }
+            val request = AudioFocusRequest.Builder(focusGain)
                 .setAudioAttributes(audioAttributes)
                 .setOnAudioFocusChangeListener(listener)
                 .setWillPauseWhenDucked(requester.willPausedWhenDucked())


### PR DESCRIPTION
## Content                                                                                                               
                                                                                                                          
Fix voice message recording being interrupted when a notification arrives. Modified `DefaultAudioFocus` to ignore transient audio focus losses (e.g., notification sounds) during recording, while still stopping on permanent focus loss (e.g., phone call). Also changed recording to request `AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE` on API 26+ for consistency with the pre-O code path.                                                                                                
                                        
## Motivation and context

This is frustrating for users who lose their progress on longer recordings due to something as common as receiving a message.                                                    
                                                                                                                  
## Screenshots / GIFs                  

N/A - no UI changes.

## Tests

- Record a voice message, trigger a notification mid-recording -> recording continues                                 
- Record a voice message, receive a phone call -> recording stops gracefully
                                                                                                                          
## Tested devices
                                                                                                                          
- [x] Physical                                                                                                    
- [ ] Emulator                         
- OS version(s):

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes - N/A
- [ ] Accessibility has been taken into account - N/A                                                                    
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user               
- [ ] Pull request includes screenshots or videos if containing UI changes - N/A                                         
- [x] You've made a self review of your PR