### PR TITLE
Fix formatting inconsistencies in latest event summaries

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
@@ -93,8 +93,8 @@ class DefaultRoomLatestEventFormatter(
                 message.prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
             }
             is StickerContent -> {
-                val message = sp.getString(CommonStrings.common_sticker) + " (" + content.bestDescription + ")"
-                message.prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
+                content.bestDescription.prefixWith(sp.getString(CommonStrings.common_sticker))
+                    .prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
             }
             is UnableToDecryptContent -> {
                 val message = sp.getString(CommonStrings.common_waiting_for_decryption_key)
@@ -110,8 +110,8 @@ class DefaultRoomLatestEventFormatter(
                 stateContentFormatter.format(content, senderDisambiguatedDisplayName, isOutgoing, RenderingMode.RoomList)
             }
             is PollContent -> {
-                val message = sp.getString(CommonStrings.common_poll_summary, content.question)
-                message.prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
+                content.question.prefixWith(sp.getString(CommonStrings.a11y_poll))
+                    .prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
             }
             is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {
                 val message = sp.getString(CommonStrings.common_unsupported_event)

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
@@ -110,7 +110,7 @@ class DefaultRoomLatestEventFormatter(
                 stateContentFormatter.format(content, senderDisambiguatedDisplayName, isOutgoing, RenderingMode.RoomList)
             }
             is PollContent -> {
-                content.question.prefixWith(sp.getString(CommonStrings.a11y_poll))
+                content.question.prefixWith(sp.getString(CommonStrings.common_poll_summary_prefix))
                     .prefixIfNeeded(senderDisambiguatedDisplayName, isDmRoom, isOutgoing)
             }
             is FailedToParseMessageLikeContent, is FailedToParseStateContent, is UnknownContent -> {

--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/PrefixWith.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/PrefixWith.kt
@@ -20,6 +20,10 @@ internal fun CharSequence.prefixWith(prefix: String): AnnotatedString {
             append(prefix)
         }
         append(": ")
-        append(this@prefixWith)
+        if (this@prefixWith is AnnotatedString) {
+            append(this@prefixWith)
+        } else {
+            append(this@prefixWith.toString())
+        }
     }
 }

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatterTest.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.eventformatter.impl
 
 import android.content.Context
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import io.element.android.libraries.matrix.api.core.UserId
@@ -104,6 +105,13 @@ class DefaultRoomLatestEventFormatterTest {
         val message = createLatestEvent(false, null, aStickerContent(body, info, aMediaSource(url = "url")))
         val result = formatter.format(message, false)
         val expectedBody = someoneElseId.value + ": Sticker: a sticker body"
+        // Check we have formatting
+        assertThat(result is AnnotatedString).isTrue()
+        // And there is a bold span for the 'Sticker' part
+        val boldSpanStyle = (result as AnnotatedString).spanStyles.lastOrNull { it.item.fontWeight == FontWeight.Bold }
+        assertThat(boldSpanStyle).isNotNull()
+        val spanStart = someoneElseId.value.length + 2
+        assertThat(boldSpanStyle!!.start..boldSpanStyle.end).isEqualTo(spanStart..spanStart + 7)
         assertThat(result.toString()).isEqualTo(expectedBody)
     }
 
@@ -913,6 +921,14 @@ class DefaultRoomLatestEventFormatterTest {
 
         val contentEvent = createLatestEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
         assertThat(formatter.format(contentEvent, true).toString()).isEqualTo("Poll: Do you like polls?")
+
+        val result = formatter.format(contentEvent, true)
+        // Check we have formatting
+        assertThat(result is AnnotatedString).isTrue()
+        // And there is a bold span for the 'Poll' part
+        val boldSpanStyle = (result as AnnotatedString).spanStyles.lastOrNull { it.item.fontWeight == FontWeight.Bold }
+        assertThat(boldSpanStyle).isNotNull()
+        assertThat(boldSpanStyle!!.start..boldSpanStyle.end).isEqualTo(0..4)
     }
 
     @Test
@@ -925,6 +941,15 @@ class DefaultRoomLatestEventFormatterTest {
 
         val contentEvent = createLatestEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
         assertThat(formatter.format(contentEvent, false).toString()).isEqualTo("Bob: Poll: Do you like polls?")
+
+        val result = formatter.format(contentEvent, false)
+        // Check we have formatting
+        assertThat(result is AnnotatedString).isTrue()
+        // And there is a bold span for the 'Poll' part
+        val boldSpanStyle = (result as AnnotatedString).spanStyles.lastOrNull { it.item.fontWeight == FontWeight.Bold }
+        assertThat(boldSpanStyle).isNotNull()
+        val spanStart = "Bob".length + 2
+        assertThat(boldSpanStyle!!.start..boldSpanStyle.end).isEqualTo(spanStart..spanStart + 4)
     }
 
     // endregion

--- a/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatterTest.kt
+++ b/libraries/eventformatter/impl/src/test/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatterTest.kt
@@ -103,7 +103,7 @@ class DefaultRoomLatestEventFormatterTest {
         val info = ImageInfo(null, null, null, null, null, null, null)
         val message = createLatestEvent(false, null, aStickerContent(body, info, aMediaSource(url = "url")))
         val result = formatter.format(message, false)
-        val expectedBody = someoneElseId.value + ": Sticker (a sticker body)"
+        val expectedBody = someoneElseId.value + ": Sticker: a sticker body"
         assertThat(result.toString()).isEqualTo(expectedBody)
     }
 
@@ -909,10 +909,10 @@ class DefaultRoomLatestEventFormatterTest {
         val pollContent = aPollContent()
 
         val mineContentEvent = createLatestEvent(sentByYou = true, senderDisplayName = "Alice", content = pollContent)
-        assertThat(formatter.format(mineContentEvent, true)).isEqualTo("Poll: Do you like polls?")
+        assertThat(formatter.format(mineContentEvent, true).toString()).isEqualTo("Poll: Do you like polls?")
 
         val contentEvent = createLatestEvent(sentByYou = false, senderDisplayName = "Bob", content = pollContent)
-        assertThat(formatter.format(contentEvent, true)).isEqualTo("Poll: Do you like polls?")
+        assertThat(formatter.format(contentEvent, true).toString()).isEqualTo("Poll: Do you like polls?")
     }
 
     @Test

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -303,6 +303,7 @@ Reason: %1$s."</string>
   <string name="common_please_wait">"Please wait…"</string>
   <string name="common_poll_end_confirmation">"Are you sure you want to end this poll?"</string>
   <string name="common_poll_summary">"Poll: %1$s"</string>
+  <string name="common_poll_summary_prefix">"Poll"</string>
   <string name="common_poll_total_votes">"Total votes: %1$s"</string>
   <string name="common_poll_undisclosed_text">"Results will show after the poll has ended"</string>
   <plurals name="common_poll_votes_count">


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

|Before|After|
|-|-|
|Poll: poll body|**Poll**: poll body|
|Sticker (sticker body)|**Sticker**: sticker body|

## Motivation and context

Make it consistent with the other message types

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

- Send a sticker/poll message
- Go back to the room list

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
