### PR TITLE
Announce checked/unchecked state for user rows in invite screen

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/CheckableUserRow.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/CheckableUserRow.kt
@@ -8,12 +8,12 @@
 
 package io.element.android.libraries.matrix.ui.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
@@ -39,8 +39,8 @@ fun CheckableUserRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(role = Role.Checkbox, enabled = enabled) {
-                onCheckedChange(!checked)
+            .toggleable(value = checked, role = Role.Checkbox, enabled = enabled) {
+                onCheckedChange(it)
             },
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -65,7 +65,7 @@ fun CheckableUserRow(
             }
         }
         Checkbox(
-            onCheckedChange = onCheckedChange,
+            onCheckedChange = null,
             checked = checked,
             enabled = enabled,
         )


### PR DESCRIPTION
## Summary

- Replaces `.clickable(role = Role.Checkbox)` with `.toggleable(value = checked, role = Role.Checkbox)` in `CheckableUserRow` so TalkBack announces the current checked state and state changes (fixes #6407)
- Sets `Checkbox.onCheckedChange = null` to make the inner checkbox a purely visual indicator, avoiding duplicate TalkBack focus on the same control

## Test plan

- [ ] Open the Invite People screen with TalkBack
- [ ] Focus a user row — verify TalkBack announces "checked" or "unchecked"
- [ ] Tap to toggle — verify TalkBack announces the state change