### PR TITLE
Fix jump-to-unread requiring two taps for an out-of-window read marker

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -333,7 +333,12 @@ class TimelinePresenter(
             }
         }
 
-        LaunchedEffect(timelineItems.size, focusRequestState.value) {
+        // Keyed on the full [timelineItems] reference (not just .size) so we re-resolve the index
+        // when a focused timeline loads with the same item count as the window it replaced — e.g.
+        // jumping to an out-of-window read marker in a busy room, where both windows fill to the
+        // same page size. With .size as the key the effect wouldn't re-run, the focused event's
+        // index would stay unresolved, and the scroll would never fire until a second tap.
+        LaunchedEffect(timelineItems, focusRequestState.value) {
             val currentFocusRequestState = focusRequestState.value
             if (currentFocusRequestState is FocusRequestState.Success && !currentFocusRequestState.rendered) {
                 val eventId = currentFocusRequestState.eventId

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -338,7 +338,7 @@ class TimelinePresenter(
         // jumping to an out-of-window read marker in a busy room, where both windows fill to the
         // same page size. With .size as the key the effect wouldn't re-run, the focused event's
         // index would stay unresolved, and the scroll would never fire until a second tap.
-        LaunchedEffect(timelineItems, focusRequestState.value) {
+        LaunchedEffect(timelineItems.map { it.identifier() }, focusRequestState.value) {
             val currentFocusRequestState = focusRequestState.value
             if (currentFocusRequestState is FocusRequestState.Success && !currentFocusRequestState.rendered) {
                 val eventId = currentFocusRequestState.eventId


### PR DESCRIPTION
## What

Tapping **Jump to unread** in a room with many unreads only loaded the focused timeline on the first tap; a second tap was needed to actually scroll to the read marker. Now a single tap scrolls to the marker.

## Why

When the read marker is older than the loaded window, the FAB loads a focused timeline around the marker event and then resolves that event to a list index to drive the scroll. That resolution effect was keyed on `timelineItems.size`. In a busy room the focused window fills to the same item count as the window it replaced, so the size never changed, the effect didn't re-run, the index stayed unresolved, and the scroll never fired until something else nudged the list.

Keying the effect on the full `timelineItems` reference (matching the jump-to-unread recompute effect just above it) makes it re-run on every emission, so the index resolves and the first tap scrolls.

Note: the `LaunchedEffect(timelineItems.size, …)` is pre-existing and also lives in `develop`, latent — this feature is just the first thing to drive an out-of-window focus into a same-size window.

## Tests

- Open a room with many unread messages so the read marker is older than the initially loaded timeline window.
- Tap the **Jump to unread** FAB once.
- Confirm the timeline scrolls to the read marker on the first tap (previously required a second tap).

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.
