### PR TITLE
Tentative fix for `ForegroundServiceStartNotAllowedException`

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/DefaultPushHandlingWakeLock.kt
@@ -14,7 +14,6 @@ import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.di.annotations.ApplicationContext
 import io.element.android.libraries.push.api.push.PushHandlingWakeLock
 import timber.log.Timber
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 
 @ContributesBinding(AppScope::class)
@@ -22,24 +21,13 @@ import kotlin.time.Duration
 class DefaultPushHandlingWakeLock(
     @ApplicationContext private val context: Context,
 ) : PushHandlingWakeLock {
-    private val count = AtomicInteger(0)
-
     override fun lock(time: Duration) {
         Timber.d("Acquiring wakelock for push handling, starting service.")
         FetchPushForegroundService.startIfNeeded(context)
-
-        count.incrementAndGet()
     }
 
     override suspend fun unlock() {
         Timber.d("Releasing wakelock used for push handling.")
         FetchPushForegroundService.stop(context)
-        if (count.decrementAndGet() <= 0) {
-            Timber.d("No more wakelock needed for push handling, stopping service.")
-            count.set(0)
-        } else {
-            Timber.d("Wakelock still needed for push handling, restarting service | count: ${count.get()}.")
-            FetchPushForegroundService.startIfNeeded(context)
-        }
     }
 }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/FetchPushForegroundService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/push/FetchPushForegroundService.kt
@@ -145,7 +145,13 @@ class FetchPushForegroundService : Service() {
         fun start(context: Context) {
             val intent = Intent(context, FetchPushForegroundService::class.java)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
+                runCatchingExceptions { context.startForegroundService(intent) }
+                    .onFailure { throwable ->
+                        Timber.e(
+                            throwable,
+                            "Failed to start FetchPushForegroundService, notifications may take longer than usual to sync"
+                        )
+                    }
             } else {
                 context.startService(intent)
             }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

A couple of tentative fixes to this crash:

- When failing to start the service in foreground, don't crash. This is a helper to speed up the scheduling by keeping the CPU awake, not a critical part that must succeed.
- Don't try to restart the service when there are pending push notification fetches, as it sometimes fails.

Either of these changes would fix the issue (or both). Another possible solution is to remove the attempt to restart and change the kind of foreground service used to keep the CPU awake, but then we need to be extra careful about always stopping it after a short time, since we won't have the default 3 minute timeout `SHORT_SERVICE` adds.

## Motivation and context

Fix https://github.com/element-hq/element-x-android-rageshakes/issues/11044

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
