### PR TITLE
Fix app having a pink top bar in the recent app list when PIN lock is setup

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -11,7 +11,14 @@
         <item name="windowSplashScreenBackground">@color/splashscreen_bg_dark</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/transparent</item>
         <item name="postSplashScreenTheme">@style/Theme.ElementX</item>
+        <item name="android:windowBackground">@color/splashscreen_bg_dark</item>
+        <item name="android:statusBarColor">@color/splashscreen_bg_dark</item>
+        <item name="android:navigationBarColor">@color/splashscreen_bg_dark</item>
     </style>
 
-    <style name="Theme.ElementX" parent="Theme.Material3.Dark.NoActionBar" />
+    <style name="Theme.ElementX" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="android:windowBackground">@color/splashscreen_bg_dark</item>
+        <item name="android:statusBarColor">@color/splashscreen_bg_dark</item>
+        <item name="android:navigationBarColor">@color/splashscreen_bg_dark</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,8 +10,14 @@
         <item name="windowSplashScreenBackground">@color/splashscreen_bg_light</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/transparent</item>
         <item name="postSplashScreenTheme">@style/Theme.ElementX</item>
+        <item name="android:windowBackground">@color/splashscreen_bg_light</item>
+        <item name="android:statusBarColor">@color/splashscreen_bg_light</item>
+        <item name="android:navigationBarColor">@color/splashscreen_bg_light</item>
     </style>
     <style name="Theme.ElementX" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+        <item name="android:windowBackground">@color/splashscreen_bg_light</item>
+        <item name="android:statusBarColor">@color/splashscreen_bg_light</item>
+        <item name="android:navigationBarColor">@color/splashscreen_bg_light</item>
     </style>
 </resources>


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Fix ambiguity in the app theme leading to the `FLAG_SECURE` splash screen having a pink top bar

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Setup the app PIN lock
- Leave the app
- Open the recent app list
  - Should have the default background canvas color (in this case `@color/splashscreen_bg_dark`) for the entire screen

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
