### PR TITLE
feat: Default to camera muted when joining ongoing voice call

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/RoomSummaryRow.kt
@@ -60,6 +60,7 @@ import io.element.android.libraries.designsystem.theme.roomListRoomMessage
 import io.element.android.libraries.designsystem.theme.roomListRoomMessageDate
 import io.element.android.libraries.designsystem.theme.roomListRoomName
 import io.element.android.libraries.designsystem.theme.unreadIndicator
+import io.element.android.libraries.matrix.api.notification.CallIntent
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 import io.element.android.libraries.matrix.ui.components.InviteSenderView
 import io.element.android.libraries.matrix.ui.model.InviteSender
@@ -349,6 +350,7 @@ private fun MessagePreviewAndIndicatorRow(
             if (room.hasRoomCall) {
                 OnGoingCallIcon(
                     color = tint,
+                    isAudio = room.activeCallIntent == CallIntent.AUDIO
                 )
             }
             if (room.userDefinedNotificationMode == RoomNotificationMode.MUTE) {
@@ -398,10 +400,11 @@ private fun InviteNameAndIndicatorRow(
 @Composable
 private fun OnGoingCallIcon(
     color: Color,
+    isAudio: Boolean
 ) {
     Icon(
         modifier = Modifier.size(16.dp),
-        imageVector = CompoundIcons.VideoCallSolid(),
+        imageVector = if (isAudio) CompoundIcons.VoiceCallSolid() else CompoundIcons.VideoCallSolid(),
         contentDescription = stringResource(CommonStrings.a11y_notifications_ongoing_call),
         tint = color,
     )

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactory.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactory.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.dateformatter.api.DateFormatter
 import io.element.android.libraries.dateformatter.api.DateFormatterMode
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.eventformatter.api.RoomLatestEventFormatter
+import io.element.android.libraries.matrix.api.room.CallIntentConsensus
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.isDm
 import io.element.android.libraries.matrix.api.roomlist.LatestEventValue
@@ -50,6 +51,11 @@ class RoomListRoomSummaryFactory(
             avatarData = avatarData,
             userDefinedNotificationMode = roomInfo.userDefinedNotificationMode,
             hasRoomCall = roomInfo.hasRoomCall,
+            activeCallIntent = when (val consensus = roomInfo.activeCallIntentConsensus) {
+                is CallIntentConsensus.Full -> consensus.callIntent
+                is CallIntentConsensus.Partial -> consensus.callIntent
+                CallIntentConsensus.None -> null
+            },
             isDirect = roomInfo.isDirect,
             isFavorite = roomInfo.isFavorite,
             inviteSender = roomInfo.inviter?.toInviteSender(),

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/model/RoomListRoomSummary.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/model/RoomListRoomSummary.kt
@@ -13,6 +13,7 @@ import io.element.android.features.invite.api.InviteData
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.notification.CallIntent
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 import io.element.android.libraries.matrix.ui.model.InviteSender
 import kotlinx.collections.immutable.ImmutableList
@@ -33,6 +34,7 @@ data class RoomListRoomSummary(
     val avatarData: AvatarData,
     val userDefinedNotificationMode: RoomNotificationMode?,
     val hasRoomCall: Boolean,
+    val activeCallIntent: CallIntent?,
     val isDirect: Boolean,
     val isDm: Boolean,
     val isFavorite: Boolean,

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/model/RoomListRoomSummaryProvider.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/model/RoomListRoomSummaryProvider.kt
@@ -14,6 +14,7 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.notification.CallIntent
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
 import io.element.android.libraries.matrix.ui.model.InviteSender
 import kotlinx.collections.immutable.toImmutableList
@@ -132,6 +133,14 @@ open class RoomListRoomSummaryProvider : PreviewParameterProvider<RoomListRoomSu
             listOf(
                 aRoomListRoomSummary(latestEvent = LatestEvent.Sending("A sending message")),
                 aRoomListRoomSummary(latestEvent = LatestEvent.Error),
+            ),
+            listOf(
+                aRoomListRoomSummary(
+                    name = "Active voice call",
+                    latestEvent = LatestEvent.Synced("No activity, call"),
+                    hasRoomCall = true,
+                    activeCallIntent = CallIntent.AUDIO
+                ),
             )
         ).flatten()
 }
@@ -158,6 +167,7 @@ internal fun aRoomListRoomSummary(
     timestamp: String? = latestEvent.takeIf { it !is LatestEvent.None }?.let { "88:88" },
     notificationMode: RoomNotificationMode? = null,
     hasRoomCall: Boolean = false,
+    activeCallIntent: CallIntent? = null,
     avatarData: AvatarData = AvatarData(id, name, size = AvatarSize.RoomListItem),
     isDirect: Boolean = false,
     isDm: Boolean = false,
@@ -181,6 +191,7 @@ internal fun aRoomListRoomSummary(
     avatarData = avatarData,
     userDefinedNotificationMode = notificationMode,
     hasRoomCall = hasRoomCall,
+    activeCallIntent = activeCallIntent,
     isDirect = isDirect,
     isDm = isDm,
     isFavorite = isFavorite,

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/model/RoomListBaseRoomSummaryTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/model/RoomListBaseRoomSummaryTest.kt
@@ -101,6 +101,7 @@ internal fun createRoomListRoomSummary(
     displayType = displayType,
     userDefinedNotificationMode = userDefinedNotificationMode,
     hasRoomCall = false,
+    activeCallIntent = null,
     isDirect = false,
     isFavorite = isFavorite,
     canonicalAlias = null,

--- a/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
+++ b/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
@@ -20,6 +20,8 @@ import io.element.android.features.call.api.CurrentCallService
 import io.element.android.features.enterprise.api.SessionEnterpriseService
 import io.element.android.features.roomcall.api.RoomCallState
 import io.element.android.libraries.architecture.Presenter
+import io.element.android.libraries.matrix.api.notification.CallIntent
+import io.element.android.libraries.matrix.api.room.CallIntentConsensus
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.isDm
 import io.element.android.libraries.matrix.api.room.powerlevels.canCall
@@ -57,8 +59,7 @@ class RoomCallStatePresenter(
                         canJoinCall = canJoinCall,
                         isUserInTheCall = isUserInTheCall,
                         isUserLocallyInTheCall = isUserLocallyInTheCall,
-                        // TODO resolve intent while the call is ongoing
-                        isAudioCall = false
+                        isAudioCall = roomInfo.activeCallIntentConsensus.isAudio(),
                     )
                     else -> RoomCallState.StandBy(
                         canStartCall = canJoinCall,
@@ -69,4 +70,13 @@ class RoomCallStatePresenter(
         }
         return callState
     }
+}
+
+fun CallIntentConsensus.isAudio(): Boolean {
+    val intent = when (this) {
+        is CallIntentConsensus.Full -> callIntent
+        is CallIntentConsensus.Partial -> callIntent
+        is CallIntentConsensus.None -> return false
+    }
+    return intent == CallIntent.AUDIO
 }

--- a/features/roomcall/impl/src/test/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenterTest.kt
+++ b/features/roomcall/impl/src/test/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenterTest.kt
@@ -14,6 +14,8 @@ import io.element.android.features.call.api.CurrentCallService
 import io.element.android.features.call.test.FakeCurrentCallService
 import io.element.android.features.enterprise.test.FakeSessionEnterpriseService
 import io.element.android.features.roomcall.api.RoomCallState
+import io.element.android.libraries.matrix.api.notification.CallIntent
+import io.element.android.libraries.matrix.api.room.CallIntentConsensus
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.StateEventType
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
@@ -182,6 +184,100 @@ class RoomCallStatePresenterTest {
                     canJoinCall = true,
                     isAudioCall = false,
                     isUserInTheCall = true,
+                    isUserLocallyInTheCall = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `present - active call with audio Intent`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                roomPermissions = roomPermissions(true),
+            ).apply {
+                givenRoomInfo(
+                    aRoomInfo(
+                        hasRoomCall = true,
+                        activeCallIntentConsensus = CallIntentConsensus.Full(CallIntent.AUDIO),
+                        activeRoomCallParticipants = emptyList(),
+                    )
+                )
+            }
+        )
+        val presenter = createRoomCallStatePresenter(
+            joinedRoom = room,
+            currentCallService = FakeCurrentCallService(MutableStateFlow(CurrentCall.RoomCall(room.roomId))),
+        )
+        presenter.test {
+            skipItems(1)
+            assertThat(awaitItem()).isEqualTo(
+                RoomCallState.OnGoing(
+                    canJoinCall = true,
+                    isAudioCall = true,
+                    isUserInTheCall = false,
+                    isUserLocallyInTheCall = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `present - active call with partial audio Intent`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                roomPermissions = roomPermissions(true),
+            ).apply {
+                givenRoomInfo(
+                    aRoomInfo(
+                        hasRoomCall = true,
+                        activeCallIntentConsensus = CallIntentConsensus.Partial(CallIntent.AUDIO, 1, 4),
+                    )
+                )
+            }
+        )
+        val presenter = createRoomCallStatePresenter(
+            joinedRoom = room,
+            currentCallService = FakeCurrentCallService(MutableStateFlow(CurrentCall.RoomCall(room.roomId))),
+        )
+        presenter.test {
+            skipItems(1)
+            assertThat(awaitItem()).isEqualTo(
+                RoomCallState.OnGoing(
+                    canJoinCall = true,
+                    isAudioCall = true,
+                    isUserInTheCall = false,
+                    isUserLocallyInTheCall = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `present - active call with no intent defaults to Audio`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                roomPermissions = roomPermissions(true),
+            ).apply {
+                givenRoomInfo(
+                    aRoomInfo(
+                        hasRoomCall = true,
+                        activeCallIntentConsensus = CallIntentConsensus.None,
+                    )
+                )
+            }
+        )
+        val presenter = createRoomCallStatePresenter(
+            joinedRoom = room,
+            currentCallService = FakeCurrentCallService(MutableStateFlow(CurrentCall.RoomCall(room.roomId))),
+        )
+        presenter.test {
+            skipItems(1)
+            assertThat(awaitItem()).isEqualTo(
+                RoomCallState.OnGoing(
+                    canJoinCall = true,
+                    isAudioCall = false,
+                    isUserInTheCall = false,
                     isUserLocallyInTheCall = true,
                 )
             )

--- a/tests/uitests/src/test/snapshots/images/features.home.impl.components_RoomSummaryRow_Day_38_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.home.impl.components_RoomSummaryRow_Day_38_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26071a6b16f4446526f6abf28274580eb0f385bd0e74f4f2b0479da5f5d4f6f2
+size 12914

--- a/tests/uitests/src/test/snapshots/images/features.home.impl.components_RoomSummaryRow_Night_38_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.home.impl.components_RoomSummaryRow_Night_38_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ddef7c50d6a791c6a32bae8506a999b198bc601b70b6ffb5e5e7a8d5a2f1543
+size 12869


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Fixes  #6291
It is now possible to know if an ongoing call is voice or video (https://github.com/matrix-org/matrix-rust-sdk/pull/6274). 
This PR use this information to update the active calls indicators in the app

In room header
<img width="419" height="183" alt="image" src="https://github.com/user-attachments/assets/a58643c5-f0b9-4101-80e4-c7cef88b8442" />

And in room list:
<img width="392" height="90" alt="image" src="https://github.com/user-attachments/assets/45fd4f2f-e902-46a9-89b2-da940e4d07c1" />



<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
