### PR TITLE
Fix accessibility for message composer input and read receipts button

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
@@ -25,9 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -57,18 +58,12 @@ fun TimelineItemReadReceiptView(
     modifier: Modifier = Modifier,
 ) {
     if (state.receipts.isNotEmpty()) {
-        ReadReceiptsRow(
-            modifier = modifier.clearAndSetSemantics {
-                hideFromAccessibility()
-            }
-        ) {
+        ReadReceiptsRow(modifier = modifier) {
             ReadReceiptsAvatars(
                 receipts = state.receipts,
                 modifier = Modifier
                     .clip(RoundedCornerShape(4.dp))
-                    .clickable {
-                        onReadReceiptsClick()
-                    }
+                    .clickable { onReadReceiptsClick() }
                     .padding(2.dp)
             )
         }
@@ -137,9 +132,10 @@ private fun ReadReceiptsAvatars(
     val receiptDescription = computeReceiptDescription(receipts)
     Row(
         modifier = modifier
-            .clearAndSetSemantics {
+            .semantics {
                 testTag = TestTags.messageReadReceipts.value
                 contentDescription = receiptDescription
+                role = Role.Button
             },
         horizontalArrangement = Arrangement.spacedBy(4.dp - avatarStrokeSize),
         verticalAlignment = Alignment.CenterVertically,

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/receipt/TimelineItemReadReceiptView.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -63,7 +63,7 @@ fun TimelineItemReadReceiptView(
                 receipts = state.receipts,
                 modifier = Modifier
                     .clip(RoundedCornerShape(4.dp))
-                    .clickable { onReadReceiptsClick() }
+                    .clickable(onClick = onReadReceiptsClick)
                     .padding(2.dp)
             )
         }
@@ -132,7 +132,7 @@ private fun ReadReceiptsAvatars(
     val receiptDescription = computeReceiptDescription(receipts)
     Row(
         modifier = modifier
-            .semantics {
+            .clearAndSetSemantics {
                 testTag = TestTags.messageReadReceipts.value
                 contentDescription = receiptDescription
                 role = Role.Button

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
@@ -93,6 +93,7 @@ fun MarkdownTextInput(
                 setText(text)
                 setHint(placeholder)
                 setHintTextColor(ColorStateList.valueOf(placeholderColor.toArgb()))
+                contentDescription = placeholder
                 inputType = InputType.TYPE_CLASS_TEXT or
                     InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
                     InputType.TYPE_TEXT_FLAG_MULTI_LINE or
@@ -129,6 +130,7 @@ fun MarkdownTextInput(
             }
         },
         update = { editText ->
+            editText.contentDescription = placeholder
             editText.applyStyleInCompose(richTextEditorStyle)
             val text = state.text.value()
             mentionSpanUpdater.updateMentionSpans(text)


### PR DESCRIPTION
## Summary

- Sets `contentDescription = placeholder` on `MarkdownEditText` (in both `factory` and `update` blocks) so TalkBack always announces the input label, not just when the field is empty (fixes #6390)
- Removes `clearAndSetSemantics { hideFromAccessibility() }` from the read receipts row so the "Seen by" button is reachable by TalkBack; adds `role = Role.Button` to the avatars (fixes #6393)

## Test plan

- [ ] Open a room in Markdown mode, type a message, then clear it — verify TalkBack announces the placeholder label in both states
- [ ] On a message with read receipts, verify TalkBack can focus and activate the "Seen by" button