### PR TITLE
Lock app

### DIFF
--- a/features/home/impl/build.gradle.kts
+++ b/features/home/impl/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
     implementation(projects.features.rolesandpermissions.api)
     implementation(projects.libraries.previewutils)
     api(projects.features.home.api)
+    api(projects.features.lockscreen.api)
+    api(projects.features.lockscreen.impl)
 
     testCommonDependencies(libs, true)
     testImplementation(projects.features.announcement.test)

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeFlowNode.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeFlowNode.kt
@@ -26,6 +26,7 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.node
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.navmodel.backstack.operation.newRoot
 import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
 import dev.zacsweers.metro.Assisted
@@ -40,6 +41,8 @@ import io.element.android.features.invite.api.InviteData
 import io.element.android.features.invite.api.acceptdecline.AcceptDeclineInviteView
 import io.element.android.features.invite.api.declineandblock.DeclineInviteAndBlockEntryPoint
 import io.element.android.features.leaveroom.api.LeaveRoomRenderer
+import io.element.android.features.lockscreen.api.LockScreenService
+import io.element.android.features.lockscreen.impl.unlock.PinLockNode
 import io.element.android.features.logout.api.direct.DirectLogoutView
 import io.element.android.features.reportroom.api.ReportRoomEntryPoint
 import io.element.android.features.rolesandpermissions.api.ChangeRoomMemberRolesEntryPoint
@@ -49,6 +52,7 @@ import io.element.android.libraries.architecture.BackstackView
 import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.architecture.appyx.launchMolecule
 import io.element.android.libraries.architecture.callback
+import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.deeplink.api.usecase.InviteFriendsUseCase
 import io.element.android.libraries.designsystem.components.ProgressDialog
@@ -88,7 +92,9 @@ class HomeFlowNode(
     private val changeRoomMemberRolesEntryPoint: ChangeRoomMemberRolesEntryPoint,
     private val leaveRoomRenderer: LeaveRoomRenderer,
     @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
-) : BaseFlowNode<HomeFlowNode.NavTarget>(
+    private val lockScreenService: LockScreenService,
+
+    ) : BaseFlowNode<HomeFlowNode.NavTarget>(
     backstack = BackStack(
         initialElement = NavTarget.Root,
         savedStateMap = buildContext.savedStateMap,
@@ -134,6 +140,8 @@ class HomeFlowNode(
 
         @Parcelize
         data class SelectNewOwnersWhenLeavingRoom(val roomId: RoomId) : NavTarget
+        @Parcelize
+        data object NavigateLockUnLock : NavTarget
     }
 
     private fun navigateToReportRoom(roomId: RoomId) {
@@ -216,6 +224,10 @@ class HomeFlowNode(
                 }
                 loadingJoinedRoomJob.value = AsyncData.Loading(job)
             }
+            fun navigateToLock() {
+                backstack.newRoot(NavTarget.NavigateLockUnLock)
+            }
+            val isLock = lockScreenService.isPinSetup().collectAsState(initial = false).value
 
             HomeView(
                 homeState = state,
@@ -244,7 +256,9 @@ class HomeFlowNode(
                         onSelectNewOwners = ::navigateToSelectNewOwnersWhenLeavingRoom,
                         modifier = Modifier
                     )
-                }
+                },
+                isLock = isLock,
+                onLock = ::navigateToLock
             )
             directLogoutView.Render(state.directLogoutState)
         }
@@ -279,6 +293,15 @@ class HomeFlowNode(
                     room = room,
                     listType = ChangeRoomMemberRolesListType.SelectNewOwnersWhenLeaving,
                 )
