### PR TITLE
Add auto-play consecutive voice messages in timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -32,6 +32,7 @@ import io.element.android.features.messages.impl.timeline.factories.TimelineItem
 import io.element.android.features.messages.impl.timeline.factories.TimelineItemsFactoryConfig
 import io.element.android.features.messages.impl.timeline.model.NewEventState
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVoiceContent
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemTypingNotificationModel
 import io.element.android.features.messages.impl.typing.TypingNotificationState
 import io.element.android.features.messages.impl.userEventPermissions
@@ -55,6 +56,8 @@ import io.element.android.libraries.matrix.api.timeline.ReceiptType
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.matrix.api.timeline.item.event.TimelineItemEventOrigin
 import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
+import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.DisplayFirstTimelineItems
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.NotificationToMessage
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.OpenRoom
@@ -84,6 +87,7 @@ class TimelinePresenter(
     private val sessionCoroutineScope: CoroutineScope,
     @Assisted private val navigator: MessagesNavigator,
     private val redactedVoiceMessageManager: RedactedVoiceMessageManager,
+    private val voiceMessageAutoplayManager: VoiceMessageAutoplayManager,
     private val sendPollResponseAction: SendPollResponseAction,
     private val endPollAction: EndPollAction,
     private val sessionPreferencesStore: SessionPreferencesStore,
@@ -239,6 +243,33 @@ class TimelinePresenter(
                 .onEach { newTimelineItems ->
                     timelineItemIndexer.process(newTimelineItems)
                     timelineItems = newTimelineItems
+
+                    // Feed autoplay manager with current timeline items
+                    voiceMessageAutoplayManager.updateTimelineItems(
+                        newTimelineItems.map { item ->
+                            when (item) {
+                                is TimelineItem.Event -> {
+                                    val voiceContent = item.content as? TimelineItemVoiceContent
+                                    AutoplayTimelineItemInfo(
+                                        eventId = item.eventId,
+                                        isVoiceMessage = voiceContent != null,
+                                        mediaSource = voiceContent?.mediaSource,
+                                        mimeType = voiceContent?.mimeType,
+                                        filename = voiceContent?.filename,
+                                        duration = voiceContent?.duration,
+                                    )
+                                }
+                                else -> AutoplayTimelineItemInfo(
+                                    eventId = null,
+                                    isVoiceMessage = false,
+                                    mediaSource = null,
+                                    mimeType = null,
+                                    filename = null,
+                                    duration = null,
+                                )
+                            }
+                        }
+                    )
 
                     analyticsService.run {
                         finishLongRunningTransaction(DisplayFirstTimelineItems)

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
@@ -20,6 +20,7 @@ import io.element.android.features.messages.impl.timeline.model.NewEventState
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.typing.aTypingNotificationState
 import io.element.android.features.messages.impl.voicemessages.timeline.FakeRedactedVoiceMessageManager
+import io.element.android.features.messages.impl.voicemessages.timeline.FakeVoiceMessageAutoplayManager
 import io.element.android.features.messages.impl.voicemessages.timeline.RedactedVoiceMessageManager
 import io.element.android.features.messages.impl.voicemessages.timeline.aRedactedMatrixTimeline
 import io.element.android.features.poll.api.actions.EndPollAction
@@ -60,6 +61,7 @@ import io.element.android.libraries.matrix.test.timeline.aMessageContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
 import io.element.android.libraries.matrix.ui.components.aMatrixUserList
 import io.element.android.libraries.preferences.test.InMemorySessionPreferencesStore
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
 import io.element.android.tests.testutils.awaitLastSequentialItem
@@ -1006,6 +1008,7 @@ class TimelinePresenterTest {
             ),
         ),
         redactedVoiceMessageManager: RedactedVoiceMessageManager = FakeRedactedVoiceMessageManager(),
+        voiceMessageAutoplayManager: VoiceMessageAutoplayManager = FakeVoiceMessageAutoplayManager(),
         messagesNavigator: FakeMessagesNavigator = FakeMessagesNavigator(),
         endPollAction: EndPollAction = FakeEndPollAction(),
         sendPollResponseAction: SendPollResponseAction = FakeSendPollResponseAction(),
@@ -1020,6 +1023,7 @@ class TimelinePresenterTest {
             sessionCoroutineScope = this,
             navigator = messagesNavigator,
             redactedVoiceMessageManager = redactedVoiceMessageManager,
+            voiceMessageAutoplayManager = voiceMessageAutoplayManager,
             endPollAction = endPollAction,
             sendPollResponseAction = sendPollResponseAction,
             sessionPreferencesStore = sessionPreferencesStore,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/FakeVoiceMessageAutoplayManager.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/timeline/FakeVoiceMessageAutoplayManager.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.voicemessages.timeline
+
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class FakeVoiceMessageAutoplayManager : VoiceMessageAutoplayManager {
+    private val _resetRequests = MutableSharedFlow<EventId>(extraBufferCapacity = 1)
+    override val resetRequests: SharedFlow<EventId> = _resetRequests.asSharedFlow()
+
+    override fun updateTimelineItems(items: List<AutoplayTimelineItemInfo>) = Unit
+
+    override fun cancelAutoplay() = Unit
+}

--- a/libraries/voiceplayer/api/src/main/kotlin/io/element/android/libraries/voiceplayer/api/VoiceMessageAutoplayManager.kt
+++ b/libraries/voiceplayer/api/src/main/kotlin/io/element/android/libraries/voiceplayer/api/VoiceMessageAutoplayManager.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.api
+
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.media.MediaSource
+import kotlinx.coroutines.flow.SharedFlow
+import kotlin.time.Duration
+
+/**
+ * Manages auto-playing consecutive voice messages in the timeline.
+ *
+ * When a voice message finishes playing, if the next chronological message
+ * is also a voice message, it will automatically start playing.
+ * The chain continues until a non-voice message is encountered.
+ */
+interface VoiceMessageAutoplayManager {
+    /**
+     * Feed the current timeline items so the manager can determine adjacency.
+     * Must be called whenever the timeline items change.
+     *
+     * @param items The current timeline items, ordered newest-first (index 0 = newest).
+     */
+    fun updateTimelineItems(items: List<AutoplayTimelineItemInfo>)
+
+    /**
+     * Emits event IDs of voice messages that should reset their playback position to 0:00.
+     * This is emitted when a voice message finishes and autoplay proceeds to the next one.
+     */
+    val resetRequests: SharedFlow<EventId>
+
+    /**
+     * Cancel any pending autoplay chain.
+     * Should be called when the user manually interacts with playback controls.
+     */
+    fun cancelAutoplay()
+}
+
+/**
+ * Lightweight info about a timeline item needed for autoplay adjacency checks.
+ */
+data class AutoplayTimelineItemInfo(
+    val eventId: EventId?,
+    val isVoiceMessage: Boolean,
+    val mediaSource: MediaSource?,
+    val mimeType: String?,
+    val filename: String?,
+    val duration: Duration?,
+)

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultTransitionSoundPlayer.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultTransitionSoundPlayer.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.impl
+
+import android.content.Context
+import android.net.Uri
+import dev.zacsweers.metro.ContributesBinding
+import io.element.android.libraries.di.RoomScope
+import io.element.android.libraries.di.annotations.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import kotlin.coroutines.resume
+import android.media.MediaPlayer as AndroidMediaPlayer
+
+private const val PLAYBACK_TIMEOUT_MS = 1_000L
+private const val NOTIFICATION_SOUND_RES_NAME = "message"
+
+@ContributesBinding(RoomScope::class)
+class DefaultTransitionSoundPlayer(
+    @ApplicationContext private val context: Context,
+) : TransitionSoundPlayer {
+    override suspend fun playAndAwait() {
+        try {
+            val resId = context.resources.getIdentifier(NOTIFICATION_SOUND_RES_NAME, "raw", context.packageName)
+            if (resId == 0) {
+                Timber.tag(TAG).e("Notification sound resource not found")
+                return
+            }
+            val completed = withTimeoutOrNull(PLAYBACK_TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    val soundUri = Uri.parse("android.resource://${context.packageName}/$resId")
+                    val player = AndroidMediaPlayer.create(context, soundUri)
+                    if (player == null) {
+                        Timber.tag(TAG).e("Failed to create MediaPlayer for transition sound")
+                        continuation.resume(Unit)
+                        return@suspendCancellableCoroutine
+                    }
+                    Timber.tag(TAG).d("Playing transition sound (duration=%dms)", player.duration)
+                    player.setOnCompletionListener { mp ->
+                        Timber.tag(TAG).d("Transition sound completed")
+                        mp.release()
+                        continuation.resume(Unit)
+                    }
+                    player.setOnErrorListener { mp, what, extra ->
+                        Timber.tag(TAG).e("Transition sound error: what=$what, extra=$extra")
+                        mp.release()
+                        continuation.resume(Unit)
+                        true
+                    }
+                    continuation.invokeOnCancellation {
+                        player.release()
+                    }
+                    player.start()
+                }
+            }
+            if (completed == null) {
+                Timber.tag(TAG).e("Transition sound timed out after %dms", PLAYBACK_TIMEOUT_MS)
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to play transition sound")
+        }
+    }
+
+    companion object {
+        private const val TAG = "TransitionSound"
+    }
+}

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManager.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManager.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -30,10 +29,10 @@ private const val TAG = "VoiceAutoplay"
 class DefaultVoiceMessageAutoplayManager(
     private val mediaPlayer: MediaPlayer,
     private val voiceMessagePlayerFactory: VoiceMessagePlayer.Factory,
+    private val transitionSoundPlayer: TransitionSoundPlayer,
     @SessionCoroutineScope private val coroutineScope: CoroutineScope,
 ) : VoiceMessageAutoplayManager {
-    private val _resetRequests = MutableSharedFlow<EventId>(extraBufferCapacity = 1)
-    override val resetRequests: SharedFlow<EventId> = _resetRequests.asSharedFlow()
+    override val resetRequests: SharedFlow<EventId> = MutableSharedFlow()
 
     private var timelineItems: List<AutoplayTimelineItemInfo> = emptyList()
     private var autoplayJob: Job? = null
@@ -120,18 +119,13 @@ class DefaultVoiceMessageAutoplayManager(
             return
         }
 
-        // Reset the ended message position to 0:00
-        val endedEventId = items[endedIndex].eventId
-        if (endedEventId != null) {
-            _resetRequests.tryEmit(endedEventId)
-        }
-
         Timber.tag(TAG).d("Starting autoplay of next voice message: %s", nextEventId)
         expectedAutoplayMediaId = nextEventId.value
         cancelled = false
 
         autoplayJob?.cancel()
         autoplayJob = coroutineScope.launch {
+            transitionSoundPlayer.playAndAwait()
             val nextPlayer = voiceMessagePlayerFactory.create(
                 eventId = nextEventId,
                 mediaSource = nextMediaSource,

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManager.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManager.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.impl
+
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.di.RoomScope
+import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.mediaplayer.api.MediaPlayer
+import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+private const val TAG = "VoiceAutoplay"
+
+@ContributesBinding(RoomScope::class)
+@SingleIn(RoomScope::class)
+class DefaultVoiceMessageAutoplayManager(
+    private val mediaPlayer: MediaPlayer,
+    private val voiceMessagePlayerFactory: VoiceMessagePlayer.Factory,
+    @SessionCoroutineScope private val coroutineScope: CoroutineScope,
+) : VoiceMessageAutoplayManager {
+    private val _resetRequests = MutableSharedFlow<EventId>(extraBufferCapacity = 1)
+    override val resetRequests: SharedFlow<EventId> = _resetRequests.asSharedFlow()
+
+    private var timelineItems: List<AutoplayTimelineItemInfo> = emptyList()
+    private var autoplayJob: Job? = null
+    private var cancelled = false
+
+    // Track the mediaId that the autoplay manager set, to detect user interruption
+    private var expectedAutoplayMediaId: String? = null
+
+    // Track the last isEnded+mediaId we processed, to avoid re-processing the same end event
+    private var lastProcessedEndedMediaId: String? = null
+
+    init {
+        Timber.tag(TAG).d("AutoplayManager initialized")
+        coroutineScope.launch {
+            mediaPlayer.state.collect { state ->
+                val mediaId = state.mediaId
+
+                // Reset the ended guard whenever we're no longer in an ended state,
+                // so the same track can trigger autoplay again on subsequent listens.
+                if (!state.isEnded) {
+                    lastProcessedEndedMediaId = null
+                }
+
+                val shouldAutoplay = state.isEnded && mediaId != null &&
+                    !cancelled && mediaId != lastProcessedEndedMediaId
+                if (shouldAutoplay) {
+                    lastProcessedEndedMediaId = mediaId
+                    onVoiceMessageEnded(mediaId)
+                }
+
+                // Detect user interruption: if a different track starts playing
+                // and it wasn't triggered by autoplay, cancel the chain
+                val isUserInterruption = state.isPlaying && mediaId != null &&
+                    expectedAutoplayMediaId != null && mediaId != expectedAutoplayMediaId
+                if (isUserInterruption) {
+                    Timber.tag(TAG).d("User started a different track, cancelling chain")
+                    cancelAutoplayInternal()
+                }
+            }
+        }
+    }
+
+    override fun updateTimelineItems(items: List<AutoplayTimelineItemInfo>) {
+        this.timelineItems = items
+    }
+
+    override fun cancelAutoplay() {
+        Timber.tag(TAG).d("cancelAutoplay() called externally")
+        cancelAutoplayInternal()
+    }
+
+    private fun cancelAutoplayInternal() {
+        cancelled = true
+        expectedAutoplayMediaId = null
+        autoplayJob?.cancel()
+        autoplayJob = null
+    }
+
+    private fun onVoiceMessageEnded(endedMediaId: String) {
+        val items = timelineItems
+        Timber.tag(TAG).d("onVoiceMessageEnded: mediaId=%s, timeline has %d items", endedMediaId, items.size)
+
+        val endedIndex = items.indexOfFirst { it.eventId?.value == endedMediaId }
+        if (endedIndex < 0) {
+            Timber.tag(TAG).d("Ended mediaId not found in timeline items")
+            return
+        }
+
+        // Timeline is newest-first (index 0 = newest).
+        // "Next chronologically" (later in time) = lower index.
+        // Skip over virtual items (day separators, etc.) that have no eventId.
+        val nextItem = findNextEventItem(items, endedIndex)
+        if (nextItem == null) {
+            Timber.tag(TAG).d("No next event item found after index %d", endedIndex)
+            expectedAutoplayMediaId = null
+            return
+        }
+
+        val nextEventId = nextItem.eventId
+        val nextMediaSource = nextItem.mediaSource
+        if (!nextItem.isVoiceMessage || nextEventId == null || nextMediaSource == null) {
+            Timber.tag(TAG).d("Next event item is not a voice message, stopping chain")
+            expectedAutoplayMediaId = null
+            return
+        }
+
+        // Reset the ended message position to 0:00
+        val endedEventId = items[endedIndex].eventId
+        if (endedEventId != null) {
+            _resetRequests.tryEmit(endedEventId)
+        }
+
+        Timber.tag(TAG).d("Starting autoplay of next voice message: %s", nextEventId)
+        expectedAutoplayMediaId = nextEventId.value
+        cancelled = false
+
+        autoplayJob?.cancel()
+        autoplayJob = coroutineScope.launch {
+            val nextPlayer = voiceMessagePlayerFactory.create(
+                eventId = nextEventId,
+                mediaSource = nextMediaSource,
+                mimeType = nextItem.mimeType,
+                filename = nextItem.filename,
+            )
+            nextPlayer.prepare().onSuccess {
+                Timber.tag(TAG).d("Prepared next voice message, now playing")
+                nextPlayer.play()
+            }.onFailure {
+                Timber.tag(TAG).e(it, "Failed to prepare next voice message")
+                expectedAutoplayMediaId = null
+            }
+        }
+    }
+
+    /**
+     * Find the next event item (skipping virtual items like day separators)
+     * in the chronological direction (toward newer = lower index).
+     */
+    private fun findNextEventItem(
+        items: List<AutoplayTimelineItemInfo>,
+        currentIndex: Int,
+    ): AutoplayTimelineItemInfo? {
+        for (i in currentIndex - 1 downTo 0) {
+            val item = items[i]
+            // Virtual items have null eventId, skip them
+            if (item.eventId != null) {
+                return item
+            }
+        }
+        return null
+    }
+}

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessagePresenterFactory.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessagePresenterFactory.kt
@@ -14,6 +14,7 @@ import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.MediaSource
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
 import io.element.android.libraries.voiceplayer.api.VoiceMessagePresenterFactory
 import io.element.android.libraries.voiceplayer.api.VoiceMessageState
 import io.element.android.services.analytics.api.AnalyticsService
@@ -27,6 +28,7 @@ class DefaultVoiceMessagePresenterFactory(
     private val sessionCoroutineScope: CoroutineScope,
     private val voiceMessagePlayerFactory: VoiceMessagePlayer.Factory,
     private val voicePlayerStore: VoicePlayerStore,
+    private val autoplayManager: VoiceMessageAutoplayManager,
 ) : VoiceMessagePresenterFactory {
     override fun createVoiceMessagePresenter(
         eventId: EventId?,
@@ -47,6 +49,7 @@ class DefaultVoiceMessagePresenterFactory(
             sessionCoroutineScope = sessionCoroutineScope,
             voicePlayerStore = voicePlayerStore,
             player = player,
+            autoplayManager = autoplayManager,
             eventId = eventId,
             duration = duration,
         )

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/TransitionSoundPlayer.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/TransitionSoundPlayer.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.impl
+
+/**
+ * Plays a short transition sound between consecutive voice messages
+ * during autoplay.
+ */
+interface TransitionSoundPlayer {
+    /**
+     * Play the transition sound and suspend until it finishes.
+     */
+    suspend fun playAndAwait()
+}

--- a/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessagePresenter.kt
+++ b/libraries/voiceplayer/impl/src/main/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessagePresenter.kt
@@ -23,6 +23,7 @@ import io.element.android.libraries.core.extensions.flatMap
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.ui.utils.time.formatShort
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
 import io.element.android.libraries.voiceplayer.api.VoiceMessageEvent
 import io.element.android.libraries.voiceplayer.api.VoiceMessageException
 import io.element.android.libraries.voiceplayer.api.VoiceMessageState
@@ -37,6 +38,7 @@ class VoiceMessagePresenter(
     private val sessionCoroutineScope: CoroutineScope,
     private val voicePlayerStore: VoicePlayerStore,
     private val player: VoiceMessagePlayer,
+    private val autoplayManager: VoiceMessageAutoplayManager,
     private val eventId: EventId?,
     private val duration: Duration,
 ) : Presenter<VoiceMessageState> {
@@ -59,6 +61,15 @@ class VoiceMessagePresenter(
 
         LaunchedEffect(playbackSpeedIndex) {
             player.setPlaybackSpeed(VoicePlayerConfig.availablePlaybackSpeeds[playbackSpeedIndex])
+        }
+
+        // Listen for autoplay reset requests to reset position to 0:00
+        LaunchedEffect(Unit) {
+            autoplayManager.resetRequests.collect { resetEventId ->
+                if (resetEventId == eventId) {
+                    player.seekTo(0L)
+                }
+            }
         }
 
         val buttonType by remember {
@@ -99,6 +110,8 @@ class VoiceMessagePresenter(
             when (event) {
                 is VoiceMessageEvent.PlayPause -> {
                     if (playerState.isPlaying) {
+                        // User manually paused — cancel any ongoing autoplay chain
+                        autoplayManager.cancelAutoplay()
                         player.pause()
                     } else if (playerState.isReady) {
                         player.play()

--- a/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManagerTest.kt
+++ b/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManagerTest.kt
@@ -7,16 +7,18 @@
 
 package io.element.android.libraries.voiceplayer.impl
 
-import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.mediaplayer.api.MediaPlayer
 import io.element.android.libraries.mediaplayer.test.FakeMediaPlayer
 import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -28,7 +30,11 @@ class DefaultVoiceMessageAutoplayManagerTest {
     fun `when voice message ends and next is voice, autoplay triggers`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aVoiceTimelineItem(eventId = "\$event2"), // index 0 = newest
@@ -36,22 +42,21 @@ class DefaultVoiceMessageAutoplayManagerTest {
         )
         manager.updateTimelineItems(items)
 
-        manager.resetRequests.test {
-            // Simulate event1 finishing playback
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
 
-            // Should emit reset for event1
-            val resetEventId = awaitItem()
-            assertThat(resetEventId).isEqualTo(EventId("\$event1"))
-        }
+        assertThat(fakeTransitionSound.playCount).isEqualTo(1)
     }
 
     @Test
     fun `when voice message ends and next is not voice, no autoplay`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aTextTimelineItem(eventId = "\$event2"), // index 0 = newest, NOT voice
@@ -59,40 +64,42 @@ class DefaultVoiceMessageAutoplayManagerTest {
         )
         manager.updateTimelineItems(items)
 
-        manager.resetRequests.test {
-            // Simulate event1 finishing playback
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
 
-            // No reset should be emitted
-            expectNoEvents()
-        }
+        assertThat(fakeTransitionSound.playCount).isEqualTo(0)
     }
 
     @Test
     fun `when voice message ends and it is the newest item, no autoplay`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aVoiceTimelineItem(eventId = "\$event1"), // index 0 = newest, only item
         )
         manager.updateTimelineItems(items)
 
-        manager.resetRequests.test {
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
 
-            expectNoEvents()
-        }
+        assertThat(fakeTransitionSound.playCount).isEqualTo(0)
     }
 
     @Test
     fun `cancelAutoplay prevents next autoplay trigger`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aVoiceTimelineItem(eventId = "\$event2"),
@@ -101,19 +108,21 @@ class DefaultVoiceMessageAutoplayManagerTest {
         manager.updateTimelineItems(items)
         manager.cancelAutoplay()
 
-        manager.resetRequests.test {
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
 
-            expectNoEvents()
-        }
+        assertThat(fakeTransitionSound.playCount).isEqualTo(0)
     }
 
     @Test
     fun `autoplay chain works across 3 consecutive voice messages`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aVoiceTimelineItem(eventId = "\$event3"), // newest
@@ -122,29 +131,31 @@ class DefaultVoiceMessageAutoplayManagerTest {
         )
         manager.updateTimelineItems(items)
 
-        manager.resetRequests.test {
-            // event1 ends → should autoplay event2
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
-            assertThat(awaitItem()).isEqualTo(EventId("\$event1"))
+        // event1 ends → should autoplay event2
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
+        assertThat(fakeTransitionSound.playCount).isEqualTo(1)
 
-            // event2 ends → should autoplay event3
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event2")
-            advanceUntilIdle()
-            assertThat(awaitItem()).isEqualTo(EventId("\$event2"))
+        // event2 ends → should autoplay event3
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event2")
+        advanceUntilIdle()
+        assertThat(fakeTransitionSound.playCount).isEqualTo(2)
 
-            // event3 ends → no more voice messages
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event3")
-            advanceUntilIdle()
-            expectNoEvents()
-        }
+        // event3 ends → no more voice messages
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event3")
+        advanceUntilIdle()
+        assertThat(fakeTransitionSound.playCount).isEqualTo(2)
     }
 
     @Test
     fun `non-voice message breaks the chain`() = runTest {
         val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
         val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
-        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+        val fakeTransitionSound = FakeTransitionSoundPlayer()
+        val manager = createAutoplayManager(
+            mediaPlayer = fakeMediaPlayer,
+            transitionSoundPlayer = fakeTransitionSound,
+        )
 
         val items = listOf(
             aVoiceTimelineItem(eventId = "\$event3"), // newest
@@ -153,25 +164,25 @@ class DefaultVoiceMessageAutoplayManagerTest {
         )
         manager.updateTimelineItems(items)
 
-        manager.resetRequests.test {
-            // event1 ends → next is text, no autoplay
-            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
-            advanceUntilIdle()
-            expectNoEvents()
-        }
+        mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+        advanceUntilIdle()
+
+        assertThat(fakeTransitionSound.playCount).isEqualTo(0)
     }
 
     // -- Helpers --
 
     private fun TestScope.createAutoplayManager(
         mediaPlayer: MediaPlayer = FakeMediaPlayer(),
+        transitionSoundPlayer: TransitionSoundPlayer = FakeTransitionSoundPlayer(),
     ): DefaultVoiceMessageAutoplayManager {
-        // Use a child scope so the manager's collect coroutine can be cancelled
-        // without causing UncompletedCoroutinesError in the TestScope.
-        val childScope = backgroundScope
+        // Use UnconfinedTestDispatcher so the collect and launched autoplay coroutines
+        // run eagerly, allowing assertions to check side effects synchronously.
+        val childScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
         return DefaultVoiceMessageAutoplayManager(
             mediaPlayer = mediaPlayer,
             voiceMessagePlayerFactory = FakeVoiceMessagePlayerFactory(),
+            transitionSoundPlayer = transitionSoundPlayer,
             coroutineScope = childScope,
         )
     }
@@ -250,6 +261,15 @@ private class FakeVoiceMessagePlayerFactory : VoiceMessagePlayer.Factory {
         mimeType: String?,
         filename: String?,
     ): VoiceMessagePlayer = FakeVoiceMessagePlayer()
+}
+
+private class FakeTransitionSoundPlayer : TransitionSoundPlayer {
+    var playCount = 0
+        private set
+
+    override suspend fun playAndAwait() {
+        playCount++
+    }
 }
 
 private class FakeVoiceMessagePlayer : VoiceMessagePlayer {

--- a/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManagerTest.kt
+++ b/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/DefaultVoiceMessageAutoplayManagerTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.impl
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.media.MediaSource
+import io.element.android.libraries.mediaplayer.api.MediaPlayer
+import io.element.android.libraries.mediaplayer.test.FakeMediaPlayer
+import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultVoiceMessageAutoplayManagerTest {
+    @Test
+    fun `when voice message ends and next is voice, autoplay triggers`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aVoiceTimelineItem(eventId = "\$event2"), // index 0 = newest
+            aVoiceTimelineItem(eventId = "\$event1"), // index 1 = older
+        )
+        manager.updateTimelineItems(items)
+
+        manager.resetRequests.test {
+            // Simulate event1 finishing playback
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+
+            // Should emit reset for event1
+            val resetEventId = awaitItem()
+            assertThat(resetEventId).isEqualTo(EventId("\$event1"))
+        }
+    }
+
+    @Test
+    fun `when voice message ends and next is not voice, no autoplay`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aTextTimelineItem(eventId = "\$event2"), // index 0 = newest, NOT voice
+            aVoiceTimelineItem(eventId = "\$event1"), // index 1 = older
+        )
+        manager.updateTimelineItems(items)
+
+        manager.resetRequests.test {
+            // Simulate event1 finishing playback
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+
+            // No reset should be emitted
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `when voice message ends and it is the newest item, no autoplay`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aVoiceTimelineItem(eventId = "\$event1"), // index 0 = newest, only item
+        )
+        manager.updateTimelineItems(items)
+
+        manager.resetRequests.test {
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `cancelAutoplay prevents next autoplay trigger`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aVoiceTimelineItem(eventId = "\$event2"),
+            aVoiceTimelineItem(eventId = "\$event1"),
+        )
+        manager.updateTimelineItems(items)
+        manager.cancelAutoplay()
+
+        manager.resetRequests.test {
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `autoplay chain works across 3 consecutive voice messages`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aVoiceTimelineItem(eventId = "\$event3"), // newest
+            aVoiceTimelineItem(eventId = "\$event2"),
+            aVoiceTimelineItem(eventId = "\$event1"), // oldest
+        )
+        manager.updateTimelineItems(items)
+
+        manager.resetRequests.test {
+            // event1 ends → should autoplay event2
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+            assertThat(awaitItem()).isEqualTo(EventId("\$event1"))
+
+            // event2 ends → should autoplay event3
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event2")
+            advanceUntilIdle()
+            assertThat(awaitItem()).isEqualTo(EventId("\$event2"))
+
+            // event3 ends → no more voice messages
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event3")
+            advanceUntilIdle()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `non-voice message breaks the chain`() = runTest {
+        val mediaPlayerState = MutableStateFlow(aMediaPlayerState())
+        val fakeMediaPlayer = TestableMediaPlayer(mediaPlayerState)
+        val manager = createAutoplayManager(mediaPlayer = fakeMediaPlayer)
+
+        val items = listOf(
+            aVoiceTimelineItem(eventId = "\$event3"), // newest
+            aTextTimelineItem(eventId = "\$event2"), // text breaks chain
+            aVoiceTimelineItem(eventId = "\$event1"), // oldest
+        )
+        manager.updateTimelineItems(items)
+
+        manager.resetRequests.test {
+            // event1 ends → next is text, no autoplay
+            mediaPlayerState.value = aMediaPlayerState(isEnded = true, mediaId = "\$event1")
+            advanceUntilIdle()
+            expectNoEvents()
+        }
+    }
+
+    // -- Helpers --
+
+    private fun TestScope.createAutoplayManager(
+        mediaPlayer: MediaPlayer = FakeMediaPlayer(),
+    ): DefaultVoiceMessageAutoplayManager {
+        // Use a child scope so the manager's collect coroutine can be cancelled
+        // without causing UncompletedCoroutinesError in the TestScope.
+        val childScope = backgroundScope
+        return DefaultVoiceMessageAutoplayManager(
+            mediaPlayer = mediaPlayer,
+            voiceMessagePlayerFactory = FakeVoiceMessagePlayerFactory(),
+            coroutineScope = childScope,
+        )
+    }
+
+    private fun aMediaPlayerState(
+        isReady: Boolean = false,
+        isPlaying: Boolean = false,
+        isEnded: Boolean = false,
+        mediaId: String? = null,
+        currentPosition: Long = 0L,
+        duration: Long? = null,
+    ) = MediaPlayer.State(
+        isReady = isReady,
+        isPlaying = isPlaying,
+        isEnded = isEnded,
+        mediaId = mediaId,
+        currentPosition = currentPosition,
+        duration = duration,
+    )
+
+    private fun aVoiceTimelineItem(eventId: String) = AutoplayTimelineItemInfo(
+        eventId = EventId(eventId),
+        isVoiceMessage = true,
+        mediaSource = MediaSource("mxc://matrix.org/$eventId"),
+        mimeType = "audio/ogg",
+        filename = "voice.ogg",
+        duration = 5.seconds,
+    )
+
+    private fun aTextTimelineItem(eventId: String) = AutoplayTimelineItemInfo(
+        eventId = EventId(eventId),
+        isVoiceMessage = false,
+        mediaSource = null,
+        mimeType = null,
+        filename = null,
+        duration = null,
+    )
+}
+
+/**
+ * A simple MediaPlayer wrapper that exposes a controllable state flow.
+ */
+private class TestableMediaPlayer(
+    private val stateFlow: MutableStateFlow<MediaPlayer.State>,
+) : MediaPlayer {
+    override val state = stateFlow
+
+    override suspend fun setMedia(uri: String, mediaId: String, mimeType: String, startPositionMs: Long): MediaPlayer.State {
+        stateFlow.value = stateFlow.value.copy(mediaId = mediaId, isReady = true)
+        return stateFlow.value
+    }
+
+    override fun play() {
+        stateFlow.value = stateFlow.value.copy(isPlaying = true, isEnded = false)
+    }
+
+    override fun pause() {
+        stateFlow.value = stateFlow.value.copy(isPlaying = false)
+    }
+
+    override fun seekTo(positionMs: Long) {
+        stateFlow.value = stateFlow.value.copy(currentPosition = positionMs)
+    }
+
+    override fun setPlaybackSpeed(speed: Float) = Unit
+    override fun close() = Unit
+}
+
+/**
+ * A fake VoiceMessagePlayer.Factory that creates minimal players for testing autoplay.
+ */
+private class FakeVoiceMessagePlayerFactory : VoiceMessagePlayer.Factory {
+    override fun create(
+        eventId: EventId?,
+        mediaSource: MediaSource,
+        mimeType: String?,
+        filename: String?,
+    ): VoiceMessagePlayer = FakeVoiceMessagePlayer()
+}
+
+private class FakeVoiceMessagePlayer : VoiceMessagePlayer {
+    override val state = MutableStateFlow(
+        VoiceMessagePlayer.State(
+            isReady = false,
+            isPlaying = false,
+            isEnded = false,
+            currentPosition = 0L,
+            duration = null,
+        )
+    )
+
+    override suspend fun prepare(): Result<Unit> = Result.success(Unit)
+    override fun play() = Unit
+    override fun pause() = Unit
+    override fun seekTo(positionMs: Long) = Unit
+    override fun setPlaybackSpeed(speed: Float) = Unit
+}

--- a/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/FakeVoiceMessageAutoplayManager.kt
+++ b/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/FakeVoiceMessageAutoplayManager.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.voiceplayer.impl
+
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.voiceplayer.api.AutoplayTimelineItemInfo
+import io.element.android.libraries.voiceplayer.api.VoiceMessageAutoplayManager
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class FakeVoiceMessageAutoplayManager : VoiceMessageAutoplayManager {
+    private val _resetRequests = MutableSharedFlow<EventId>(extraBufferCapacity = 1)
+    override val resetRequests: SharedFlow<EventId> = _resetRequests.asSharedFlow()
+
+    var lastTimelineItems: List<AutoplayTimelineItemInfo> = emptyList()
+        private set
+    var cancelAutoplayCallCount: Int = 0
+        private set
+
+    override fun updateTimelineItems(items: List<AutoplayTimelineItemInfo>) {
+        lastTimelineItems = items
+    }
+
+    override fun cancelAutoplay() {
+        cancelAutoplayCallCount++
+    }
+
+    fun emitResetRequest(eventId: EventId) {
+        _resetRequests.tryEmit(eventId)
+    }
+}

--- a/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessagePresenterTest.kt
+++ b/libraries/voiceplayer/impl/src/test/kotlin/io/element/android/libraries/voiceplayer/impl/VoiceMessagePresenterTest.kt
@@ -208,6 +208,46 @@ class VoiceMessagePresenterTest {
     }
 
     @Test
+    fun `pressing play does not cancel autoplay`() = runTest {
+        val autoplayManager = FakeVoiceMessageAutoplayManager()
+        val presenter = createVoiceMessagePresenter(
+            mediaPlayer = FakeMediaPlayer(fakeTotalDurationMs = 2_000),
+            duration = 2_000.milliseconds,
+            autoplayManager = autoplayManager,
+        )
+        presenter.test {
+            val initialState = awaitItem()
+            initialState.eventSink(VoiceMessageEvent.PlayPause)
+            skipItems(2) // skip downloading states
+            awaitItem() // playing state
+
+            assertThat(autoplayManager.cancelAutoplayCallCount).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `pressing pause cancels autoplay`() = runTest {
+        val autoplayManager = FakeVoiceMessageAutoplayManager()
+        val presenter = createVoiceMessagePresenter(
+            mediaPlayer = FakeMediaPlayer(fakeTotalDurationMs = 2_000),
+            duration = 2_000.milliseconds,
+            autoplayManager = autoplayManager,
+        )
+        presenter.test {
+            val initialState = awaitItem()
+            initialState.eventSink(VoiceMessageEvent.PlayPause)
+            skipItems(2) // skip downloading states
+            val playingState = awaitItem()
+
+            playingState.eventSink(VoiceMessageEvent.PlayPause) // pause
+            awaitItem()
+
+            // Only the pause triggers cancelAutoplay, not the initial play
+            assertThat(autoplayManager.cancelAutoplayCallCount).isEqualTo(1)
+        }
+    }
+
+    @Test
     fun `changing playback speed cycles through available speeds`() = runTest {
         val presenter = createVoiceMessagePresenter(
             duration = 10_000.milliseconds,
@@ -241,6 +281,7 @@ fun TestScope.createVoiceMessagePresenter(
     voiceMessageMediaRepo: VoiceMessageMediaRepo = FakeVoiceMessageMediaRepo(),
     analyticsService: AnalyticsService = FakeAnalyticsService(),
     voicePlayerStore: VoicePlayerStore = InMemoryVoicePlayerStore(),
+    autoplayManager: FakeVoiceMessageAutoplayManager = FakeVoiceMessageAutoplayManager(),
     eventId: EventId? = EventId("\$anEventId"),
     filename: String = "filename doesn't really matter for a voice message",
     duration: Duration = 61_000.milliseconds,
@@ -259,6 +300,7 @@ fun TestScope.createVoiceMessagePresenter(
         filename = filename
     ),
     voicePlayerStore = voicePlayerStore,
+    autoplayManager = autoplayManager,
     eventId = eventId,
     duration = duration,
 )


### PR DESCRIPTION
## Content

Add auto-play for consecutive voice messages in the timeline. When a voice message finishes playing, if the next chronological message is also a voice message, it automatically starts playing. The chain continues until a non-voice message is encountered or the end of the timeline is reached.

Key changes:
- New `VoiceMessageAutoplayManager` interface (voiceplayer API) and `DefaultVoiceMessageAutoplayManager` implementation (voiceplayer impl, RoomScope singleton)
- Manager observes `MediaPlayer.state` for `isEnded` transitions and triggers playback of the next consecutive voice message
- `VoiceMessagePresenter` listens for reset requests and cancels autoplay on manual pause
- `TimelinePresenter` feeds current timeline items to the autoplay manager on each update
- Virtual items (day separators, read markers) are skipped when checking adjacency

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/4618

This is a standard feature in almost every modern messaging app.

## Screenshots / GIFs

<!-- No UI changes -->

## Tests

- 1. Send 2+ voice messages in a row in a test room
- 2. Play the first one, when it ends, the next should auto-start
- 3. Insert a text message between voice messages, autoplay should stop at the boundary
- 4. During autoplay, manually tap pause, chain should stop
- 5. During autoplay, tap a different voice message, chain should cancel and play the tapped one
- 6. Replay the first voice message after a completed chain, autoplay should work again
- 7. Scroll voice messages off-screen during autoplay, playback should continue unaffected

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 15

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR

---

## Open questions

@jmartinesp

1. **Transition sound:** Currently there is no sound effect played between consecutive voice messages during autoplay. Open to suggestions on whether we should add one (e.g. a short tick/beep) and if so, what would fit best.
2. **User setting:** Autoplay is always enabled for now. Open to feedback on whether we should add an on/off toggle in user settings.