### PR TITLE
Add floating/sticky date badge in the timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesView.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -464,6 +465,9 @@ private fun MessagesViewContent(
             val scrollBehavior = PinnedMessagesBannerViewDefaults.rememberScrollBehavior(
                 pinnedMessagesCount = (state.pinnedMessagesBannerState as? PinnedMessagesBannerState.Visible)?.pinnedMessagesCount() ?: 0,
             )
+            val density = LocalDensity.current
+            var pinnedBannerHeightDp by remember { mutableStateOf(0.dp) }
+
             TimelineView(
                 state = state.timelineState,
                 timelineProtectionState = state.timelineProtectionState,
@@ -479,11 +483,13 @@ private fun MessagesViewContent(
                 forceJumpToBottomVisibility = forceJumpToBottomVisibility,
                 onJoinCallClick = onJoinCallClick,
                 nestedScrollConnection = scrollBehavior.nestedScrollConnection,
+                floatingDateTopOffset = pinnedBannerHeightDp,
             )
 
             if (state.timelineState.timelineMode !is Timeline.Mode.Thread) {
                 AnimatedVisibility(
                     visible = state.pinnedMessagesBannerState is PinnedMessagesBannerState.Visible && scrollBehavior.isVisible,
+                    modifier = Modifier.onSizeChanged { pinnedBannerHeightDp = with(density) { it.height.toDp() } },
                     enter = expandVertically(),
                     exit = shrinkVertically(),
                 ) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -149,6 +149,9 @@ class TimelinePresenter(
         val displayThreadSummaries by produceState(false) {
             value = featureFlagService.isFeatureEnabled(FeatureFlags.Threads)
         }
+        val displayFloatingDateBadge by produceState(false) {
+            value = featureFlagService.isFeatureEnabled(FeatureFlags.FloatingDateBadge)
+        }
 
         fun handleEvent(event: TimelineEvent) {
             when (event) {
@@ -315,6 +318,7 @@ class TimelinePresenter(
             messageShieldDialogData = messageShieldDialogData.value,
             resolveVerifiedUserSendFailureState = resolveVerifiedUserSendFailureState,
             displayThreadSummaries = displayThreadSummaries,
+            displayFloatingDateBadge = displayFloatingDateBadge,
             eventSink = ::handleEvent,
         )
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineState.kt
@@ -34,6 +34,7 @@ data class TimelineState(
     val messageShieldDialogData: MessageShieldData?,
     val resolveVerifiedUserSendFailureState: ResolveVerifiedUserSendFailureState,
     val displayThreadSummaries: Boolean,
+    val displayFloatingDateBadge: Boolean,
     val eventSink: (TimelineEvent) -> Unit,
 ) {
     private val lastTimelineEvent = timelineItems.firstOrNull { it is TimelineItem.Event } as? TimelineItem.Event

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineStateProvider.kt
@@ -56,6 +56,7 @@ fun aTimelineState(
     messageShield: MessageShield? = null,
     resolveVerifiedUserSendFailureState: ResolveVerifiedUserSendFailureState = aResolveVerifiedUserSendFailureState(),
     displayThreadSummaries: Boolean = false,
+    displayFloatingDateBadge: Boolean = false,
     eventSink: (TimelineEvent) -> Unit = {},
 ): TimelineState {
     val focusedEventId = timelineItems.filterIsInstance<TimelineItem.Event>().getOrNull(focusedEventIndex)?.eventId
@@ -75,6 +76,7 @@ fun aTimelineState(
         messageShieldDialogData = messageShield?.let { MessageShieldData(it) },
         resolveVerifiedUserSendFailureState = resolveVerifiedUserSendFailureState,
         displayThreadSummaries = displayThreadSummaries,
+        displayFloatingDateBadge = displayFloatingDateBadge,
         eventSink = eventSink,
     )
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -214,13 +214,15 @@ fun TimelineView(
                 onFocusEventRender = ::onFocusEventRender,
             )
 
-            FloatingDateBadgeOverlay(
-                lazyListState = lazyListState,
-                timelineItems = state.timelineItems,
-                isLive = state.isLive,
-                useReverseLayout = useReverseLayout,
-                topOffset = floatingDateTopOffset,
-            )
+            if (state.displayFloatingDateBadge) {
+                FloatingDateBadgeOverlay(
+                    lazyListState = lazyListState,
+                    timelineItems = state.timelineItems,
+                    isLive = state.isLive,
+                    useReverseLayout = useReverseLayout,
+                    topOffset = floatingDateTopOffset,
+                )
+            }
         }
     }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -47,10 +47,12 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.crypto.sendfailure.resolve.ResolveVerifiedUserSendFailureView
+import io.element.android.features.messages.impl.timeline.components.FloatingDateBadgeOverlay
 import io.element.android.features.messages.impl.timeline.components.TimelineItemRow
 import io.element.android.features.messages.impl.timeline.components.toText
 import io.element.android.features.messages.impl.timeline.di.LocalTimelineItemPresenterFactories
@@ -105,6 +107,7 @@ fun TimelineView(
     lazyListState: LazyListState = rememberLazyListState(),
     forceJumpToBottomVisibility: Boolean = false,
     nestedScrollConnection: NestedScrollConnection = rememberNestedScrollInteropConnection(),
+    floatingDateTopOffset: Dp = 0.dp,
 ) {
     fun clearFocusRequestState() {
         state.eventSink(TimelineEvent.ClearFocusRequestState)
@@ -209,6 +212,14 @@ fun TimelineView(
                 onScrollFinishAt = ::onScrollFinishAt,
                 onJumpToLive = ::onJumpToLive,
                 onFocusEventRender = ::onFocusEventRender,
+            )
+
+            FloatingDateBadgeOverlay(
+                lazyListState = lazyListState,
+                timelineItems = state.timelineItems,
+                isLive = state.isLive,
+                useReverseLayout = useReverseLayout,
+                topOffset = floatingDateTopOffset,
             )
         }
     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -214,12 +214,11 @@ fun TimelineView(
                 onFocusEventRender = ::onFocusEventRender,
             )
 
-            if (state.displayFloatingDateBadge) {
+            if (state.displayFloatingDateBadge && useReverseLayout) {
                 FloatingDateBadgeOverlay(
                     lazyListState = lazyListState,
                     timelineItems = state.timelineItems,
                     isLive = state.isLive,
-                    useReverseLayout = useReverseLayout,
                     topOffset = floatingDateTopOffset,
                 )
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
@@ -45,7 +45,6 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
     lazyListState: LazyListState,
     timelineItems: ImmutableList<TimelineItem>,
     isLive: Boolean,
-    useReverseLayout: Boolean,
     topOffset: Dp = 0.dp,
 ) {
     val currentDateText by remember(timelineItems) {
@@ -54,11 +53,7 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
             if (visibleItems.isEmpty()) return@derivedStateOf null
 
             // In reverse layout, the last visible item is at the top of the screen
-            val topVisibleIndex = if (useReverseLayout) {
-                visibleItems.last().index
-            } else {
-                visibleItems.first().index
-            }
+            val topVisibleIndex = visibleItems.last().index
 
             // Search forward (toward older items) for the nearest day separator
             for (i in topVisibleIndex until timelineItems.size) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -48,16 +49,19 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
     isLive: Boolean,
     topOffset: Dp = 0.dp,
 ) {
+    // This needs to be a state to trigger a `derivedState` recalculation
+    val updatedTimelineItems by rememberUpdatedState(timelineItems)
+
     // Look for the last visible item with a timestamp, starting from the last visible item and going backwards until we find one or reach the start of the list
-    val lastVisibleItemWithTimestamp by remember(timelineItems) {
+    val lastVisibleItemWithTimestamp by remember {
         derivedStateOf {
             var index = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@derivedStateOf null
             while (index >= 0) {
-                when (val item = timelineItems.getOrNull(index)) {
+                when (val item = updatedTimelineItems.getOrNull(index)) {
                     is TimelineItem.Event -> return@derivedStateOf item
                     is TimelineItem.Virtual -> if (item.model is TimelineItemDaySeparatorModel) return@derivedStateOf item
                     is TimelineItem.GroupedEvents -> return@derivedStateOf item.events.firstOrNull()
-                    else -> Unit
+                    null -> Unit
                 }
                 index--
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
@@ -47,30 +47,28 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
     isLive: Boolean,
     topOffset: Dp = 0.dp,
 ) {
-    val currentDateText by remember(timelineItems) {
+    // Look for the last visible item with a timestamp, starting from the last visible item and going backwards until we find one or reach the start of the list
+    val lastVisibleItemWithTimestamp by remember(timelineItems) {
         derivedStateOf {
-            val visibleItems = lazyListState.layoutInfo.visibleItemsInfo
-            if (visibleItems.isEmpty()) return@derivedStateOf null
-
-            // In reverse layout, the last visible item is at the top of the screen
-            val topVisibleIndex = visibleItems.last().index
-
-            // Search forward (toward older items) for the nearest day separator
-            for (i in topVisibleIndex until timelineItems.size) {
-                val item = timelineItems[i]
-                if (item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel) {
-                    return@derivedStateOf item.model.formattedDate
+            var index = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@derivedStateOf null
+            while (index >= 0) {
+                when (val item = timelineItems.getOrNull(index)) {
+                    is TimelineItem.Event -> return@derivedStateOf item
+                    is TimelineItem.Virtual -> if (item.model is TimelineItemDaySeparatorModel) return@derivedStateOf item
+                    is TimelineItem.GroupedEvents -> return@derivedStateOf item.events.firstOrNull()
+                    else -> Unit
                 }
-            }
-            // Fallback: search backward (toward newer items)
-            for (i in topVisibleIndex - 1 downTo 0) {
-                val item = timelineItems[i]
-                if (item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel) {
-                    return@derivedStateOf item.model.formattedDate
-                }
+                index--
             }
             null
         }
+    }
+
+    // Store the formatted date so we recompute it lazily and can keep it around even if we need to dispose the badge because the timeline items changed
+    var formattedDate: String? by remember { mutableStateOf(null) }
+    // Update the formatted date when we have a new non-null timestamp
+    LaunchedEffect(lastVisibleItemWithTimestamp) {
+        lastVisibleItemWithTimestamp?.formattedDate()?.let { formattedDate = it }
     }
 
     val isAtBottom by remember {
@@ -93,7 +91,7 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
             }
     }
 
-    val showBadge = isBadgeVisible && !isAtBottom && currentDateText != null
+    val showBadge = isBadgeVisible && !isAtBottom && formattedDate != null
 
     AnimatedVisibility(
         visible = showBadge,
@@ -105,6 +103,10 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
     ) {
         currentDateText?.let { dateText ->
             FloatingDateBadge(dateText = dateText)
+        formattedDate?.let { dateText ->
+            FloatingDateBadge(
+                dateText = dateText,
+            )
         }
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
@@ -101,10 +102,9 @@ internal fun BoxScope.FloatingDateBadgeOverlay(
         enter = fadeIn(animationSpec = tween(150)),
         exit = fadeOut(animationSpec = tween(300)),
     ) {
-        currentDateText?.let { dateText ->
-            FloatingDateBadge(dateText = dateText)
         formattedDate?.let { dateText ->
             FloatingDateBadge(
+                modifier = Modifier.padding(8.dp),
                 dateText = dateText,
             )
         }
@@ -120,6 +120,7 @@ internal fun FloatingDateBadge(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
         color = ElementTheme.colors.floatingDateBadgeBackground,
+        shadowElevation = 4.dp,
     ) {
         Text(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -133,5 +134,7 @@ internal fun FloatingDateBadge(
 @PreviewsDayNight
 @Composable
 internal fun FloatingDateBadgePreview() = ElementPreview {
-    FloatingDateBadge(dateText = "March 9, 2026")
+    Box(modifier = Modifier.padding(16.dp)) {
+        FloatingDateBadge(dateText = "March 9, 2026")
+    }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/FloatingDateBadge.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.timeline.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.element.android.compound.theme.ElementTheme
+import io.element.android.features.messages.impl.timeline.model.TimelineItem
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemDaySeparatorModel
+import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.theme.components.Surface
+import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.designsystem.theme.floatingDateBadgeBackground
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlin.time.Duration.Companion.milliseconds
+
+@Composable
+internal fun BoxScope.FloatingDateBadgeOverlay(
+    lazyListState: LazyListState,
+    timelineItems: ImmutableList<TimelineItem>,
+    isLive: Boolean,
+    useReverseLayout: Boolean,
+    topOffset: Dp = 0.dp,
+) {
+    val currentDateText by remember(timelineItems) {
+        derivedStateOf {
+            val visibleItems = lazyListState.layoutInfo.visibleItemsInfo
+            if (visibleItems.isEmpty()) return@derivedStateOf null
+
+            // In reverse layout, the last visible item is at the top of the screen
+            val topVisibleIndex = if (useReverseLayout) {
+                visibleItems.last().index
+            } else {
+                visibleItems.first().index
+            }
+
+            // Search forward (toward older items) for the nearest day separator
+            for (i in topVisibleIndex until timelineItems.size) {
+                val item = timelineItems[i]
+                if (item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel) {
+                    return@derivedStateOf item.model.formattedDate
+                }
+            }
+            // Fallback: search backward (toward newer items)
+            for (i in topVisibleIndex - 1 downTo 0) {
+                val item = timelineItems[i]
+                if (item is TimelineItem.Virtual && item.model is TimelineItemDaySeparatorModel) {
+                    return@derivedStateOf item.model.formattedDate
+                }
+            }
+            null
+        }
+    }
+
+    val isAtBottom by remember {
+        derivedStateOf {
+            lazyListState.firstVisibleItemIndex < 3 && isLive
+        }
+    }
+
+    var isBadgeVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { lazyListState.isScrollInProgress }
+            .collectLatest { isScrolling ->
+                if (isScrolling) {
+                    isBadgeVisible = true
+                } else {
+                    delay(2000.milliseconds)
+                    isBadgeVisible = false
+                }
+            }
+    }
+
+    val showBadge = isBadgeVisible && !isAtBottom && currentDateText != null
+
+    AnimatedVisibility(
+        visible = showBadge,
+        modifier = Modifier
+            .align(Alignment.TopCenter)
+            .padding(top = 8.dp + topOffset),
+        enter = fadeIn(animationSpec = tween(150)),
+        exit = fadeOut(animationSpec = tween(300)),
+    ) {
+        currentDateText?.let { dateText ->
+            FloatingDateBadge(dateText = dateText)
+        }
+    }
+}
+
+@Composable
+internal fun FloatingDateBadge(
+    dateText: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = ElementTheme.colors.floatingDateBadgeBackground,
+    ) {
+        Text(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            text = dateText,
+            style = ElementTheme.typography.fontBodyMdMedium,
+            color = ElementTheme.colors.textPrimary,
+        )
+    }
+}
+
+@PreviewsDayNight
+@Composable
+internal fun FloatingDateBadgePreview() = ElementPreview {
+    FloatingDateBadge(dateText = "March 9, 2026")
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
@@ -66,6 +66,11 @@ class TimelineItemEventFactory(
             timestamp = currentTimelineItem.event.timestamp,
             mode = DateFormatterMode.TimeOnly,
         )
+        val sentDate = dateFormatter.format(
+            timestamp = currentTimelineItem.event.timestamp,
+            mode = DateFormatterMode.Day,
+            useRelative = true,
+        )
         val senderAvatarData = AvatarData(
             id = currentSender.value,
             name = senderProfile.getDisambiguatedDisplayName(currentSender),
@@ -108,6 +113,7 @@ class TimelineItemEventFactory(
             canBeRepliedTo = currentTimelineItem.event.canBeRepliedTo,
             sentTimeMillis = currentTimelineItem.event.timestamp,
             sentTime = sentTime,
+            sentDate = sentDate,
             groupPosition = groupPosition,
             reactionsState = currentTimelineItem.computeReactionsState(),
             readReceiptState = currentTimelineItem.computeReadReceiptState(roomMembers),

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/TimelineItem.kt
@@ -15,6 +15,7 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemStickerContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemVideoContent
+import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemDaySeparatorModel
 import io.element.android.features.messages.impl.timeline.model.virtual.TimelineItemVirtualModel
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.matrix.api.core.EventId
@@ -59,6 +60,12 @@ sealed interface TimelineItem {
         is GroupedEvents -> "groupedEvent"
     }
 
+    fun formattedDate(): String? = when (this) {
+        is Event -> sentDate.takeIf { it.isNotEmpty() }
+        is Virtual -> (model as? TimelineItemDaySeparatorModel)?.formattedDate?.takeIf { it.isNotEmpty() }
+        is GroupedEvents -> null
+    }
+
     data class Virtual(
         val id: UniqueId,
         val model: TimelineItemVirtualModel
@@ -75,6 +82,7 @@ sealed interface TimelineItem {
         val content: TimelineItemEventContent,
         val sentTimeMillis: Long = 0L,
         val sentTime: String = "",
+        val sentDate: String = "",
         val isMine: Boolean = false,
         val isEditable: Boolean,
         val canBeRepliedTo: Boolean,

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ColorAliases.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ColorAliases.kt
@@ -76,7 +76,7 @@ val SemanticColors.pinnedMessageBannerBorder
     get() = if (isLight) LightColorTokens.colorAlphaGray400 else DarkColorTokens.colorAlphaGray400
 
 val SemanticColors.floatingDateBadgeBackground
-    get() = if (isLight) bgCanvasDefault.copy(alpha = 0.85f) else bgSubtlePrimary
+    get() = if (isLight) bgCanvasDefault else bgSubtlePrimary
 
 @PreviewsDayNight
 @Composable

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ColorAliases.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/ColorAliases.kt
@@ -75,6 +75,9 @@ val SemanticColors.pinnedMessageBannerIndicator
 val SemanticColors.pinnedMessageBannerBorder
     get() = if (isLight) LightColorTokens.colorAlphaGray400 else DarkColorTokens.colorAlphaGray400
 
+val SemanticColors.floatingDateBadgeBackground
+    get() = if (isLight) bgCanvasDefault.copy(alpha = 0.85f) else bgSubtlePrimary
+
 @PreviewsDayNight
 @Composable
 internal fun ColorAliasesPreview() = ElementPreview {

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -156,10 +156,17 @@ enum class FeatureFlags(
     ),
     ValidateNetworkWhenSchedulingNotificationFetching(
         key = "feature.validate_network_when_scheduling_notification_fetching",
-        title = "validate internet connectivity when scheduling notification fetching",
+        title = "Validate internet connectivity when scheduling notification fetching",
         description = "Only fetch events for push notifications when the device has internet connectivity. " +
             "Enabling this can be problematic in air-gapped environments.",
         defaultValue = { true },
+        isFinished = false,
+    ),
+    FloatingDateBadge(
+        key = "feature.floating_date_badge",
+        title = "Display sticky date headers in the timeline",
+        description = "When scrolling, a sticky date badge will be displayed so you can easily know on which date the messages you're seeing were sent.",
+        defaultValue = { false },
         isFinished = false,
     ),
 }

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3c3bba3740da538d01e29fd85628ffd8ac841a7321df0a2b33975da47645b64
-size 6646
+oid sha256:8109af7397a43f24a27b7c988f7b6bd23e555df038ff9a272068707796a60962
+size 8465

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Day_0_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c3bba3740da538d01e29fd85628ffd8ac841a7321df0a2b33975da47645b64
+size 6646

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cb491a1860eed8554e391c9df9308b70974badd3d4077e62bd39cb4fd657e3f
-size 7208
+oid sha256:25ba3336d226da0fb5956750b02f389c59b81c93e6150d8fb17d5195fd161204
+size 7705

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.timeline.components_FloatingDateBadge_Night_0_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cb491a1860eed8554e391c9df9308b70974badd3d4077e62bd39cb4fd657e3f
+size 7208


### PR DESCRIPTION
## Content

Based on https://github.com/element-hq/element-x-android/pull/6433 (thanks @kalix127 !).

Adds the floating badge created in that PR, and a disabled by default feature flag to actually display it.

## Motivation and context

The equivalent [Element X iOS PR](https://github.com/element-hq/element-x-ios/pull/5313/changes#diff-e59f20a145020d88d30221b07336f5a5b5bac2df8650af2e9d2d9cc58c043cfbR440) added this feature disabled at the moment so we can test it for a bit longer.

## Screenshots / GIFs

In the original PR.

## Tests

Enable the feature flag, the badge should be visible. Disable it and it should be gone.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
