### PR TITLE
Add extra logs for timeline pagination

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -130,6 +130,8 @@ class RustTimeline(
         Timeline.PaginationStatus(isPaginating = false, hasMoreToLoad = mode is Timeline.Mode.FocusedOnEvent)
     )
 
+    private val loggerTag = "Timeline($mode)"
+
     init {
         when (mode) {
             is Timeline.Mode.Live, is Timeline.Mode.FocusedOnEvent -> coroutineScope.fetchMembers()
@@ -177,10 +179,11 @@ class RustTimeline(
     }
 
     private fun updatePaginationStatus(direction: Timeline.PaginationDirection, update: (Timeline.PaginationStatus) -> Timeline.PaginationStatus) {
-        when (direction) {
+        val result = when (direction) {
             Timeline.PaginationDirection.BACKWARDS -> backwardPaginationStatus.getAndUpdate(update)
             Timeline.PaginationDirection.FORWARDS -> forwardPaginationStatus.getAndUpdate(update)
         }
+        Timber.tag(loggerTag).d("updatePaginationStatus $direction: $result")
     }
 
     // Use NonCancellable to avoid breaking the timeline when the coroutine is cancelled.
@@ -195,12 +198,13 @@ class RustTimeline(
                 }
             }.onFailure { error ->
                 if (error is TimelineException.CannotPaginate) {
-                    Timber.d("Can't paginate $direction on room ${joinedRoom.roomId} with paginationStatus: ${backwardPaginationStatus.value}")
+                    Timber.tag(loggerTag).d("Can't paginate $direction on room ${joinedRoom.roomId} with paginationStatus: ${backwardPaginationStatus.value}")
                 } else {
                     updatePaginationStatus(direction) { it.copy(isPaginating = false) }
-                    Timber.e(error, "Error paginating $direction on room ${joinedRoom.roomId}")
+                    Timber.tag(loggerTag).e(error, "Error paginating $direction on room ${joinedRoom.roomId}")
                 }
             }.onSuccess { hasReachedEnd ->
+                Timber.tag(loggerTag).d("Finished paginating $direction on room ${joinedRoom.roomId}, hasReachedEnd: $hasReachedEnd")
                 updatePaginationStatus(direction) { it.copy(isPaginating = false, hasMoreToLoad = !hasReachedEnd) }
             }
         }
@@ -264,7 +268,7 @@ class RustTimeline(
         try {
             inner.fetchMembers()
         } catch (exception: Exception) {
-            Timber.e(exception, "Error fetching members for room ${joinedRoom.roomId}")
+            Timber.tag(loggerTag).e(exception, "Error fetching members for room ${joinedRoom.roomId}")
         }
     }
 
@@ -370,7 +374,7 @@ class RustTimeline(
         formattedCaption: String?,
         inReplyToEventId: EventId?,
     ): Result<MediaUploadHandler> {
-        Timber.d("Sending image ${file.path.hash()}")
+        Timber.tag(loggerTag).d("Sending image ${file.path.hash()}")
         return sendAttachment(listOfNotNull(file, thumbnailFile)) {
             inner.sendImage(
                 params = UploadParameters(
@@ -396,7 +400,7 @@ class RustTimeline(
         formattedCaption: String?,
         inReplyToEventId: EventId?,
     ): Result<MediaUploadHandler> {
-        Timber.d("Sending video ${file.path.hash()}")
+        Timber.tag(loggerTag).d("Sending video ${file.path.hash()}")
         return sendAttachment(listOfNotNull(file, thumbnailFile)) {
             inner.sendVideo(
                 params = UploadParameters(
@@ -421,7 +425,7 @@ class RustTimeline(
         formattedCaption: String?,
         inReplyToEventId: EventId?,
     ): Result<MediaUploadHandler> {
-        Timber.d("Sending audio ${file.path.hash()}")
+        Timber.tag(loggerTag).d("Sending audio ${file.path.hash()}")
         return sendAttachment(listOf(file)) {
             inner.sendAudio(
                 params = UploadParameters(
@@ -445,7 +449,7 @@ class RustTimeline(
         formattedCaption: String?,
         inReplyToEventId: EventId?,
     ): Result<MediaUploadHandler> {
-        Timber.d("Sending file ${file.path.hash()}")
+        Timber.tag(loggerTag).d("Sending file ${file.path.hash()}")
         return sendAttachment(listOf(file)) {
             inner.sendFile(
                 params = UploadParameters(
@@ -475,7 +479,7 @@ class RustTimeline(
         runCatchingExceptions {
             roomContentForwarder.forward(fromTimeline = inner, eventId = eventId, toRoomIds = roomIds)
         }.onFailure {
-            Timber.e(it)
+            Timber.tag(loggerTag).e(it)
         }
     }
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Add some new logs for what happens when we update the pagination status of different timelines.

Also, add the current timeline mode as part of the log tag so we can be sure about which timeline is being updated.

## Motivation and context

Try to debug issues with pagination more easily.

## Tests

Check the logs.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
