### PR TITLE
Only load full media on media viewer when it's the visible item

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -19,6 +19,7 @@ import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.core.extensions.mapCatchingExceptions
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaFile
+import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaviewer.api.MediaViewerEntryPoint.MediaViewerMode
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
 
 class MediaViewerDataSource(
     mode: MediaViewerMode,
@@ -51,7 +53,7 @@ class MediaViewerDataSource(
     private val pagerKeysHandler: PagerKeysHandler,
 ) {
     // List of media files that are currently being loaded
-    private val mediaFiles: MutableList<MediaFile> = mutableListOf()
+    private val mediaFiles: ConcurrentHashMap<MediaSource, MediaFile> = ConcurrentHashMap()
 
     private val galleryMode = when (mode) {
         MediaViewerMode.SingleMedia,
@@ -69,7 +71,7 @@ class MediaViewerDataSource(
 
     fun dispose() {
         Timber.d("Disposing MediaViewerDataSource, closing ${mediaFiles.size} media files")
-        mediaFiles.forEach { it.close() }
+        mediaFiles.values.forEach { it.close() }
         mediaFiles.clear()
         localMediaStates.clear()
     }
@@ -163,6 +165,12 @@ class MediaViewerDataSource(
     }
 
     suspend fun loadMedia(data: MediaViewerPageData.MediaViewerData) {
+        val currentState = localMediaStates[data.mediaSource.safeUrl]?.value
+        // If the media is already loading or has been loaded successfully, do nothing
+        if (currentState?.isLoading() == true || currentState?.isSuccess() == true) {
+            return
+        }
+
         Timber.d("loadMedia for ${data.eventId}")
         val localMediaState = localMediaStates.getOrPut(data.mediaSource.safeUrl) {
             mutableStateOf(AsyncData.Uninitialized)
@@ -175,7 +183,7 @@ class MediaViewerDataSource(
                 filename = data.mediaInfo.filename
             )
             .onSuccess { mediaFile ->
-                mediaFiles.add(mediaFile)
+                mediaFiles[data.mediaSource] = mediaFile
             }
             .mapCatchingExceptions { mediaFile ->
                 localMediaFactory.createFromMediaFile(

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -198,4 +198,12 @@ class MediaViewerDataSource(
                 localMediaState.value = AsyncData.Failure(it)
             }
     }
+
+    fun cancelLoadingMedia(data: MediaViewerPageData.MediaViewerData) {
+        if (localMediaStates[data.mediaSource.safeUrl]?.value?.isLoading() == true) {
+            Timber.d("cancelLoadingMedia for ${data.eventId}")
+            mediaFiles.remove(data.mediaSource)?.close()
+            localMediaStates[data.mediaSource.safeUrl]?.value = AsyncData.Uninitialized
+        }
+    }
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerEvent.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerEvent.kt
@@ -29,4 +29,5 @@ sealed interface MediaViewerEvent {
     data class Delete(val eventId: EventId) : MediaViewerEvent
     data class OnNavigateTo(val index: Int) : MediaViewerEvent
     data class LoadMore(val direction: Timeline.PaginationDirection) : MediaViewerEvent
+    data class CancelLoadingMedia(val data: MediaViewerPageData.MediaViewerData) : MediaViewerEvent
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -100,6 +100,9 @@ class MediaViewerPresenter(
                 is MediaViewerEvent.LoadMedia -> {
                     coroutineScope.downloadMedia(data = event.data)
                 }
+                is MediaViewerEvent.CancelLoadingMedia -> {
+                    dataSource.cancelLoadingMedia(event.data)
+                }
                 is MediaViewerEvent.ClearLoadingError -> {
                     dataSource.clearLoadingError(event.data)
                 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.onVisibilityChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
@@ -208,11 +209,15 @@ fun MediaViewerView(
                 }
                 is MediaViewerPageData.MediaViewerData -> {
                     var bottomPaddingInPixels by remember { mutableIntStateOf(defaultBottomPaddingInPixels) }
-                    LaunchedEffect(Unit) {
-                        state.eventSink(MediaViewerEvent.LoadMedia(dataForPage))
-                    }
                     Box(
                         modifier = Modifier.fillMaxSize()
+                        modifier = Modifier
+                            .onVisibilityChanged(minDurationMs = 200L) { isVisible ->
+                                if (isVisible) {
+                                    state.eventSink(MediaViewerEvent.LoadMedia(dataForPage))
+                                }
+                            }
+                            .fillMaxSize()
                     ) {
                         val isDisplayed = remember(pagerState.settledPage) {
                             // This 'item provider' lambda will be called when the data source changes with an outdated `settlePage` value

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -210,11 +210,12 @@ fun MediaViewerView(
                 is MediaViewerPageData.MediaViewerData -> {
                     var bottomPaddingInPixels by remember { mutableIntStateOf(defaultBottomPaddingInPixels) }
                     Box(
-                        modifier = Modifier.fillMaxSize()
                         modifier = Modifier
                             .onVisibilityChanged(minDurationMs = 200L) { isVisible ->
                                 if (isVisible) {
                                     state.eventSink(MediaViewerEvent.LoadMedia(dataForPage))
+                                } else {
+                                    state.eventSink(MediaViewerEvent.CancelLoadingMedia(dataForPage))
                                 }
                             }
                             .fillMaxSize()

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
@@ -52,6 +52,10 @@ class MediaViewerViewTest {
                 state = state,
                 onBackClick = callback,
             )
+
+            // Wait for enough time for the onVisibilityChanged modifier to trigger
+            mainClock.advanceTimeBy(200)
+
             pressBack()
         }
         eventsRecorder.assertList(
@@ -110,6 +114,10 @@ class MediaViewerViewTest {
                 eventSink = eventsRecorder
             ),
         )
+
+        // Wait for enough time for the onVisibilityChanged modifier to trigger
+        mainClock.advanceTimeBy(200)
+
         val contentDescription = activity!!.getString(contentDescriptionRes)
         onNodeWithContentDescription(contentDescription).performClick()
         eventsRecorder.assertList(
@@ -241,6 +249,10 @@ class MediaViewerViewTest {
                 eventSink = eventsRecorder
             ),
         )
+
+        // Wait for enough time for the onVisibilityChanged modifier to trigger
+        mainClock.advanceTimeBy(200)
+
         clickOn(CommonStrings.action_retry)
         eventsRecorder.assertList(
             listOf(
@@ -263,6 +275,10 @@ class MediaViewerViewTest {
                 eventSink = eventsRecorder
             ),
         )
+
+        // Wait for enough time for the onVisibilityChanged modifier to trigger
+        mainClock.advanceTimeBy(200)
+
         clickOn(CommonStrings.action_cancel)
         eventsRecorder.assertList(
             listOf(


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

In the media viewer screen:
- Only load the full media for the currently displayed item.
- Cancel loading the full media for items if you scroll to another item.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6792.

What's not addressed but could also be useful:

- Loading the full media only when using Wi-Fi.
- Delay loading the full media for videos until the play button is clicked on.

## Screenshots / GIFs

No UI changes, I hope.

## Tests

Open the media viewer in a room where you have a mix of images and videos. Check the logs only contain `/download` log lines for the current item, and if you scroll fast enough you see logs for cancelled downloads.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
