### PR TITLE
Fix 'Conversation label cannot be empty' error

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -571,7 +571,7 @@ class MessageComposerPresenter(
         notificationConversationService.onSendMessage(
             sessionId = room.sessionId,
             roomId = roomInfo.id,
-            roomName = roomInfo.name ?: roomInfo.id.value,
+            roomName = roomInfo.name,
             roomIsDirect = roomInfo.isDm,
             roomAvatarUrl = roomInfo.avatarUrl ?: roomMembers.getDirectRoomMember(roomInfo = roomInfo, sessionId = room.sessionId)?.avatarUrl,
         )

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/notifications/conversations/NotificationConversationService.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/notifications/conversations/NotificationConversationService.kt
@@ -22,7 +22,7 @@ interface NotificationConversationService {
     suspend fun onSendMessage(
         sessionId: SessionId,
         roomId: RoomId,
-        roomName: String,
+        roomName: String?,
         roomIsDirect: Boolean,
         roomAvatarUrl: String?,
     )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
@@ -76,7 +76,7 @@ class DefaultNotificationConversationService(
     override suspend fun onSendMessage(
         sessionId: SessionId,
         roomId: RoomId,
-        roomName: String,
+        roomName: String?,
         roomIsDirect: Boolean,
         roomAvatarUrl: String?,
     ) {
@@ -93,10 +93,11 @@ class DefaultNotificationConversationService(
         val imageLoader = imageLoaderHolder.get(client)
 
         val defaultShortcutIconSize = ShortcutManagerCompat.getIconMaxWidth(context)
+        val name = roomName?.takeIf { it.isNotBlank() } ?: roomId.value
         val icon = bitmapLoader.getRoomBitmap(
             avatarData = AvatarData(
                 id = roomId.value,
-                name = roomName,
+                name = name,
                 url = roomAvatarUrl,
                 size = AvatarSize.RoomDetailsHeader,
             ),
@@ -105,7 +106,7 @@ class DefaultNotificationConversationService(
         )?.let(IconCompat::createWithBitmap)
 
         val shortcutInfo = ShortcutInfoCompat.Builder(context, createShortcutId(sessionId, roomId))
-            .setShortLabel(roomName)
+            .setShortLabel(name)
             .setIcon(icon)
             .setIntent(intentProvider.getViewRoomIntent(sessionId, roomId, threadId = null, eventId = null))
             .setCategories(categories)

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/conversations/FakeNotificationConversationService.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/conversations/FakeNotificationConversationService.kt
@@ -16,7 +16,7 @@ class FakeNotificationConversationService : NotificationConversationService {
     override suspend fun onSendMessage(
         sessionId: SessionId,
         roomId: RoomId,
-        roomName: String,
+        roomName: String?,
         roomIsDirect: Boolean,
         roomAvatarUrl: String?,
     ) = Unit


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Make sure we provide a non-blank room name or id to the shortcut info builder.

## Motivation and context

This happens when building a `ShortcutInfoCompat` in `DefaultNotificationConversationService.onSendMessage` when the provided room name is not null but it's empty.

Fixes a rageshake: https://github.com/element-hq/element-x-android-rageshakes/issues/13220

## Tests

<del>To be honest, I'm not entirely sure how to reproduce this because an empty room name state event translates to a room with an `Empty room` name according to my tests, but I guess some users somehow bypassed this. Assuming you'd be able to do the same, the flow to test this would be:</del>

- Rename a room to a blank value like a single whitespace character.
- Send a message to that room.
- Check the app doesn't crash and the shortcut is created using the room id.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
