### PR TITLE
Stop removing the `logs` dir when clearing cache

### DIFF
--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
@@ -55,7 +55,12 @@ class DefaultClearCacheUseCase(
         // Clear OkHttp cache
         okHttpClient().cache?.delete()
         // Clear app cache
-        context.cacheDir.deleteRecursively()
+        context.cacheDir?.listFiles {
+            // But keep the logs
+            it.name != "logs"
+        }?.onEach {
+            it.deleteRecursively()
+        }
         // Clear some settings
         seenInvitesStore.clear()
         // Ensure any error will be displayed again


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

When we manually clear the cache from developer settings, don't remove the `logs` directory.

## Motivation and context

When we remove this directory, we also remove the current log file the SDK is using and usually this means it keeps trying to write new log lines to this deleted file while silently failing. So we end up with no old logs and no *current* logs until the log rotation logic creates a new log file.

To be honest, I can't remember if we removed this directory on purpose so we had a way to free some space taken by the logs or if it was a side-effect of it being in the cache directory.

It also matches the Element X iOS behavior.

## Tests

Clear the cache, check the log files are still there.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