+            }
+            is NavTarget.NavigateLockUnLock -> {
+                val callback = object : PinLockNode.Callback {
+                    override fun onUnlock() {
+                        backstack.newRoot(NavTarget.Root)
+                    }
+                }
+
+                createNode<PinLockNode>(buildContext, plugins = listOf(callback))
             }
             NavTarget.Root -> rootNode(buildContext)
         }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -87,6 +87,8 @@ fun HomeView(
     acceptDeclineInviteView: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     leaveRoomView: @Composable () -> Unit,
+    isLock: Boolean,
+    onLock: () -> Unit
 ) {
     val state: RoomListState = homeState.roomListState
     val coroutineScope = rememberCoroutineScope()
@@ -121,6 +123,8 @@ fun HomeView(
             onStartChatClick = { if (firstThrottler.canHandle()) onStartChatClick() },
             onCreateSpaceClick = { if (firstThrottler.canHandle()) onCreateSpaceClick() },
             onMenuActionClick = onMenuActionClick,
+            isLock = isLock,
+            onLock = onLock,
         )
         // This overlaid view will only be visible when state.displaySearchResults is true
         RoomListSearchView(
@@ -148,6 +152,8 @@ private fun HomeScaffold(
     onCreateSpaceClick: () -> Unit,
     onMenuActionClick: (RoomListMenuAction) -> Unit,
     modifier: Modifier = Modifier,
+    isLock: Boolean,
+    onLock: () -> Unit,
 ) {
     fun onRoomClick(room: RoomListRoomSummary) {
         onRoomClick(room.roomId)
@@ -195,7 +201,9 @@ private fun HomeScaffold(
                 modifier = Modifier.hazeEffect(
                     state = hazeState,
                     style = HazeMaterials.thick(),
-                )
+                ),
+                isLock = isLock,
+                onLock = onLock
             )
         },
         floatingActionButton = {
@@ -351,7 +359,9 @@ internal fun HomeViewPreview(@PreviewParameter(HomeStateProvider::class) state: 
         onMenuActionClick = {},
         onDeclineInviteAndBlockUser = {},
         acceptDeclineInviteView = {},
-        leaveRoomView = {}
+        leaveRoomView = {},
+        isLock = true,
+        onLock = {}
     )
 }
 
@@ -371,6 +381,8 @@ internal fun HomeViewA11yPreview() = ElementPreview {
         onMenuActionClick = {},
         onDeclineInviteAndBlockUser = {},
         acceptDeclineInviteView = {},
-        leaveRoomView = {}
+        leaveRoomView = {},
+        isLock = true,
+        onLock = {}
     )
 }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -70,7 +70,7 @@ import io.element.android.libraries.designsystem.utils.snackbar.rememberSnackbar
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.launch
-
+//test
 @Composable
 fun HomeView(
     homeState: HomeState,

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeView.kt
@@ -70,7 +70,7 @@ import io.element.android.libraries.designsystem.utils.snackbar.rememberSnackbar
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.launch
-//test
+
 @Composable
 fun HomeView(
     homeState: HomeState,

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/HomeTopBar.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/components/HomeTopBar.kt
@@ -95,6 +95,8 @@ fun HomeTopBar(
     filtersState: RoomListFiltersState,
     spaceFiltersState: SpaceFiltersState,
     modifier: Modifier = Modifier,
+    isLock:Boolean,
+    onLock: () -> Unit,
 ) {
     Column(modifier) {
         TopAppBar(
@@ -140,6 +142,8 @@ fun HomeTopBar(
                         onMenuActionClick = onMenuActionClick,
                         canReportBug = canReportBug,
                         spaceFiltersState = spaceFiltersState,
+                        isLock = isLock,
+                        onLock = onLock
                     )
                 }
             },
@@ -166,7 +170,17 @@ private fun RowScope.RoomListMenuItems(
     onMenuActionClick: (RoomListMenuAction) -> Unit,
     canReportBug: Boolean,
     spaceFiltersState: SpaceFiltersState,
+    isLock: Boolean,
+    onLock: () -> Unit
 ) {
+    if (isLock) IconButton(
+        onClick = onLock,
+    ) {
+        Icon(
+            imageVector = CompoundIcons.Lock(),
+            contentDescription = stringResource(CommonStrings.common_screen_lock),
+        )
+    }
     IconButton(
         onClick = onToggleSearch,
     ) {
@@ -360,6 +374,8 @@ internal fun HomeTopBarPreview() = ElementPreview {
         filtersState = aRoomListFiltersState(),
         spaceFiltersState = anUnselectedSpaceFiltersState(),
         onMenuActionClick = {},
+        isLock = true,
+        onLock = {}
     )
 }
 
@@ -381,6 +397,8 @@ internal fun HomeTopBarSpaceFiltersSelectedPreview() = ElementPreview {
         filtersState = aRoomListFiltersState(),
         spaceFiltersState = aSelectedSpaceFiltersState(),
         onMenuActionClick = {},
+        isLock = true,
+        onLock = {}
     )
 }
 
@@ -402,6 +420,8 @@ internal fun HomeTopBarSpacesPreview() = ElementPreview {
         filtersState = aRoomListFiltersState(),
         spaceFiltersState = anUnselectedSpaceFiltersState(),
         onMenuActionClick = {},
+        isLock = true,
+        onLock = {}
     )
 }
 
@@ -423,6 +443,8 @@ internal fun HomeTopBarWithIndicatorPreview() = ElementPreview {
         filtersState = aRoomListFiltersState(),
         spaceFiltersState = anUnselectedSpaceFiltersState(),
         onMenuActionClick = {},
+        isLock = true,
+        onLock = {}
     )
 }
 
@@ -444,5 +466,7 @@ internal fun HomeTopBarMultiAccountPreview() = ElementPreview {
         filtersState = aRoomListFiltersState(),
         spaceFiltersState = anUnselectedSpaceFiltersState(),
         onMenuActionClick = {},
+        isLock = true,
+        onLock = {}
     )
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinLockNode.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinLockNode.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2023-2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.lockscreen.impl.unlock
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.plugin.Plugin
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import io.element.android.annotations.ContributesNode
+import io.element.android.libraries.architecture.callback
+import io.element.android.libraries.di.SessionScope
+
+@ContributesNode(SessionScope::class)
+@AssistedInject
+class PinLockNode(
+    @Assisted buildContext: BuildContext,
+    @Assisted plugins: List<Plugin>,
+    presenterFactory: PinUnlockPresenter.Factory,
+
+    ) : Node(buildContext, plugins = plugins) {
+    interface Callback : Plugin {
+        fun onUnlock()
+
+    }
+
+    private val callback: Callback = callback()
+    val presenter = presenterFactory.create(forDeviceUnlock = false)
+
+    @Composable
+    override fun View(modifier: Modifier) {
+        val state = presenter.present()
+        LaunchedEffect(state.isUnlocked) {
+            if (state.isUnlocked) {
+                callback.onUnlock()
+            }
+        }
+        PinUnlockView(
+            state = state,
+            // UnlockNode is only used for in-app unlock, so we can safely set isInAppUnlock to true.
+            // It's set to false in PinUnlockActivity.
+            isInAppUnlock = false,
+            onCancel = {},
+        )
+    }
+}


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content
Lock app

## Motivation and context
I added a lock icon to the main window, if the screen lock is on, it will be visible, otherwise it will not be visible, in case of emergency, if you click it to lock the application, the application will go into screen lock mode and security will be ensured 

## Screenshots / GIFs
<img width="1280" height="2856" alt="Screenshot_20260626_105451" src="https://github.com/user-attachments/assets/0e8453ba-b63e-451c-aa5a-28ee4cc2bbc8" />
<img width="1280" height="2856" alt="Screenshot_20260626_105654" src="https://github.com/user-attachments/assets/8dbaea55-c3cc-4a4a-b001-791e05eeb03f" />

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- The icon is clicked and the app is locked.
- After typing a special password in the screen lock window, access to the main window of the application opens.
- If you enter the wrong password 3 times, it will log you out of all accounts and take you to the login section.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):13

## Checklist


<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
