### PR TITLE
Add accessibility label to search input

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchView.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -112,10 +114,12 @@ private fun RoomListSearchContent(
                 title = {
                     // The stateSaver will keep the selection state when returning to this UI
                     val focusRequester = remember { FocusRequester() }
+                    val searchLabel = stringResource(CommonStrings.action_search)
                     FilledTextField(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .focusRequester(focusRequester),
+                            .focusRequester(focusRequester)
+                            .semantics { contentDescription = searchLabel },
                         state = state.query,
                         lineLimits = TextFieldLineLimits.SingleLine,
                         colors = TextFieldDefaults.colors(
@@ -132,7 +136,7 @@ private fun RoomListSearchContent(
                                 IconButton(onClick = { state.eventSink(RoomListSearchEvent.ClearQuery) }) {
                                     Icon(
                                         imageVector = CompoundIcons.Close(),
-                                        contentDescription = stringResource(CommonStrings.action_cancel)
+                                        contentDescription = stringResource(CommonStrings.a11y_clear_search_field)
                                     )
                                 }
                             }

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -4,6 +4,7 @@
   <string name="a11y_add_reaction">"Add reaction: %1$s"</string>
   <string name="a11y_address">"Address"</string>
   <string name="a11y_avatar">"Avatar"</string>
+  <string name="a11y_clear_search_field">"Clear search field"</string>
   <string name="a11y_collapse_message_text_field">"Minimise message text field"</string>
   <string name="a11y_create_poll_votes_allowed_decrease">"Decrease votes allowed per person"</string>
   <string name="a11y_create_poll_votes_allowed_increase">"Increase votes allowed per person"</string>


### PR DESCRIPTION
## Summary

- Adds `semantics { contentDescription = "Search" }` to the search `FilledTextField` in `RoomListSearchView` so TalkBack announces the field label (fixes #6389)

## Test plan

- [ ] Open the Chats search with TalkBack — verify the text field is announced as "Search"
- [ ] Type some chars and focus on the Close button - the announced text if "Clear search field"