### PR TITLE
Render nested bullet points as outline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemContentMessageFactory.kt
@@ -26,6 +26,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVoiceContent
 import io.element.android.features.messages.impl.utils.TextPillificationHelper
+import io.element.android.features.messages.impl.utils.replaceNestedBulletsWithOutlines
 import io.element.android.libraries.androidutils.filesize.FileSizeFormatter
 import io.element.android.libraries.androidutils.text.safeLinkify
 import io.element.android.libraries.core.mimetype.MimeTypes
@@ -281,6 +282,7 @@ class TimelineItemContentMessageFactory(
     private fun parseHtml(document: Document): CharSequence? {
         return htmlConverterProvider.provide()
             .fromDocumentToSpans(document)
+            .replaceNestedBulletsWithOutlines()
             .let { textPillificationHelper.pillify(it) }
             .safeLinkify()
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/BulletListStyler.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/utils/BulletListStyler.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2023-2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.utils
+
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import androidx.core.text.getSpans
+import io.element.android.libraries.textcomposer.spans.OutlineBulletSpan
+import io.element.android.wysiwyg.view.spans.UnorderedListSpan
+
+private val gapWidthField = UnorderedListSpan::class.java.getDeclaredField("gapWidth").apply { isAccessible = true }
+private val bulletRadiusField = UnorderedListSpan::class.java.getDeclaredField("bulletRadius").apply { isAccessible = true }
+
+private fun UnorderedListSpan.getGapWidth(): Int = gapWidthField.getInt(this)
+private fun UnorderedListSpan.getBulletRadius(): Int = bulletRadiusField.getInt(this)
+
+fun CharSequence.replaceNestedBulletsWithOutlines(): CharSequence {
+    val ssb = SpannableStringBuilder(this)
+    val spans = ssb.getSpans<UnorderedListSpan>()
+    if (spans.size <= 1) return this
+
+    val spanInfo = spans.map { span ->
+        Triple(span, ssb.getSpanStart(span), ssb.getSpanEnd(span))
+    }
+
+    for ((span, start, end) in spanInfo) {
+        val isNested = spanInfo.any { (other, otherStart, otherEnd) ->
+            other !== span && otherStart <= start && otherEnd >= end
+        }
+        if (isNested) {
+            ssb.removeSpan(span)
+            ssb.setSpan(
+                OutlineBulletSpan(
+                    gapWidth = span.getGapWidth(),
+                    bulletRadius = span.getBulletRadius(),
+                ),
+                start,
+                end,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
+    }
+
+    return ssb
+}

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/spans/OutlineBulletSpan.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/spans/OutlineBulletSpan.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2023-2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.textcomposer.spans
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.text.Layout
+import android.text.Spanned
+import android.text.style.LeadingMarginSpan
+
+class OutlineBulletSpan(
+    private val gapWidth: Int,
+    private val bulletRadius: Int,
+) : LeadingMarginSpan {
+    override fun getLeadingMargin(first: Boolean): Int {
+        return 2 * bulletRadius + gapWidth
+    }
+
+    override fun drawLeadingMargin(
+        canvas: Canvas,
+        paint: Paint,
+        x: Int,
+        dir: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        isFirst: Boolean,
+        layout: Layout,
+    ) {
+        if ((text as Spanned).getSpanStart(this) != start) return
+
+        val originalStyle = paint.style
+        val originalStrokeWidth = paint.strokeWidth
+
+        paint.style = Paint.Style.STROKE
+        paint.strokeWidth = (bulletRadius / 4f).coerceAtLeast(1f)
+
+        val textBounds = Rect()
+        paint.getTextBounds("x", 0, 1, textBounds)
+        val cy = baseline - textBounds.height() / 2f
+        val cx = x + dir * bulletRadius
+
+        canvas.drawCircle(cx.toFloat(), cy, bulletRadius.toFloat(), paint)
+
+        paint.style = originalStyle
+        paint.strokeWidth = originalStrokeWidth
+    }
+}


### PR DESCRIPTION
## Content

Render nested bullet points as outline

## Motivation and context

Nested bullet points has a filled shape as any other point. With this change, nested bullet points will have an outline shape.
## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Check if nested bullet points has an outline shape
  - like this

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR