### PR TITLE
Fix calls on Huawei devices: skip addWebMessageListener on Chromium < 119

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
@@ -140,26 +140,32 @@ class WebViewWidgetMessageInterceptor(
             }
         }
 
-        // Create a WebMessageListener, which will receive messages from the WebView and reply to them
-        val webMessageListener = WebViewCompat.WebMessageListener { _, message, _, _, _ ->
-            onMessageReceived(message.data)
-        }
+        // Always register JavascriptInterface as the baseline message channel.
+        // This works on all WebView implementations including Huawei.
+        webView.addJavascriptInterface(object {
+            @JavascriptInterface
+            fun postMessage(json: String?) {
+                onMessageReceived(json)
+            }
+        }, LISTENER_NAME)
 
-        // Use WebMessageListener if supported, otherwise use JavascriptInterface
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+        // Additionally register WebMessageListener on WebViews that reliably support it.
+        // Huawei WebView (Chromium < 119) reports WEB_MESSAGE_LISTENER as supported
+        // but silently drops messages, so we only trust it on Chrome 119+.
+        // See: https://github.com/element-hq/element-x-android/issues/6632
+        val webViewVersion = WebViewCompat.getCurrentWebViewPackage(webView.context)
+            ?.versionName?.split(".")?.firstOrNull()?.toIntOrNull() ?: 0
+
+        if (webViewVersion >= 119 &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
             WebViewCompat.addWebMessageListener(
                 webView,
                 LISTENER_NAME,
                 setOf("*"),
-                webMessageListener
-            )
-        } else {
-            webView.addJavascriptInterface(object {
-                @JavascriptInterface
-                fun postMessage(json: String?) {
-                    onMessageReceived(json)
+                WebViewCompat.WebMessageListener { _, message, _, _, _ ->
+                    onMessageReceived(message.data)
                 }
-            }, LISTENER_NAME)
+            )
         }
     }
 

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewWidgetMessageInterceptor.kt
@@ -151,12 +151,13 @@ class WebViewWidgetMessageInterceptor(
 
         // Additionally register WebMessageListener on WebViews that reliably support it.
         // Huawei WebView (Chromium < 119) reports WEB_MESSAGE_LISTENER as supported
-        // but silently drops messages, so we only trust it on Chrome 119+.
+        // but silently drops messages, so we only trust it on Chromium 119+.
         // See: https://github.com/element-hq/element-x-android/issues/6632
-        val webViewVersion = WebViewCompat.getCurrentWebViewPackage(webView.context)
-            ?.versionName?.split(".")?.firstOrNull()?.toIntOrNull() ?: 0
+        val webViewVersionName = WebViewCompat.getCurrentWebViewPackage(webView.context)?.versionName.orEmpty()
+        Timber.d("Using WebView version: $webViewVersionName")
+        val webViewVersionCode = webViewVersionName.split(".").firstOrNull()?.toIntOrNull() ?: 0
 
-        if (webViewVersion >= 119 &&
+        if (webViewVersionCode >= 119 &&
             WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
             WebViewCompat.addWebMessageListener(
                 webView,


### PR DESCRIPTION
## Problem

Calls do not work on Huawei and other devices with system WebView based on Chromium < 119. The call screen shows "Join as guest" instead of the call UI.

Huawei WebView reports `WEB_MESSAGE_LISTENER` as supported via `WebViewFeature.isFeatureSupported()`, but silently drops messages sent through `addWebMessageListener`. This is a known issue across the Android ecosystem. Capacitor, Home Assistant, Flutter InAppWebView and Tauri have all documented workarounds for Huawei WebView (see ionic-team/capacitor#6555, ionic-team/capacitor#6258).

Huawei does not allow users to change the WebView provider on their devices.

## Fix

- Register `addJavascriptInterface` unconditionally as the baseline message channel (works on all WebView implementations)
- Only use `addWebMessageListener` when the WebView is based on Chromium 119+, where it is known to work reliably
- On Chrome 119+ both are registered, `addWebMessageListener` takes priority (same behavior as before)
- On Chromium < 119 only `addJavascriptInterface` is used, avoiding the broken `addWebMessageListener`

## Note

There is a second issue affecting these devices: Element Call JS bundle uses `Promise.withResolvers` (Chrome 119+), which causes the ES module to silently fail on older WebViews. A polyfill fix for that has been submitted to Element Call: element-hq/element-call#3905

## Test plan

- Tested on Huawei device with WebView Chromium 114: calls work correctly
- Built from source, full debug APK verified on device
- `compileDebugKotlin` passes, full `assembleDebug` passes

Related: #6632