### PR TITLE
Use `runBlocking` for the token refresh logic

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegate.kt
@@ -8,7 +8,7 @@
 
 package io.element.android.libraries.matrix.impl
 
-import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.matrix.impl.core.SdkBackgroundTaskError
 import io.element.android.libraries.matrix.impl.mapper.toSessionData
@@ -19,6 +19,7 @@ import io.element.android.services.analytics.api.AnalyticsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.matrix.rustcomponents.sdk.ClientDelegate
 import org.matrix.rustcomponents.sdk.ClientSessionDelegate
 import org.matrix.rustcomponents.sdk.Session
@@ -41,13 +42,9 @@ class RustClientSessionDelegate(
     private val sessionStore: SessionStore,
     private val appCoroutineScope: CoroutineScope,
     private val analyticsService: AnalyticsService,
-    coroutineDispatchers: CoroutineDispatchers,
 ) : ClientSessionDelegate, ClientDelegate {
     // Used to ensure several calls to `didReceiveAuthError` don't trigger multiple logouts
     private val isLoggingOut = AtomicBoolean(false)
-
-    // To make sure only one coroutine affecting the token persistence can run at a time
-    private val updateTokensDispatcher = coroutineDispatchers.io.limitedParallelism(1)
 
     // This Client needs to be set up as soon as possible so `didReceiveAuthError` can work properly.
     private var client: WeakReference<RustMatrixClient> = WeakReference(null)
@@ -66,9 +63,10 @@ class RustClientSessionDelegate(
         this.client.clear()
     }
 
+    // This always runs on a background thread, so we *can* do blocking calls here, although we should avoid doing heavy work
     override fun saveSessionInKeychain(session: Session) {
-        appCoroutineScope.launch(updateTokensDispatcher) {
-            val existingData = sessionStore.getSession(session.userId) ?: return@launch
+        runCatchingExceptions {
+            val existingData = runBlocking { sessionStore.getSession(session.userId) } ?: return
             val (anonymizedAccessToken, anonymizedRefreshToken) = session.anonymizedTokens()
             Timber.tag(loggerTag.value).d(
                 "Saving new session data with token: access token '$anonymizedAccessToken' and refresh token '$anonymizedRefreshToken'. " +
@@ -80,28 +78,27 @@ class RustClientSessionDelegate(
                 passphrase = existingData.passphrase,
                 sessionPaths = existingData.getSessionPaths(),
             )
-            sessionStore.updateData(newData)
+            runBlocking { sessionStore.updateData(newData) }
             Timber.tag(loggerTag.value).d("Saved new session data with access token: '$anonymizedAccessToken'.")
-        }.invokeOnCompletion {
-            if (it != null) {
-                Timber.tag(loggerTag.value).e(it, "Failed to save new session data.")
-            }
+        }.onFailure {
+            Timber.tag(loggerTag.value).e(it, "Failed to save new session data.")
         }
     }
 
+    // This always runs on a background thread, so we *can* do blocking calls here, although we should avoid doing heavy work
     override fun didReceiveAuthError(isSoftLogout: Boolean) {
-        Timber.tag(loggerTag.value).w("didReceiveAuthError(isSoftLogout=$isSoftLogout)")
-        if (isLoggingOut.getAndSet(true).not()) {
-            Timber.tag(loggerTag.value).v("didReceiveAuthError -> do the cleanup")
-            // TODO handle isSoftLogout parameter.
-            appCoroutineScope.launch(updateTokensDispatcher) {
+        runCatchingExceptions {
+            Timber.tag(loggerTag.value).w("didReceiveAuthError(isSoftLogout=$isSoftLogout)")
+            if (isLoggingOut.getAndSet(true).not()) {
+                Timber.tag(loggerTag.value).v("didReceiveAuthError -> do the cleanup")
+                // TODO handle isSoftLogout parameter.
                 val currentClient = client.get()
                 if (currentClient == null) {
                     Timber.tag(loggerTag.value).w("didReceiveAuthError -> no client, exiting")
                     isLoggingOut.set(false)
-                    return@launch
+                    return
                 }
-                val existingData = sessionStore.getSession(currentClient.sessionId.value)
+                val existingData = runBlocking { sessionStore.getSession(currentClient.sessionId.value) }
                 val (anonymizedAccessToken, anonymizedRefreshToken) = existingData.anonymizedTokens()
                 Timber.tag(loggerTag.value).d(
                     "Removing session data with access token '$anonymizedAccessToken' " +
@@ -110,19 +107,17 @@ class RustClientSessionDelegate(
                 if (existingData != null) {
                     // Set isTokenValid to false
                     val newData = existingData.copy(isTokenValid = false)
-                    sessionStore.updateData(newData)
+                    runBlocking { sessionStore.updateData(newData) }
                     Timber.tag(loggerTag.value).d("Invalidated session data with access token: '$anonymizedAccessToken'.")
                 } else {
                     Timber.tag(loggerTag.value).d("No session data found.")
                 }
-                currentClient.logout(userInitiated = false, ignoreSdkError = true)
-            }.invokeOnCompletion {
-                if (it != null) {
-                    Timber.tag(loggerTag.value).e(it, "Failed to remove session data.")
-                }
+                appCoroutineScope.launch { currentClient.logout(userInitiated = false, ignoreSdkError = true) }
+            } else {
+                Timber.tag(loggerTag.value).v("didReceiveAuthError -> already cleaning up")
             }
-        } else {
-            Timber.tag(loggerTag.value).v("didReceiveAuthError -> already cleaning up")
+        }.onFailure {
+            Timber.tag(loggerTag.value).e(it, "Failed to remove session data.")
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -72,7 +72,6 @@ class RustMatrixClientFactory(
         sessionStore = sessionStore,
         appCoroutineScope = appCoroutineScope,
         analyticsService = analyticsService,
-        coroutineDispatchers = coroutineDispatchers
     )
 
     suspend fun create(sessionData: SessionData): RustMatrixClient = withContext(coroutineDispatchers.io) {

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustClientSessionDelegateTest.kt
@@ -16,15 +16,11 @@ import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
 import io.element.android.libraries.sessionstorage.test.aSessionData
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.test.FakeAnalyticsService
-import io.element.android.tests.testutils.testCoroutineDispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import uniffi.matrix_sdk_common.BackgroundTaskFailureReason
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RustClientSessionDelegateTest {
     @Test
     fun `saveSessionInKeychain should update the store`() = runTest {
@@ -43,7 +39,6 @@ class RustClientSessionDelegateTest {
                 refreshToken = "rt",
             )
         )
-        runCurrent()
         val result = sessionStore.getLatestSession()
         assertThat(result!!.accessToken).isEqualTo("at")
         assertThat(result.refreshToken).isEqualTo("rt")
@@ -80,5 +75,4 @@ fun TestScope.aRustClientSessionDelegate(
     sessionStore = sessionStore,
     appCoroutineScope = this,
     analyticsService = analyticsService,
-    coroutineDispatchers = testCoroutineDispatchers(),
 )


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

The `RustClientSessionDelegate` callbacks always run in a separate thread, so they don't block the main thread. For the `suspend` calls of these functions, use `runBlocking`.

## Motivation and context

This ensures the token refresh is fully done (data saved/failed to) before the SDK continues sending the pending previously failed requests.

Should help with https://github.com/element-hq/element-x-android/issues/6656.

Also, @sandhose mentioned this is the way we should handle this flow: refresh, save, then use it, with no parallelization.

## Tests

Have this branch running for a while, until your tokens are refreshed. Then check the UI doesn't get frozen/janky when this happens. In my case, the logs didn't display any frame drops:

```
18:09:06.896 org.matrix.rust.sdk     io.element.android.x.debug           V  matrix_sdk::authentication::oauth: Token refresh: attempting to refresh with refresh_token xxx | crates/matrix-sdk/src/authentication/oauth/mod.rs:1137
18:09:07.045 org.matrix.rust.sdk     io.element.android.x.debug           V  matrix_sdk::authentication::oauth: Token refresh: new refresh_token: xxx / access_token: xxx | crates/matrix-sdk/src/authentication/oauth/mod.rs:1155
18:09:07.045 org.matrix.rust.sdk     io.element.android.x.debug           D  matrix_sdk::authentication::oauth: call save_session_callback | crates/matrix-sdk/src/authentication/oauth/mod.rs:1178
18:09:07.054 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: [RustClientSessionDelegate] Saving new session data with token: access token 'xxx' and refresh token 'xxx'. Was token valid: true | RustClientSessionDelegate.kt:71
18:09:07.068 org.matrix.rust.sdk     io.element.android.x.debug           D  elementx: [RustClientSessionDelegate] Saved new session data with access token: 'xxx'. | RustClientSessionDelegate.kt:82
```

And when adding some logs to check the threads the callbacks are running on I saw `Running on Thread XX` with no mention of 'main' at all.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
