### PR TITLE
Add "Allow screenshots" option to the Screen lock

### DIFF
--- a/features/lockscreen/api/src/main/kotlin/io/element/android/features/lockscreen/api/LockScreenService.kt
+++ b/features/lockscreen/api/src/main/kotlin/io/element/android/features/lockscreen/api/LockScreenService.kt
@@ -14,6 +14,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -34,6 +35,12 @@ interface LockScreenService {
      * @return true if the pin is setup, false otherwise.
      */
     fun isPinSetup(): Flow<Boolean>
+
+    /**
+     * Check if screenshots are allowed when the lock screen is enabled.
+     * @return true if screenshots are allowed, false otherwise.
+     */
+    fun isAllowScreenshotsAllowed(): Flow<Boolean>
 }
 
 /**
@@ -41,12 +48,17 @@ interface LockScreenService {
  * @param activity the activity to set the flag on.
  */
 fun LockScreenService.handleSecureFlag(activity: ComponentActivity) {
-    isPinSetup()
-        .onEach { isPinSetup ->
+    combine(
+        isPinSetup(),
+        isAllowScreenshotsAllowed()
+    ) { isPinSetup, isAllowScreenshotsAllowed ->
+        isPinSetup && !isAllowScreenshotsAllowed
+    }
+        .onEach { shouldSetSecureFlag ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                activity.setRecentsScreenshotEnabled(!isPinSetup)
+                activity.setRecentsScreenshotEnabled(!shouldSetSecureFlag)
             } else {
-                if (isPinSetup) {
+                if (shouldSetSecureFlag) {
                     activity.window.setFlags(
                         WindowManager.LayoutParams.FLAG_SECURE,
                         WindowManager.LayoutParams.FLAG_SECURE

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
@@ -107,6 +107,10 @@ class DefaultLockScreenService(
         return pinCodeManager.hasPinCode()
     }
 
+    override fun isAllowScreenshotsAllowed(): Flow<Boolean> {
+        return lockScreenStore.isAllowScreenshotsAllowed()
+    }
+
     override fun isSetupRequired(): Flow<Boolean> {
         return isPinSetup().map { isPinSetup ->
             !isPinSetup && lockScreenConfig.isPinMandatory

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsEvent.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsEvent.kt
@@ -13,4 +13,5 @@ sealed interface LockScreenSettingsEvent {
     data object ConfirmRemovePin : LockScreenSettingsEvent
     data object CancelRemovePin : LockScreenSettingsEvent
     data object ToggleBiometricAllowed : LockScreenSettingsEvent
+    data object ToggleAllowScreenshots : LockScreenSettingsEvent
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
@@ -37,13 +37,17 @@ class LockScreenSettingsPresenter(
 ) : Presenter<LockScreenSettingsState> {
     @Composable
     override fun present(): LockScreenSettingsState {
-        val showRemovePinOption by produceState(initialValue = false) {
+        val hasPinCode by produceState(initialValue = false) {
             pinCodeManager.hasPinCode().collect { hasPinCode ->
-                value = !lockScreenConfig.isPinMandatory && hasPinCode
+                value = hasPinCode
             }
         }
+        val showRemovePinOption = !lockScreenConfig.isPinMandatory && hasPinCode
         val isBiometricEnabled by remember {
             lockScreenStore.isBiometricUnlockAllowed()
+        }.collectAsState(initial = false)
+        val isAllowScreenshotsEnabled by remember {
+            lockScreenStore.isAllowScreenshotsAllowed()
         }.collectAsState(initial = false)
         var showRemovePinConfirmation by remember {
             mutableStateOf(false)
@@ -76,6 +80,11 @@ class LockScreenSettingsPresenter(
                         }
                     }
                 }
+                LockScreenSettingsEvent.ToggleAllowScreenshots -> {
+                    coroutineScope.launch {
+                        lockScreenStore.setIsAllowScreenshotsAllowed(!isAllowScreenshotsEnabled)
+                    }
+                }
             }
         }
 
@@ -84,6 +93,8 @@ class LockScreenSettingsPresenter(
             isBiometricEnabled = isBiometricEnabled,
             showRemovePinConfirmation = showRemovePinConfirmation,
             showToggleBiometric = biometricAuthenticatorManager.isDeviceSecured,
+            isAllowScreenshotsEnabled = isAllowScreenshotsEnabled,
+            showAllowScreenshots = hasPinCode,
             eventSink = ::handleEvent,
         )
     }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsState.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsState.kt
@@ -13,5 +13,7 @@ data class LockScreenSettingsState(
     val isBiometricEnabled: Boolean,
     val showRemovePinConfirmation: Boolean,
     val showToggleBiometric: Boolean,
+    val isAllowScreenshotsEnabled: Boolean,
+    val showAllowScreenshots: Boolean,
     val eventSink: (LockScreenSettingsEvent) -> Unit
 )

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsStateProvider.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsStateProvider.kt
@@ -24,10 +24,14 @@ fun aLockScreenSettingsState(
     isBiometricEnabled: Boolean = false,
     showRemovePinConfirmation: Boolean = false,
     showToggleBiometric: Boolean = true,
+    isAllowScreenshotsEnabled: Boolean = false,
+    showAllowScreenshots: Boolean = true,
 ) = LockScreenSettingsState(
     showRemovePinOption = isLockMandatory,
     isBiometricEnabled = isBiometricEnabled,
     showRemovePinConfirmation = showRemovePinConfirmation,
     showToggleBiometric = showToggleBiometric,
+    isAllowScreenshotsEnabled = isAllowScreenshotsEnabled,
+    showAllowScreenshots = showAllowScreenshots,
     eventSink = {}
 )

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsView.kt
@@ -65,6 +65,16 @@ fun LockScreenSettingsView(
                     }
                 )
             }
+            if (state.showAllowScreenshots) {
+                PreferenceDivider()
+                PreferenceSwitch(
+                    title = stringResource(id = R.string.screen_app_lock_settings_allow_screenshots),
+                    isChecked = state.isAllowScreenshotsEnabled,
+                    onCheckedChange = {
+                        state.eventSink(LockScreenSettingsEvent.ToggleAllowScreenshots)
+                    }
+                )
+            }
         }
     }
     if (state.showRemovePinConfirmation) {

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/LockScreenStore.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/LockScreenStore.kt
@@ -35,4 +35,14 @@ interface LockScreenStore : EncryptedPinCodeStorage {
      * Sets whether the biometric unlock is allowed or not.
      */
     suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean)
+
+    /**
+     * Returns whether screenshots are allowed when the lock screen is enabled.
+     */
+    fun isAllowScreenshotsAllowed(): Flow<Boolean>
+
+    /**
+     * Sets whether screenshots are allowed when the lock screen is enabled.
+     */
+    suspend fun setIsAllowScreenshotsAllowed(isAllowed: Boolean)
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
@@ -31,6 +31,7 @@ class PreferencesLockScreenStore(
     private val pinCodeKey = stringPreferencesKey("encoded_pin_code")
     private val remainingAttemptsKey = intPreferencesKey("remaining_pin_code_attempts")
     private val biometricUnlockKey = booleanPreferencesKey("biometric_unlock_enabled")
+    private val allowScreenshotsKey = booleanPreferencesKey("allow_screenshots")
 
     override suspend fun getRemainingPinCodeAttemptsNumber(): Int {
         return dataStore.data.map { preferences ->
@@ -79,6 +80,18 @@ class PreferencesLockScreenStore(
     override suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean) {
         dataStore.edit { preferences ->
             preferences[biometricUnlockKey] = isAllowed
+        }
+    }
+
+    override fun isAllowScreenshotsAllowed(): Flow<Boolean> {
+        return dataStore.data.map { preferences ->
+            preferences[allowScreenshotsKey] ?: false
+        }
+    }
+
+    override suspend fun setIsAllowScreenshotsAllowed(isAllowed: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[allowScreenshotsKey] = isAllowed
         }
     }
 

--- a/features/lockscreen/impl/src/main/res/values/temporary.xml
+++ b/features/lockscreen/impl/src/main/res/values/temporary.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+  <string name="screen_app_lock_settings_allow_screenshots">"Allow screenshots"</string>
+</resources>

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/pin/storage/InMemoryLockScreenStore.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/pin/storage/InMemoryLockScreenStore.kt
@@ -18,6 +18,7 @@ class InMemoryLockScreenStore : LockScreenStore {
     private var pinCode: String? = null
     private var remainingAttempts: Int = DEFAULT_REMAINING_ATTEMPTS
     private var isBiometricUnlockAllowed = MutableStateFlow(false)
+    private var isAllowScreenshotsAllowed = MutableStateFlow(false)
 
     override suspend fun getRemainingPinCodeAttemptsNumber(): Int {
         return remainingAttempts
@@ -49,5 +50,13 @@ class InMemoryLockScreenStore : LockScreenStore {
 
     override suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean) {
         isBiometricUnlockAllowed.value = isAllowed
+    }
+
+    override fun isAllowScreenshotsAllowed(): Flow<Boolean> {
+        return isAllowScreenshotsAllowed
+    }
+
+    override suspend fun setIsAllowScreenshotsAllowed(isAllowed: Boolean) {
+        isAllowScreenshotsAllowed.value = isAllowed
     }
 }

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenterTest.kt
@@ -30,6 +30,7 @@ class LockScreenSettingsPresenterTest {
     fun `present - remove pin option is hidden when mandatory`() = runTest {
         val presenter = createLockScreenSettingsPresenter(lockScreenConfig = aLockScreenConfig(isPinMandatory = true))
         presenter.test {
+            skipItems(1)
             awaitItem().also { state ->
                 assertThat(state.showRemovePinOption).isFalse()
             }
@@ -115,6 +116,35 @@ class LockScreenSettingsPresenterTest {
             skipItems(1)
             awaitItem().also { state ->
                 state.eventSink(LockScreenSettingsEvent.ToggleBiometricAllowed)
+            }
+        }
+    }
+
+    @Test
+    fun `present - allow screenshots is disabled by default`() = runTest {
+        val presenter = createLockScreenSettingsPresenter()
+        presenter.test {
+            skipItems(1)
+            awaitItem().also { state ->
+                assertThat(state.isAllowScreenshotsEnabled).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `present - toggle allow screenshots`() = runTest {
+        val presenter = createLockScreenSettingsPresenter()
+        presenter.test {
+            skipItems(1)
+            awaitItem().also { state ->
+                state.eventSink(LockScreenSettingsEvent.ToggleAllowScreenshots)
+            }
+            awaitItem().also { state ->
+                assertThat(state.isAllowScreenshotsEnabled).isTrue()
+                state.eventSink(LockScreenSettingsEvent.ToggleAllowScreenshots)
+            }
+            awaitItem().also { state ->
+                assertThat(state.isAllowScreenshotsEnabled).isFalse()
             }
         }
     }

--- a/features/lockscreen/test/src/main/kotlin/io/element/android/features/lockscreen/test/FakeLockScreenService.kt
+++ b/features/lockscreen/test/src/main/kotlin/io/element/android/features/lockscreen/test/FakeLockScreenService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.map
 
 class FakeLockScreenService : LockScreenService {
     private var isPinSetup = MutableStateFlow(false)
+    private var isAllowScreenshotsAllowed = MutableStateFlow(false)
     private val _lockState: MutableStateFlow<LockScreenLockState> = MutableStateFlow(LockScreenLockState.Locked)
     override val lockState: StateFlow<LockScreenLockState> = _lockState
 
@@ -30,6 +31,14 @@ class FakeLockScreenService : LockScreenService {
 
     override fun isPinSetup(): Flow<Boolean> {
         return isPinSetup
+    }
+
+    override fun isAllowScreenshotsAllowed(): Flow<Boolean> {
+        return isAllowScreenshotsAllowed
+    }
+
+    fun setIsAllowScreenshotsAllowed(isAllowed: Boolean) {
+        isAllowScreenshotsAllowed.value = isAllowed
     }
 
     fun setLockState(lockState: LockScreenLockState) {


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Add an "Allow screenshots" option (disabled by default) in the "Screen lock" to disable `FLAG_SECURE`

## Motivation and context

Fixes #6912

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the option and take a screnshot

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
