### PR TITLE
Allow adding DMs to private spaces

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceSearchDataSource.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceSearchDataSource.kt
@@ -22,6 +22,7 @@ import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.roomlist.updateVisibleRange
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
+import io.element.android.libraries.matrix.api.spaces.SpaceRoomVisibility
 import io.element.android.libraries.matrix.ui.model.SelectRoomInfo
 import io.element.android.libraries.matrix.ui.model.toSelectRoomInfo
 import kotlinx.collections.immutable.ImmutableList
@@ -40,7 +41,8 @@ private const val MAX_SUGGESTIONS_COUNT = 5
 
 /**
  * DataSource for rooms that can be added to a space.
- * Filters out DMs, spaces, rooms already in the space, and only includes rooms the user has joined.
+ * Filters out spaces, rooms already in the space, and only includes rooms the user has joined.
+ * DMs are only included when the space is private/personal.
  */
 @AssistedInject
 class AddRoomToSpaceSearchDataSource(
@@ -76,9 +78,13 @@ class AddRoomToSpaceSearchDataSource(
         addedRoomIdsFlow.value += roomIds
     }
 
-    private val filterRoomPredicate: (RoomInfo, Set<RoomId>, Set<RoomId>) -> Boolean = { info, childIds, addedIds ->
+    private val isPrivateSpaceFlow = spaceRoomList.currentSpaceFlow.map { spaceOptional ->
+        spaceOptional.map { it.visibility == SpaceRoomVisibility.Private }.orElse(true)
+    }
+
+    private val filterRoomPredicate: (RoomInfo, Set<RoomId>, Set<RoomId>, Boolean) -> Boolean = { info, childIds, addedIds, isPrivateSpace ->
         !info.isSpace &&
-            !info.isDm &&
+            (isPrivateSpace || !info.isDm) &&
             info.currentUserMembership == CurrentUserMembership.JOINED &&
             info.id !in childIds &&
             info.id !in addedIds
@@ -88,9 +94,10 @@ class AddRoomToSpaceSearchDataSource(
         roomList.summaries,
         spaceChildrenFlow,
         addedRoomIdsFlow,
-    ) { roomSummaries, childIds, addedIds ->
+        isPrivateSpaceFlow,
+    ) { roomSummaries, childIds, addedIds, isPrivateSpace ->
         roomSummaries
-            .filter { filterRoomPredicate(it.info, childIds, addedIds) }
+            .filter { filterRoomPredicate(it.info, childIds, addedIds, isPrivateSpace) }
             .map { it.info.toSelectRoomInfo() }
             .toImmutableList()
     }.flowOn(coroutineDispatchers.computation)
@@ -98,9 +105,10 @@ class AddRoomToSpaceSearchDataSource(
     val suggestions: Flow<ImmutableList<SelectRoomInfo>> = combine(
         spaceChildrenFlow,
         addedRoomIdsFlow,
-    ) { childIds, addedIds ->
+        isPrivateSpaceFlow,
+    ) { childIds, addedIds, isPrivateSpace ->
         matrixClient
-            .getRecentlyVisitedRoomInfoFlow { filterRoomPredicate(it, childIds, addedIds) }
+            .getRecentlyVisitedRoomInfoFlow { filterRoomPredicate(it, childIds, addedIds, isPrivateSpace) }
             .take(MAX_SUGGESTIONS_COUNT)
             .toList()
             .map { it.toSelectRoomInfo() }

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpacePresenterTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpacePresenterTest.kt
@@ -15,6 +15,7 @@ import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
@@ -26,6 +27,7 @@ import io.element.android.libraries.matrix.test.spaces.FakeSpaceRoomList
 import io.element.android.libraries.matrix.test.spaces.FakeSpaceService
 import io.element.android.libraries.matrix.ui.components.aSelectRoomInfo
 import io.element.android.libraries.matrix.ui.model.SelectRoomInfo
+import io.element.android.libraries.previewutils.room.aSpaceRoom
 import io.element.android.tests.testutils.lambda.assert
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.test
@@ -364,6 +366,92 @@ class AddRoomToSpacePresenterTest {
             failureState.eventSink(AddRoomToSpaceEvent.Dismiss)
             advanceUntilIdle()
             assert(resetResult).isCalledOnce()
+        }
+    }
+
+    @Test
+    fun `present - DMs are included in search results when space is private`() = runTest {
+        val roomList = FakeDynamicRoomList()
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { roomList }
+        )
+        val spaceRoomList = FakeSpaceRoomList(
+            paginateResult = { Result.success(Unit) },
+            resetResult = { Result.success(Unit) },
+            initialSpaceFlowValue = aSpaceRoom(joinRule = null), // Private space
+        )
+        val presenter = createAddRoomToSpacePresenter(
+            roomListService = roomListService,
+            spaceRoomList = spaceRoomList,
+        )
+        presenter.test {
+            awaitItem() // Initial state
+            // Post a DM room to the service
+            roomList.summaries.emit(
+                listOf(
+                    aRoomSummary(
+                        roomId = A_ROOM_ID,
+                        name = "DM Room",
+                        isDirect = true,
+                        isSpace = false,
+                        activeMembersCount = 2,
+                        currentUserMembership = CurrentUserMembership.JOINED,
+                    )
+                )
+            )
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertThat(state.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
+            val results = (state.searchResults as SearchBarResultState.Results).results
+            assertThat(results).hasSize(1)
+            assertThat(results.first().roomId).isEqualTo(A_ROOM_ID)
+        }
+    }
+
+    @Test
+    fun `present - DMs are excluded from search results when space is public`() = runTest {
+        val roomList = FakeDynamicRoomList()
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { roomList }
+        )
+        val spaceRoomList = FakeSpaceRoomList(
+            paginateResult = { Result.success(Unit) },
+            resetResult = { Result.success(Unit) },
+            initialSpaceFlowValue = aSpaceRoom(joinRule = JoinRule.Public), // Public space
+        )
+        val presenter = createAddRoomToSpacePresenter(
+            roomListService = roomListService,
+            spaceRoomList = spaceRoomList,
+        )
+        presenter.test {
+            awaitItem() // Initial state
+            // Post a DM room and a regular room to the service
+            roomList.summaries.emit(
+                listOf(
+                    aRoomSummary(
+                        roomId = A_ROOM_ID,
+                        name = "DM Room",
+                        isDirect = true,
+                        isSpace = false,
+                        activeMembersCount = 2,
+                        currentUserMembership = CurrentUserMembership.JOINED,
+                    ),
+                    aRoomSummary(
+                        roomId = A_ROOM_ID_2,
+                        name = "Regular Room",
+                        isDirect = false,
+                        isSpace = false,
+                        currentUserMembership = CurrentUserMembership.JOINED,
+                    )
+                )
+            )
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertThat(state.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
+            val results = (state.searchResults as SearchBarResultState.Results).results
+            // Only the regular room should be included, not the DM
+            assertThat(results).hasSize(1)
+            assertThat(results.first().roomId).isEqualTo(A_ROOM_ID_2)
         }
     }
 

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SpaceRoomItemView.kt
@@ -103,7 +103,11 @@ fun SpaceRoomItemView(
             Text(
                 modifier = Modifier.weight(1f),
                 style = ElementTheme.typography.fontBodyMdRegular,
-                text = pluralStringResource(CommonPlurals.common_member_count, spaceRoom.numJoinedMembers, spaceRoom.numJoinedMembers),
+                text = if (spaceRoom.isDirect == true) {
+                    stringResource(CommonStrings.common_direct_chat)
+                } else {
+                    pluralStringResource(CommonPlurals.common_member_count, spaceRoom.numJoinedMembers, spaceRoom.numJoinedMembers)
+                },
                 color = ElementTheme.colors.textSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Allow adding DMs to private spaces

## Motivation and context

https://github.com/element-hq/element-meta/issues/3193#issuecomment-4154510973
Seems to be what Element Web already allows.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
