### PR TITLE
[Media bottom sheet] UI iteration

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaBottomSheetState.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaBottomSheetState.kt
@@ -16,6 +16,7 @@ sealed interface MediaBottomSheetState {
     data object Hidden : MediaBottomSheetState
 
     data class Details(
+        val fromGallery: Boolean,
         val eventId: EventId?,
         val canDelete: Boolean,
         val mediaInfo: MediaInfo,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaBottomSheetStateDetailsProvider.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaBottomSheetStateDetailsProvider.kt
@@ -29,10 +29,14 @@ open class MediaBottomSheetStateDetailsProvider : PreviewParameterProvider<Media
             aMediaBottomSheetStateDetails(
                 eventId = null,
             ),
+            aMediaBottomSheetStateDetails(
+                fromGallery = true,
+            ),
         )
 }
 
 fun aMediaBottomSheetStateDetails(
+    fromGallery: Boolean = false,
     eventId: EventId? = EventId($$"$eventId"),
     canDelete: Boolean = true,
     mediaInfo: MediaInfo = anImageMediaInfo(
@@ -40,6 +44,7 @@ fun aMediaBottomSheetStateDetails(
         dateSentFull = "December 6, 2024 at 12:59",
     ),
 ) = MediaBottomSheetState.Details(
+    fromGallery = fromGallery,
     eventId = eventId,
     canDelete = canDelete,
     mediaInfo = mediaInfo,

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaDetailsBottomSheet.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaDetailsBottomSheet.kt
@@ -10,7 +10,6 @@ package io.element.android.libraries.mediaviewer.impl.details
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,7 +26,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -102,34 +100,6 @@ fun MediaDetailsBottomSheet(
             Spacer(modifier = Modifier.height(16.dp))
             if (state.eventId != null) {
                 HorizontalDivider()
-                ListItem(
-                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.VisibilityOn())),
-                    headlineContent = { Text(stringResource(CommonStrings.action_view_in_timeline)) },
-                    onClick = {
-                        onViewInTimeline(state.eventId)
-                    }
-                )
-                ListItem(
-                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.ShareAndroid())),
-                    headlineContent = { Text(stringResource(CommonStrings.action_share)) },
-                    onClick = {
-                        onShare(state.eventId)
-                    }
-                )
-                ListItem(
-                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Forward())),
-                    headlineContent = { Text(stringResource(CommonStrings.action_forward)) },
-                    onClick = {
-                        onForward(state.eventId)
-                    }
-                )
-                ListItem(
-                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Download())),
-                    headlineContent = { Text(stringResource(CommonStrings.action_download)) },
-                    onClick = {
-                        onDownload(state.eventId)
-                    }
-                )
                 val mimeType = state.mediaInfo.mimeType
                 val icon = when (mimeType) {
                     MimeTypes.Apk ->
@@ -148,11 +118,41 @@ fun MediaDetailsBottomSheet(
                         onOpenWith(state.eventId)
                     }
                 )
+                ListItem(
+                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.VisibilityOn())),
+                    headlineContent = { Text(stringResource(CommonStrings.action_view_in_timeline)) },
+                    onClick = {
+                        onViewInTimeline(state.eventId)
+                    }
+                )
+                if (state.fromGallery) {
+                    ListItem(
+                        leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.ShareAndroid())),
+                        headlineContent = { Text(stringResource(CommonStrings.action_share)) },
+                        onClick = {
+                            onShare(state.eventId)
+                        }
+                    )
+                    ListItem(
+                        leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Download())),
+                        headlineContent = { Text(stringResource(CommonStrings.action_download)) },
+                        onClick = {
+                            onDownload(state.eventId)
+                        }
+                    )
+                }
+                ListItem(
+                    leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Forward())),
+                    headlineContent = { Text(stringResource(CommonStrings.action_forward)) },
+                    onClick = {
+                        onForward(state.eventId)
+                    }
+                )
                 if (state.canDelete) {
                     HorizontalDivider()
                     ListItem(
                         leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Delete())),
