### PR TITLE
Use reverse ordering for `FilterEmptyDayPostProcessor`

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/FilterEmptyDayPostProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/FilterEmptyDayPostProcessor.kt
@@ -18,10 +18,10 @@ class FilterEmptyDayPostProcessor {
      * Filters out day separators from [items] for days that don't contain any events.
      */
     fun process(items: List<MatrixTimelineItem>): List<MatrixTimelineItem> = buildList {
-        // The timeline is ordered by descending timestamp, so events that happened during a day appear before the day separator for that day.
-        // We can use this to determine if a day separator should be kept or not.
+        // The timeline is ordered by ascending timestamp, so events that happened during a day appear after the day separator for that day.
+        // We can use this to determine if a day separator should be kept or not by traversing the list in reverse.
         var hasEvent = false
-        for (item in items) {
+        for (item in items.asReversed()) {
             if (item is MatrixTimelineItem.Event) {
                 hasEvent = true
                 add(item)
@@ -35,4 +35,6 @@ class FilterEmptyDayPostProcessor {
             }
         }
     }
+        // Then reverse the result to restore the original order, minus the empty day separators.
+        .asReversed()
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/FilterEmptyDayPostProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/timeline/postprocessor/FilterEmptyDayPostProcessorTest.kt
@@ -32,36 +32,36 @@ class FilterEmptyDayPostProcessorTest {
     @Test
     fun `filterEmptyDaySeparators keeps day separator with events after it`() {
         val items = listOf(
-            anEvent,
             aDaySeparator(TODAY),
+            anEvent,
         )
         val result = FilterEmptyDayPostProcessor().process(items)
         assertThat(result).hasSize(2)
-        assertThat(result[0]).isEqualTo(anEvent)
-        assertThat(result[1]).isEqualTo(aDaySeparator(TODAY))
+        assertThat(result[0]).isEqualTo(aDaySeparator(TODAY))
+        assertThat(result[1]).isEqualTo(anEvent)
     }
 
     @Test
     fun `filterEmptyDaySeparators removes day separator with no events after it`() {
         val items = listOf(
-            aDaySeparator(TODAY),
             aDaySeparator(YESTERDAY),
+            aDaySeparator(TODAY),
         )
         val result = FilterEmptyDayPostProcessor().process(items)
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun `filterEmptyDaySeparators removes first day separator and keeps second when only second has events`() {
+    fun `filterEmptyDaySeparators removes second day separator and keeps first when only first has events`() {
         val items = listOf(
-            aDaySeparator(TODAY),
-            anEvent,
             aDaySeparator(YESTERDAY),
+            anEvent,
+            aDaySeparator(TODAY),
         )
         val result = FilterEmptyDayPostProcessor().process(items)
         assertThat(result).hasSize(2)
-        assertThat(result[0]).isEqualTo(anEvent)
-        assertThat(result[1]).isEqualTo(aDaySeparator(YESTERDAY))
+        assertThat(result[0]).isEqualTo(aDaySeparator(YESTERDAY))
+        assertThat(result[1]).isEqualTo(anEvent)
     }
 
     @Test
@@ -78,15 +78,15 @@ class FilterEmptyDayPostProcessorTest {
     @Test
     fun `filterEmptyDaySeparators keeps all items when no day separators`() {
         val items = listOf(
-            anEvent,
             anEvent.copy(uniqueId = UniqueId("event2")),
+            anEvent,
         )
         val result = FilterEmptyDayPostProcessor().process(items)
         assertThat(result).hasSize(2)
     }
 
     @Test
-    fun `filterEmptyDaySeparators removes day separator followed by non-event virtual item`() {
+    fun `filterEmptyDaySeparators removes day separator preceded by non-event virtual item`() {
         val readMarker = MatrixTimelineItem.Virtual(
             uniqueId = UniqueId("readMarker"),
             virtual = VirtualTimelineItem.ReadMarker
@@ -107,12 +107,12 @@ class FilterEmptyDayPostProcessorTest {
             virtual = VirtualTimelineItem.ReadMarker
         )
         val items = listOf(
-            anEvent,
-            readMarker,
             aDaySeparator(TODAY),
+            readMarker,
+            anEvent,
         )
         val result = FilterEmptyDayPostProcessor().process(items)
         assertThat(result).hasSize(3)
-        assertThat(result[2]).isEqualTo(aDaySeparator(TODAY))
+        assertThat(result[0]).isEqualTo(aDaySeparator(TODAY))
     }
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

In `FilterEmptyDayPostProcessor`, traverse the list in reverse order and then return the resulting list reversed again so it follows the original ordering.

## Motivation and context

It turns out the original ordering was correct, I just realised I saw some unexpected day dividers in a room and that was caused by the latest code I changed using the wrong ordering.

Fixes https://github.com/element-hq/element-x-android/issues/6928

## Tests

Open a public room where the only event for a day is a membership join/leave event. Check neither that event nor the day divider for that day are present.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
