### PR TITLE
Reduce FeatureFlag `Knock` effect on room creation and room edition forms

### DIFF
--- a/features/knockrequests/impl/build.gradle.kts
+++ b/features/knockrequests/impl/build.gradle.kts
@@ -33,9 +33,7 @@ dependencies {
     implementation(projects.libraries.matrixui)
     implementation(projects.libraries.uiStrings)
     implementation(projects.libraries.designsystem)
-    implementation(projects.libraries.featureflag.api)
 
     testCommonDependencies(libs, true)
     testImplementation(projects.libraries.matrix.test)
-    testImplementation(projects.libraries.featureflag.test)
 }

--- a/features/knockrequests/impl/src/main/kotlin/io/element/android/features/knockrequests/impl/data/KnockRequestsModule.kt
+++ b/features/knockrequests/impl/src/main/kotlin/io/element/android/features/knockrequests/impl/data/KnockRequestsModule.kt
@@ -15,8 +15,6 @@ import dev.zacsweers.metro.SingleIn
 import io.element.android.features.knockrequests.api.KnockRequestPermissions
 import io.element.android.features.knockrequests.api.knockRequestPermissions
 import io.element.android.libraries.di.RoomScope
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.powerlevels.permissionsFlow
 
@@ -25,14 +23,13 @@ import io.element.android.libraries.matrix.api.room.powerlevels.permissionsFlow
 object KnockRequestsModule {
     @Provides
     @SingleIn(RoomScope::class)
-    fun knockRequestsService(room: JoinedRoom, featureFlagService: FeatureFlagService): KnockRequestsService {
+    fun knockRequestsService(room: JoinedRoom): KnockRequestsService {
         return KnockRequestsService(
             knockRequestsFlow = room.knockRequestsFlow,
             permissionsFlow = room.permissionsFlow(KnockRequestPermissions.DEFAULT) { perms ->
                 perms.knockRequestPermissions()
             },
-            isKnockFeatureEnabledFlow = featureFlagService.isFeatureEnabledFlow(FeatureFlags.Knock),
-            coroutineScope = room.roomCoroutineScope
+            coroutineScope = room.roomCoroutineScope,
         )
     }
 }

--- a/features/knockrequests/impl/src/main/kotlin/io/element/android/features/knockrequests/impl/data/KnockRequestsService.kt
+++ b/features/knockrequests/impl/src/main/kotlin/io/element/android/features/knockrequests/impl/data/KnockRequestsService.kt
@@ -12,7 +12,6 @@ import io.element.android.features.knockrequests.api.KnockRequestPermissions
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.room.knock.KnockRequest
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -28,26 +27,20 @@ import kotlinx.coroutines.supervisorScope
 class KnockRequestsService(
     knockRequestsFlow: Flow<List<KnockRequest>>,
     permissionsFlow: Flow<KnockRequestPermissions>,
-    isKnockFeatureEnabledFlow: Flow<Boolean>,
     coroutineScope: CoroutineScope,
 ) {
     // Keep track of the knock requests that have been handled, so we don't have to wait for sync to remove them.
     private val handledKnockRequestIds = MutableStateFlow<Set<EventId>>(emptySet())
 
     val knockRequestsFlow = combine(
-        isKnockFeatureEnabledFlow,
         knockRequestsFlow,
         handledKnockRequestIds,
-    ) { isKnockEnabled, knockRequests, handledKnockIds ->
-        if (!isKnockEnabled) {
-            AsyncData.Success(persistentListOf())
-        } else {
-            val presentableKnockRequests = knockRequests
-                .filter { it.eventId !in handledKnockIds }
-                .map { inner -> KnockRequestWrapper(inner) }
-                .toImmutableList()
-            AsyncData.Success(presentableKnockRequests)
-        }
+    ) { knockRequests, handledKnockIds ->
+        val presentableKnockRequests = knockRequests
+            .filter { it.eventId !in handledKnockIds }
+            .map { inner -> KnockRequestWrapper(inner) }
+            .toImmutableList()
+        AsyncData.Success(presentableKnockRequests)
     }.stateIn(coroutineScope, SharingStarted.Lazily, AsyncData.Loading())
 
     val permissionsFlow = permissionsFlow.stateIn(

--- a/features/knockrequests/impl/src/test/kotlin/io/element/android/features/knockrequests/impl/banner/KnockRequestsBannerPresenterTest.kt
+++ b/features/knockrequests/impl/src/test/kotlin/io/element/android/features/knockrequests/impl/banner/KnockRequestsBannerPresenterTest.kt
@@ -29,18 +29,6 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class) class KnockRequestsBannerPresenterTest {
     @Test
-    fun `present - when feature is disabled then the banner should be hidden`() = runTest {
-        val knockRequests = flowOf(listOf(FakeKnockRequest()))
-        val presenter = createKnockRequestsBannerPresenter(isFeatureEnabled = false, knockRequestsFlow = knockRequests)
-        presenter.test {
-            skipItems(1)
-            awaitItem().also { state ->
-                assertThat(state.isVisible).isFalse()
-            }
-        }
-    }
-
-    @Test
     fun `present - when empty knock request list then the banner should be hidden`() = runTest {
         val knockRequests = flowOf(emptyList<KnockRequest>())
         val presenter = createKnockRequestsBannerPresenter(knockRequestsFlow = knockRequests)
@@ -229,12 +217,10 @@ import org.junit.Test
 private fun TestScope.createKnockRequestsBannerPresenter(
     knockRequestsFlow: Flow<List<KnockRequest>> = flowOf(emptyList()),
     canAcceptKnockRequests: Boolean = true,
-    isFeatureEnabled: Boolean = true,
 ): KnockRequestsBannerPresenter {
     val knockRequestsService = KnockRequestsService(
         knockRequestsFlow = knockRequestsFlow,
         coroutineScope = backgroundScope,
-        isKnockFeatureEnabledFlow = flowOf(isFeatureEnabled),
         permissionsFlow = flowOf(KnockRequestPermissions(canAcceptKnockRequests, canAcceptKnockRequests, canAcceptKnockRequests)),
     )
     return KnockRequestsBannerPresenter(

--- a/features/knockrequests/impl/src/test/kotlin/io/element/android/features/knockrequests/impl/list/KnockRequestsListPresenterTest.kt
+++ b/features/knockrequests/impl/src/test/kotlin/io/element/android/features/knockrequests/impl/list/KnockRequestsListPresenterTest.kt
@@ -298,7 +298,6 @@ internal fun TestScope.createKnockRequestsListPresenter(
     val knockRequestsService = KnockRequestsService(
         knockRequestsFlow = knockRequestsFlow,
         coroutineScope = backgroundScope,
-        isKnockFeatureEnabledFlow = flowOf(true),
         permissionsFlow = flowOf(KnockRequestPermissions(canAccept, canDecline, canBan)),
     )
     return KnockRequestsListPresenter(knockRequestsService = knockRequestsService)

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -35,8 +35,6 @@ import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.designsystem.utils.snackbar.LocalSnackbarDispatcher
 import io.element.android.libraries.designsystem.utils.snackbar.SnackbarMessage
 import io.element.android.libraries.designsystem.utils.snackbar.collectSnackbarMessageAsState
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.encryption.identity.IdentityState
 import io.element.android.libraries.matrix.api.notificationsettings.NotificationSettingsService
@@ -61,7 +59,6 @@ import kotlinx.coroutines.launch
 class RoomDetailsPresenter(
     private val client: MatrixClient,
     private val room: JoinedRoom,
-    private val featureFlagService: FeatureFlagService,
     private val notificationSettingsService: NotificationSettingsService,
     private val roomMembersDetailsPresenterFactory: RoomMemberDetailsPresenter.Factory,
     private val leaveRoomPresenter: Presenter<LeaveRoomState>,
@@ -110,14 +107,11 @@ class RoomDetailsPresenter(
             }
         }
 
-        val isKnockRequestsEnabled by remember {
-            featureFlagService.isFeatureEnabledFlow(FeatureFlags.Knock)
-        }.collectAsState(false)
         val knockRequestsCount by produceState<Int?>(null) {
             room.knockRequestsFlow.collect { value = it.size }
         }
         val canShowKnockRequests by remember {
-            derivedStateOf { isKnockRequestsEnabled && permissions.knockRequestsPermissions.hasAny && joinRule == JoinRule.Knock }
+            derivedStateOf { permissions.knockRequestsPermissions.hasAny && joinRule == JoinRule.Knock }
         }
         val canShowSecurityAndPrivacy by remember {
             derivedStateOf { !isDm && permissions.securityAndPrivacyPermissions.hasAny(isSpace = false, joinRule = joinRule) }

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
@@ -21,9 +21,6 @@ import io.element.android.libraries.androidutils.clipboard.ClipboardHelper
 import io.element.android.libraries.androidutils.clipboard.FakeClipboardHelper
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
-import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.RoomMembersState
@@ -80,11 +77,6 @@ class RoomDetailsPresenterTest {
         dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
         notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
         analyticsService: AnalyticsService = FakeAnalyticsService(),
-        featureFlagService: FeatureFlagService = FakeFeatureFlagService(
-            mapOf(
-                FeatureFlags.Knock.key to false,
-            )
-        ),
         encryptionService: FakeEncryptionService = FakeEncryptionService(),
         clipboardHelper: ClipboardHelper = FakeClipboardHelper(),
         appPreferencesStore: AppPreferencesStore = InMemoryAppPreferencesStore()
@@ -106,7 +98,6 @@ class RoomDetailsPresenterTest {
         return RoomDetailsPresenter(
             client = matrixClient,
             room = room,
-            featureFlagService = featureFlagService,
             notificationSettingsService = matrixClient.notificationSettingsService,
             roomMembersDetailsPresenterFactory = roomMemberDetailsPresenterFactory,
             leaveRoomPresenter = { leaveRoomState },
@@ -564,17 +555,11 @@ class RoomDetailsPresenterTest {
             roomPermissions = roomPermissions(),
             joinRule = JoinRule.Knock,
         )
-        val featureFlagService = FakeFeatureFlagService(
-            mapOf(FeatureFlags.Knock.key to false)
-        )
         val presenter = createRoomDetailsPresenter(
             room = room,
-            featureFlagService = featureFlagService,
         )
         presenter.testWithLifecycleOwner(lifecycleOwner = fakeLifecycleOwner) {
             skipItems(1)
-            assertThat(awaitItem().canShowKnockRequests).isFalse()
-            featureFlagService.setFeatureEnabled(FeatureFlags.Knock, true)
             assertThat(awaitItem().canShowKnockRequests).isTrue()
             room.givenRoomInfo(aRoomInfo(joinRule = JoinRule.Invite))
             assertThat(awaitItem().canShowKnockRequests).isFalse()
@@ -587,8 +572,7 @@ class RoomDetailsPresenterTest {
         val room = aJoinedRoom(
             roomPermissions = roomPermissions(),
         )
-        val featureFlagService = FakeFeatureFlagService()
-        val presenter = createRoomDetailsPresenter(room = room, featureFlagService = featureFlagService)
+        val presenter = createRoomDetailsPresenter(room = room)
         presenter.testWithLifecycleOwner(lifecycleOwner = fakeLifecycleOwner) {
             skipItems(1)
             with(awaitItem()) {


### PR DESCRIPTION

<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
Reduce FeatureFlag `Knock` effect on room creation and room edition forms

Even when the flag is disabled, one can accept or reject knock requests.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6701

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- From another client, ask to join a room
- See that even when the FF is disabled, the user can accept or reject the request using EXA

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
