### PR TITLE
Fix media viewer flickering and crashing

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -122,25 +122,11 @@ class MediaViewerDataSource(
      */
     private fun buildMediaViewerPageList(groupedItems: List<MediaItem>) = buildList {
         // Filter out DateSeparator items, we do not need them for the media viewer
-        val itemsNoDateSeparator = groupedItems.filterNot { it is MediaItem.DateSeparator }
-        // Separate loading indicators and media events
-        val loadingIndicators = itemsNoDateSeparator.filterIsInstance<MediaItem.LoadingIndicator>()
-        val mediaEvents = itemsNoDateSeparator.filterIsInstance<MediaItem.Event>()
-        // Determine backward and forward loading indicators
-        val backwardLoading = loadingIndicators.find { it.direction == Timeline.PaginationDirection.BACKWARDS }
-        val forwardLoading = loadingIndicators.find { it.direction == Timeline.PaginationDirection.FORWARDS }
-        // Build ordered list: backward loading, media events (oldest first), forward loading
-        // Media events are currently newest first, reverse to get oldest first
-        val orderedEvents = mediaEvents.reversed()
-        // Create new list of MediaItem in order: backwardLoading, orderedEvents, forwardLoading
-        val orderedItems = buildList {
-            backwardLoading?.let { add(it) }
-            addAll(orderedEvents)
-            forwardLoading?.let { add(it) }
-        }
-        pagerKeysHandler.accept(orderedItems)
-        orderedItems.forEach { mediaItem ->
+        val groupedItemsNoDateSeparator = groupedItems.filterNot { it is MediaItem.DateSeparator }
+        pagerKeysHandler.accept(groupedItemsNoDateSeparator)
+        groupedItemsNoDateSeparator.forEach { mediaItem ->
             when (mediaItem) {
+                is MediaItem.DateSeparator -> Unit
                 is MediaItem.Event -> {
                     val sourceUrl = mediaItem.mediaSource().safeUrl
                     val localMedia = localMediaStates.getOrPut(sourceUrl) {
@@ -164,7 +150,6 @@ class MediaViewerDataSource(
                         pagerKey = pagerKeysHandler.getKey(mediaItem),
                     )
                 )
-                is MediaItem.DateSeparator -> Unit // already filtered out
             }
         }
     }.toImmutableList()

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -177,21 +177,18 @@ class MediaViewerPresenter(
         currentIndex: IntState,
         data: State<ImmutableList<MediaViewerPageData>>,
     ) {
+        // With newest-first ordering, backward loading indicator is at the last index
         val isRenderingLoadingBackward by remember {
             derivedStateOf {
-                currentIndex.intValue == 0 &&
+                currentIndex.intValue == data.value.lastIndex &&
                     data.value.size > 1 &&
-                    data.value.firstOrNull() is MediaViewerPageData.Loading &&
-                    (data.value.firstOrNull() as? MediaViewerPageData.Loading)?.direction == Timeline.PaginationDirection.BACKWARDS
+                    data.value.lastOrNull() is MediaViewerPageData.Loading
             }
         }
         if (isRenderingLoadingBackward) {
             LaunchedEffect(Unit) {
                 // Observe the loading data vanishing
-                snapshotFlow {
-                    val first = data.value.firstOrNull()
-                    first is MediaViewerPageData.Loading && first.direction == Timeline.PaginationDirection.BACKWARDS
-                }
+                snapshotFlow { data.value.lastOrNull() is MediaViewerPageData.Loading }
                     .distinctUntilChanged()
                     .filter { !it }
                     .onEach { showNoMoreItemsSnackbar() }
@@ -205,21 +202,18 @@ class MediaViewerPresenter(
         currentIndex: IntState,
         data: State<ImmutableList<MediaViewerPageData>>,
     ) {
+        // With newest-first ordering, forward loading indicator is at the first index
         val isRenderingLoadingForward by remember {
             derivedStateOf {
-                currentIndex.intValue == data.value.lastIndex &&
+                currentIndex.intValue == 0 &&
                     data.value.size > 1 &&
-                    data.value.lastOrNull() is MediaViewerPageData.Loading &&
-                    (data.value.lastOrNull() as? MediaViewerPageData.Loading)?.direction == Timeline.PaginationDirection.FORWARDS
+                    data.value.firstOrNull() is MediaViewerPageData.Loading
             }
         }
         if (isRenderingLoadingForward) {
             LaunchedEffect(Unit) {
                 // Observe the loading data vanishing
-                snapshotFlow {
-                    val last = data.value.lastOrNull()
-                    last is MediaViewerPageData.Loading && last.direction == Timeline.PaginationDirection.FORWARDS
-                }
+                snapshotFlow { data.value.firstOrNull() is MediaViewerPageData.Loading }
                     .distinctUntilChanged()
                     .filter { !it }
                     .onEach { showNoMoreItemsSnackbar() }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -136,6 +136,7 @@ fun MediaViewerView(
             // Pre-load previous and next pages
             beyondViewportPageCount = 1,
             key = { index -> state.listData[index].pagerKey },
+            reverseLayout = true,
         ) { page ->
             when (val dataForPage = state.listData[page]) {
                 is MediaViewerPageData.Failure -> {

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenterTest.kt
@@ -593,20 +593,20 @@ class MediaViewerPresenterTest {
                     if (mode is MediaViewerEntryPoint.MediaViewerMode.TimelineFilesAndAudios) {
                         GroupedMediaItems(
                             imageAndVideoItems = persistentListOf(),
-                            fileItems = persistentListOf(aBackwardLoadingIndicator, anImage, aForwardLoadingIndicator),
+                            fileItems = persistentListOf(aForwardLoadingIndicator, anImage, aBackwardLoadingIndicator),
                         )
                     } else {
                         GroupedMediaItems(
-                            imageAndVideoItems = persistentListOf(aBackwardLoadingIndicator, anImage, aForwardLoadingIndicator),
+                            imageAndVideoItems = persistentListOf(aForwardLoadingIndicator, anImage, aBackwardLoadingIndicator),
                             fileItems = persistentListOf(),
                         )
                     }
                 )
             )
             val updatedState = awaitItem()
-            // User navigate to the last item (forward loading indicator)
+            // User navigate to the first item (forward loading indicator)
             updatedState.eventSink(
-                MediaViewerEvent.OnNavigateTo(2)
+                MediaViewerEvent.OnNavigateTo(0)
             )
             // data source claims that there is no more items to load forward
             mediaGalleryDataSource.emitGroupedMediaItems(
@@ -614,21 +614,19 @@ class MediaViewerPresenterTest {
                     if (mode is MediaViewerEntryPoint.MediaViewerMode.TimelineFilesAndAudios) {
                         GroupedMediaItems(
                             imageAndVideoItems = persistentListOf(),
-                            fileItems = persistentListOf(aBackwardLoadingIndicator, anImage),
+                            fileItems = persistentListOf(anImage, aBackwardLoadingIndicator),
                         )
                     } else {
                         GroupedMediaItems(
-                            imageAndVideoItems = persistentListOf(aBackwardLoadingIndicator, anImage),
+                            imageAndVideoItems = persistentListOf(anImage, aBackwardLoadingIndicator),
                             fileItems = persistentListOf(),
                         )
                     }
                 )
             )
-            var stateWithSnackbar = awaitItem()
-            while (stateWithSnackbar.snackbarMessage == null) {
-                stateWithSnackbar = awaitItem()
-            }
-            assertThat(stateWithSnackbar.snackbarMessage.messageResId).isEqualTo(expectedSnackbarResId)
+            skipItems(1)
+            val stateWithSnackbar = awaitItem()
+            assertThat(stateWithSnackbar.snackbarMessage!!.messageResId).isEqualTo(expectedSnackbarResId)
         }
     }
 
@@ -667,42 +665,41 @@ class MediaViewerPresenterTest {
                     if (mode is MediaViewerEntryPoint.MediaViewerMode.TimelineFilesAndAudios) {
                         GroupedMediaItems(
                             imageAndVideoItems = persistentListOf(),
-                            fileItems = persistentListOf(aBackwardLoadingIndicator, anImage, aForwardLoadingIndicator),
+                            fileItems = persistentListOf(aForwardLoadingIndicator, anImage, aBackwardLoadingIndicator),
                         )
                     } else {
                         GroupedMediaItems(
-                            imageAndVideoItems = persistentListOf(aBackwardLoadingIndicator, anImage, aForwardLoadingIndicator),
+                            imageAndVideoItems = persistentListOf(aForwardLoadingIndicator, anImage, aBackwardLoadingIndicator),
                             fileItems = persistentListOf(),
                         )
                     }
                 )
             )
             val updatedState = awaitItem()
-            // User navigate to the first item (backward loading indicator)
+            // User navigate to the last item (backward loading indicator)
             updatedState.eventSink(
-                MediaViewerEvent.OnNavigateTo(0)
+                MediaViewerEvent.OnNavigateTo(2)
             )
+            skipItems(1)
             // data source claims that there is no more items to load backward
             mediaGalleryDataSource.emitGroupedMediaItems(
                 AsyncData.Success(
                     if (mode is MediaViewerEntryPoint.MediaViewerMode.TimelineFilesAndAudios) {
                         GroupedMediaItems(
                             imageAndVideoItems = persistentListOf(),
-                            fileItems = persistentListOf(anImage, aForwardLoadingIndicator),
+                            fileItems = persistentListOf(aForwardLoadingIndicator, anImage),
                         )
                     } else {
                         GroupedMediaItems(
-                            imageAndVideoItems = persistentListOf(anImage, aForwardLoadingIndicator),
+                            imageAndVideoItems = persistentListOf(aForwardLoadingIndicator, anImage),
                             fileItems = persistentListOf(),
                         )
                     }
                 )
             )
-            var stateWithSnackbar = awaitItem()
-            while (stateWithSnackbar.snackbarMessage == null) {
-                stateWithSnackbar = awaitItem()
-            }
-            assertThat(stateWithSnackbar.snackbarMessage.messageResId).isEqualTo(expectedSnackbarResId)
+            skipItems(1)
+            val stateWithSnackbar = awaitItem()
+            assertThat(stateWithSnackbar.snackbarMessage!!.messageResId).isEqualTo(expectedSnackbarResId)
         }
     }
 
@@ -720,7 +717,7 @@ class MediaViewerPresenterTest {
             mediaGalleryDataSource.emitGroupedMediaItems(
                 AsyncData.Success(
                     GroupedMediaItems(
-                        imageAndVideoItems = persistentListOf(aBackwardLoadingIndicator, anImage, aForwardLoadingIndicator),
+                        imageAndVideoItems = persistentListOf(aForwardLoadingIndicator, anImage, aBackwardLoadingIndicator),
                         fileItems = persistentListOf(),
                     )
                 )


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

1. Reverts `6a4fed2`
2. Reimplements it in a much simpler way (just adds `reverseLayout = true`)

## Motivation and context

Fixes #6695
Fixes #6709

I haven't tried to fix the previous (pre-`6a4fed2`) media viewer header flicker, but at least this fixes the regressions introduced by `6a4fed2`.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a media

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
