### PR TITLE
devx: fix build sdk script options for macos

### DIFF
--- a/docs/_developer_onboarding.md
+++ b/docs/_developer_onboarding.md
@@ -144,6 +144,11 @@ Prerequisites:
   export ANDROID_HOME=$HOME/android/sdk
   ```
 
+* On macos ensure gnu-getopt is installed
+  ```
+  brew install gnu-getopt
+  ```
+
 You can then build the Rust SDK by running the script
 [`tools/sdk/build-rust-sdk`](../tools/sdk/build-rust-sdk). Type
 `./tools/sdk/build-rust-sdk --help` for help.

--- a/tools/sdk/build-rust-sdk
+++ b/tools/sdk/build-rust-sdk
@@ -41,7 +41,14 @@ sdkArg=""
 
 ## Argument parsing
 
-TEMP=$(getopt -o 'rs:b:at:h' --long 'remote,sdk:,branch:,build-app,target-arch:,help' -- "$@")
+# Use GNU getopt (required for --long support on macOS)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    GNU_GETOPT="$(brew --prefix gnu-getopt)/bin/getopt"
+else
+    GNU_GETOPT="getopt"
+fi
+
+TEMP=$("$GNU_GETOPT" -o 'rs:b:at:h' --long 'remote,sdk:,branch:,build-app,target-arch:,help' -- "$@")
 
 if [ $? -ne 0 ]; then
     echo 'Terminating...' >&2
@@ -53,32 +60,32 @@ unset TEMP
 
 while true; do
     case "$1" in
-        'r'|'--remote')
+        '-r'|'--remote')
             buildLocal=1
             shift
             continue
         ;;
-        's'|'--sdk')
+        '-s'|'--sdk')
             sdkArg="$2"
             shift 2
             continue
         ;;
-        'b'|'--branch')
+        '-b'|'--branch')
             rustSdkBranch="$2"
             shift 2
             continue
         ;;
-        'a'|'--build-app')
+        '-a'|'--build-app')
             buildApp=0
             shift
             continue
         ;;
-        't'|'--target-arch')
+        '-t'|'--target-arch')
             target_arch="$2"
             shift 2
             continue
         ;;
-        'h'|'--help')
+        '-h'|'--help')
             cat << END
 SYNOPSIS
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->

I just noticed that the `./tools/sdk/build-rust-sdk --help` was not working anymore on my mac.
It just proceed and launch the full script.

After some assisted investigation, I noticed two things:

**Missing `-`  prefix on short option cases in the while loop**
I have been checking for some examples, and the `-` appears to be expected? https://stackoverflow.com/questions/402377/using-getopts-to-process-long-and-short-command-line-options

**BSD getopt vs GNU getopt shenanigan**
Apparently the `getopt` shipped in macOS does not support the `--` long option format

https://man.freebsd.org/cgi/man.cgi?getopt(1)
> The special option `--' is used to delimit the end  of  the options 

That explains why it just runs the script, ignoring what is after --?

Gnu getopt https://man7.org/linux/man-pages/man1/getopt.1.html

It talks about short and long option 
>  If no '-o' or '--options' option is found in the first part, the
       first parameter of the second part is used as the short options
       string.
       
       

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
