### PR TITLE
Release proximity wakelock on Element Call when call ends

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/WebViewAudioManager.kt
@@ -201,12 +201,9 @@ class WebViewAudioManager(
             return
         }
 
-        coroutineScope.launch {
-            proximitySensorMutex.withLock {
-                if (proximitySensorWakeLock?.isHeld == true) {
-                    proximitySensorWakeLock?.release()
-                }
-            }
+        // Since this should run when the call is no longer running, it should be OK to not use the mutex here
+        if (proximitySensorWakeLock?.isHeld == true) {
+            proximitySensorWakeLock?.release()
         }
 
         audioManager.mode = AudioManager.MODE_NORMAL


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

The `CoroutineScope` that launched this logic was cancelled by that point, so the wakelock was never released. Since the call already ended it should be OK to skip the mutex and ensure the wakelock is released in the main thread.

## Motivation and context

Replacement of https://github.com/element-hq/element-x-android/pull/6752.

Fixes https://github.com/element-hq/element-x-android/issues/6815.

## Tests

- In a DM, start a voice call.
- Don't answer it and let it automatically end with a timeout.
- Check the proximity sensor is no longer active, dimming the screen brightness when you place your device next to your ear.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
