### PR TITLE
Don't compress images sent through the Files attachment picker

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/Attachment.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/Attachment.kt
@@ -16,5 +16,11 @@ import kotlinx.parcelize.Parcelize
 @Immutable
 sealed interface Attachment : Parcelable {
     @Parcelize
-    data class Media(val localMedia: LocalMedia) : Attachment
+    data class Media(
+        val localMedia: LocalMedia,
+        // When true, the media was picked through the "Files" picker and should be
+        // uploaded without any optimization (image compression / video re-encoding pass).
+        // See https://github.com/element-hq/element-x-android/issues/6365
+        val sendAsFile: Boolean = false,
+    ) : Attachment
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -96,7 +96,10 @@ class AttachmentsPreviewPresenter(
 
         val mediaAttachment = attachment as Attachment.Media
         val mediaOptimizationSelectorPresenter = remember {
-            mediaOptimizationSelectorPresenterFactory.create(mediaAttachment.localMedia)
+            mediaOptimizationSelectorPresenterFactory.create(
+                localMedia = mediaAttachment.localMedia,
+                sendAsFile = mediaAttachment.sendAsFile,
+            )
         }
         val mediaOptimizationSelectorState by rememberUpdatedState(mediaOptimizationSelectorPresenter.present())
 
@@ -109,9 +112,18 @@ class AttachmentsPreviewPresenter(
             // to prepare it for sending. This is done to avoid blocking the UI thread when the
             // user clicks on the send button.
             if (mediaOptimizationSelectorState.displayMediaSelectorViews == false) {
+                val config = if (mediaAttachment.sendAsFile) {
+                    // Send-as-file: never compress images; videos use HIGH (best available) preset.
+                    MediaOptimizationConfig(
+                        compressImages = false,
+                        videoCompressionPreset = VideoCompressionPreset.HIGH,
+                    )
+                } else {
+                    mediaOptimizationConfigProvider.get()
+                }
                 preprocessMediaJob = preProcessAttachment(
                     attachment = attachment,
-                    mediaOptimizationConfig = mediaOptimizationConfigProvider.get(),
+                    mediaOptimizationConfig = config,
                     displayProgress = false,
                     sendActionState = sendActionState,
                 )

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenter.kt
@@ -37,6 +37,7 @@ import kotlin.math.roundToLong
 @AssistedInject
 class DefaultMediaOptimizationSelectorPresenter(
     @Assisted private val localMedia: LocalMedia,
+    @Assisted private val sendAsFile: Boolean,
     private val maxUploadSizeProvider: MaxUploadSizeProvider,
     private val featureFlagService: FeatureFlagService,
     private val mediaOptimizationConfigProvider: MediaOptimizationConfigProvider,
@@ -47,6 +48,7 @@ class DefaultMediaOptimizationSelectorPresenter(
     interface Factory : MediaOptimizationSelectorPresenter.Factory {
         override fun create(
             localMedia: LocalMedia,
+            sendAsFile: Boolean,
         ): DefaultMediaOptimizationSelectorPresenter
     }
 
@@ -55,7 +57,9 @@ class DefaultMediaOptimizationSelectorPresenter(
     @Composable
     override fun present(): MediaOptimizationSelectorState {
         val displayMediaSelectorViews by produceState<Boolean?>(null) {
-            value = featureFlagService.isFeatureEnabled(FeatureFlags.SelectableMediaQuality)
+            // When sending as a raw file, never show the optimization selector: the user
+            // explicitly opted into uploading the original.
+            value = !sendAsFile && featureFlagService.isFeatureEnabled(FeatureFlags.SelectableMediaQuality)
         }
 
         var displayVideoPresetSelectorDialog by remember { mutableStateOf(false) }
@@ -123,6 +127,17 @@ class DefaultMediaOptimizationSelectorPresenter(
         var selectedVideoOptimizationPreset by remember { mutableStateOf<AsyncData<VideoCompressionPreset>>(AsyncData.Loading()) }
 
         LaunchedEffect(videoSizeEstimations.dataOrNull()) {
+            if (sendAsFile) {
+                // Send-as-file path: pin to no image compression, and pick the highest-quality
+                // video preset that still fits the upload limit (we have no true "do not re-encode
+                // video" path in the pre-processor right now).
+                selectedImageOptimization = AsyncData.Success(false)
+                selectedVideoOptimizationPreset = findBestVideoPreset(
+                    defaultVideoPreset = VideoCompressionPreset.HIGH,
+                    videoSizeEstimations = videoSizeEstimations,
+                )
+                return@LaunchedEffect
+            }
             val mediaOptimizationConfig = mediaOptimizationConfigProvider.get()
             selectedImageOptimization = AsyncData.Success(mediaOptimizationConfig.compressImages)
             // Find the best video preset based on the default preset and the video size estimations

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/MediaOptimizationSelectorPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/MediaOptimizationSelectorPresenter.kt
@@ -15,6 +15,7 @@ fun interface MediaOptimizationSelectorPresenter : Presenter<MediaOptimizationSe
     interface Factory {
         fun create(
             localMedia: LocalMedia,
+            sendAsFile: Boolean,
         ): MediaOptimizationSelectorPresenter
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -180,7 +180,7 @@ class MessageComposerPresenter(
             handlePickedMedia(uri, mimeType)
         }
         val filesPicker = mediaPickerProvider.registerFilePicker(AnyMimeTypes) { uri, mimeType ->
-            handlePickedMedia(uri, mimeType ?: MimeTypes.OctetStream)
+            handlePickedMedia(uri, mimeType ?: MimeTypes.OctetStream, sendAsFile = true)
         }
         val cameraPhotoPicker = mediaPickerProvider.registerCameraPhotoPicker { uri ->
             handlePickedMedia(uri, MimeTypes.Jpeg)
@@ -606,6 +606,7 @@ class MessageComposerPresenter(
     private fun handlePickedMedia(
         uri: Uri?,
         mimeType: String? = null,
+        sendAsFile: Boolean = false,
     ) {
         uri ?: return
         val localMedia = localMediaFactory.createFromUri(
@@ -614,7 +615,7 @@ class MessageComposerPresenter(
             name = null,
             formattedFileSize = null
         )
-        val mediaAttachment = Attachment.Media(localMedia)
+        val mediaAttachment = Attachment.Media(localMedia, sendAsFile = sendAsFile)
         val inReplyToEventId = (messageComposerContext.composerMode as? MessageComposerMode.Reply)?.eventId
         navigator.navigateToPreviewAttachments(persistentListOf(mediaAttachment), inReplyToEventId)
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -548,10 +548,41 @@ class AttachmentsPreviewPresenterTest {
         }
     }
 
+    @Test
+    fun `present - sendAsFile attachment is pre-processed without image compression`() = runTest {
+        // Even though the user has enabled "Optimize media quality" globally, picking the file
+        // through the Files picker (sendAsFile = true) must skip compression. Regression test
+        // for https://github.com/element-hq/element-x-android/issues/6365
+        val mediaPreProcessor = FakeMediaPreProcessor()
+        val presenter = createAttachmentsPreviewPresenter(
+            sendAsFile = true,
+            mediaPreProcessor = mediaPreProcessor,
+            // Selector views are hidden in the sendAsFile flow, which triggers the auto pre-process path.
+            displayMediaQualitySelectorViews = false,
+            mediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(
+                config = MediaOptimizationConfig(
+                    compressImages = true,
+                    videoCompressionPreset = VideoCompressionPreset.STANDARD,
+                )
+            ),
+        )
+
+        presenter.test {
+            consumeItemsUntilPredicate { mediaPreProcessor.processCallCount > 0 }
+            assertThat(mediaPreProcessor.lastMediaOptimizationConfig).isEqualTo(
+                MediaOptimizationConfig(
+                    compressImages = false,
+                    videoCompressionPreset = VideoCompressionPreset.HIGH,
+                )
+            )
+        }
+    }
+
     private fun TestScope.createAttachmentsPreviewPresenter(
         localMedia: LocalMedia = aLocalMedia(
             uri = mockMediaUrl,
         ),
+        sendAsFile: Boolean = false,
         room: JoinedRoom = FakeJoinedRoom(),
         timelineMode: Timeline.Mode = Timeline.Mode.Live,
         permalinkBuilder: PermalinkBuilder = FakePermalinkBuilder(),
@@ -575,7 +606,7 @@ class AttachmentsPreviewPresenterTest {
         mediaOptimizationConfigProvider: FakeMediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(),
     ): AttachmentsPreviewPresenter {
         return AttachmentsPreviewPresenter(
-            attachment = aMediaAttachment(localMedia),
+            attachment = aMediaAttachment(localMedia, sendAsFile = sendAsFile),
             onDoneListener = onDoneListener,
             mediaSenderFactory = MediaSenderFactory { timelineMode ->
                 DefaultMediaSender(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenterTest.kt
@@ -210,15 +210,60 @@ class DefaultMediaOptimizationSelectorPresenterTest {
         }
     }
 
+    @Test
+    fun `present - sendAsFile hides selector views and disables image compression for images`() = runTest {
+        val presenter = createDefaultMediaOptimizationSelectorPresenter(
+            localMedia = aLocalMedia(mockMediaUrl, anImageMediaInfo()),
+            // Even with the feature flag on, sendAsFile must hide the selector.
+            featureFlagService = FakeFeatureFlagService(mapOf(FeatureFlags.SelectableMediaQuality.key to true)),
+            // And it must override the user's "optimize images" preference.
+            mediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(),
+            sendAsFile = true,
+        )
+        presenter.test {
+            // Initial loading state
+            skipItems(1)
+            awaitItem().run {
+                assertThat(displayMediaSelectorViews).isFalse()
+                assertThat(isImageOptimizationEnabled).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `present - sendAsFile picks HIGH video preset when the video fits the upload limit`() = runTest {
+        val presenter = createDefaultMediaOptimizationSelectorPresenter(
+            // Plenty of room: even HIGH preset will fit.
+            maxUploadSizeProvider = MaxUploadSizeProvider { Result.success(Long.MAX_VALUE) },
+            mediaExtractorFactory = FakeVideoMetadataExtractorFactory(
+                FakeVideoMetadataExtractor(
+                    sizeResult = Result.success(Size(1920, 1080)),
+                    duration = Result.success(10.minutes)
+                )
+            ),
+            sendAsFile = true,
+        )
+        presenter.test {
+            // Initial loading state, then the one with size estimations loaded.
+            skipItems(1)
+            awaitItem().run {
+                assertThat(displayMediaSelectorViews).isFalse()
+                assertThat(selectedVideoPreset).isEqualTo(VideoCompressionPreset.HIGH)
+            }
+        }
+    }
+
     private fun createDefaultMediaOptimizationSelectorPresenter(
         localMedia: LocalMedia = aLocalMedia(mockMediaUrl, aVideoMediaInfo()),
         maxUploadSizeProvider: MaxUploadSizeProvider = MaxUploadSizeProvider { Result.success(1_000L) },
         featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(mapOf(FeatureFlags.SelectableMediaQuality.key to true)),
         mediaExtractorFactory: FakeVideoMetadataExtractorFactory = FakeVideoMetadataExtractorFactory(),
         mediaOptimizationConfigProvider: FakeMediaOptimizationConfigProvider = FakeMediaOptimizationConfigProvider(),
+        sendAsFile: Boolean = false,
     ): DefaultMediaOptimizationSelectorPresenter {
         return DefaultMediaOptimizationSelectorPresenter(
             localMedia = localMedia,
+            sendAsFile = sendAsFile,
             maxUploadSizeProvider = maxUploadSizeProvider,
             featureFlagService = featureFlagService,
             mediaExtractorFactory = mediaExtractorFactory,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/fixtures/MediaAttachmentFixtures.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/fixtures/MediaAttachmentFixtures.kt
@@ -11,6 +11,7 @@ package io.element.android.features.messages.impl.fixtures
 import io.element.android.features.messages.impl.attachments.Attachment
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
 
-fun aMediaAttachment(localMedia: LocalMedia) = Attachment.Media(
+fun aMediaAttachment(localMedia: LocalMedia, sendAsFile: Boolean = false) = Attachment.Media(
     localMedia = localMedia,
+    sendAsFile = sendAsFile,
 )

--- a/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/attachments/video/FakeMediaOptimizationSelectorPresenterFactory.kt
+++ b/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/attachments/video/FakeMediaOptimizationSelectorPresenterFactory.kt
@@ -26,7 +26,7 @@ class FakeMediaOptimizationSelectorPresenterFactory(
         )
     }
 ) : MediaOptimizationSelectorPresenter.Factory {
-    override fun create(localMedia: LocalMedia): MediaOptimizationSelectorPresenter {
+    override fun create(localMedia: LocalMedia, sendAsFile: Boolean): MediaOptimizationSelectorPresenter {
         return fakePresenter
     }
 }

--- a/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaPreProcessor.kt
+++ b/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaPreProcessor.kt
@@ -31,6 +31,10 @@ class FakeMediaPreProcessor(
     var cleanUpCallCount = 0
         private set
 
+    /** The [MediaOptimizationConfig] passed to the most recent [process] call, or `null` if it was never called. */
+    var lastMediaOptimizationConfig: MediaOptimizationConfig? = null
+        private set
+
     private var result: Result<MediaUploadInfo> = Result.success(
         MediaUploadInfo.AnyFile(
             File("test"),
@@ -51,6 +55,7 @@ class FakeMediaPreProcessor(
     ): Result<MediaUploadInfo> = simulateLongTask {
         processLatch?.await()
         processCallCount++
+        lastMediaOptimizationConfig = mediaOptimizationConfig
         result
     }
 


### PR DESCRIPTION
## Content

Don't compress images sent through the Files attachment picker

## Motivation and context

Images and videos picked through the "Attachment" picker are now uploaded without re-encoding, regardless of the "Optimize media quality" setting. The gallery and camera pickers keep the existing behaviour, matching what Element Web/Desktop and most other messengers do.

Fixes #6365

## Screenshots / GIFs

## Tests

Manual test:
- built baseline APK and installed in phone
- Media optimization is enabled. Sent a photo as media, and as a file.
  - Both got resized.
- built APK from this branch and installed in phone
- Media optimization is still enabled. Sent a photo as media, and as a file.
  - Photo got resized, file retained original quality (visually - much smaller details are visible. I did not check byte equality)

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): LineageOS 22

## Checklist

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
  - Tested on Android device: yes. Not sure about API 42.
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
