### PR TITLE
Attempt to fix room list item duplicates at midnight

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSource.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSource.kt
@@ -83,8 +83,8 @@ class RoomListDataSource(
 
     val loadingState = roomList.loadingState
 
-    fun launchIn(coroutineScope: CoroutineScope) {
-        roomList
+    fun launchIn(coroutineScope: CoroutineScope): Job {
+        return roomList
             .summaries
             .onEach { roomSummaries ->
                 replaceWith(roomSummaries)
@@ -212,6 +212,7 @@ class RoomListDataSource(
     private suspend fun rebuildAllRoomSummaries() {
         lock.withLock {
             roomList.summaries.replayCache.firstOrNull()?.let { roomSummaries ->
+                diffCacheUpdater.updateWith(roomSummaries)
                 buildAndEmitAllRooms(roomSummaries, useCache = false)
             }
         }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSourceTest.kt
@@ -12,7 +12,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.impl.FakeDateTimeObserver
 import io.element.android.libraries.androidutils.system.DateTimeObserver
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.dateformatter.test.FakeDateFormatter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.test.A_ROOM_ID
@@ -217,7 +216,6 @@ class RoomListDataSourceTest {
             ),
             dateTimeObserver = dateTimeObserver,
         )
-        val testScope = this
         roomListDataSource.roomSummariesFlow.test {
             // Observe room list items changes
             val job = roomListDataSource.launchIn(backgroundScope)
@@ -268,11 +266,10 @@ class RoomListDataSourceTest {
         notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
         dateTimeObserver: FakeDateTimeObserver = FakeDateTimeObserver(),
         analyticsService: FakeAnalyticsService = FakeAnalyticsService(),
-        dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
     ) = RoomListDataSource(
         roomListService = roomListService,
         roomListRoomSummaryFactory = roomListRoomSummaryFactory,
-        coroutineDispatchers = dispatchers,
+        coroutineDispatchers = testCoroutineDispatchers(),
         notificationSettingsService = notificationSettingsService,
         sessionCoroutineScope = backgroundScope,
         dateTimeObserver = dateTimeObserver,

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSourceTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListDataSourceTest.kt
@@ -12,10 +12,12 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.impl.FakeDateTimeObserver
 import io.element.android.libraries.androidutils.system.DateTimeObserver
+import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.dateformatter.test.FakeDateFormatter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
+import io.element.android.libraries.matrix.test.A_ROOM_ID_3
 import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.room.aRoomSummary
 import io.element.android.libraries.matrix.test.roomlist.FakeDynamicRoomList
@@ -197,16 +199,80 @@ class RoomListDataSourceTest {
         }
     }
 
+    @Test
+    fun `regression test for race with DateTimeObserver and new items`() = runTest {
+        val roomList = FakeDynamicRoomList(summaries = MutableStateFlow(listOf(aRoomSummary(), aRoomSummary(A_ROOM_ID_2))))
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { roomList }
+        ).apply {
+            postState(RoomListService.State.Running)
+        }
+        val dateTimeObserver = FakeDateTimeObserver()
+        var dateFormatterResult = "Today"
+        val dateFormatter = FakeDateFormatter({ _, _, _ -> dateFormatterResult })
+        val roomListDataSource = createRoomListDataSource(
+            roomListService = roomListService,
+            roomListRoomSummaryFactory = aRoomListRoomSummaryFactory(
+                dateFormatter = dateFormatter,
+            ),
+            dateTimeObserver = dateTimeObserver,
+        )
+        val testScope = this
+        roomListDataSource.roomSummariesFlow.test {
+            // Observe room list items changes
+            val job = roomListDataSource.launchIn(backgroundScope)
+            // Get the initial room list
+            val initialRoomList = awaitItem()
+            assertThat(initialRoomList).hasSize(2)
+            assertThat(initialRoomList[0].roomId).isEqualTo(A_ROOM_ID)
+            assertThat(initialRoomList[0].timestamp).isEqualTo(dateFormatterResult)
+            assertThat(initialRoomList[1].roomId).isEqualTo(A_ROOM_ID_2)
+            assertThat(initialRoomList[1].timestamp).isEqualTo(dateFormatterResult)
+
+            // Stop processing room list updates so we can force a race condition with the date time observer updates
+            job.cancel()
+
+            // Trigger a date change and a new item at the same time
+            dateFormatterResult = "Yesterday"
+            roomList.summaries.tryEmit(listOf(aRoomSummary(roomId = A_ROOM_ID), aRoomSummary(roomId = A_ROOM_ID_3), aRoomSummary(roomId = A_ROOM_ID_2)))
+            dateTimeObserver.given(DateTimeObserver.Event.DateChanged(Instant.MIN, Instant.now()))
+
+            // The race condition would have caused the cache indices to be corrupted and only 2 items would be emitted
+            val rebuiltRoomList = awaitItem()
+            assertThat(rebuiltRoomList).hasSize(3)
+            assertThat(rebuiltRoomList[0].roomId).isEqualTo(A_ROOM_ID)
+            assertThat(rebuiltRoomList[0].timestamp).isEqualTo(dateFormatterResult)
+            assertThat(rebuiltRoomList[1].roomId).isEqualTo(A_ROOM_ID_3)
+            assertThat(rebuiltRoomList[1].timestamp).isEqualTo(dateFormatterResult)
+            assertThat(rebuiltRoomList[2].roomId).isEqualTo(A_ROOM_ID_2)
+            assertThat(rebuiltRoomList[2].timestamp).isEqualTo(dateFormatterResult)
+
+            // Restart processing room list updates
+            roomListDataSource.launchIn(backgroundScope)
+
+            // Check there is a new list and it's not the same as the previous one
+            val newRoomList = awaitItem()
+            assertThat(newRoomList).hasSize(3)
+            assertThat(newRoomList[0].roomId).isEqualTo(A_ROOM_ID)
+            assertThat(newRoomList[0].timestamp).isEqualTo(dateFormatterResult)
+            assertThat(newRoomList[1].roomId).isEqualTo(A_ROOM_ID_3)
+            assertThat(newRoomList[1].timestamp).isEqualTo(dateFormatterResult)
+            assertThat(newRoomList[2].roomId).isEqualTo(A_ROOM_ID_2)
+            assertThat(newRoomList[2].timestamp).isEqualTo(dateFormatterResult)
+        }
+    }
+
     private fun TestScope.createRoomListDataSource(
         roomListService: FakeRoomListService = FakeRoomListService(),
         roomListRoomSummaryFactory: RoomListRoomSummaryFactory = aRoomListRoomSummaryFactory(),
         notificationSettingsService: FakeNotificationSettingsService = FakeNotificationSettingsService(),
         dateTimeObserver: FakeDateTimeObserver = FakeDateTimeObserver(),
         analyticsService: FakeAnalyticsService = FakeAnalyticsService(),
+        dispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
     ) = RoomListDataSource(
         roomListService = roomListService,
         roomListRoomSummaryFactory = roomListRoomSummaryFactory,
-        coroutineDispatchers = testCoroutineDispatchers(),
+        coroutineDispatchers = dispatchers,
         notificationSettingsService = notificationSettingsService,
         sessionCoroutineScope = backgroundScope,
         dateTimeObserver = dateTimeObserver,


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

This seems to happen because of a race condition between `RoomListDataSource.observeDateTimeChanges` and `RoomListDataSource.replaceWith` being called at almost the same time and the first one using the newly received items from observing the timeline items but not updating the cache which will be later reused by `replaceWith`, containing incorrect indices.

Updating `diffCacheUpdater` inside `rebuildAllRoomSummaries` should fix this. The changes introduced in https://github.com/element-hq/element-x-android/pull/6791 should also make sure the issue is gone.

## Motivation and context

*Should* fix https://github.com/element-hq/element-x-android/issues/4182 and https://github.com/element-hq/element-x-android/issues/5031.

## Tests

Remove the line added in this PR and run the regression test. It should fail, proving the issue.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes (used Claude to confirm where this issue was coming from). In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
