### PR TITLE
Fix image resizing behavior.

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/imageeditor/AttachmentImageEditorView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/imageeditor/AttachmentImageEditorView.kt
@@ -316,11 +316,13 @@ private fun BoxScope.CropEditorCanvas(
                     ) { change, dragAmount ->
                         val activeTarget = dragTarget ?: return@detectDragGestures
                         change.consume()
+                        val gestureAreaWidth = imageRect.width.takeIf { it > 0f } ?: size.width.toFloat()
+                        val gestureAreaHeight = imageRect.height.takeIf { it > 0f } ?: size.height.toFloat()
                         onCropRectChange(
                             latestCropRect.applyChange(
                                 dragTarget = activeTarget,
-                                deltaX = dragAmount.x / size.width.toFloat(),
-                                deltaY = dragAmount.y / size.height.toFloat(),
+                                deltaX = dragAmount.x / gestureAreaWidth,
+                                deltaY = dragAmount.y / gestureAreaHeight,
                             )
                         )
                     }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
Fix image resizing behavior.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Have handles for resizing work as expected

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Add an image
- In the preview click on edit
- play with the 8 handles to resize the image
- If the handle stays below the finger during the drag (to the limit of the image size), the bug is fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
