### PR TITLE
Restore custom user certificate provider

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.di.annotations.AppCoroutineScope
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.impl.analytics.UtdTracker
+import io.element.android.libraries.matrix.impl.certificates.UserCertificatesProvider
 import io.element.android.libraries.matrix.impl.paths.SessionPaths
 import io.element.android.libraries.matrix.impl.paths.getSessionPaths
 import io.element.android.libraries.matrix.impl.proxy.ProxyProvider
@@ -57,6 +58,7 @@ class RustMatrixClientFactory(
     private val sessionStore: SessionStore,
     private val userAgentProvider: UserAgentProvider,
     private val proxyProvider: ProxyProvider,
+    private val userCertificatesProvider: UserCertificatesProvider,
     private val clock: SystemClock,
     private val analyticsService: AnalyticsService,
     private val featureFlagService: FeatureFlagService,
@@ -141,6 +143,7 @@ class RustMatrixClientFactory(
             }
             .setSessionDelegate(sessionDelegate)
             .userAgent(userAgentProvider.provide())
+            .addRootCertificates(userCertificatesProvider.provides())
             .autoEnableBackups(true)
             .autoEnableCrossSigning(true)
             .roomKeyRecipientStrategy(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustHomeServerLoginCompatibilityChecker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustHomeServerLoginCompatibilityChecker.kt
@@ -13,16 +13,19 @@ import dev.zacsweers.metro.ContributesBinding
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.auth.HomeServerLoginCompatibilityChecker
 import io.element.android.libraries.matrix.impl.ClientBuilderProvider
+import io.element.android.libraries.matrix.impl.certificates.UserCertificatesProvider
 import timber.log.Timber
 
 @ContributesBinding(AppScope::class)
 class RustHomeServerLoginCompatibilityChecker(
     private val clientBuilderProvider: ClientBuilderProvider,
-) : HomeServerLoginCompatibilityChecker {
+    private val userCertificatesProvider: UserCertificatesProvider,
+    ) : HomeServerLoginCompatibilityChecker {
     override suspend fun check(url: String): Result<Boolean> = runCatchingExceptions {
         clientBuilderProvider.provide()
             .inMemoryStore()
             .serverNameOrHomeserverUrl(url)
+            .addRootCertificates(userCertificatesProvider.provides())
             .build()
             .use {
                 it.homeserverLoginDetails()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/certificates/DefaultUserCertificatesProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/certificates/DefaultUserCertificatesProvider.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.certificates
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import timber.log.Timber
+import java.security.KeyStore
+import java.security.KeyStoreException
+
+@ContributesBinding(AppScope::class)
+class DefaultUserCertificatesProvider : UserCertificatesProvider {
+    /**
+     * Get additional user-installed certificates from the `AndroidCAStore` `Keystore`.
+     *
+     * The Rust HTTP client doesn't include user-installed certificates in its internal certificate
+     * store. This means that whatever the user installs will be ignored.
+     *
+     * While most users don't need user-installed certificates some special deployments or debugging
+     * setups using a proxy might want to use them.
+     *
+     * @return A list of byte arrays where each byte array is a single user-installed certificate
+     *         in encoded form.
+     */
+    override fun provides(): List<ByteArray> {
+        // At least for API 34 the `AndroidCAStore` `Keystore` type contained user certificates as well.
+        // I have not found this to be documented anywhere.
+        val keyStore: KeyStore = try {
+            KeyStore.getInstance("AndroidCAStore")
+        } catch (e: KeyStoreException) {
+            Timber.w(e, "Failed to get AndroidCAStore keystore")
+            return emptyList()
+        }
+        val aliases = try {
+            keyStore.load(null)
+            keyStore.aliases()
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to load and get aliases AndroidCAStore keystore")
+            return emptyList()
+        }
+        return aliases.toList()
+            .filter { alias ->
+                // The certificate alias always contains the prefix `system` or
+                // `user` and the MD5 subject hash separated by a colon.
+                //
+                // The subject hash can be calculated using openssl as such:
+                //     openssl x509 -subject_hash_old -noout -in mycert.cer
+                //
+                // Again, I have not found this to be documented somewhere.
+                alias.startsWith("user")
+            }
+            .mapNotNull { alias ->
+                try {
+                    keyStore.getEntry(alias, null)
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to get entry for alias $alias")
+                    null
+                }
+            }
+            .filterIsInstance<KeyStore.TrustedCertificateEntry>()
+            .map { trustedCertificateEntry ->
+                trustedCertificateEntry.trustedCertificate.encoded
+            }
+            .also {
+                // Let's at least log the number of user-installed certificates we found,
+                // since the alias isn't particularly useful nor does the issuer seem to
+                // be easily available.
+                Timber.i("Found ${it.size} additional user-provided certificates.")
+            }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/certificates/UserCertificatesProvider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/certificates/UserCertificatesProvider.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.certificates
+
+interface UserCertificatesProvider {
+    fun provides(): List<ByteArray>
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactoryTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactoryTest.kt
@@ -12,6 +12,7 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.impl.auth.FakeProxyProvider
+import io.element.android.libraries.matrix.impl.auth.FakeUserCertificatesProvider
 import io.element.android.libraries.matrix.impl.room.FakeTimelineEventFilterFactory
 import io.element.android.libraries.matrix.impl.storage.FakeSqliteStoreBuilderProvider
 import io.element.android.libraries.network.useragent.SimpleUserAgentProvider
@@ -57,6 +58,7 @@ fun TestScope.createRustMatrixClientFactory(
     coroutineDispatchers = testCoroutineDispatchers(),
     sessionStore = sessionStore,
     userAgentProvider = SimpleUserAgentProvider(),
+    userCertificatesProvider = FakeUserCertificatesProvider(),
     proxyProvider = FakeProxyProvider(),
     clock = FakeSystemClock(),
     analyticsService = FakeAnalyticsService(),

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/FakeUserCertificatesProvider.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/FakeUserCertificatesProvider.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.auth
+
+import io.element.android.libraries.matrix.impl.certificates.UserCertificatesProvider
+
+class FakeUserCertificatesProvider : UserCertificatesProvider {
+    override fun provides(): List<ByteArray> {
+        return emptyList()
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/RustHomeserverLoginCompatibilityCheckerTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/auth/RustHomeserverLoginCompatibilityCheckerTest.kt
@@ -49,5 +49,6 @@ class RustHomeserverLoginCompatibilityCheckerTest {
                 FakeFfiClient(homeserverLoginDetailsResult = result)
             }
         },
+        userCertificatesProvider = FakeUserCertificatesProvider(),
     )
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Brings back the custom user certificate provider that was removed because the SDK temporarily didn't accept them anymore for Android.

## Motivation and context

Restoring this functionality after https://github.com/element-hq/element-x-android/pull/6444 makes it work again.

## Tests

My tests were using a custom cert with a mitm proxy and checking it works without disabling SSL verification.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
