### PR TITLE
Change native back button behavior in EC view (close settings in EC with os native back)

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
@@ -10,7 +10,6 @@ internal sealed interface CallScreenBackPressAction {
 
     data object DispatchEscapeToWebView : CallScreenBackPressAction
     data object EnterPictureInPicture : CallScreenBackPressAction
-    data object Hangup : CallScreenBackPressAction
 }
 
 internal object CallScreenBackPressPolicy {
@@ -18,11 +17,11 @@ internal object CallScreenBackPressPolicy {
         supportPip: Boolean,
         hasWebView: Boolean,
         fromNative: Boolean,
-    ): CallScreenBackPressAction {
+    ): CallScreenBackPressAction? {
         return when {
             hasWebView && fromNative -> CallScreenBackPressAction.DispatchEscapeToWebView
             hasWebView && supportPip -> CallScreenBackPressAction.EnterPictureInPicture
-            else -> CallScreenBackPressAction.Hangup
+            else -> null
         }
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
@@ -6,7 +6,6 @@
  */
 
 package io.element.android.features.call.impl.ui
-
 internal sealed interface CallScreenBackPressAction {
 
     data object DispatchEscapeToWebView : CallScreenBackPressAction

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.impl.ui
+
+internal sealed interface CallScreenBackPressAction {
+
+    data object DispatchEscapeToWebView : CallScreenBackPressAction
+    data object EnterPictureInPicture : CallScreenBackPressAction
+    data object Hangup : CallScreenBackPressAction
+}
+
+internal object CallScreenBackPressPolicy {
+    fun resolve(
+        supportPip: Boolean,
+        hasWebView: Boolean,
+        fromNative: Boolean,
+    ): CallScreenBackPressAction {
+        return when {
+            hasWebView && fromNative -> CallScreenBackPressAction.DispatchEscapeToWebView
+            hasWebView && supportPip -> CallScreenBackPressAction.EnterPictureInPicture
+            else -> CallScreenBackPressAction.Hangup
+        }
+    }
+}
+

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenBackPressPolicy.kt
@@ -7,7 +7,6 @@
 
 package io.element.android.features.call.impl.ui
 internal sealed interface CallScreenBackPressAction {
-
     data object DispatchEscapeToWebView : CallScreenBackPressAction
     data object EnterPictureInPicture : CallScreenBackPressAction
 }
@@ -25,4 +24,3 @@ internal object CallScreenBackPressPolicy {
         }
     }
 }
-

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -67,12 +67,12 @@ internal fun CallScreenView(
     var callWebView by remember { mutableStateOf<WebView?>(null) }
 
     fun handleBack(fromNative: Boolean = false) {
-        when (CallScreenBackPressPolicy.resolve(supportPip = pipState.supportPip, hasWebView = callWebView!=null,fromNative)) {
+        when (CallScreenBackPressPolicy.resolve(supportPip = pipState.supportPip, hasWebView = callWebView != null, fromNative)) {
             CallScreenBackPressAction.EnterPictureInPicture ->
                 pipState.eventSink(PictureInPictureEvents.EnterPictureInPicture)
             CallScreenBackPressAction.DispatchEscapeToWebView ->
                 callWebView?.dispatchEscKeyEvent()
-            null-> Timber.d("Back press with unsupported pip is a no-op")
+            null -> Timber.d("Back press with unsupported pip is a no-op")
         }
     }
 

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -75,8 +75,9 @@ internal fun CallScreenView(
     Scaffold(
         modifier = modifier,
     ) { padding ->
+        var callWebView by remember { mutableStateOf<WebView?>(null) }
         BackHandler {
-            handleBack()
+            callWebView?.dispatchEscKeyEvent()
         }
         if (state.webViewError != null) {
             ErrorDialog(
@@ -111,6 +112,7 @@ internal fun CallScreenView(
                 },
                 onConsoleMessage = onConsoleMessage,
                 onCreateWebView = { webView ->
+                    callWebView = webView
                     webView.addBackHandler(onBackPressed = ::handleBack)
                     val interceptor = WebViewWidgetMessageInterceptor(
                         webView = webView,
@@ -135,6 +137,9 @@ internal fun CallScreenView(
                     pipState.eventSink(PictureInPictureEvents.SetPipController(pipController))
                 },
                 onDestroyWebView = {
+                    if (callWebView === it) {
+                        callWebView = null
+                    }
                     // Reset audio mode
                     webViewAudioManager?.onCallStopped()
                 }
@@ -143,6 +148,7 @@ internal fun CallScreenView(
                 AsyncData.Uninitialized,
                 is AsyncData.Loading ->
                     ProgressDialog(text = stringResource(id = CommonStrings.common_please_wait))
+
                 is AsyncData.Failure -> {
                     Timber.e(state.urlState.error, "WebView failed to load URL: ${state.urlState.error.message}")
                     ErrorDialog(
@@ -150,6 +156,7 @@ internal fun CallScreenView(
                         onSubmit = { state.eventSink(CallScreenEvents.Hangup) },
                     )
                 }
+
                 is AsyncData.Success -> Unit
             }
         }
@@ -255,6 +262,10 @@ private fun WebView.addBackHandler(onBackPressed: () -> Unit) {
         },
         "backHandler"
     )
+}
+
+private fun WebView.dispatchEscKeyEvent() {
+    this.dispatchKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_ESCAPE))
 }
 
 @PreviewsDayNight

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -77,7 +77,10 @@ internal fun CallScreenView(
     ) { padding ->
         var callWebView by remember { mutableStateOf<WebView?>(null) }
         BackHandler {
-            callWebView?.dispatchEscKeyEvent()
+            val handledByWebView = callWebView?.dispatchEscKeyEvent() == true
+            if (!handledByWebView) {
+                handleBack()
+            }
         }
         if (state.webViewError != null) {
             ErrorDialog(
@@ -264,8 +267,20 @@ private fun WebView.addBackHandler(onBackPressed: () -> Unit) {
     )
 }
 
-private fun WebView.dispatchEscKeyEvent() {
-    this.dispatchKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_ESCAPE))
+private fun WebView.dispatchEscKeyEvent(): Boolean {
+    val downHandled = dispatchKeyEvent(
+        android.view.KeyEvent(
+            android.view.KeyEvent.ACTION_DOWN,
+            android.view.KeyEvent.KEYCODE_ESCAPE
+        )
+    )
+    val upHandled = dispatchKeyEvent(
+        android.view.KeyEvent(
+            android.view.KeyEvent.ACTION_UP,
+            android.view.KeyEvent.KEYCODE_ESCAPE
+        )
+    )
+    return downHandled && upHandled
 }
 
 @PreviewsDayNight

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -64,23 +64,27 @@ internal fun CallScreenView(
     requestPermissions: (Array<String>, RequestPermissionCallback) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    fun handleBack() {
-        if (pipState.supportPip) {
-            pipState.eventSink.invoke(PictureInPictureEvents.EnterPictureInPicture)
-        } else {
-            state.eventSink(CallScreenEvents.Hangup)
+    var callWebView by remember { mutableStateOf<WebView?>(null) }
+
+    fun handleBack(fromNative: Boolean = false) {
+        when (CallScreenBackPressPolicy.resolve(supportPip = pipState.supportPip, hasWebView = callWebView!=null,fromNative)) {
+            CallScreenBackPressAction.EnterPictureInPicture -> {
+                pipState.eventSink(PictureInPictureEvents.EnterPictureInPicture)
+            }
+            CallScreenBackPressAction.DispatchEscapeToWebView -> {
+                callWebView?.dispatchEscKeyEvent()
+            }
+            CallScreenBackPressAction.Hangup -> {
+                state.eventSink(CallScreenEvents.Hangup)
+            }
         }
     }
 
     Scaffold(
         modifier = modifier,
     ) { padding ->
-        var callWebView by remember { mutableStateOf<WebView?>(null) }
         BackHandler {
-            val handledByWebView = callWebView?.dispatchEscKeyEvent() == true
-            if (!handledByWebView) {
-                handleBack()
-            }
+            handleBack(fromNative = true)
         }
         if (state.webViewError != null) {
             ErrorDialog(
@@ -267,20 +271,9 @@ private fun WebView.addBackHandler(onBackPressed: () -> Unit) {
     )
 }
 
-private fun WebView.dispatchEscKeyEvent(): Boolean {
-    val downHandled = dispatchKeyEvent(
-        android.view.KeyEvent(
-            android.view.KeyEvent.ACTION_DOWN,
-            android.view.KeyEvent.KEYCODE_ESCAPE
-        )
-    )
-    val upHandled = dispatchKeyEvent(
-        android.view.KeyEvent(
-            android.view.KeyEvent.ACTION_UP,
-            android.view.KeyEvent.KEYCODE_ESCAPE
-        )
-    )
-    return downHandled && upHandled
+private fun WebView.dispatchEscKeyEvent() {
+    dispatchKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_ESCAPE))
+    dispatchKeyEvent(android.view.KeyEvent(android.view.KeyEvent.ACTION_UP, android.view.KeyEvent.KEYCODE_ESCAPE))
 }
 
 @PreviewsDayNight

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -68,15 +68,12 @@ internal fun CallScreenView(
 
     fun handleBack(fromNative: Boolean = false) {
         when (CallScreenBackPressPolicy.resolve(supportPip = pipState.supportPip, hasWebView = callWebView!=null,fromNative)) {
-            CallScreenBackPressAction.EnterPictureInPicture -> {
+            CallScreenBackPressAction.EnterPictureInPicture ->
                 pipState.eventSink(PictureInPictureEvents.EnterPictureInPicture)
-            }
-            CallScreenBackPressAction.DispatchEscapeToWebView -> {
+            CallScreenBackPressAction.DispatchEscapeToWebView ->
                 callWebView?.dispatchEscKeyEvent()
-            }
-            CallScreenBackPressAction.Hangup -> {
+            CallScreenBackPressAction.Hangup ->
                 state.eventSink(CallScreenEvents.Hangup)
-            }
         }
     }
 
@@ -144,9 +141,7 @@ internal fun CallScreenView(
                     pipState.eventSink(PictureInPictureEvents.SetPipController(pipController))
                 },
                 onDestroyWebView = {
-                    if (callWebView === it) {
-                        callWebView = null
-                    }
+                    callWebView = null
                     // Reset audio mode
                     webViewAudioManager?.onCallStopped()
                 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -72,8 +72,7 @@ internal fun CallScreenView(
                 pipState.eventSink(PictureInPictureEvents.EnterPictureInPicture)
             CallScreenBackPressAction.DispatchEscapeToWebView ->
                 callWebView?.dispatchEscKeyEvent()
-            CallScreenBackPressAction.Hangup ->
-                state.eventSink(CallScreenEvents.Hangup)
+            null-> Timber.d("Back press with unsupported pip is a no-op")
         }
     }
 
@@ -257,10 +256,8 @@ private fun WebView.setup(
 
 private fun WebView.addBackHandler(onBackPressed: () -> Unit) {
     addJavascriptInterface(
-        object {
-            @Suppress("unused")
-            @JavascriptInterface
-            fun onBackPressed() = onBackPressed()
+        JavascriptBackHandler {
+            onBackPressed()
         },
         "backHandler"
     )
@@ -288,4 +285,9 @@ internal fun CallScreenViewPreview(
 @Composable
 internal fun InvalidAudioDeviceDialogPreview() = ElementPreview {
     InvalidAudioDeviceDialog(invalidAudioDeviceReason = InvalidAudioDeviceReason.BT_AUDIO_DEVICE_DISABLED) {}
+}
+
+internal fun interface JavascriptBackHandler {
+    @JavascriptInterface
+    fun onBackPressed()
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.ui
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.call.impl.ui.CallScreenBackPressAction
+import io.element.android.features.call.impl.ui.CallScreenBackPressPolicy
+import org.junit.Test
+
+class CallScreenBackPressPolicyTest {
+    @Test
+    fun `resolve returns dispatch escape when a web view is available and native button is pressed`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = false,
+            hasWebView = true,
+            fromNative = true,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.DispatchEscapeToWebView)
+    }
+
+    @Test
+    fun `resolve dispatch escape when there is a web view and pip is supported on native button press`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = true,
+            hasWebView = true,
+            fromNative = true,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.DispatchEscapeToWebView)
+    }
+
+    @Test
+    fun `resolve returns hangup when there is no web view and pip is not supported from native button`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = false,
+            hasWebView = false,
+            fromNative = true,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+    }
+
+    @Test
+    fun `resolve returns hangup when there is no web view even though pip is supported from native button`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = true,
+            hasWebView = false,
+            fromNative = true,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+    }
+
+    @Test
+    fun `resolve goes to pip if its not from native but from the webview`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = true,
+            hasWebView = true,
+            fromNative = false,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.EnterPictureInPicture)
+    }
+    @Test
+    fun `resolve hangs up if its not from native but from the webview and pip is not supported`() {
+        val result = CallScreenBackPressPolicy.resolve(
+            supportPip = false,
+            hasWebView = true,
+            fromNative = false,
+        )
+
+        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+    }
+
+    @Test
+    fun `invalid cases (event comes from webview but there is now webview) all result in hangup`() {
+        val withPipSupport = CallScreenBackPressPolicy.resolve(
+            supportPip = true,
+            hasWebView = false,
+            fromNative = false,
+        )
+        assertThat(withPipSupport).isEqualTo(CallScreenBackPressAction.Hangup)
+        val withOutPipSupport = CallScreenBackPressPolicy.resolve(
+            supportPip = false,
+            hasWebView = false,
+            fromNative = false,
+        )
+        assertThat(withOutPipSupport).isEqualTo(CallScreenBackPressAction.Hangup)
+    }
+}
+

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
@@ -43,7 +43,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = true,
         )
 
-        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+        assertThat(result).isEqualTo(null)
     }
 
     @Test
@@ -54,7 +54,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = true,
         )
 
-        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+        assertThat(result).isEqualTo(null)
     }
 
     @Test
@@ -75,7 +75,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = false,
         )
 
-        assertThat(result).isEqualTo(CallScreenBackPressAction.Hangup)
+        assertThat(result).isEqualTo(null)
     }
 
     @Test
@@ -85,13 +85,13 @@ class CallScreenBackPressPolicyTest {
             hasWebView = false,
             fromNative = false,
         )
-        assertThat(withPipSupport).isEqualTo(CallScreenBackPressAction.Hangup)
+        assertThat(withPipSupport).isEqualTo(null)
         val withOutPipSupport = CallScreenBackPressPolicy.resolve(
             supportPip = false,
             hasWebView = false,
             fromNative = false,
         )
-        assertThat(withOutPipSupport).isEqualTo(CallScreenBackPressAction.Hangup)
+        assertThat(withOutPipSupport).isEqualTo(null)
     }
 }
 

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenBackPressPolicyTest.kt
@@ -43,7 +43,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = true,
         )
 
