### PR TITLE
Create log messages from `WebView` just once

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/browser/ConsoleMessageLogger.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/browser/ConsoleMessageLogger.kt
@@ -33,6 +33,11 @@ class DefaultConsoleMessageLogger : ConsoleMessageLogger {
             else -> Log.DEBUG
         }
 
+        // Avoid logging any messages that contain "password" to prevent leaking sensitive information
+        if (consoleMessage.message().contains("password=")) {
+            return
+        }
+
         val message = buildString {
             append(consoleMessage.sourceId())
             append(":")
@@ -41,20 +46,6 @@ class DefaultConsoleMessageLogger : ConsoleMessageLogger {
             append(consoleMessage.message())
         }
 
-        // Avoid logging any messages that contain "password" to prevent leaking sensitive information
-        if (message.contains("password=")) {
-            return
-        }
-
-        Timber.tag(tag).log(
-            priority = priority,
-            message = buildString {
-                append(consoleMessage.sourceId())
-                append(":")
-                append(consoleMessage.lineNumber())
-                append(" ")
-                append(consoleMessage.message())
-            },
-        )
+        Timber.tag(tag).log(priority = priority, message = message)
     }
 }


### PR DESCRIPTION
## Content

What the title says.

Also, check the retrieved message for passwords before formatting the log line instead of after: this way we don't create a new formatted log line to just discard it.

## Motivation and context

We were creating the same message twice by mistake. We saw some crashes related to `OutOfMemoryError`s where this code was mentioned: while it's probably not the root cause, it's probably not helping either 😅 .

## Tests

Not much to test, other than the logs still being displayed and the log lines with passwords in them being discarded.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
