### PR TITLE
Support replying to messages with voice recordings

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerView.kt
@@ -83,6 +83,7 @@ internal fun MessageComposerView(
 
     val onSendVoiceMessage = {
         voiceMessageState.eventSink(VoiceMessageComposerEvent.SendVoiceMessage)
+        state.eventSink(MessageComposerEvent.CloseSpecialMode)
     }
 
     val onDeleteVoiceMessage = {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
@@ -153,7 +153,7 @@ class DefaultVoiceMessageComposerPresenter(
             }
         }
 
-        fun sendVoiceMessage(inReplyToEventId: EventId?, composerEvent: Composer) {
+        fun sendVoiceMessage(inReplyToEventId: EventId?) {
             val finishedState = recorderState as? VoiceRecorderState.Finished
             if (finishedState == null) {
                 val exception = VoiceMessageException.FileException("No file to send")
@@ -166,7 +166,7 @@ class DefaultVoiceMessageComposerPresenter(
             }
             isSending = true
             player.pause()
-            analyticsService.capture(composerEvent)
+            analyticsService.captureComposerEvent()
             sessionCoroutineScope.launch {
                 val result = sendMessage(
                     file = finishedState.file,
@@ -187,12 +187,11 @@ class DefaultVoiceMessageComposerPresenter(
                 is VoiceMessageComposerEvent.RecorderEvent -> handleVoiceMessageRecorderEvent(event.recorderEvent)
                 is VoiceMessageComposerEvent.PlayerEvent -> handleVoiceMessagePlayerEvent(event.playerEvent)
                 is VoiceMessageComposerEvent.SendVoiceMessage -> {
-                    // Capture mode eagerly before any coroutine dispatch, since CloseSpecialMode
-                    // may reset it before the coroutine runs.
+                    // Capture reply info eagerly before any coroutine dispatch, since CloseSpecialMode
+                    // may reset composerMode before the coroutine runs.
                     val inReplyToEventId = (messageComposerContext.composerMode as? MessageComposerMode.Reply)?.eventId
-                    val composerEvent = buildComposerEvent()
                     localCoroutineScope.launch {
-                        sendVoiceMessage(inReplyToEventId, composerEvent)
+                        sendVoiceMessage(inReplyToEventId)
                     }
                 }
                 VoiceMessageComposerEvent.DeleteVoiceMessage -> {
@@ -308,12 +307,14 @@ class DefaultVoiceMessageComposerPresenter(
         return result
     }
 
-    private fun buildComposerEvent() =
-        Composer(
-            inThread = messageComposerContext.composerMode.inThread,
-            isEditing = messageComposerContext.composerMode.isEditing,
-            isReply = messageComposerContext.composerMode.isReply,
-            messageType = Composer.MessageType.VoiceMessage,
+    private fun AnalyticsService.captureComposerEvent() =
+        capture(
+            Composer(
+                inThread = messageComposerContext.composerMode.inThread,
+                isEditing = messageComposerContext.composerMode.isEditing,
+                isReply = messageComposerContext.composerMode.isReply,
+                messageType = Composer.MessageType.VoiceMessage,
+            )
         )
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
@@ -34,10 +34,12 @@ import io.element.android.libraries.audio.api.AudioFocus
 import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaupload.api.MediaSenderFactory
 import io.element.android.libraries.permissions.api.PermissionsEvent
 import io.element.android.libraries.permissions.api.PermissionsPresenter
+import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.libraries.textcomposer.model.VoiceMessagePlayerEvent
 import io.element.android.libraries.textcomposer.model.VoiceMessageRecorderEvent
 import io.element.android.libraries.textcomposer.model.VoiceMessageState
@@ -151,7 +153,7 @@ class DefaultVoiceMessageComposerPresenter(
             }
         }
 
-        fun sendVoiceMessage() {
+        fun sendVoiceMessage(inReplyToEventId: EventId?, composerEvent: Composer) {
             val finishedState = recorderState as? VoiceRecorderState.Finished
             if (finishedState == null) {
                 val exception = VoiceMessageException.FileException("No file to send")
@@ -164,12 +166,13 @@ class DefaultVoiceMessageComposerPresenter(
             }
             isSending = true
             player.pause()
-            analyticsService.captureComposerEvent()
+            analyticsService.capture(composerEvent)
             sessionCoroutineScope.launch {
                 val result = sendMessage(
                     file = finishedState.file,
                     mimeType = finishedState.mimeType,
                     waveform = finishedState.waveform,
+                    inReplyToEventId = inReplyToEventId,
                 )
                 if (result.isFailure) {
                     showSendFailureDialog = true
@@ -183,8 +186,14 @@ class DefaultVoiceMessageComposerPresenter(
             when (event) {
                 is VoiceMessageComposerEvent.RecorderEvent -> handleVoiceMessageRecorderEvent(event.recorderEvent)
                 is VoiceMessageComposerEvent.PlayerEvent -> handleVoiceMessagePlayerEvent(event.playerEvent)
-                is VoiceMessageComposerEvent.SendVoiceMessage -> localCoroutineScope.launch {
-                    sendVoiceMessage()
+                is VoiceMessageComposerEvent.SendVoiceMessage -> {
+                    // Capture mode eagerly before any coroutine dispatch, since CloseSpecialMode
+                    // may reset it before the coroutine runs.
+                    val inReplyToEventId = (messageComposerContext.composerMode as? MessageComposerMode.Reply)?.eventId
+                    val composerEvent = buildComposerEvent()
+                    localCoroutineScope.launch {
+                        sendVoiceMessage(inReplyToEventId, composerEvent)
+                    }
                 }
                 VoiceMessageComposerEvent.DeleteVoiceMessage -> {
                     player.pause()
@@ -280,11 +289,13 @@ class DefaultVoiceMessageComposerPresenter(
         file: File,
         mimeType: String,
         waveform: List<Float>,
+        inReplyToEventId: EventId? = null,
     ): Result<Unit> {
         val result = mediaSender.sendVoiceMessage(
             uri = file.toUri(),
             mimeType = mimeType,
             waveForm = waveform,
+            inReplyToEventId = inReplyToEventId,
         )
 
         if (result.isFailure) {
@@ -297,14 +308,12 @@ class DefaultVoiceMessageComposerPresenter(
         return result
     }
 
-    private fun AnalyticsService.captureComposerEvent() =
-        capture(
-            Composer(
-                inThread = messageComposerContext.composerMode.inThread,
-                isEditing = messageComposerContext.composerMode.isEditing,
-                isReply = messageComposerContext.composerMode.isReply,
-                messageType = Composer.MessageType.VoiceMessage,
-            )
+    private fun buildComposerEvent() =
+        Composer(
+            inThread = messageComposerContext.composerMode.inThread,
+            isEditing = messageComposerContext.composerMode.isEditing,
+            isReply = messageComposerContext.composerMode.isReply,
+            messageType = Composer.MessageType.VoiceMessage,
         )
 }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
@@ -24,6 +24,7 @@ import io.element.android.libraries.audio.api.AudioFocusRequester
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.AudioInfo
 import io.element.android.libraries.matrix.api.timeline.Timeline
+import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
 import io.element.android.libraries.matrix.test.timeline.FakeTimeline
@@ -46,7 +47,9 @@ import io.element.android.libraries.voicerecorder.api.VoiceRecorder
 import io.element.android.libraries.voicerecorder.test.FakeVoiceRecorder
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.lambda.any
 import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
 import io.element.android.tests.testutils.test
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -59,6 +62,7 @@ import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("LargeClass")
 class DefaultVoiceMessageComposerPresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
@@ -401,6 +405,38 @@ class DefaultVoiceMessageComposerPresenterTest {
                 aVoiceMessageComposerEvent(isReply = false),
                 aVoiceMessageComposerEvent(isReply = true)
             )
+
+            testPauseAndDestroy(finalState)
+        }
+    }
+
+    @Test
+    fun `present - send voice message passes reply event ID only when in reply mode`() = runTest {
+        val presenter = createDefaultVoiceMessageComposerPresenter()
+        presenter.test {
+            // Send without reply - should pass null
+            messageComposerContext.composerMode = MessageComposerMode.Normal
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Stop))
+            awaitItem().eventSink(VoiceMessageComposerEvent.SendVoiceMessage)
+            skipItems(1) // Sending state
+            advanceUntilIdle()
+
+            sendVoiceMessageResult.assertions().isCalledOnce()
+                .with(any(), any(), any(), value(null))
+
+            // Send as reply - should pass event ID
+            messageComposerContext.composerMode = aReplyMode()
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Stop))
+            awaitItem().eventSink(VoiceMessageComposerEvent.SendVoiceMessage)
+            val finalState = awaitItem() // Sending state
+
+            sendVoiceMessageResult.assertions().isCalledExactly(2)
+                .withSequence(
+                    listOf(any(), any(), any(), value(null)),
+                    listOf(any(), any(), any(), value(AN_EVENT_ID)),
+                )
 
             testPauseAndDestroy(finalState)
         }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
@@ -414,23 +414,22 @@ class DefaultVoiceMessageComposerPresenterTest {
     fun `present - send voice message passes reply event ID only when in reply mode`() = runTest {
         val presenter = createDefaultVoiceMessageComposerPresenter()
         presenter.test {
-            // Send without reply - should pass null
-            messageComposerContext.composerMode = MessageComposerMode.Normal
+            // First send in Normal mode (default composerMode).
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Stop))
             awaitItem().eventSink(VoiceMessageComposerEvent.SendVoiceMessage)
-            skipItems(1) // Sending state
-            advanceUntilIdle()
+            assertThat(awaitItem().voiceMessageState).isEqualTo(aPreviewState().toSendingState())
+            val idleAfterFirstSend = awaitItem()
+            assertThat(idleAfterFirstSend.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
 
-            sendVoiceMessageResult.assertions().isCalledOnce()
-                .with(any(), any(), any(), value(null))
-
-            // Send as reply - should pass event ID
+            // Switching to reply mode does not trigger recomposition, so reuse the prior eventSink.
             messageComposerContext.composerMode = aReplyMode()
-            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            idleAfterFirstSend.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Stop))
             awaitItem().eventSink(VoiceMessageComposerEvent.SendVoiceMessage)
-            val finalState = awaitItem() // Sending state
+            assertThat(awaitItem().voiceMessageState).isEqualTo(aPreviewState().toSendingState())
+            val finalState = awaitItem()
+            assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
 
             sendVoiceMessageResult.assertions().isCalledExactly(2)
                 .withSequence(

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -400,6 +401,7 @@ fun TextComposer(
             onAddAttachment = onAddAttachment,
             onDeleteVoiceMessage = onDeleteVoiceMessage,
             onVoiceRecorderEvent = onVoiceRecorderEvent,
+            onResetComposerMode = onResetComposerMode,
         )
     }
 
@@ -408,6 +410,14 @@ fun TextComposer(
     }
 
     SoftKeyboardEffect(showTextFormatting, onRequestFocus) { it }
+
+    // Dismiss keyboard when voice recording starts
+    val keyboardController = LocalSoftwareKeyboardController.current
+    LaunchedEffect(voiceMessageState) {
+        if (voiceMessageState !is VoiceMessageState.Idle) {
+            keyboardController?.hide()
+        }
+    }
 
     val latestOnReceiveSuggestion by rememberUpdatedState(onReceiveSuggestion)
     if (state is TextEditorState.Rich) {
@@ -440,6 +450,7 @@ private fun StandardLayout(
     onAddAttachment: () -> Unit,
     onDeleteVoiceMessage: () -> Unit,
     onVoiceRecorderEvent: (VoiceMessageRecorderEvent) -> Unit,
+    onResetComposerMode: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -506,6 +517,14 @@ private fun StandardLayout(
             ) {
                 if (voiceMessageState is VoiceMessageState.Idle) {
                     textInput()
+                } else if (composerMode is MessageComposerMode.Special) {
+                    TextInputBox(
+                        composerMode = composerMode,
+                        onResetComposerMode = onResetComposerMode,
+                        isTextEmpty = true,
+                    ) {
+                        voiceRecording()
+                    }
                 } else {
                     voiceRecording()
                 }

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -411,13 +410,6 @@ fun TextComposer(
 
     SoftKeyboardEffect(showTextFormatting, onRequestFocus) { it }
 
-    // Dismiss keyboard when voice recording starts
-    val keyboardController = LocalSoftwareKeyboardController.current
-    LaunchedEffect(voiceMessageState) {
-        if (voiceMessageState !is VoiceMessageState.Idle) {
-            keyboardController?.hide()
-        }
-    }
 
     val latestOnReceiveSuggestion by rememberUpdatedState(onReceiveSuggestion)
     if (state is TextEditorState.Rich) {

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -410,6 +410,14 @@ fun TextComposer(
 
     SoftKeyboardEffect(showTextFormatting, onRequestFocus) { it }
 
+    // Re-focus the text input when voice recording ends so the user can continue typing
+    var previousVoiceMessageState by remember { mutableStateOf(voiceMessageState) }
+    LaunchedEffect(voiceMessageState) {
+        if (voiceMessageState is VoiceMessageState.Idle && previousVoiceMessageState !is VoiceMessageState.Idle) {
+            onRequestFocus()
+        }
+        previousVoiceMessageState = voiceMessageState
+    }
 
     val latestOnReceiveSuggestion by rememberUpdatedState(onReceiveSuggestion)
     if (state is TextEditorState.Rich) {


### PR DESCRIPTION
## Content

Add support for replying to messages with a voice recording. The infrastructure already existed end-to-end (`MediaSender.sendVoiceMessage()` accepts `inReplyToEventId`), but the voice message presenter was not wiring it through.

Changes:
- Extract reply event ID from composer mode and pass it to `mediaSender.sendVoiceMessage()`
- Show the reply banner during voice recording/preview using the same `TextInputBox` wrapper
- Reset composer mode after sending a voice message reply
- Dismiss keyboard when voice recording starts
- Add unit test verifying reply event ID is passed correctly

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/4053

Users could not reply to a message with a voice recording. Tapping "Reply" and then recording audio would send the voice message without the reply relation, and the reply banner would disappear during recording.

## Screenshots / GIFs

https://github.com/user-attachments/assets/89f81cf1-e1fd-4bda-9e6e-63b9d65e519b

## Tests

- Open a room, long-press a message, tap Reply
- Record a voice message - verify the reply banner stays visible during recording and preview
- Verify the keyboard dismisses when recording starts
- Send the voice message - verify the banner closes and the message appears as a reply in the timeline
- Send a voice message without replying - verify it sends as a normal message

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