-                        headlineContent = { Text(stringResource(CommonStrings.action_delete)) },
+                        headlineContent = { Text(stringResource(CommonStrings.action_delete_file)) },
                         style = ListItemStyle.Destructive,
                         onClick = {
                             onDelete(state.eventId)
@@ -216,16 +216,14 @@ private fun SenderRow(
 }
 
 @Composable
-private fun ColumnScope.Title() {
+private fun Title() {
     Text(
         modifier = Modifier
-            .align(Alignment.CenterHorizontally)
             .padding(top = 16.dp, bottom = 8.dp, start = 16.dp, end = 16.dp)
             .semantics {
                 heading()
             },
         text = stringResource(R.string.screen_media_details_title),
-        textAlign = TextAlign.Center,
         style = ElementTheme.typography.fontBodyLgMedium,
         color = ElementTheme.colors.textPrimary,
     )

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenter.kt
@@ -129,6 +129,7 @@ class MediaGalleryPresenter(
                 }
                 is MediaGalleryEvent.OpenInfo -> coroutineScope.launch {
                     mediaBottomSheetState = MediaBottomSheetState.Details(
+                        fromGallery = true,
                         eventId = event.mediaItem.eventId(),
                         canDelete = when (event.mediaItem.mediaInfo().senderId) {
                             null -> false

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerPresenter.kt
@@ -145,6 +145,7 @@ class MediaViewerPresenter(
                 }
                 is MediaViewerEvent.OpenInfo -> coroutineScope.launch {
                     mediaBottomSheetState = MediaBottomSheetState.Details(
+                        fromGallery = false,
                         eventId = event.data.eventId,
                         canDelete = when (event.data.mediaInfo.senderId) {
                             null -> false

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -277,6 +277,7 @@ fun MediaViewerView(
                     state.eventSink(MediaViewerEvent.ViewInTimeline(it))
                 },
                 onShare = {
+                    // Note: share action is not rendered when the bottom sheet is opened from the media viewer
                     (currentData as? MediaViewerPageData.MediaViewerData)?.let {
                         state.eventSink(MediaViewerEvent.Share(currentData))
                     }
@@ -285,6 +286,7 @@ fun MediaViewerView(
                     state.eventSink(MediaViewerEvent.Forward(it))
                 },
                 onDownload = {
+                    // Note: download action is not rendered when the bottom sheet is opened from the media viewer
                     (currentData as? MediaViewerPageData.MediaViewerData)?.let {
                         state.eventSink(MediaViewerEvent.SaveOnDisk(currentData))
                     }

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaDetailsBottomSheetTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/details/MediaDetailsBottomSheetTest.kt
@@ -45,7 +45,9 @@ class MediaDetailsBottomSheetTest {
     @Test
     @Config(qualifiers = "h1024dp")
     fun `clicking on Share invokes expected callback`() = runAndroidComposeUiTest {
-        val state = aMediaBottomSheetStateDetails()
+        val state = aMediaBottomSheetStateDetails(
+            fromGallery = true,
+        )
         ensureCalledOnceWithParam(state.eventId) { callback ->
             setMediaDetailsBottomSheet(
                 state = state,
@@ -53,6 +55,15 @@ class MediaDetailsBottomSheetTest {
             )
             clickOn(CommonStrings.action_share)
         }
+    }
+
+    @Test
+    @Config(qualifiers = "h1024dp")
+    fun `item Share is not displayed when opened from the media viewer`() = runAndroidComposeUiTest {
+        setMediaDetailsBottomSheet(
+            state = aMediaBottomSheetStateDetails(),
+        )
+        onNodeWithText(activity!!.getString(CommonStrings.action_share)).assertDoesNotExist()
     }
 
     @Test
@@ -71,7 +82,9 @@ class MediaDetailsBottomSheetTest {
     @Test
     @Config(qualifiers = "h1024dp")
     fun `clicking on Download invokes expected callback`() = runAndroidComposeUiTest {
-        val state = aMediaBottomSheetStateDetails()
+        val state = aMediaBottomSheetStateDetails(
+            fromGallery = true,
+        )
         ensureCalledOnceWithParam(state.eventId) { callback ->
             setMediaDetailsBottomSheet(
                 state = state,
@@ -79,6 +92,15 @@ class MediaDetailsBottomSheetTest {
             )
             clickOn(CommonStrings.action_download)
         }
+    }
+
+    @Test
+    @Config(qualifiers = "h1024dp")
+    fun `item Download is not displayed when opened from the media viewer`() = runAndroidComposeUiTest {
+        setMediaDetailsBottomSheet(
+            state = aMediaBottomSheetStateDetails(),
+        )
+        onNodeWithText(activity!!.getString(CommonStrings.action_download)).assertDoesNotExist()
     }
 
     @Config(qualifiers = "h1024dp")
@@ -90,8 +112,8 @@ class MediaDetailsBottomSheetTest {
                 state = state,
                 onDelete = callback,
             )
-            onNodeWithText(activity!!.getString(CommonStrings.action_delete)).assertExists()
-            clickOn(CommonStrings.action_delete)
+            onNodeWithText(activity!!.getString(CommonStrings.action_delete_file)).assertExists()
+            clickOn(CommonStrings.action_delete_file)
         }
     }
 

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenterTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/gallery/MediaGalleryPresenterTest.kt
@@ -137,6 +137,7 @@ class MediaGalleryPresenterTest {
             val state = awaitItem()
             assertThat(state.mediaBottomSheetState).isEqualTo(
                 MediaBottomSheetState.Details(
+                    fromGallery = true,
                     eventId = AN_EVENT_ID,
                     canDelete = canDeleteOwn,
                     mediaInfo = item.mediaInfo,
@@ -184,6 +185,7 @@ class MediaGalleryPresenterTest {
             val state = awaitItem()
             assertThat(state.mediaBottomSheetState).isEqualTo(
                 MediaBottomSheetState.Details(
+                    fromGallery = true,
                     eventId = AN_EVENT_ID,
                     canDelete = canDeleteOther,
                     mediaInfo = item.mediaInfo,

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
@@ -135,28 +135,6 @@ class MediaViewerViewTest {
         )
     }
 
-    @Test
-    @Config(qualifiers = "h1024dp")
-    fun `clicking on download emits expected Event`() {
-        val data = aMediaViewerPageData()
-        testBottomSheetAction(
-            data,
-            CommonStrings.action_download,
-            MediaViewerEvent.SaveOnDisk(data),
-        )
-    }
-
-    @Test
-    @Config(qualifiers = "h1024dp")
-    fun `clicking on share emits expected Event`() {
-        val data = aMediaViewerPageData()
-        testBottomSheetAction(
-            data,
-            CommonStrings.action_share,
-            MediaViewerEvent.Share(data),
-        )
-    }
-
     @Config(qualifiers = "h1024dp")
     @Test
     fun `clicking on open in emits expected Event`() {

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be6223e16a2b9936164ec4ba659129ceb80ed5746e3376f32559b4942b271502
-size 40656
+oid sha256:3239eba4debc9249ecd75a11f9f96aa543ea0bab3f527a654a5ea58e07b942fb
+size 40364

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be6223e16a2b9936164ec4ba659129ceb80ed5746e3376f32559b4942b271502
-size 40656
+oid sha256:e2c67d25e8e74b9ab7ebcff3d167bc72de2bc2ae7ef827c7785c64b551426eb7
+size 38652

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b57d412a5815756b453d907543bc74b4a154814633d8664a3dcffaa0057c7279
-size 44962
+oid sha256:7c7aebf16d23748e4a0a3a035c6ff1d67277d11fac223e2fb2bf66fdbc13ac99
+size 44576

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6144f221b9d11c70d15b54321bfbff3d1de1454e6c73be34d7b2e82bd1625a94
-size 30701
+oid sha256:a335f858bbca40a0bdb3bd239fdc3625975d44ddc45bb653815f20acde9ffd0f
+size 30710

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Day_4_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90ed265904cdf988d9b2ef6b5695d5793c48fa9d33d4db8c6f4bf94c3055844d
+size 40720

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e3e43f4dbd1bf0e271de57c962b93100720439d608a7d552669ede42141dbc1
-size 39705
+oid sha256:73ee558ceb73554e8ab72797797a3e4fb4ae60bc805d9603cc23a5ec3325ae71
+size 39361

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e3e43f4dbd1bf0e271de57c962b93100720439d608a7d552669ede42141dbc1
-size 39705
+oid sha256:16b6c38de0dcb40f5141f06a8957c6a64c406ec45765a38a5a371f873cca676f
+size 37330

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:086c64f4094cb2e0fda8e415a0d8d89b7dafe67f4d42088eded7abbf45b8de93
-size 44088
+oid sha256:4e37123303553d032b579ce0cdace8c6f2aa6c32b3ccce8ef04abac4c84e16b7
+size 43659

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2898f00a828a69ce9cdd56994d7878f6aae8c5b2ea5d1150df57aa2ebd7e537b
-size 29233
+oid sha256:423e92ee408ca6c3ab7c1071245810fcbc2d25a7ce62b3068f1616c933ad008c
+size 29216

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.details_MediaDetailsBottomSheet_Night_4_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5fd5c4d8d9d2ca9709a2b03d423899ef99738b4ba2e081d9456168605e65e07
+size 39788

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.gallery_MediaGalleryView_Day_8_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.gallery_MediaGalleryView_Day_8_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad4bf14c2f6d2d36c978d90c7641fc8b3a9c71062d6b23362eea12c0b7ff24e4
-size 40572
+oid sha256:0c8c1dd110d367173c8a918ff9f94aa4e67e9bcba6d417e8ddd0b6660f6ecf20
+size 40280

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.gallery_MediaGalleryView_Night_8_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.gallery_MediaGalleryView_Night_8_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b44ce089c932019d58e7f1c993f80871352878adf0f5a133a72edce18f5bcb9
-size 39496
+oid sha256:00c97219fdc6377f9f965635b3ed696f3595f6de413528a96ea05d2c4b385c9a
+size 39155

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.viewer_MediaViewerViewLandscape_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.viewer_MediaViewerViewLandscape_11_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e641d1d6604b6c5f489ab38438d9f3b8dcea9802113011200e9ea589c4e2dbee
-size 25310
+oid sha256:5a9b7b0c427f40aa8f0a61025fdcfb8093c611e15ef10f22576545a64c6ec35c
+size 25286

--- a/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.viewer_MediaViewerView_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.mediaviewer.impl.viewer_MediaViewerView_11_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b44ce089c932019d58e7f1c993f80871352878adf0f5a133a72edce18f5bcb9
-size 39496
+oid sha256:00c97219fdc6377f9f965635b3ed696f3595f6de413528a96ea05d2c4b385c9a
+size 39155


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
 - Hide "Download" and "Share" from the media bottom sheet when opened from the media viewer
 - Align title to left
 - reorder items
 - change wording "Delete" to "Delete file"

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6907 

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Navigate to the media and file of a room
- Long click on an image
- observe that Share and Download action are displayed in the bottom sheet
- close the bottom sheet
- click on the same image
- click on the info icon
- observe that Share and Download action are not displayed in the bottom sheet

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
