### PR TITLE
Mitigate a deadlock when loading room timelines

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/MediaGalleryDataSource.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.matrix.api.timeline.item.event.toEventOrTransactionId
 import io.element.android.libraries.mediaviewer.impl.model.GroupedMediaItems
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,10 +28,11 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface MediaGalleryDataSource {
-    fun start()
+    fun start(coroutineScope: CoroutineScope)
     fun groupedMediaItemsFlow(): Flow<AsyncData<GroupedMediaItems>>
     fun getLastData(): AsyncData<GroupedMediaItems>
     suspend fun loadMore(direction: Timeline.PaginationDirection)
@@ -58,7 +60,7 @@ class TimelineMediaGalleryDataSource(
     private val isStarted = AtomicBoolean(false)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun start() {
+    override fun start(coroutineScope: CoroutineScope) {
         if (!isStarted.compareAndSet(false, true)) {
             return
         }
@@ -96,9 +98,12 @@ class TimelineMediaGalleryDataSource(
             groupedMediaItemsFlow.emit(AsyncData.Success(groupedMediaItems))
         }
             .onCompletion {
-                timeline?.close()
+                timeline?.let {
+                    Timber.d("Timeline media gallery data source flow completed for room ${room.roomId}, closing timeline")
+                    it.close()
+                }
             }
-            .launchIn(room.roomCoroutineScope)
+            .launchIn(coroutineScope)
     }
 
     override suspend fun loadMore(direction: Timeline.PaginationDirection) {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenter.kt
@@ -78,7 +78,7 @@ class MediaGalleryPresenter(
             .collectAsState(AsyncData.Uninitialized)
 
         LaunchedEffect(Unit) {
-            mediaGalleryDataSource.start()
+            mediaGalleryDataSource.start(this)
         }
 
         val permissions by room.permissionsAsState(MediaPermissions.DEFAULT) { perms ->

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -35,6 +35,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -62,11 +63,12 @@ class MediaViewerDataSource(
     private val localMediaStates: MutableMap<String, MutableState<AsyncData<LocalMedia>>> =
         mutableMapOf()
 
-    fun setup() {
-        galleryDataSource.start()
+    fun setup(coroutineScope: CoroutineScope) {
+        galleryDataSource.start(coroutineScope)
     }
 
     fun dispose() {
+        Timber.d("Disposing MediaViewerDataSource, closing ${mediaFiles.size} media files")
         mediaFiles.forEach { it.close() }
         mediaFiles.clear()
         localMediaStates.clear()

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -88,7 +88,7 @@ class MediaViewerPresenter(
         var mediaBottomSheetState by remember { mutableStateOf<MediaBottomSheetState>(MediaBottomSheetState.Hidden) }
 
         DisposableEffect(Unit) {
-            dataSource.setup()
+            dataSource.setup(coroutineScope)
             onDispose {
                 dataSource.dispose()
             }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/SingleMediaGalleryDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/SingleMediaGalleryDataSource.kt
@@ -20,12 +20,13 @@ import io.element.android.libraries.mediaviewer.impl.datasource.MediaGalleryData
 import io.element.android.libraries.mediaviewer.impl.model.GroupedMediaItems
 import io.element.android.libraries.mediaviewer.impl.model.MediaItem
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 
 class SingleMediaGalleryDataSource(
     private val data: GroupedMediaItems,
 ) : MediaGalleryDataSource {
-    override fun start() = Unit
+    override fun start(coroutineScope: CoroutineScope) = Unit
     override fun groupedMediaItemsFlow() = flowOf(AsyncData.Success(data))
     override fun getLastData(): AsyncData<GroupedMediaItems> = AsyncData.Success(data)
 

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/FakeMediaGalleryDataSource.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/FakeMediaGalleryDataSource.kt
@@ -13,6 +13,7 @@ import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaviewer.impl.model.GroupedMediaItems
 import io.element.android.tests.testutils.lambda.lambdaError
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -21,7 +22,7 @@ class FakeMediaGalleryDataSource(
     private val loadMoreLambda: (Timeline.PaginationDirection) -> Unit = { lambdaError() },
     private val deleteItemLambda: (EventId) -> Unit = { lambdaError() },
     ) : MediaGalleryDataSource {
-    override fun start() = startLambda()
+    override fun start(coroutineScope: CoroutineScope) = startLambda()
 
     private val groupedMediaItemsFlow = MutableSharedFlow<AsyncData<GroupedMediaItems>>(
         replay = 1

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/TimelineMediaGalleryDataSourceTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/datasource/TimelineMediaGalleryDataSourceTest.kt
@@ -80,7 +80,7 @@ class TimelineMediaGalleryDataSourceTest {
                     roomCoroutineScope = backgroundScope,
                 )
             )
-            sut.start()
+            sut.start(backgroundScope)
             assertThat(sut.getLastData()).isEqualTo(AsyncData.Uninitialized)
             sut.groupedMediaItemsFlow().test {
                 assertThat(awaitItem().isLoading()).isTrue()
@@ -95,7 +95,7 @@ class TimelineMediaGalleryDataSourceTest {
                 )
                 assertThat(sut.getLastData().isSuccess()).isTrue()
                 // Also test that starting again should have no effect
-                sut.start()
+                sut.start(backgroundScope)
             }
         }
         // Ensure that the timeline has been closed on flow completion
@@ -117,7 +117,7 @@ class TimelineMediaGalleryDataSourceTest {
                 roomCoroutineScope = backgroundScope,
             )
         )
-        sut.start()
+        sut.start(backgroundScope)
         sut.groupedMediaItemsFlow().test {
             skipItems(2)
             sut.loadMore(Timeline.PaginationDirection.BACKWARDS)
@@ -140,7 +140,7 @@ class TimelineMediaGalleryDataSourceTest {
                 roomCoroutineScope = backgroundScope,
             )
         )
-        sut.start()
+        sut.start(backgroundScope)
         sut.groupedMediaItemsFlow().test {
             skipItems(2)
             sut.deleteItem(AN_EVENT_ID)
@@ -159,7 +159,7 @@ class TimelineMediaGalleryDataSourceTest {
                 roomCoroutineScope = backgroundScope,
             )
         )
-        sut.start()
+        sut.start(backgroundScope)
         sut.groupedMediaItemsFlow().test {
             assertThat(awaitItem().isLoading()).isTrue()
             assertThat(sut.getLastData().isLoading()).isTrue()
@@ -181,7 +181,7 @@ class TimelineMediaGalleryDataSourceTest {
                 roomCoroutineScope = backgroundScope,
             )
         )
-        sut.start()
+        sut.start(backgroundScope)
         sut.groupedMediaItemsFlow().test {
             assertThat(awaitItem().isLoading()).isTrue()
             assertThat(sut.getLastData().isLoading()).isTrue()

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSourceTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSourceTest.kt
@@ -50,7 +50,7 @@ class MediaViewerDataSourceTest {
         val sut = createMediaViewerDataSource(
             galleryDataSource = galleryDataSource,
         )
-        sut.setup()
+        sut.setup(backgroundScope)
         startLambda.assertions().isCalledOnce()
     }
 

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/SingleMediaGalleryDataSourceTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/SingleMediaGalleryDataSourceTest.kt
@@ -37,9 +37,9 @@ class SingleMediaGalleryDataSourceTest {
     val warmUpRule = WarmUpRule()
 
     @Test
-    fun `function start is no op`() {
+    fun `function start is no op`() = runTest {
         val sut = SingleMediaGalleryDataSource(aGroupedMediaItems())
-        sut.start()
+        sut.start(backgroundScope)
     }
 
     @Test


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Ensure we destroy the media focused timeline when closing the media viewer/gallery screens, not when the room is disposed.

## Motivation and context

This may be happening because we were not destroying focused event timelines used for the media viewer/gallery when necessary, and having several of those in memory back paginating *may* have caused a deadlock in the event cache.

At least I can't reproduce the deadlock anymore, while previously I could reproduce it at least 1/3 of the times I used the media viewer in some rooms.

The symptoms match https://github.com/element-hq/element-x-android/issues/6534, but not the way to reproduce it. That may have been a different deadlock.

## Tests

Since this is a deadlock, it wasn't possible to consistently reproduce it. What I did was opening an image in the timeline, closing it, then opening another one and checking the logs and the screen state: if it's loading forever and you see no back pagination logs, then you have a deadlock. If you then exit the room and try to open it again, you'll be stuck in the home screen with an infinite loading dialog.

**EDIT:** the changes don't fully fix the issue, but they mitigate it, making it way less likely to happen. I've had some success on reproducing it with this branch by opening the media viewer, paginating and then closing and opening it quickly, with quick iterations.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
