### PR TITLE
Ensure that the application rotate the QrCode if one day the SDK emits the `.Expired` error.

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/linknewdevice/RustLinkMobileHandler.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/linknewdevice/RustLinkMobileHandler.kt
@@ -51,6 +51,10 @@ class RustLinkMobileHandler(
             )
             // We emit Done in case the progress listener was deallocated before generate() sent the Done
             _linkMobileStep.emit(LinkMobileStep.Done)
+        } catch (e: HumanQrGrantLoginException.Expired) {
+            // Note: the SDK does not return this error, but is returning `.NotFound` instead when the QR code expires. We catch both just in case.
+            Timber.tag(tag.value).w(e, "QR code has expired")
+            _linkMobileStep.emit(LinkMobileStep.QrRotating)
         } catch (e: HumanQrGrantLoginException.NotFound) {
             Timber.tag(tag.value).w(e, "Error during QR login grant")
             // Catch timeout here?

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/linknewdevice/RustLinkMobileHandlerTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/linknewdevice/RustLinkMobileHandlerTest.kt
@@ -147,6 +147,32 @@ class RustLinkMobileHandlerTest {
         }
     }
 
+    @Test
+    fun `when start throws HumanQrGrantLoginException_Expired, the handler emits QrRotating step`() = runTest {
+        val completable = CompletableDeferred<Unit>()
+        val handler = FakeFfiGrantLoginWithQrCodeHandler(
+            generateResult = {
+                completable.await()
+                throw HumanQrGrantLoginException.Expired("Expired")
+            }
+        )
+        val sut = createRustLinkMobileHandler(
+            handler,
+        )
+        sut.linkMobileStep.test {
+            val initialItem = awaitItem()
+            assertThat(initialItem).isEqualTo(LinkMobileStep.Uninitialized)
+            backgroundScope.launch {
+                sut.start()
+            }
+            runCurrent()
+            // generate returns, error is emitted
+            completable.complete(Unit)
+            val qrRotatingState = awaitItem()
+            assertThat(qrRotatingState).isEqualTo(LinkMobileStep.QrRotating)
+        }
+    }
+
     private fun TestScope.createRustLinkMobileHandler(
         handler: FakeFfiGrantLoginWithQrCodeHandler = FakeFfiGrantLoginWithQrCodeHandler(),
     ) = RustLinkMobileHandler(


### PR DESCRIPTION


<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
Ensure that the application rotate the QrCode if one day the SDK emits the `.Expired` error.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Be robust

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
Cannot really be tested with the current implementation. A unit test is covering the state change.

## Tested devices

NA

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
