### PR TITLE
build-rust-sdk: allow skipping git update for kotlin components

### DIFF
--- a/tools/sdk/build-rust-sdk
+++ b/tools/sdk/build-rust-sdk
@@ -27,6 +27,7 @@ set -u
 
 buildLocal=0
 rustSdkPath="../matrix-rust-sdk/"
+kotlinComponentsPath="../matrix-rust-components-kotlin"
 rustSdkUrl="https://github.com/matrix-org/matrix-rust-sdk.git"
 rustSdkBranch="main"
 buildApp=1
@@ -38,6 +39,7 @@ default_arch="${default_arch/arm64/aarch64}"
 target_arch="${default_arch}"
 
 sdkArg=""
+update_components=1
 
 ## Argument parsing
 
@@ -48,7 +50,7 @@ else
     GNU_GETOPT="getopt"
 fi
 
-TEMP=$("$GNU_GETOPT" -o 'rs:b:at:h' --long 'remote,sdk:,branch:,build-app,target-arch:,help' -- "$@")
+TEMP=$("$GNU_GETOPT" -o 'rs:b:at:nh' --long 'remote,sdk:,branch:,build-app,target-arch:,no-update-components,help' -- "$@")
 
 if [ $? -ne 0 ]; then
     echo 'Terminating...' >&2
@@ -85,6 +87,11 @@ while true; do
             shift 2
             continue
         ;;
+        '-n'|'--no-update-components')
+            update_components=0
+            shift
+            continue
+        ;;
         '-h'|'--help')
             cat << END
 SYNOPSIS
@@ -109,6 +116,9 @@ ARGUMENTS
 
     -t --target-arch
         The architecture for which to build the app. Defaults to the architecture of this machine (${default_arch}).
+
+    -n --no-update-components
+        Do not attempt to update matrix-rust-components-kotlin from git. It must already be cloned and up-to-date.
 
 EXAMPLES
 
@@ -194,20 +204,24 @@ cd "${elementPwd}"
 
 ## Clone matrix-rust-components-kotlin if needed
 
-if [ ! -d "../matrix-rust-components-kotlin" ]; then
-    printf "\nFolder ../matrix-rust-components-kotlin does not exist."
-    printf "Cloning the repository into ../matrix-rust-components-kotlin.\n\n"
-    git clone \
-        https://github.com/matrix-org/matrix-rust-components-kotlin.git \
-        ../matrix-rust-components-kotlin
+if [ "$update_components" == "1" ]; then
+    if [ ! -d "${kotlinComponentsPath}" ]; then
+        printf "\nFolder ${kotlinComponentsPath} does not exist."
+        printf "Cloning the repository into ${kotlinComponentsPath}.\n\n"
+        git clone \
+            https://github.com/matrix-org/matrix-rust-components-kotlin.git \
+            "${kotlinComponentsPath}"
+    fi
+
+    printf "\n## Resetting ${kotlinComponentsPath} to the latest main...\n\n"
+
+    cd "${kotlinComponentsPath}"
+    git reset --hard
+    git checkout main
+    git pull
+else
+    cd "${kotlinComponentsPath}"
 fi
-
-printf "\n## Resetting matrix-rust-components-kotlin to the latest main...\n\n"
-
-cd ../matrix-rust-components-kotlin
-git reset --hard
-git checkout main
-git pull
 
 ## Build the SDK
 


### PR DESCRIPTION
Updating matrix-rust-components-kotlin from git on every build is time-consuming, and requires network connectivity. It's useful to be able to skip it, particularly when working offline.

Add an option to the build script to skip this step.