### PR TITLE
Remove DI-generated code from Kover reports

### DIFF
--- a/plugins/src/main/kotlin/extension/KoverExtension.kt
+++ b/plugins/src/main/kotlin/extension/KoverExtension.kt
@@ -126,6 +126,11 @@ fun Project.setupKover() {
                         "io.element.android.tests.konsist.failures",
                         // Copied from Appyx
                         "io.element.android.libraries.architecture.appyx.SafeChildrenTransitionScope",
+                        // DI-generated classes
+                        "io.element.android.x.di.*Impl",
+                        "io.element.android.x.di.*Impls",
+                        "io.element.android.x.di.*Mirror",
+                        "io.element.android.x.di.*Factory",
                     )
                     annotatedBy(
                         "androidx.compose.ui.tooling.preview.Preview",

--- a/plugins/src/main/kotlin/extension/KoverExtension.kt
+++ b/plugins/src/main/kotlin/extension/KoverExtension.kt
@@ -131,6 +131,9 @@ fun Project.setupKover() {
                         "io.element.android.x.di.*Impls",
                         "io.element.android.x.di.*Mirror",
                         "io.element.android.x.di.*Factory",
+                        $$"io.element.android.*$Metro*",
+                        $$"io.element.android.*$Factory*",
+                        $$"io.element.android.*$Impl*",
                     )
                     annotatedBy(
                         "androidx.compose.ui.tooling.preview.Preview",


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says.

## Motivation and context

In https://github.com/element-hq/element-x-android/pull/6832 I realised a DI-only change was causing generated code changes that modified the coverage.

This PR mostly reverts the coverage percentage lost by not measuring some common generated classed by Metro DI.

## Tests

Coverage should go up. The regexes should be specific enough to only affect classes related to Metro DI, like:

<img width="522" height="306" alt="image" src="https://github.com/user-attachments/assets/94778c31-6486-4f05-ae2b-7d824db19f51" />

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
