### PR TITLE
Back off sync restarts after repeated sync failures

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
@@ -29,9 +29,11 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -99,34 +101,47 @@ class SyncOrchestrator(
             isInForeground || isInCall || isSyncingNotificationEvent || hasRingingCall
         }
 
+        val syncRetryStateFlow = syncService.syncState
+            .scan(SyncRetryState()) { retryState, syncState ->
+                retryState.updated(syncState)
+            }
+            .distinctUntilChanged()
+
         combine(
             // small debounce to avoid spamming startSync when the state is changing quickly in case of error.
-            syncService.syncState.debounce(100.milliseconds),
+            syncRetryStateFlow.debounce(100.milliseconds),
             networkMonitor.connectivity,
             isAppActiveFlow,
-        ) { syncState, networkState, isAppActive ->
+        ) { retryState, networkState, isAppActive ->
             val isNetworkAvailable = networkState == NetworkStatus.Connected
 
-            Timber.tag(tag).d("isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable")
-            if (syncState == SyncState.Running && !isAppActive) {
+            Timber.tag(tag).d(
+                "isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable, " +
+                    "syncState=${retryState.syncState}, consecutiveFailures=${retryState.consecutiveFailures}"
+            )
+            if (retryState.syncState == SyncState.Running && !isAppActive) {
                 SyncStateAction.StopSync
-            } else if (syncState == SyncState.Idle && isAppActive && isNetworkAvailable) {
-                SyncStateAction.StartSync
+            } else if (retryState.syncState == SyncState.Idle && isAppActive && isNetworkAvailable) {
+                SyncStateAction.StartSync(retryState.startDelay)
             } else {
                 SyncStateAction.NoOp
             }
         }
             .distinctUntilChanged()
             .debounce { action ->
-                // Don't stop the sync immediately, wait a bit to avoid starting/stopping the sync too often
-                if (action == SyncStateAction.StopSync) 3.seconds else 0.seconds
+                when (action) {
+                    is SyncStateAction.StartSync -> action.delay
+                    // Don't stop the sync immediately, wait a bit to avoid starting/stopping the sync too often
+                    SyncStateAction.StopSync -> 3.seconds
+                    SyncStateAction.NoOp -> 0.seconds
+                }
             }
             .onCompletion {
                 Timber.tag(tag).d("has been stopped")
             }
             .collect { action ->
                 when (action) {
-                    SyncStateAction.StartSync -> {
+                    is SyncStateAction.StartSync -> {
                         syncService.startSync()
                     }
                     SyncStateAction.StopSync -> {
@@ -138,8 +153,34 @@ class SyncOrchestrator(
     }
 }
 
-private enum class SyncStateAction {
-    StartSync,
-    StopSync,
-    NoOp,
+private sealed interface SyncStateAction {
+    data class StartSync(val delay: Duration) : SyncStateAction
+
+    data object StopSync : SyncStateAction
+
+    data object NoOp : SyncStateAction
+}
+
+private data class SyncRetryState(
+    val syncState: SyncState = SyncState.Idle,
+    val consecutiveFailures: Int = 0,
+) {
+    val startDelay: Duration
+        get() = when (consecutiveFailures) {
+            0 -> 0.seconds
+            1 -> 250.milliseconds
+            2 -> 1.seconds
+            3 -> 3.seconds
+            else -> 10.seconds
+        }
+
+    fun updated(nextSyncState: SyncState): SyncRetryState {
+        return when (nextSyncState) {
+            SyncState.Error -> copy(syncState = nextSyncState, consecutiveFailures = (consecutiveFailures + 1).coerceAtMost(4))
+            SyncState.Running,
+            SyncState.Terminated,
+            SyncState.Offline -> SyncRetryState(syncState = nextSyncState)
+            SyncState.Idle -> copy(syncState = nextSyncState)
+        }
+    }
 }

--- a/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
@@ -381,6 +381,66 @@ class SyncOrchestratorTest {
         startSyncRecorder.assertions().isNeverCalled()
     }
 
+    @Test
+    fun `when sync repeatedly fails, restarts from idle are backed off`() = runTest {
+        val startSyncRecorder = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val syncService = FakeSyncService(initialSyncState = SyncState.Error).apply {
+            startSyncLambda = startSyncRecorder
+        }
+        val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
+        val syncOrchestrator = createSyncOrchestrator(
+            syncService = syncService,
+            networkMonitor = networkMonitor,
+        )
+
+        syncOrchestrator.observeStates()
+
+        advanceTimeBy(100.milliseconds)
+        startSyncRecorder.assertions().isNeverCalled()
+
+        syncService.emitSyncState(SyncState.Idle)
+
+        advanceTimeBy(249.milliseconds)
+        startSyncRecorder.assertions().isNeverCalled()
+        advanceTimeBy(1.milliseconds)
+        startSyncRecorder.assertions().isCalledOnce()
+
+        syncService.emitSyncState(SyncState.Error)
+        syncService.emitSyncState(SyncState.Idle)
+
+        advanceTimeBy(999.milliseconds)
+        startSyncRecorder.assertions().isCalledOnce()
+        advanceTimeBy(1.milliseconds)
+        startSyncRecorder.assertions().isCalledExactly(2)
+    }
+
+    @Test
+    fun `when sync recovers, the restart backoff resets`() = runTest {
+        val startSyncRecorder = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val syncService = FakeSyncService(initialSyncState = SyncState.Error).apply {
+            startSyncLambda = startSyncRecorder
+        }
+        val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
+        val syncOrchestrator = createSyncOrchestrator(
+            syncService = syncService,
+            networkMonitor = networkMonitor,
+        )
+
+        syncOrchestrator.observeStates()
+
+        advanceTimeBy(100.milliseconds)
+        syncService.emitSyncState(SyncState.Idle)
+
+        advanceTimeBy(250.milliseconds)
+        startSyncRecorder.assertions().isCalledOnce()
+
+        syncService.emitSyncState(SyncState.Running)
+        syncService.emitSyncState(SyncState.Idle)
+
+        advanceTimeBy(1.milliseconds)
+        startSyncRecorder.assertions().isCalledExactly(2)
+    }
+
     private fun TestScope.createSyncOrchestrator(
         syncService: FakeSyncService = FakeSyncService(),
         networkMonitor: FakeNetworkMonitor = FakeNetworkMonitor(),


### PR DESCRIPTION
## Content

Add bounded backoff to the sync restart path in `SyncOrchestrator` so the app does not keep hammering the same failing sync state after repeated `Error -> Idle` transitions.

This also adds unit coverage for repeated failures and for resetting the backoff once sync reaches a healthy state again.

## Motivation and context

This is a client-side mitigation for this Sliding Sync failure: https://github.com/element-hq/synapse/pull/19651

The issue reported here was that after leaving a room in a bad server state, Element X could get stuck syncing forever. The useful server-side signal was in `../synapse.log`: incremental Sliding Sync was returning HTTP 500 because Synapse asserted while reconstructing a newly-left room whose current membership snapshot had already been removed.

On the Android side `SyncOrchestrator` would still aggressively call `startSync()` again whenever the session came back to `Idle` while the app was active and the network was available. If the same persisted sync state kept failing, that turned into an avoidable retry loop.

This change adds bounded backoff of `250ms`, `1s`, `3s`, and `10s`, and resets that backoff once sync genuinely recovers.

## Screenshots / GIFs

No UI changes.

## Tests

- Added tests in `appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt` for repeated failure backoff.
- Added tests in `appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt` for resetting the backoff after sync recovery.
- Attempted to run `./gradlew :appnav:testDebugUnitTest --tests "io.element.android.appnav.SyncOrchestratorTest"`.
- No dev environment to test just reporting.

## Tested devices

- [ ] Physical
- [ ] Emulator

## Checklist

- This PR was made with the help of AI:
    - [x] Yes.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR.