### PR TITLE
Add margin after bullet points

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/ElementRichTextEditorStyle.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/ElementRichTextEditorStyle.kt
@@ -50,6 +50,9 @@ object ElementRichTextEditorStyle {
         val codeCornerRadius = 4.dp
         val codeBorderWidth = 1.dp
         return RichTextEditorDefaults.style(
+            bulletList = RichTextEditorDefaults.bulletListStyle(
+                bulletGapWidth = 8.dp,
+            ),
             text = RichTextEditorDefaults.textStyle(
                 color = LocalTextStyle.current.color.takeIf { it.isSpecified } ?: LocalContentColor.current,
                 fontStyle = LocalTextStyle.current.fontStyle,


### PR DESCRIPTION
## Content

Add margin after bullet points in message

## Motivation and context

Currently, bullet points doesn't have margin, which looks a bit broken.

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="364" height="378" alt="image" src="https://github.com/user-attachments/assets/c2b7c182-f26c-4897-a6ba-06208b75f621" />|<img width="406" height="368" alt="image" src="https://github.com/user-attachments/assets/773d195b-0772-4747-9557-e4c4d376b9be" />|

## Tests

<!-- Explain how you tested your development -->

- Check if bullet points has a margin after them

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
