### PR TITLE
Fix sharing media inside the app

### DIFF
--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultOnSharedData.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultOnSharedData.kt
@@ -7,6 +7,7 @@
 
 package io.element.android.features.share.impl
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -15,13 +16,14 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.features.share.api.OnSharedData
 import io.element.android.features.share.api.ShareIntentData
+import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.di.annotations.ApplicationContext
 import timber.log.Timber
-import kotlin.collections.forEach
 
 @ContributesBinding(AppScope::class)
 class DefaultOnSharedData(
     @ApplicationContext private val context: Context,
+    private val buildMeta: BuildMeta,
 ) : OnSharedData {
     override fun invoke(data: ShareIntentData) {
         when (data) {
@@ -29,6 +31,13 @@ class DefaultOnSharedData(
                 // No-op, there is nothing to do for plain text intents.
             }
             is ShareIntentData.Uris -> {
+                val fileProvider = "${buildMeta.applicationId}.fileprovider"
+                for (sharedUri in data.uris) {
+                    // Remove the local copy of the shared file, as it is not needed anymore
+                    if (sharedUri.uri.scheme == ContentResolver.SCHEME_CONTENT && sharedUri.uri.host == fileProvider) {
+                        context.contentResolver.delete(sharedUri.uri, null)
+                    }
+                }
                 revokeUriPermissions(data.uris.map { it.uri })
             }
         }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/AndroidLocalMediaActions.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/AndroidLocalMediaActions.kt
@@ -100,7 +100,11 @@ class AndroidLocalMediaActions(
     override suspend fun share(localMedia: LocalMedia): Result<Unit> = withContext(coroutineDispatchers.io) {
         require(localMedia.uri.scheme == ContentResolver.SCHEME_FILE)
         runCatchingExceptions {
-            val shareableUri = localMedia.toShareableUri()
+            // Make a copy of the shared file in the cache directory, otherwise the original file will be gone once this screen is dismissed
+            // and will prevent sharing the media to another room inside the app.
+            val copiedFile = localMedia.uri.toFile()
+                .copyTo(File(context.cacheDir, "temp/media/" + (localMedia.uri.lastPathSegment ?: "shared_file")), true)
+            val shareableUri = copiedFile.toShareableUri()
             val shareMediaIntent = Intent(Intent.ACTION_SEND)
                 .setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 .putExtra(Intent.EXTRA_STREAM, shareableUri)
@@ -157,10 +161,13 @@ class AndroidLocalMediaActions(
         }
     }
 
-    private fun LocalMedia.toShareableUri(): Uri {
-        val mediaAsFile = this.toFile()
+    private fun File.toShareableUri(): Uri {
         val authority = "${buildMeta.applicationId}.fileprovider"
-        return FileProvider.getUriForFile(context, authority, mediaAsFile).normalizeScheme()
+        return FileProvider.getUriForFile(context, authority, this).normalizeScheme()
+    }
+
+    private fun LocalMedia.toShareableUri(): Uri {
+        return this.toFile().toShareableUri()
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Create a copy of the file to share in the media viewer, share that copy and make sure to delete it after trying to share it.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/6987 if I understood the issue right.

When a `MediaSource` is disposed, the local temp file associated to it will be deleted from disk.

When we try sharing a media from the media viewer screen to another room, this will dismiss the screen, which in turn will dispose of the media source and remove the file, which then fails to be shared.

If we copy it first and then make sure we delete it after trying to send it, it works fine.

## Tests

From a room, open the media viewer and try to share some file to another room. If it works, it's fixed.

Note there is a separate issue with multi-account and navigation that can crash the app.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
