### PR TITLE
Fix content scrolling not working in the RTE

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ExpandableBottomSheetLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/ExpandableBottomSheetLayout.kt
@@ -16,7 +16,10 @@ import android.widget.EditText
 import androidx.appcompat.app.ActionBar.LayoutParams
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitVerticalPointerSlopOrCancellation
+import androidx.compose.foundation.gestures.verticalDrag
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -41,10 +44,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
@@ -94,7 +101,7 @@ fun ExpandableBottomSheetLayout(
                 .run {
                     if (isSwipeGestureEnabled) {
                         pointerInput(maxBottomSheetContentHeight) {
-                            detectVerticalDragGestures(
+                            customDetectVerticalDragGestures(
                                 onVerticalDrag = { _, dragAmount ->
                                     val calculatedHeight = max(minBottomContentHeightPx, currentBottomContentHeightPx - dragAmount.roundToInt())
                                     val newHeight = min(calculatedMaxBottomContentHeightPx, calculatedHeight)
@@ -120,7 +127,11 @@ fun ExpandableBottomSheetLayout(
 
                                         animatable.animateTo(destination)
                                     }
-                                }
+                                },
+                                canScroll = {
+                                    // We only consider we can scroll in the contents if the min size matches the max size so it's maximized
+                                    minBottomContentHeightPx == calculatedMaxBottomContentHeightPx
+                                },
                             )
                         }
                     } else {
@@ -187,6 +198,45 @@ fun ExpandableBottomSheetLayout(
             }
         }
     )
+}
+
+// The original detectVerticalDragGestures doesn't allow us to conditionally consume the initial slop event that triggers the drag,
+// which is necessary in our case to allow inner scrollables to work when the sheet is not fully expanded, so we need to re-implement it here
+private suspend fun PointerInputScope.customDetectVerticalDragGestures(
+    onDragStart: (Offset) -> Unit = {},
+    onDragEnd: () -> Unit = {},
+    onDragCancel: () -> Unit = {},
+    canScroll: () -> Boolean = { false },
+    onVerticalDrag: (change: PointerInputChange, dragAmount: Float) -> Unit,
+) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        var overSlop = 0f
+        val drag =
+            awaitVerticalPointerSlopOrCancellation(down.id, down.type) { change, over ->
+                // Consuming this event is what triggers the dragging instead of the inner content scrolling
+                // We should only consume it if we can't scroll in the inner content so we drag the bottom sheet instead, otherwise we let it pass through
+                // This is the only change compared to the original detectVerticalDragGestures implementation
+                if (!canScroll()) {
+                    change.consume()
+                }
+                overSlop = over
+            }
+        if (drag != null) {
+            onDragStart.invoke(drag.position)
+            onVerticalDrag.invoke(drag, overSlop)
+            if (
+                verticalDrag(drag.id) {
+                    onVerticalDrag(it, it.positionChange().y)
+                    it.consume()
+                }
+            ) {
+                onDragEnd()
+            } else {
+                onDragCancel()
+            }
+        }
+    }
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Implement a `customDetectVerticalDragGestures` that matches the original `detectVerticalDragGestures` expect we conditionally consume the initial DOWN event in compose to decide whether we need to drag the bottom sheet or scroll inside the Android `EditText`.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6490

It seems like some Compose version upgrade probably broke this unexpectedly.

## Screenshots / GIFs

[Screen_recording_20260331_112635.webm](https://github.com/user-attachments/assets/a7da4caa-f3b1-4d25-8e98-217778ab55b5)


## Tests

- With no text or a few lines in the RTE try the dragging gesture: the expandable bottom sheet should grow or shrink.
- With lots of lines (so it overflows the max height) try this again: it should now scroll instead of dragging the bottom sheet.

Previously, it would get stuck and at most scroll a few pixels up or down, always centered on the cursor for some reason.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
