### PR TITLE
Fix `isInAirGappedEnvironment` check for older APIs

### DIFF
--- a/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
+++ b/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
@@ -15,7 +15,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.os.Build
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -84,9 +83,7 @@ class DefaultNetworkMonitor(
                 if (network.networkHandle == connectivityManager.activeNetwork?.networkHandle) {
                     // If the network doesn't have the NET_CAPABILITY_VALIDATED capability, it means that the network is not able to reach the internet
                     // (according to Google), which is a common case in air-gapped environments.
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        isInAirGappedEnvironment.value = !networkCapabilities.capabilities.contains(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                    }
+                    isInAirGappedEnvironment.value = !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                 }
             }
 

--- a/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
+++ b/features/networkmonitor/impl/src/main/kotlin/io/element/android/features/networkmonitor/impl/DefaultNetworkMonitor.kt
@@ -20,7 +20,6 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.api.NetworkStatus
-import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.di.annotations.AppCoroutineScope
 import io.element.android.libraries.di.annotations.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -43,7 +42,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class DefaultNetworkMonitor(
     @ApplicationContext context: Context,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
-    private val buildMeta: BuildMeta,
 ) : NetworkMonitor {
     private val connectivityManager: ConnectivityManager = context.getSystemService(ConnectivityManager::class.java)
 
@@ -75,11 +73,6 @@ class DefaultNetworkMonitor(
             }
 
             override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
-                if (!buildMeta.isEnterpriseBuild) {
-                    // The air-gapped environment detection is only relevant for the enterprise build.
-                    return
-                }
-
                 if (network.networkHandle == connectivityManager.activeNetwork?.networkHandle) {
                     // If the network doesn't have the NET_CAPABILITY_VALIDATED capability, it means that the network is not able to reach the internet
                     // (according to Google), which is a common case in air-gapped environments.

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -138,7 +138,7 @@ enum class FeatureFlags(
         title = "Validate internet connectivity when scheduling notification fetching",
         description = "Only fetch events for push notifications when the device has internet connectivity. " +
             "Enabling this can be problematic in air-gapped environments.",
-        defaultValue = { it.isEnterpriseBuild },
+        defaultValue = { true },
         isFinished = false,
     ),
     FloatingDateBadge(

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -138,7 +138,7 @@ enum class FeatureFlags(
         title = "Validate internet connectivity when scheduling notification fetching",
         description = "Only fetch events for push notifications when the device has internet connectivity. " +
             "Enabling this can be problematic in air-gapped environments.",
-        defaultValue = { true },
+        defaultValue = { it.isEnterpriseBuild },
         isFinished = false,
     ),
     FloatingDateBadge(

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
@@ -76,7 +76,6 @@ class DefaultSyncPendingNotificationsRequestBuilder(
             .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
 
         // If we're in an air-gapped environment, we shouldn't validate internet connectivity, as the checker will fail and the worker won't run at all.
-        // Note this will always be false for FOSS, since the feature is only enabled in Element Pro.
         if (networkMonitor.isInAirGappedEnvironment.first()) {
             Timber.d("In an air-gapped environment, not adding NET_CAPABILITY_VALIDATED to the network request")
             networkRequestBuilder.removeCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
@@ -80,6 +80,9 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             sessionId = A_SESSION_ID,
             sdkVersion = 33,
             isInAirGapEnvironment = false,
+            featureFlagService = FakeFeatureFlagService(initialState = mapOf(
+                FeatureFlags.ValidateNetworkWhenSchedulingNotificationFetching.key to true
+            )),
         )
 
         val results = request.build()
@@ -100,6 +103,9 @@ class DefaultSyncPendingNotificationsRequestBuilderTest {
             sessionId = A_SESSION_ID,
             sdkVersion = 33,
             isInAirGapEnvironment = true,
+            featureFlagService = FakeFeatureFlagService(initialState = mapOf(
+                FeatureFlags.ValidateNetworkWhenSchedulingNotificationFetching.key to true
+            )),
         )
 
         val results = request.build()


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Use `networkCapabilities.hasCapability` instead of `networkCapabilities.capabilities.contains`, which only works on Android 12 and newer versions.

Also, enable validating the network in `WorkManager` only in enterprise builds by default.

## Motivation and context

This check wasn't working on API 30 and lower. I didn't realise `hasCapability` existed, so I incorrectly assumed if you could only check the capability in API 31 and greater it meant it was only enforced on those APIs too, and the tests I ran were on a device with API 36 🫤 .

Should fix https://github.com/element-hq/element-x-android/issues/6551.

## Tests

It's kind of difficult to test, but try using a device with Android 11 or lower in a network with no access to google APIs (or at least to the connectivity check endpoint). You should see some logs saying it's in air gapped env, and you should still be able to receive push notifications using unified push.

## Tested devices

I don't have a setup to test these changes at the moment, I did try the previous check with a real device using Android 16 and it worked, so I assume generalising the same check for all Android APIs should work the same.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
