### PR TITLE
Prevent unnecessary downloads when quickly swiping through media

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -142,9 +142,6 @@ fun MediaViewerView(
                 }
                 is MediaViewerPageData.MediaViewerData -> {
                     var bottomPaddingInPixels by remember { mutableIntStateOf(defaultBottomPaddingInPixels) }
-                    LaunchedEffect(Unit) {
-                        state.eventSink(MediaViewerEvents.LoadMedia(dataForPage))
-                    }
                     Box(
                         modifier = Modifier.fillMaxSize()
                     ) {
@@ -152,6 +149,18 @@ fun MediaViewerView(
                             // This 'item provider' lambda will be called when the data source changes with an outdated `settlePage` value
                             // So we need to update this value only when the `settledPage` value changes. It seems like a bug that needs to be fixed in Compose.
                             page == pagerState.settledPage
+                        }
+                        var hasLoadedOnce by remember { mutableStateOf(false) }
+                        LaunchedEffect(isDisplayed) {
+                            if (isDisplayed) {
+                                if (!hasLoadedOnce) {
+                                    hasLoadedOnce = true
+                                    state.eventSink(MediaViewerEvents.LoadMedia(dataForPage))
+                                } else {
+                                    delay(300)
+                                    state.eventSink(MediaViewerEvents.LoadMedia(dataForPage))
+                                }
+                            }
                         }
                         MediaViewerPage(
                             isDisplayed = isDisplayed,


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Debounce download when quickly swiping through media files to prevent unnecessary downloads.

## Motivation and context

The media player would start download on each swipe, which would make a big queue for downloading and ultimately make the media player broken as you'd need to wait for all downloads to finish.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Swipe in media player

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
