### PR TITLE
Fix crash when using `View.hideKeyboardAndAwaitAnimation`

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
@@ -16,8 +16,8 @@ import android.view.ViewTreeObserver
 import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
 import androidx.core.content.getSystemService
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
 import kotlin.coroutines.resume
 
 fun View.hideKeyboard() {
@@ -28,11 +28,13 @@ fun View.hideKeyboard() {
 suspend fun View.hideKeyboardAndAwaitAnimation() {
     val imm = context?.getSystemService<InputMethodManager>()
 
-    val mutex = Mutex()
+    val future = CompletableDeferred(Unit)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         setOnApplyWindowInsetsListener { view, insets ->
             if (!insets.isVisible(WindowInsets.Type.ime())) {
-                mutex.unlock()
+                future.complete(Unit)
+                // Remove the listener now, it's a single use operation
+                setOnApplyWindowInsetsListener(null)
             }
             insets
         }
@@ -41,14 +43,15 @@ suspend fun View.hideKeyboardAndAwaitAnimation() {
         @Suppress("DEPRECATION")
         imm?.hideSoftInputFromWindow(windowToken, 0, object : ResultReceiver(null) {
             override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
-                if (resultCode == InputMethodManager.RESULT_UNCHANGED_HIDDEN ||
-                    resultCode == InputMethodManager.RESULT_HIDDEN) {
-                    mutex.unlock()
+                if (resultCode == InputMethodManager.RESULT_UNCHANGED_HIDDEN || resultCode == InputMethodManager.RESULT_HIDDEN) {
+                    future.complete(Unit)
                 }
             }
         })
     }
-    mutex.lock()
+
+    // Await the future to ensure the keyboard hide animation has completed before proceeding
+    future.await()
 }
 
 fun View.showKeyboard(andRequestFocus: Boolean = false) {

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
@@ -18,7 +18,9 @@ import android.view.inputmethod.InputMethodManager
 import androidx.core.content.getSystemService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
 
 fun View.hideKeyboard() {
     val imm = context?.getSystemService<InputMethodManager>()
@@ -26,9 +28,14 @@ fun View.hideKeyboard() {
 }
 
 suspend fun View.hideKeyboardAndAwaitAnimation() {
-    val imm = context?.getSystemService<InputMethodManager>()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !rootWindowInsets.isVisible(WindowInsets.Type.ime())) {
+        // Keyboard is already hidden, no need to do anything
+        return
+    }
 
+    val imm = context?.getSystemService<InputMethodManager>() ?: return
     val future = CompletableDeferred<Unit>()
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         setOnApplyWindowInsetsListener { view, insets ->
             if (!insets.isVisible(WindowInsets.Type.ime())) {
@@ -38,20 +45,25 @@ suspend fun View.hideKeyboardAndAwaitAnimation() {
             }
             insets
         }
-        imm?.hideSoftInputFromWindow(windowToken, 0)
+        imm.hideSoftInputFromWindow(windowToken, 0)
     } else {
         @Suppress("DEPRECATION")
-        imm?.hideSoftInputFromWindow(windowToken, 0, object : ResultReceiver(null) {
+        val requested = imm.hideSoftInputFromWindow(windowToken, 0, object : ResultReceiver(null) {
             override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
                 if (resultCode == InputMethodManager.RESULT_UNCHANGED_HIDDEN || resultCode == InputMethodManager.RESULT_HIDDEN) {
                     future.complete(Unit)
                 }
             }
         })
+
+        if (!requested) {
+            // If the request to hide the keyboard was not accepted, complete the future immediately
+            future.complete(Unit)
+        }
     }
 
     // Await the future to ensure the keyboard hide animation has completed before proceeding
-    future.await()
+    withTimeoutOrNull(1.seconds) { future.await() }
 }
 
 fun View.showKeyboard(andRequestFocus: Boolean = false) {

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
@@ -28,7 +28,7 @@ fun View.hideKeyboard() {
 suspend fun View.hideKeyboardAndAwaitAnimation() {
     val imm = context?.getSystemService<InputMethodManager>()
 
-    val future = CompletableDeferred(Unit)
+    val future = CompletableDeferred<Unit>()
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         setOnApplyWindowInsetsListener { view, insets ->
             if (!insets.isVisible(WindowInsets.Type.ime())) {

--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/ui/View.kt
@@ -36,7 +36,7 @@ suspend fun View.hideKeyboardAndAwaitAnimation() {
     val imm = context?.getSystemService<InputMethodManager>() ?: return
     val future = CompletableDeferred<Unit>()
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    val requested = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         setOnApplyWindowInsetsListener { view, insets ->
             if (!insets.isVisible(WindowInsets.Type.ime())) {
                 future.complete(Unit)
@@ -48,22 +48,19 @@ suspend fun View.hideKeyboardAndAwaitAnimation() {
         imm.hideSoftInputFromWindow(windowToken, 0)
     } else {
         @Suppress("DEPRECATION")
-        val requested = imm.hideSoftInputFromWindow(windowToken, 0, object : ResultReceiver(null) {
+        imm.hideSoftInputFromWindow(windowToken, 0, object : ResultReceiver(null) {
             override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
                 if (resultCode == InputMethodManager.RESULT_UNCHANGED_HIDDEN || resultCode == InputMethodManager.RESULT_HIDDEN) {
                     future.complete(Unit)
                 }
             }
         })
-
-        if (!requested) {
-            // If the request to hide the keyboard was not accepted, complete the future immediately
-            future.complete(Unit)
-        }
     }
 
-    // Await the future to ensure the keyboard hide animation has completed before proceeding
-    withTimeoutOrNull(1.seconds) { future.await() }
+    if (requested) {
+        // Await the future to ensure the keyboard hide animation has completed before proceeding
+        withTimeoutOrNull(1.seconds) { future.await() }
+    }
 }
 
 fun View.showKeyboard(andRequestFocus: Boolean = false) {


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Remove the `View.OnApplyWindowInsetsListener` used in modern Android versions to detect if the insets changed after they do the first time: this is a single use operation and the listener will be called every time the insets change.

Also, replace `Mutex` with `CompletableDeferred`: it will have the same effect, but it won't throw an exception if for some reason we have several `future.complete` calls.

## Motivation and context

Fix a crash observed live.

## Tests

I'm not sure how to test this, to be honest. On my case, it crashed automatically.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
