### PR TITLE
Replace `ContentResolver.delete` usage with a backwards-compatible version

### DIFF
--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultOnSharedData.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultOnSharedData.kt
@@ -35,7 +35,7 @@ class DefaultOnSharedData(
                 for (sharedUri in data.uris) {
                     // Remove the local copy of the shared file, as it is not needed anymore
                     if (sharedUri.uri.scheme == ContentResolver.SCHEME_CONTENT && sharedUri.uri.host == fileProvider) {
-                        context.contentResolver.delete(sharedUri.uri, null)
+                        context.contentResolver.delete(sharedUri.uri, null, emptyArray())
                     }
                 }
                 revokeUriPermissions(data.uris.map { it.uri })


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says.

## Motivation and context

Fix a potential crash on older Android versions. The previous signature needed API 30, the new one is available since API 1.

## Tests

If you have a device with API < 30 you can try sharing a media file from a room to another one inside the app. If it doesn't crash, it's fixed.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 29

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
