### PR TITLE
Strip formatting from media captions in room summary

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultPinnedMessagesBannerFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultPinnedMessagesBannerFormatter.kt
@@ -77,26 +77,28 @@ class DefaultPinnedMessagesBannerFormatter(
                 messageType.toPlainText(permalinkParser)
             }
             is VideoMessageType -> {
-                messageType.bestDescription.prefixWith(CommonStrings.common_video)
+                messageType.toPlainText(permalinkParser).prefixWith(CommonStrings.common_video)
             }
             is ImageMessageType -> {
-                messageType.bestDescription.prefixWith(CommonStrings.common_image)
+                messageType.toPlainText(permalinkParser).prefixWith(CommonStrings.common_image)
             }
             is StickerMessageType -> {
-                messageType.bestDescription.prefixWith(CommonStrings.common_sticker)
+                messageType.toPlainText(permalinkParser).prefixWith(CommonStrings.common_sticker)
             }
             is LocationMessageType -> {
                 messageType.body.prefixWith(CommonStrings.common_shared_location)
             }
             is FileMessageType -> {
-                messageType.bestDescription.prefixWith(CommonStrings.common_file)
+                messageType.toPlainText(permalinkParser).prefixWith(CommonStrings.common_file)
             }
             is AudioMessageType -> {
-                messageType.bestDescription.prefixWith(CommonStrings.common_audio)
+                messageType.toPlainText(permalinkParser).prefixWith(CommonStrings.common_audio)
             }
             is VoiceMessageType -> {
-                // In this case, do not use bestDescription, because the filename is useless, only use the caption if available.
-                messageType.caption?.prefixWith(sp.getString(CommonStrings.common_voice_message))
+                messageType
+                    .toPlainText(permalinkParser, "")
+                    .takeIf { it.isNotEmpty() }
+                    ?.prefixWith(sp.getString(CommonStrings.common_voice_message))
                     ?: sp.getString(CommonStrings.common_voice_message)
             }
             is OtherMessageType -> {

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
@@ -139,26 +139,28 @@ class DefaultRoomLatestEventFormatter(
                 messageType.toPlainText(permalinkParser)
             }
             is VideoMessageType -> {
-                messageType.bestDescription.prefixWith(sp.getString(CommonStrings.common_video))
+                messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_video))
             }
             is ImageMessageType -> {
-                messageType.bestDescription.prefixWith(sp.getString(CommonStrings.common_image))
+                messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_image))
             }
             is StickerMessageType -> {
-                messageType.bestDescription.prefixWith(sp.getString(CommonStrings.common_sticker))
+                messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_sticker))
             }
             is LocationMessageType -> {
                 sp.getString(CommonStrings.common_shared_location)
             }
             is FileMessageType -> {
-                messageType.bestDescription.prefixWith(sp.getString(CommonStrings.common_file))
+                messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_file))
             }
             is AudioMessageType -> {
-                messageType.bestDescription.prefixWith(sp.getString(CommonStrings.common_audio))
+                messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_audio))
             }
             is VoiceMessageType -> {
-                // In this case, do not use bestDescription, because the filename is useless, only use the caption if available.
-                messageType.caption?.prefixWith(sp.getString(CommonStrings.common_voice_message))
+                messageType
+                    .toPlainText(permalinkParser, "")
+                    .takeIf { it.isNotEmpty() }
+                    ?.prefixWith(sp.getString(CommonStrings.common_voice_message))
                     ?: sp.getString(CommonStrings.common_voice_message)
             }
             is OtherMessageType -> {

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
@@ -11,6 +11,7 @@ package io.element.android.libraries.matrix.ui.messages
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.timeline.item.event.FormattedBody
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
+import io.element.android.libraries.matrix.api.timeline.item.event.MessageTypeWithAttachment
 import io.element.android.libraries.matrix.api.timeline.item.event.TextMessageType
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -25,6 +26,19 @@ import org.jsoup.select.NodeVisitor
 fun TextMessageType.toPlainText(
     permalinkParser: PermalinkParser,
 ) = formatted?.toPlainText(permalinkParser) ?: body
+
+/**
+ * Converts the HTML string in [MessageTypeWithAttachment.formattedCaption] to a plain text representation by parsing it and removing all formatting.
+ * If the caption is not formatted or the format is not [MessageFormat.HTML], the [MessageTypeWithAttachment.caption] is returned instead.
+ * If there is no caption, returns [default].
+ */
+fun MessageTypeWithAttachment.toPlainText(
+    permalinkParser: PermalinkParser,
+    default: String = filename,
+): String {
+    val plainTextFromFormatted = formattedCaption?.toPlainText(permalinkParser)
+    return plainTextFromFormatted ?: caption ?: default
+}
 
 /**
  * Converts the HTML string in [FormattedBody.body] to a plain text representation by parsing it and removing all formatting.


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

Fixes #6542

Media captions used plain `body` instead of removing formatting from `formatted_body` like in normal messages.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Test that media captions are displayed without markups in the room summary

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR