### PR TITLE
Remove legacy `mx-reply` from `toPlainText` formatted event contents

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -12,8 +12,10 @@ import io.element.android.libraries.matrix.api.permalink.PermalinkData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.timeline.item.event.FormattedBody
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
-import io.element.android.wysiwyg.utils.HtmlToDomParser
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Document.OutputSettings
+import org.jsoup.safety.Safelist
 
 /**
  * Converts the HTML string [FormattedBody.body] to a [Document] by parsing it.
@@ -59,4 +61,23 @@ private fun fixMentions(
             }
         }
     }
+}
+
+/** Custom Html to DOM parser, based on the one included in the rich text editor library. */
+private object HtmlToDomParser {
+    fun document(html: String): Document {
+        val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
+        val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)
+        return Jsoup.parse(cleanHtml)
+    }
+
+    private val safeList = Safelist()
+        .addTags(
+            "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
+            "blockquote", "p", "br",
+            // Add custom `mx-reply` tag, even if it's just to remove its contents from the plain text version of the message
+            "mx-reply"
+        )
+        .addAttributes("a", "href", "data-mention-type", "contenteditable")
+        .addAttributes("ol", "start")
 }

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -36,9 +36,9 @@ fun FormattedBody.toHtmlDocument(
         ?.trimEnd()
         ?.let { formattedBody ->
             val dom = if (prefix != null) {
-                HtmlToDomParser.document("$prefix $formattedBody")
+                CustomHtmlToDomParser.document("$prefix $formattedBody")
             } else {
-                HtmlToDomParser.document(formattedBody)
+                CustomHtmlToDomParser.document(formattedBody)
             }
 
             // Prepend `@` to mentions
@@ -64,7 +64,7 @@ private fun fixMentions(
 }
 
 /** Custom Html to DOM parser, based on the one included in the rich text editor library. */
-private object HtmlToDomParser {
+private object CustomHtmlToDomParser {
     fun document(html: String): Document {
         val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
         val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -73,8 +73,21 @@ private object HtmlToDomParser {
 
     private val safeList = Safelist()
         .addTags(
-            "a", "b", "strong", "i", "em", "u", "del", "code", "ul", "ol", "li", "pre",
-            "blockquote", "p", "br",
+            "a",
+            "b",
+            "strong",
+            "i",
+            "em",
+            "u",
+            "del",
+            "code",
+            "ul",
+            "ol",
+            "li",
+            "pre",
+            "blockquote",
+            "p",
+            "br",
             // Add custom `mx-reply` tag, even if it's just to remove its contents from the plain text version of the message
             "mx-reply"
         )

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
@@ -51,6 +51,8 @@ fun Document.toPlainText(): String {
     return visitor.build()
 }
 
+private const val FALLBACK_REPLY_NODE_TAG = "mx-reply"
+
 private class PlainTextNodeVisitor : NodeVisitor {
     private val builder = StringBuilder()
 
@@ -78,7 +80,7 @@ private class PlainTextNodeVisitor : NodeVisitor {
             } else {
                 builder.append("• ")
             }
-        } else if (node is Element && node.tagName() == "mx-reply") {
+        } else if (node is Element && node.tagName() == FALLBACK_REPLY_NODE_TAG) {
             // Remove the fallback reply node and its contents so they aren't added to the plain text message
             node.remove()
         } else if (node is Element && node.isBlock && builder.lastOrNull() != '\n') {

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
@@ -78,6 +78,9 @@ private class PlainTextNodeVisitor : NodeVisitor {
             } else {
                 builder.append("• ")
             }
+        } else if (node is Element && node.tagName() == "mx-reply") {
+            // Remove the fallback reply node and its contents so they aren't added to the plain text message
+            node.remove()
         } else if (node is Element && node.isBlock && builder.lastOrNull() != '\n') {
             builder.append("\n")
         }

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
@@ -136,4 +136,19 @@ class ToPlainTextTest {
         )
         assertThat(messageType.toPlainText(permalinkParser = FakePermalinkParser())).isEqualTo("This is the fallback text")
     }
+
+    @Test
+    fun `TextMessageType toPlainText - ignores mx-reply element`() {
+        val messageType = TextMessageType(
+            body = "This is the fallback text",
+            formatted = FormattedBody(
+                format = MessageFormat.HTML,
+                body = """
+                    <mx-reply>In reply to...</mx-reply>
+                    This is the message content.
+                """.trimIndent()
+            )
+        )
+        assertThat(messageType.toPlainText(permalinkParser = FakePermalinkParser())).isEqualTo("This is the message content.")
+    }
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says, when formatting a text message to display in plain text, ignore the contents of the `mx-reply` elements.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6673.

## Tests

Send or receive a text message with a formatted body and an `mx-reply` element. Check the contents of this HTML element  are not added to the latest event text in the room list.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
