### PR TITLE
Fix loading initial items of non-live timelines

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -84,6 +84,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -262,11 +263,16 @@ private fun TimelinePrefetchingHelper(
             firstVisibleItemIndex + layoutInfo.visibleItemsInfo.size >= layoutInfo.totalItemsCount - 40
         }
 
+        // If we have no timeline items, we need to back paginate to load some messages. This usually happens on all timelines except for live ones.
+        // This automatic pagination was previously done by the SDK, and we received a `Reset` update, but now we need to do it ourselves.
+        val isEmptyTimelineFlow = layoutInfoFlow.map { it.totalItemsCount == 0 }
+
         combine(
             isCloseToStartOfLoadedTimelineFlow.distinctUntilChanged(),
             isScrollingFlow.distinctUntilChanged(),
-        ) { needsPrefetch, isScrolling ->
-            needsPrefetch && isScrolling
+            isEmptyTimelineFlow,
+        ) { needsPrefetch, isScrolling, isEmptyAndNeedsBackPagination ->
+            isEmptyAndNeedsBackPagination || needsPrefetch && isScrolling
         }
             .distinctUntilChanged()
             .collectLatest { needsPrefetch ->

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/MessagesViewTest.kt
@@ -522,6 +522,9 @@ class MessagesViewTest {
         rule.setMessagesView(
             state = stateWithActionListState,
         )
+        // Clear initial 'LoadMore' event emitted when setting the state
+        eventsRecorder.clear()
+
         val verifiedUserSendFailure = rule.activity.getString(CommonStrings.screen_timeline_item_menu_send_failure_changed_identity, "Alice")
         rule.onNodeWithText(verifiedUserSendFailure).performClick()
         // Give time for the close animation to complete
@@ -585,6 +588,9 @@ class MessagesViewTest {
             ),
         )
         rule.setMessagesView(state = state)
+        // Clear initial 'LoadMore' event emitted when setting the state
+        eventsRecorder.clear()
+
         rule.onNodeWithText("This is a pinned message").performClick()
         eventsRecorder.assertSingle(TimelineEvent.FocusOnEvent(AN_EVENT_ID, debounce = FOCUS_ON_PINNED_EVENT_DEBOUNCE_DURATION_IN_MILLIS.milliseconds))
     }
@@ -601,6 +607,9 @@ class MessagesViewTest {
             timelineState = aTimelineState(eventSink = eventsRecorder)
         )
         rule.setMessagesView(state = state)
+        // Clear initial 'LoadMore' event emitted when setting the state
+        eventsRecorder.clear()
+
         val text = rule.activity.getString(R.string.screen_room_timeline_tombstoned_room_action)
         // The bottomsheet subcompose seems to make the node to appear twice
         rule.onAllNodesWithText(text).onFirst().performClick()

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -67,24 +67,31 @@ class TimelineViewTest {
 
     @Test
     fun `reaching the end of the timeline does not send a LoadMore event`() {
-        val eventsRecorder = EventsRecorder<TimelineEvent>(expectEvents = false)
+        val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
+                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
                 eventSink = eventsRecorder,
             ),
         )
+        eventsRecorder.assertSingle(TimelineEvent.OnScrollFinished(firstIndex = 0))
     }
 
     @Test
     fun `scroll to bottom on live timeline does not emit the Event`() {
-        val eventsRecorder = EventsRecorder<TimelineEvent>(expectEvents = false)
+        val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
+                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
                 isLive = true,
                 eventSink = eventsRecorder,
             ),
             forceJumpToBottomVisibility = true,
         )
+
+        eventsRecorder.assertSingle(TimelineEvent.OnScrollFinished(firstIndex = 0))
+        eventsRecorder.clear()
+
         val contentDescription = rule.activity.getString(CommonStrings.a11y_jump_to_bottom)
         rule.onNodeWithContentDescription(contentDescription).performClick()
     }
@@ -94,13 +101,31 @@ class TimelineViewTest {
         val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
+                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
                 isLive = false,
                 eventSink = eventsRecorder,
             ),
         )
+
+        eventsRecorder.assertSingle(TimelineEvent.OnScrollFinished(firstIndex = 0))
+        eventsRecorder.clear()
+
         val contentDescription = rule.activity.getString(CommonStrings.a11y_jump_to_bottom)
         rule.onNodeWithContentDescription(contentDescription).performClick()
         eventsRecorder.assertSingle(TimelineEvent.JumpToLive)
+    }
+
+    @Test
+    fun `an empty timeline triggers a prefetch`() {
+        val eventsRecorder = EventsRecorder<TimelineEvent>()
+        rule.setTimelineView(
+            state = aTimelineState(
+                timelineItems = persistentListOf(),
+                eventSink = eventsRecorder,
+            ),
+        )
+
+        eventsRecorder.assertSingle(TimelineEvent.LoadMore(Timeline.PaginationDirection.BACKWARDS))
     }
 
     @Test
@@ -133,11 +158,15 @@ class TimelineViewTest {
         val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
+                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
                 isLive = false,
                 eventSink = eventsRecorder,
                 messageShield = aCriticalShield(),
             ),
         )
+        eventsRecorder.assertSingle(TimelineEvent.OnScrollFinished(firstIndex = 0))
+        eventsRecorder.clear()
+
         rule.clickOn(CommonStrings.action_ok)
         eventsRecorder.assertSingle(TimelineEvent.HideShieldDialog)
     }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -101,7 +101,7 @@ class TimelineViewTest {
         val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
-                timelineItems = persistentListOf(aTimelineItemEvent()),
+                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
                 isLive = false,
                 eventSink = eventsRecorder,
             ),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelineViewTest.kt
@@ -101,7 +101,7 @@ class TimelineViewTest {
         val eventsRecorder = EventsRecorder<TimelineEvent>()
         rule.setTimelineView(
             state = aTimelineState(
-                timelineItems = persistentListOf(aTimelineItemEvent(content = aTimelineItemImageContent())),
+                timelineItems = persistentListOf(aTimelineItemEvent()),
                 isLive = false,
                 eventSink = eventsRecorder,
             ),


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Items in non-live timelines aren't loaded automatically anymore if they're not present in the cache. This is specially easy to spot when loading a thread timeline.

This was done automatically by the SDK in the past by returning a `Reset` timeline update, but this behaviour changed and now we have to do it.

## Motivation and context

Fix the initial loading of timeline items when they're not cached after https://github.com/matrix-org/matrix-rust-sdk/pull/6380.

## Tests

Either clear the cache or make sure you're opening a thread you haven't loaded yet. Open the thread screen, if timelines appear, this should be fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