-        assertThat(result).isEqualTo(null)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -54,7 +54,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = true,
         )
 
-        assertThat(result).isEqualTo(null)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -75,7 +75,7 @@ class CallScreenBackPressPolicyTest {
             fromNative = false,
         )
 
-        assertThat(result).isEqualTo(null)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -85,13 +85,12 @@ class CallScreenBackPressPolicyTest {
             hasWebView = false,
             fromNative = false,
         )
-        assertThat(withPipSupport).isEqualTo(null)
+        assertThat(withPipSupport).isNull()
         val withOutPipSupport = CallScreenBackPressPolicy.resolve(
             supportPip = false,
             hasWebView = false,
             fromNative = false,
         )
-        assertThat(withOutPipSupport).isEqualTo(null)
+        assertThat(withOutPipSupport).isNull()
     }
 }
-

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
@@ -14,20 +14,20 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.element.android.features.call.impl.pip.PictureInPictureEvents
 import io.element.android.features.call.impl.pip.aPictureInPictureState
 import io.element.android.features.call.impl.ui.CallScreenEvents
 import io.element.android.features.call.impl.ui.CallScreenView
+import io.element.android.features.call.impl.ui.JavascriptBackHandler
 import io.element.android.features.call.impl.ui.aCallScreenState
 import io.element.android.tests.testutils.EventsRecorder
 import io.element.android.tests.testutils.pressBackKey
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.element.android.features.call.impl.ui.JavascriptBackHandler
-import org.junit.Assert.assertEquals
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
@@ -56,8 +56,6 @@ class CallScreenViewTest {
     @Config(shadows = [RecordingShadowWebView::class])
     @Test
     fun `pressing back key dispatches escape key events to web view when pip is unsupported`() {
-
-
         rule.setCallScreenView(
             state = aCallScreenState(),
             useInspectionMode = false,
@@ -76,7 +74,6 @@ class CallScreenViewTest {
     @Config(shadows = [RecordingShadowWebView::class])
     @Test
     fun `web view javascript back handler emits pip event when pip is supported`() {
-
         val pipEvents = EventsRecorder<PictureInPictureEvents>()
 
         rule.setCallScreenView(
@@ -151,4 +148,3 @@ internal class RecordingShadowWebView : ShadowWebView() {
         return false
     }
 }
-

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.element.android.features.call.impl.ui.JavascriptBackHandler
 import org.junit.Assert.assertEquals
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
@@ -49,13 +50,13 @@ class CallScreenViewTest {
 
         rule.pressBackKey()
 
-        callEvents.assertSingle(CallScreenEvents.Hangup)
+        callEvents.assertEmpty()
     }
 
     @Config(shadows = [RecordingShadowWebView::class])
     @Test
     fun `pressing back key dispatches escape key events to web view when pip is unsupported`() {
-        RecordingShadowWebView.clearDispatchedEvents()
+
 
         rule.setCallScreenView(
             state = aCallScreenState(),
@@ -75,7 +76,7 @@ class CallScreenViewTest {
     @Config(shadows = [RecordingShadowWebView::class])
     @Test
     fun `web view javascript back handler emits pip event when pip is supported`() {
-        RecordingShadowWebView.clearDispatchedEvents()
+
         val pipEvents = EventsRecorder<PictureInPictureEvents>()
 
         rule.setCallScreenView(
@@ -119,26 +120,19 @@ private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setCallS
 internal class RecordingShadowWebView : ShadowWebView() {
     companion object {
         val dispatchedEvents = mutableListOf<KeyEvent>()
-        private var backHandlerJavascriptInterface: Any? = null
+        private var backHandlerJavascriptInterface: JavascriptBackHandler? = null
 
-        fun clearDispatchedEvents() {
+        @Resetter
+        @JvmStatic
+        @Suppress("unused")
+        fun resetRecordedEvents() {
             dispatchedEvents.clear()
             backHandlerJavascriptInterface = null
         }
 
         fun invokeJavascriptBackHandler() {
             val backHandler = checkNotNull(backHandlerJavascriptInterface) { "Expected backHandler JavaScript interface to be registered" }
-            backHandler.javaClass.getDeclaredMethod("onBackPressed").apply {
-                isAccessible = true
-                invoke(backHandler)
-            }
-        }
-
-        @Resetter
-        @JvmStatic
-        fun resetRecordedEvents() {
-            dispatchedEvents.clear()
-            backHandlerJavascriptInterface = null
+            backHandler.onBackPressed()
         }
     }
 
@@ -146,12 +140,13 @@ internal class RecordingShadowWebView : ShadowWebView() {
     protected override fun addJavascriptInterface(`object`: Any, name: String) {
         super.addJavascriptInterface(`object`, name)
         if (name == "backHandler") {
-            backHandlerJavascriptInterface = `object`
+            backHandlerJavascriptInterface = `object` as? JavascriptBackHandler
         }
     }
 
     @Implementation
-    protected fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    @Suppress("unused")
+    fun dispatchKeyEvent(event: KeyEvent): Boolean {
         dispatchedEvents += KeyEvent(event)
         return false
     }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import io.element.android.features.call.impl.pip.aPictureInPictureState
+import io.element.android.features.call.impl.ui.CallScreenEvents
+import io.element.android.features.call.impl.ui.CallScreenView
+import io.element.android.features.call.impl.ui.aCallScreenState
+import io.element.android.tests.testutils.EventsRecorder
+import io.element.android.tests.testutils.pressBackKey
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+@RunWith(AndroidJUnit4::class)
+class CallScreenViewTest {
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `pressing back key triggers hangup when no web view is available and pip is unsupported`() {
+        val callEvents = EventsRecorder<CallScreenEvents>()
+
+        rule.setCallScreenView(
+            state = aCallScreenState(eventSink = callEvents),
+        )
+
+        rule.pressBackKey()
+
+        callEvents.assertSingle(CallScreenEvents.Hangup)
+    }
+}
+
+private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setCallScreenView(
+    state: io.element.android.features.call.impl.ui.CallScreenState,
+) {
+    setContent {
+        // Force inspection mode so AndroidView is not created and BackHandler goes through native fallback.
+        CompositionLocalProvider(LocalInspectionMode provides true) {
+            CallScreenView(
+                state = state,
+                pipState = aPictureInPictureState(supportPip = false),
+                onConsoleMessage = {},
+                requestPermissions = { _, _ -> },
+            )
+        }
+    }
+}
+

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
@@ -7,11 +7,14 @@
 
 package io.element.android.features.call.ui
 
+import android.view.KeyEvent
+import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import io.element.android.features.call.impl.pip.PictureInPictureEvents
 import io.element.android.features.call.impl.pip.aPictureInPictureState
 import io.element.android.features.call.impl.ui.CallScreenEvents
 import io.element.android.features.call.impl.ui.CallScreenView
@@ -23,6 +26,12 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.annotation.Resetter
+import org.robolectric.shadows.ShadowWebView
 
 @RunWith(AndroidJUnit4::class)
 class CallScreenViewTest {
@@ -35,27 +44,116 @@ class CallScreenViewTest {
 
         rule.setCallScreenView(
             state = aCallScreenState(eventSink = callEvents),
+            useInspectionMode = true,
         )
 
         rule.pressBackKey()
 
         callEvents.assertSingle(CallScreenEvents.Hangup)
     }
+
+    @Config(shadows = [RecordingShadowWebView::class])
+    @Test
+    fun `pressing back key dispatches escape key events to web view when pip is unsupported`() {
+        RecordingShadowWebView.clearDispatchedEvents()
+
+        rule.setCallScreenView(
+            state = aCallScreenState(),
+            useInspectionMode = false,
+        )
+
+        rule.pressBackKey()
+
+        val dispatchedEvents = RecordingShadowWebView.dispatchedEvents
+        assertEquals(2, dispatchedEvents.size)
+        assertEquals(KeyEvent.ACTION_DOWN, dispatchedEvents[0].action)
+        assertEquals(KeyEvent.KEYCODE_ESCAPE, dispatchedEvents[0].keyCode)
+        assertEquals(KeyEvent.ACTION_UP, dispatchedEvents[1].action)
+        assertEquals(KeyEvent.KEYCODE_ESCAPE, dispatchedEvents[1].keyCode)
+    }
+
+    @Config(shadows = [RecordingShadowWebView::class])
+    @Test
+    fun `web view javascript back handler emits pip event when pip is supported`() {
+        RecordingShadowWebView.clearDispatchedEvents()
+        val pipEvents = EventsRecorder<PictureInPictureEvents>()
+
+        rule.setCallScreenView(
+            state = aCallScreenState(),
+            useInspectionMode = false,
+            pipState = aPictureInPictureState(
+                supportPip = true,
+                eventSink = pipEvents,
+            ),
+        )
+
+        rule.runOnIdle {
+            RecordingShadowWebView.invokeJavascriptBackHandler()
+        }
+
+        pipEvents.assertSize(2)
+        pipEvents.assertTrue(0) { it is PictureInPictureEvents.SetPipController }
+        pipEvents.assertTrue(1) { it is PictureInPictureEvents.EnterPictureInPicture }
+    }
 }
 
 private fun <R : TestRule> AndroidComposeTestRule<R, ComponentActivity>.setCallScreenView(
     state: io.element.android.features.call.impl.ui.CallScreenState,
+    useInspectionMode: Boolean,
+    pipState: io.element.android.features.call.impl.pip.PictureInPictureState = aPictureInPictureState(supportPip = false),
 ) {
     setContent {
-        // Force inspection mode so AndroidView is not created and BackHandler goes through native fallback.
-        CompositionLocalProvider(LocalInspectionMode provides true) {
+        // Inspection mode disables AndroidView creation; keep it configurable per test.
+        CompositionLocalProvider(LocalInspectionMode provides useInspectionMode) {
             CallScreenView(
                 state = state,
-                pipState = aPictureInPictureState(supportPip = false),
+                pipState = pipState,
                 onConsoleMessage = {},
                 requestPermissions = { _, _ -> },
             )
         }
+    }
+}
+
+@Implements(WebView::class)
+internal class RecordingShadowWebView : ShadowWebView() {
+    companion object {
+        val dispatchedEvents = mutableListOf<KeyEvent>()
+        private var backHandlerJavascriptInterface: Any? = null
+
+        fun clearDispatchedEvents() {
+            dispatchedEvents.clear()
+            backHandlerJavascriptInterface = null
+        }
+
+        fun invokeJavascriptBackHandler() {
+            val backHandler = checkNotNull(backHandlerJavascriptInterface) { "Expected backHandler JavaScript interface to be registered" }
+            backHandler.javaClass.getDeclaredMethod("onBackPressed").apply {
+                isAccessible = true
+                invoke(backHandler)
+            }
+        }
+
+        @Resetter
+        @JvmStatic
+        fun resetRecordedEvents() {
+            dispatchedEvents.clear()
+            backHandlerJavascriptInterface = null
+        }
+    }
+
+    @Implementation
+    protected override fun addJavascriptInterface(`object`: Any, name: String) {
+        super.addJavascriptInterface(`object`, name)
+        if (name == "backHandler") {
+            backHandlerJavascriptInterface = `object`
+        }
+    }
+
+    @Implementation
+    protected fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        dispatchedEvents += KeyEvent(event)
+        return false
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/element-hq/element-call/issues/3909
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content
this changes the back button behavior to:
 - inject escape into webview instead of going back.
 - the webview will call back when no other modal is open.


## Motivation and context
https://github.com/element-hq/element-call/issues/3385

## Screenshots / GIFs

[Screen_recording_20260428_155256.webm](https://github.com/user-attachments/assets/6c923472-b26f-4bcb-98ec-9ef0f7988262)


(At the end it looks like things don't react. This is a slow emulator. Just wait it will react eventually)
## Tests

<!-- Explain how you tested your development -->

- Run the correct EX version
- Setup the correct EC version in the devtools: https://github.com/element-hq/element-call/pull/3927 (using `https://pr3927--element-call.netlify.app/room` as the url)
- start a call
- open settings
- press native back (or use gesture)
- see the settings closing
- press back again
- observe that we move into pip if nothing is focussed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot. (all code was written by hand but AI helped with api usage AND the Robolectric tests for the CallScreenView.kt has been fully generated based on the exact test cases)
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
