### PR TITLE
Remove distributed tracing of the 'timeline loading' flow

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -25,7 +25,6 @@ import io.element.android.libraries.matrix.impl.room.preview.RoomPreviewInfoMapp
 import io.element.android.libraries.matrix.impl.roomlist.roomOrNull
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction
 import io.element.android.services.analytics.api.AnalyticsService
-import io.element.android.services.analytics.api.inBridgeSdkSpan
 import io.element.android.services.analytics.api.recordTransaction
 import io.element.android.services.analyticsproviders.api.recordChildTransaction
 import io.element.android.services.toolbox.api.systemclock.SystemClock

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RustRoomFactory.kt
@@ -128,19 +128,17 @@ class RustRoomFactory(
                     val timeline = transaction.recordChildTransaction(
                         operation = "sdkRoom.timelineWithConfiguration",
                         description = "Get timeline from the SDK",
-                    ) { timelineTransaction ->
-                        analyticsService.inBridgeSdkSpan(parentTraceId = timelineTransaction.traceId()) {
-                            sdkRoom.timelineWithConfiguration(
-                                TimelineConfiguration(
-                                    focus = TimelineFocus.Live(hideThreadedEvents = hideThreadedEvents),
-                                    filter = eventFilters?.let(TimelineFilter::EventFilter) ?: TimelineFilter.All,
-                                    internalIdPrefix = "live",
-                                    dateDividerMode = DateDividerMode.DAILY,
-                                    trackReadReceipts = TimelineReadReceiptTracking.ALL_EVENTS,
-                                    reportUtds = true,
-                                )
+                    ) {
+                        sdkRoom.timelineWithConfiguration(
+                            TimelineConfiguration(
+                                focus = TimelineFocus.Live(hideThreadedEvents = hideThreadedEvents),
+                                filter = eventFilters?.let(TimelineFilter::EventFilter) ?: TimelineFilter.All,
+                                internalIdPrefix = "live",
+                                dateDividerMode = DateDividerMode.DAILY,
+                                trackReadReceipts = TimelineReadReceiptTracking.ALL_EVENTS,
+                                reportUtds = true,
                             )
-                        }
+                        )
                     }
 
                     GetRoomResult.Joined(

--- a/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsSdkSpan.kt
+++ b/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsSdkSpan.kt
@@ -7,9 +7,12 @@
 
 package io.element.android.services.analytics.api
 
+import androidx.annotation.Discouraged
+
 /**
  * Represents an analytics span in the Rust SDK.
  */
+@Discouraged("This component can cause crashes of the app when using debug builds of the Rust SDK.")
 interface AnalyticsSdkSpan {
     /** Enters the span and starts collecting metrics. */
     fun enter()

--- a/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsService.kt
+++ b/services/analytics/api/src/main/kotlin/io/element/android/services/analytics/api/AnalyticsService.kt
@@ -8,6 +8,7 @@
 
 package io.element.android.services.analytics.api
 
+import androidx.annotation.Discouraged
 import io.element.android.services.analyticsproviders.api.AnalyticsProvider
 import io.element.android.services.analyticsproviders.api.AnalyticsTransaction
 import io.element.android.services.analyticsproviders.api.trackers.AnalyticsTracker
@@ -74,6 +75,7 @@ interface AnalyticsService : AnalyticsTracker, ErrorTracker {
     fun removeLongRunningTransaction(longRunningTransaction: AnalyticsLongRunningTransaction): AnalyticsTransaction?
 
     /** Enter a span inside the Rust SDK tracing system. If a [parentTraceId] is provided, the SDK trace will be added as a child of that trace. */
+    @Discouraged("This method can cause crashes of the app when using debug builds of the Rust SDK.")
     fun enterSdkSpan(name: String?, parentTraceId: String?): AnalyticsSdkSpan
 }
 
@@ -116,6 +118,7 @@ fun AnalyticsService.finishLongRunningTransaction(
     } ?: false
 }
 
+@Discouraged("This method can cause crashes of the app when using debug builds of the Rust SDK.")
 inline fun <T> AnalyticsService.inBridgeSdkSpan(parentTraceId: String?, block: (AnalyticsSdkSpan) -> T): T {
     val span = enterSdkSpan(name = null, parentTraceId = parentTraceId)
     return try {


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Remove calls to start 'bridge spans' with the SDK used for distributed tracing.

Also add `@Discouraged` annotations for the methods that call these APIs.

## Motivation and context

This is causing crashes in the app when a debug SDK build is used.

## Tests

1. Use a debug version of the SDK by building the source code locally.
2. Open 10 rooms or so.

If there are no crashes, it's fixed.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
