### PR TITLE
Fix media cover placeholder floating

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/audio/MediaAudioView.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -51,6 +52,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import com.bumble.appyx.core.node.LocalNodeTargetVisibility
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.libraries.audio.api.AudioFocus
@@ -130,6 +132,8 @@ private fun ExoPlayerMediaAudioView(
         mutableStateOf(null)
     }
 
+    val isTargetVisible = LocalNodeTargetVisibility.current
+
     val playableState: PlayableState.Playable by remember {
         derivedStateOf {
             PlayableState.Playable(
@@ -196,13 +200,21 @@ private fun ExoPlayerMediaAudioView(
             exoPlayer.pause()
         }
     }
+    LaunchedEffect(isTargetVisible) {
+        if (!isTargetVisible) {
+            exoPlayer.pause()
+        }
+    }
     if (localMedia?.uri != null) {
         LaunchedEffect(localMedia.uri) {
             val mediaItem = MediaItem.fromUri(localMedia.uri)
             exoPlayer.setMediaItem(mediaItem)
+            exoPlayer.prepare()
         }
     } else {
-        exoPlayer.setMediaItems(emptyList())
+        LaunchedEffect(Unit) {
+            exoPlayer.setMediaItems(emptyList())
+        }
     }
     val context = LocalContext.current
     val waveform = info?.waveform
@@ -247,7 +259,7 @@ private fun ExoPlayerMediaAudioView(
                             }
                         },
                         update = { playerView ->
-                            playerView.isVisible = metadata.hasArtwork()
+                            playerView.isVisible = metadata.hasArtwork() && isTargetVisible
                         },
                         onRelease = { playerView ->
                             playerView.player = null
@@ -317,16 +329,19 @@ private fun ExoPlayerMediaAudioView(
         )
     }
 
-    OnLifecycleEvent { _, event ->
-        when (event) {
-            Lifecycle.Event.ON_CREATE -> exoPlayer.addListener(playerListener)
-            Lifecycle.Event.ON_RESUME -> exoPlayer.prepare()
-            Lifecycle.Event.ON_PAUSE -> exoPlayer.pause()
-            Lifecycle.Event.ON_DESTROY -> {
-                exoPlayer.release()
+    DisposableEffect(exoPlayer) {
+        exoPlayer.addListener(playerListener)
+        onDispose {
+            if (!exoPlayer.isReleased) {
                 exoPlayer.removeListener(playerListener)
+                exoPlayer.release()
             }
-            else -> Unit
+        }
+    }
+
+    OnLifecycleEvent { _, event ->
+        if (event == Lifecycle.Event.ON_PAUSE) {
+            exoPlayer.pause()
         }
     }
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Fix media cover placeholder floating by destroying it properly

## Motivation and context

When closing media player with a file that has a cover art, for a moment there will be a square over the timeline.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Close a media player that has a cover art

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
