### PR TITLE
Add sha256 signing certificate on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Compared to the previous-generation [Element Classic](https://github.com/element
 
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=io.element.android.x)[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/io.element.android.x)
 
+> Github releases can be verified with the following SHA-256 fingerprint certificate: `6A:2F:DC:31:48:04:9C:E0:D5:C6:E8:50:10:72:3B:83:FB:20:7D:20:C7:47:7F:5C:22:AC:53:C8:77:E9:2D:47`
+
 ## Table of contents
 
 <!--- TOC -->


### PR DESCRIPTION
Add SHA-256 signing certificate hash to README to allow users to verify apps they download and install

Close https://github.com/element-hq/element-x-android/issues/5544