### PR TITLE
Make timeline sender avatars and display names update reactively

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
@@ -19,6 +19,7 @@ import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.libraries.androidutils.diff.DiffCacheUpdater
 import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import kotlinx.collections.immutable.ImmutableList
@@ -75,19 +76,22 @@ class TimelineItemsFactory(
         timelineItems: List<MatrixTimelineItem>,
         roomMembers: List<RoomMember>,
     ) {
+        // Index the member list once per batch so per-item sender / receipt lookups are O(1)
+        // rather than O(N) — N can reach tens of thousands in large public rooms.
+        val roomMembersById = roomMembers.associateBy { it.userId }
         val newTimelineItemStates = ArrayList<TimelineItem>()
         for (index in diffCache.indices().reversed()) {
             val cacheItem = diffCache.get(index)
             if (cacheItem == null) {
-                buildAndCacheItem(timelineItems, index, roomMembers)?.also { timelineItemState ->
+                buildAndCacheItem(timelineItems, index, roomMembersById)?.also { timelineItemState ->
                     newTimelineItemStates.add(timelineItemState)
                 }
             } else {
-                val updatedItem = if (cacheItem is TimelineItem.Event && roomMembers.isNotEmpty()) {
+                val updatedItem = if (cacheItem is TimelineItem.Event && roomMembersById.isNotEmpty()) {
                     eventItemFactory.update(
                         timelineItem = cacheItem,
                         receivedMatrixTimelineItem = timelineItems[index] as MatrixTimelineItem.Event,
-                        roomMembers = roomMembers
+                        roomMembersById = roomMembersById,
                     )
                 } else {
                     cacheItem
@@ -102,11 +106,11 @@ class TimelineItemsFactory(
     private suspend fun buildAndCacheItem(
         timelineItems: List<MatrixTimelineItem>,
         index: Int,
-        roomMembers: List<RoomMember>,
+        roomMembersById: Map<UserId, RoomMember>,
     ): TimelineItem? {
         val timelineItem =
             when (val currentTimelineItem = timelineItems[index]) {
-                is MatrixTimelineItem.Event -> eventItemFactory.create(currentTimelineItem, index, timelineItems, roomMembers)
+                is MatrixTimelineItem.Event -> eventItemFactory.create(currentTimelineItem, index, timelineItems, roomMembersById)
                 is MatrixTimelineItem.Virtual -> virtualItemFactory.create(currentTimelineItem)
                 MatrixTimelineItem.Other -> null
             }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
@@ -59,7 +59,7 @@ class TimelineItemEventFactory(
         currentTimelineItem: MatrixTimelineItem.Event,
         index: Int,
         timelineItems: List<MatrixTimelineItem>,
-        roomMembers: List<RoomMember>,
+        roomMembersById: Map<UserId, RoomMember>,
     ): TimelineItem.Event {
         val currentSender = currentTimelineItem.event.sender
         val groupPosition =
@@ -67,7 +67,7 @@ class TimelineItemEventFactory(
         val (senderProfile, senderAvatarData) = resolveSender(
             sender = currentSender,
             eventSenderProfile = currentTimelineItem.event.senderProfile,
-            roomMembers = roomMembers,
+            roomMembersById = roomMembersById,
         )
         val sentTime = dateFormatter.format(
             timestamp = currentTimelineItem.event.timestamp,
@@ -117,7 +117,7 @@ class TimelineItemEventFactory(
             sentDate = sentDate,
             groupPosition = groupPosition,
             reactionsState = currentTimelineItem.computeReactionsState(),
-            readReceiptState = currentTimelineItem.computeReadReceiptState(roomMembers),
+            readReceiptState = currentTimelineItem.computeReadReceiptState(roomMembersById),
             localSendState = currentTimelineItem.event.localSendState,
             inReplyTo = currentTimelineItem.event.inReplyTo()?.map(permalinkParser = permalinkParser),
             threadInfo = mappedThreadInfo,
@@ -133,19 +133,19 @@ class TimelineItemEventFactory(
     fun update(
         timelineItem: TimelineItem.Event,
         receivedMatrixTimelineItem: MatrixTimelineItem.Event,
-        roomMembers: List<RoomMember>,
+        roomMembersById: Map<UserId, RoomMember>,
     ): TimelineItem.Event {
         // Recompute the sender profile so that avatar / display name updates propagate to rows
         // already in the diff cache. The avatar is also rebuilt because it derives from senderProfile.
         val (senderProfile, senderAvatarData) = resolveSender(
             sender = timelineItem.senderId,
             eventSenderProfile = receivedMatrixTimelineItem.event.senderProfile,
-            roomMembers = roomMembers,
+            roomMembersById = roomMembersById,
         )
         return timelineItem.copy(
             senderProfile = senderProfile,
             senderAvatar = senderAvatarData,
-            readReceiptState = receivedMatrixTimelineItem.computeReadReceiptState(roomMembers),
+            readReceiptState = receivedMatrixTimelineItem.computeReadReceiptState(roomMembersById),
         )
     }
 
@@ -158,10 +158,10 @@ class TimelineItemEventFactory(
     private fun resolveSender(
         sender: UserId,
         eventSenderProfile: ProfileDetails,
-        roomMembers: List<RoomMember>,
+        roomMembersById: Map<UserId, RoomMember>,
     ): Pair<ProfileDetails, AvatarData> {
         val senderProfile = eventSenderProfile.withLiveMemberOverride(
-            roomMembers.find { it.userId == sender }
+            roomMembersById[sender]
         )
         val avatarData = AvatarData(
             id = sender.value,
@@ -212,7 +212,7 @@ class TimelineItemEventFactory(
     }
 
     private fun MatrixTimelineItem.Event.computeReadReceiptState(
-        roomMembers: List<RoomMember>,
+        roomMembersById: Map<UserId, RoomMember>,
     ): TimelineItemReadReceipts {
         if (!config.computeReadReceipts) {
             return TimelineItemReadReceipts(receipts = persistentListOf())
@@ -220,7 +220,7 @@ class TimelineItemEventFactory(
         return TimelineItemReadReceipts(
             receipts = event.receipts
                 .map { receipt ->
-                    val roomMember = roomMembers.find { it.userId == receipt.userId }
+                    val roomMember = roomMembersById[receipt.userId]
                     ReadReceiptData(
                         avatarData = AvatarData(
                             id = receipt.userId.value,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
@@ -28,10 +28,13 @@ import io.element.android.libraries.dateformatter.api.DateFormatterMode
 import io.element.android.libraries.designsystem.components.avatar.AvatarData
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.room.RoomMember
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.EventThreadInfo
+import io.element.android.libraries.matrix.api.timeline.item.event.ProfileDetails
 import io.element.android.libraries.matrix.api.timeline.item.event.getAvatarUrl
 import io.element.android.libraries.matrix.api.timeline.item.event.getDisambiguatedDisplayName
 import io.element.android.libraries.matrix.ui.messages.reply.map
@@ -61,7 +64,11 @@ class TimelineItemEventFactory(
         val currentSender = currentTimelineItem.event.sender
         val groupPosition =
             computeGroupPosition(currentTimelineItem, timelineItems, index)
-        val senderProfile = currentTimelineItem.event.senderProfile
+        val (senderProfile, senderAvatarData) = resolveSender(
+            sender = currentSender,
+            eventSenderProfile = currentTimelineItem.event.senderProfile,
+            roomMembers = roomMembers,
+        )
         val sentTime = dateFormatter.format(
             timestamp = currentTimelineItem.event.timestamp,
             mode = DateFormatterMode.TimeOnly,
@@ -70,12 +77,6 @@ class TimelineItemEventFactory(
             timestamp = currentTimelineItem.event.timestamp,
             mode = DateFormatterMode.Day,
             useRelative = true,
-        )
-        val senderAvatarData = AvatarData(
-            id = currentSender.value,
-            name = senderProfile.getDisambiguatedDisplayName(currentSender),
-            url = senderProfile.getAvatarUrl(),
-            size = AvatarSize.TimelineSender
         )
         val mappedThreadInfo = when (val threadInfo = currentTimelineItem.event.threadInfo()) {
             is EventThreadInfo.ThreadResponse -> {
@@ -134,9 +135,41 @@ class TimelineItemEventFactory(
         receivedMatrixTimelineItem: MatrixTimelineItem.Event,
         roomMembers: List<RoomMember>,
     ): TimelineItem.Event {
-        return timelineItem.copy(
-            readReceiptState = receivedMatrixTimelineItem.computeReadReceiptState(roomMembers)
+        // Recompute the sender profile so that avatar / display name updates propagate to rows
+        // already in the diff cache. The avatar is also rebuilt because it derives from senderProfile.
+        val (senderProfile, senderAvatarData) = resolveSender(
+            sender = timelineItem.senderId,
+            eventSenderProfile = receivedMatrixTimelineItem.event.senderProfile,
+            roomMembers = roomMembers,
         )
+        return timelineItem.copy(
+            senderProfile = senderProfile,
+            senderAvatar = senderAvatarData,
+            readReceiptState = receivedMatrixTimelineItem.computeReadReceiptState(roomMembers),
+        )
+    }
+
+    /**
+     * Resolves the sender's [ProfileDetails] and [AvatarData] for a timeline event, preferring the
+     * live [RoomMember] over the event-level snapshot so that avatar / display name updates
+     * propagate to existing rows. Falls back to the event snapshot when the sender isn't in the
+     * member list (e.g. they have left the room).
+     */
+    private fun resolveSender(
+        sender: UserId,
+        eventSenderProfile: ProfileDetails,
+        roomMembers: List<RoomMember>,
+    ): Pair<ProfileDetails, AvatarData> {
+        val senderProfile = eventSenderProfile.withLiveMemberOverride(
+            roomMembers.find { it.userId == sender }
+        )
+        val avatarData = AvatarData(
+            id = sender.value,
+            name = senderProfile.getDisambiguatedDisplayName(sender),
+            url = senderProfile.getAvatarUrl(),
+            size = AvatarSize.TimelineSender,
+        )
+        return senderProfile to avatarData
     }
 
     private fun MatrixTimelineItem.Event.computeReactionsState(): TimelineItemReactions {
@@ -254,5 +287,23 @@ class TimelineItemEventFactory(
             }
             else -> TimelineItemGroupPosition.None
         }
+    }
+}
+
+/**
+ * Returns a [ProfileDetails.Ready] sourced from the live [RoomMember] when available, otherwise
+ * the original event-level snapshot. This lets timeline rows reflect avatar / display name updates
+ * that arrived via sync after the event was first cached. Banned members are skipped so the
+ * existing convention of hiding their identity (see [RoomMember.toMatrixUser]) is preserved.
+ */
+internal fun ProfileDetails.withLiveMemberOverride(liveMember: RoomMember?): ProfileDetails {
+    return if (liveMember == null || liveMember.membership == RoomMembershipState.BAN) {
+        this
+    } else {
+        ProfileDetails.Ready(
+            displayName = liveMember.displayName,
+            displayNameAmbiguous = liveMember.isNameAmbiguous,
+            avatarUrl = liveMember.avatarUrl,
+        )
     }
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactoryTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.timeline.factories.event
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.timeline.item.event.ProfileDetails
+import io.element.android.libraries.matrix.test.room.aRoomMember
+import org.junit.Test
+
+class TimelineItemEventFactoryTest {
+    private val eventProfile = ProfileDetails.Ready(
+        displayName = "Stale name",
+        displayNameAmbiguous = false,
+        avatarUrl = "mxc://example.org/stale",
+    )
+
+    @Test
+    fun `withLiveMemberOverride uses the live member when present`() {
+        val liveMember = aRoomMember(
+            userId = UserId("@bob:server.org"),
+            displayName = "Fresh name",
+            avatarUrl = "mxc://example.org/fresh",
+        )
+
+        val result = eventProfile.withLiveMemberOverride(liveMember)
+
+        assertThat(result).isEqualTo(
+            ProfileDetails.Ready(
+                displayName = "Fresh name",
+                displayNameAmbiguous = false,
+                avatarUrl = "mxc://example.org/fresh",
+            )
+        )
+    }
+
+    @Test
+    fun `withLiveMemberOverride falls back to the event snapshot when no live member`() {
+        val result = eventProfile.withLiveMemberOverride(liveMember = null)
+
+        assertThat(result).isSameInstanceAs(eventProfile)
+    }
+
+    @Test
+    fun `withLiveMemberOverride falls back when the live member is banned`() {
+        val banned = aRoomMember(
+            userId = UserId("@bob:server.org"),
+            displayName = "Should be hidden",
+            avatarUrl = "mxc://example.org/banned",
+            membership = RoomMembershipState.BAN,
+        )
+
+        val result = eventProfile.withLiveMemberOverride(banned)
+
+        assertThat(result).isSameInstanceAs(eventProfile)
+    }
+
+    @Test
+    fun `withLiveMemberOverride propagates display-name ambiguity from the live member`() {
+        val liveMember = aRoomMember(
+            userId = UserId("@bob:server.org"),
+            displayName = "Bob",
+            avatarUrl = null,
+            isNameAmbiguous = true,
+        )
+
+        val result = eventProfile.withLiveMemberOverride(liveMember)
+
+        assertThat(result).isEqualTo(
+            ProfileDetails.Ready(
+                displayName = "Bob",
+                displayNameAmbiguous = true,
+                avatarUrl = null,
+            )
+        )
+    }
+
+    @Test
+    fun `withLiveMemberOverride starts from Unavailable snapshot and still uses live data`() {
+        val liveMember = aRoomMember(
+            userId = UserId("@bob:server.org"),
+            displayName = "Fresh name",
+            avatarUrl = "mxc://example.org/fresh",
+        )
+
+        val result = ProfileDetails.Unavailable.withLiveMemberOverride(liveMember)
+
+        assertThat(result).isEqualTo(
+            ProfileDetails.Ready(
+                displayName = "Fresh name",
+                displayNameAmbiguous = false,
+                avatarUrl = "mxc://example.org/fresh",
+            )
+        )
+    }
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/Timeline.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/Timeline.kt
@@ -54,6 +54,13 @@ interface Timeline : AutoCloseable {
     }
 
     val mode: Mode
+
+    /**
+     * Emits when a room member event arrives via sync that may have changed the cached member list,
+     * including both actual membership transitions (join/leave/invite/ban) and profile-only changes
+     * (display name / avatar). Subscribers should refetch members so that observers of
+     * [io.element.android.libraries.matrix.api.room.BaseRoom.membersStateFlow] see fresh data.
+     */
     val membershipChangeEventReceived: Flow<Unit>
     val onSyncedEventReceived: Flow<Unit>
     suspend fun sendReadReceipt(eventId: EventId, receiptType: ReceiptType): Result<Unit>

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessor.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.matrix.impl.timeline
 
 import androidx.compose.ui.util.fastForEach
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.ProfileChangeContent
 import io.element.android.libraries.matrix.api.timeline.item.event.RoomMembershipContent
 import io.element.android.libraries.matrix.api.timeline.item.event.TimelineItemEventOrigin
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -158,7 +159,8 @@ private class DiffingResult(initialItems: List<MatrixTimelineItem>) {
                 if (item.event.origin == TimelineItemEventOrigin.SYNC) {
                     hasNewEventsFromSync = true
                     when (item.event.content) {
-                        is RoomMembershipContent -> hasMembershipChangeEventFromSync = true
+                        is RoomMembershipContent,
+                        is ProfileChangeContent -> hasMembershipChangeEventFromSync = true
                         else -> Unit
                     }
                 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/TimelineItemContentMember.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/TimelineItemContentMember.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.fixtures.factories
+
+import io.element.android.libraries.matrix.test.A_USER_ID
+import org.matrix.rustcomponents.sdk.MembershipChange
+import org.matrix.rustcomponents.sdk.TimelineItemContent
+
+internal fun aRustTimelineItemContentProfileChange(
+    displayName: String? = "new-name",
+    prevDisplayName: String? = "old-name",
+    avatarUrl: String? = "mxc://example.org/new",
+    prevAvatarUrl: String? = "mxc://example.org/old",
+) = TimelineItemContent.ProfileChange(
+    displayName = displayName,
+    prevDisplayName = prevDisplayName,
+    avatarUrl = avatarUrl,
+    prevAvatarUrl = prevAvatarUrl,
+)
+
+internal fun aRustTimelineItemContentRoomMembership(
+    userId: String = A_USER_ID.value,
+    userDisplayName: String? = "name",
+    change: MembershipChange? = MembershipChange.JOINED,
+    reason: String? = null,
+) = TimelineItemContent.RoomMembership(
+    userId = userId,
+    userDisplayName = userDisplayName,
+    change = change,
+    reason = reason,
+)

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/MatrixTimelineDiffProcessorTest.kt
@@ -8,8 +8,13 @@
 
 package io.element.android.libraries.matrix.impl.timeline
 
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustEventTimelineItem
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustTimelineItemContentMsgLike
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustTimelineItemContentProfileChange
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustTimelineItemContentRoomMembership
 import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeFfiTimelineItem
 import io.element.android.libraries.matrix.impl.timeline.item.event.EventTimelineItemMapper
 import io.element.android.libraries.matrix.impl.timeline.item.event.TimelineEventContentMapper
@@ -23,6 +28,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.matrix.rustcomponents.sdk.TimelineDiff
+import uniffi.matrix_sdk_ui.EventItemOrigin
 
 class MatrixTimelineDiffProcessorTest {
     private val timelineItems = MutableStateFlow<List<MatrixTimelineItem>>(emptyList())
@@ -153,6 +159,69 @@ class MatrixTimelineDiffProcessorTest {
         assertThat(timelineItems.value).containsExactly(
             MatrixTimelineItem.Other,
         )
+    }
+
+    @Test
+    fun `RoomMembership event from sync emits on the membership change flow`() = runTest {
+        val membershipChangeFlow = MutableSharedFlow<Unit>(replay = 1)
+        val processor = createMatrixTimelineDiffProcessor(membershipChangeEventReceivedFlow = membershipChangeFlow)
+        membershipChangeFlow.test {
+            processor.postDiffs(
+                listOf(
+                    TimelineDiff.PushBack(
+                        FakeFfiTimelineItem(
+                            asEventResult = aRustEventTimelineItem(
+                                origin = EventItemOrigin.SYNC,
+                                content = aRustTimelineItemContentRoomMembership(),
+                            ),
+                        ),
+                    ),
+                )
+            )
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `ProfileChange event from sync emits on the membership change flow`() = runTest {
+        val membershipChangeFlow = MutableSharedFlow<Unit>(replay = 1)
+        val processor = createMatrixTimelineDiffProcessor(membershipChangeEventReceivedFlow = membershipChangeFlow)
+        membershipChangeFlow.test {
+            processor.postDiffs(
+                listOf(
+                    TimelineDiff.PushBack(
+                        FakeFfiTimelineItem(
+                            asEventResult = aRustEventTimelineItem(
+                                origin = EventItemOrigin.SYNC,
+                                content = aRustTimelineItemContentProfileChange(),
+                            ),
+                        ),
+                    ),
+                )
+            )
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `Plain message event does not emit on the membership change flow`() = runTest {
+        val membershipChangeFlow = MutableSharedFlow<Unit>(replay = 1)
+        val processor = createMatrixTimelineDiffProcessor(membershipChangeEventReceivedFlow = membershipChangeFlow)
+        membershipChangeFlow.test {
+            processor.postDiffs(
+                listOf(
+                    TimelineDiff.PushBack(
+                        FakeFfiTimelineItem(
+                            asEventResult = aRustEventTimelineItem(
+                                origin = EventItemOrigin.SYNC,
+                                content = aRustTimelineItemContentMsgLike(),
+                            ),
+                        ),
+                    ),
+                )
+            )
+            expectNoEvents()
+        }
     }
 }
 


### PR DESCRIPTION
## Content

Let live `RoomMember` updates override the event-level sender snapshot in `TimelineItemEventFactory`, so timeline rows already in the diff cache reflect avatar / display name changes that arrived via sync. Banned members keep the existing hide-identity behavior.

## Motivation and context

Closes #5176. Customers report that when another user changes their avatar or display name, the update doesn't appear until the app is restarted or the cache is cleared.

The issue was tagged `X-Needs-Rust`, but no `matrix-rust-sdk` change turned out to be necessary: the SDK already emits profile changes as `ProfileChangeContent` timeline events. The only SDK-layer tweak is in `MatrixTimelineDiffProcessor`, which now treats `ProfileChangeContent` (alongside the already-handled `RoomMembershipContent`) as a trigger for `membershipChangeEventReceived` so subscribers refresh the cached members list.

## Open question
Do we want this behind a feature flag for users who may want to keep the behavior of seeing historical snapshots of timeline events?

## Screenshots / GIFs

<!-- attach before/after recording of avatar updating live -->

## Tests

- New unit tests for `ProfileDetails.withLiveMemberOverride`: live member wins, null falls back, banned falls back, ambiguous name propagates, `Unavailable` snapshot still uses live data.
- Manual: change a peer's avatar from another client, confirm the timeline reflects it without restarting EXA.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Samsung Galaxy S24, Android 16

## Checklist

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR