### PR TITLE
Add content description to video preview for screen readers

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/DefaultLocalMediaRenderer.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/DefaultLocalMediaRenderer.kt
@@ -40,6 +40,7 @@ class DefaultLocalMediaRenderer(
             localMediaViewState = localMediaViewState,
             textFileViewer = textFileViewer,
             audioFocus = audioFocus,
+            forPreview = true,
             onClick = {},
             onOpenWith = null,
         )

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/LocalMediaView.kt
@@ -33,6 +33,7 @@ fun LocalMediaView(
     onClick: () -> Unit,
     onOpenWith: (() -> Unit)?,
     textFileViewer: TextFileViewer,
+    forPreview: Boolean,
     modifier: Modifier = Modifier,
     isDisplayed: Boolean = true,
     isUserSelected: Boolean = false,
@@ -45,6 +46,7 @@ fun LocalMediaView(
             localMediaViewState = localMediaViewState,
             localMedia = localMedia,
             modifier = modifier,
+            forPreview = forPreview,
             onClick = onClick,
         )
         mimeType.isMimeTypeVideo() -> MediaVideoView(
@@ -54,6 +56,7 @@ fun LocalMediaView(
             localMedia = localMedia,
             autoplay = isUserSelected,
             audioFocus = audioFocus,
+            forPreview = forPreview,
             modifier = modifier,
         )
         mimeType == MimeTypes.PlainText -> TextFileView(

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/image/MediaImageView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/image/MediaImageView.kt
@@ -30,6 +30,7 @@ import me.saket.telephoto.zoomable.rememberZoomableImageState
 fun MediaImageView(
     localMediaViewState: LocalMediaViewState,
     localMedia: LocalMedia?,
+    forPreview: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -42,11 +43,16 @@ fun MediaImageView(
     } else {
         val zoomableImageState = rememberZoomableImageState(localMediaViewState.zoomableState)
         localMediaViewState.isReady = zoomableImageState.isImageDisplayed
+        val imageDescription = if (forPreview) {
+            stringResource(CommonStrings.a11y_photo_preview)
+        } else {
+            stringResource(CommonStrings.common_image)
+        }
         ZoomableAsyncImage(
             modifier = modifier,
             state = zoomableImageState,
             model = localMedia?.uri,
-            contentDescription = stringResource(id = CommonStrings.common_image),
+            contentDescription = imageDescription,
             contentScale = ContentScale.Fit,
             onClick = { onClick() }
         )
@@ -60,6 +66,7 @@ internal fun MediaImageViewPreview() = ElementPreview {
         modifier = Modifier.fillMaxSize(),
         localMediaViewState = rememberLocalMediaViewState(),
         localMedia = null,
+        forPreview = false,
         onClick = {},
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.media3.common.MediaItem
@@ -60,6 +61,7 @@ import io.element.android.libraries.mediaviewer.impl.local.player.rememberExoPla
 import io.element.android.libraries.mediaviewer.impl.local.player.seekToEnsurePlaying
 import io.element.android.libraries.mediaviewer.impl.local.player.togglePlay
 import io.element.android.libraries.mediaviewer.impl.local.rememberLocalMediaViewState
+import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.libraries.ui.utils.a11y.isTalkbackActive
 import kotlinx.coroutines.delay
 import me.saket.telephoto.zoomable.zoomable
@@ -218,6 +220,7 @@ private fun ExoPlayerMediaVideoView(
                 text = "A Video Player will render here",
             )
         } else {
+            val videoDescription = stringResource(CommonStrings.a11y_video_preview)
             AndroidView(
                 modifier = Modifier
                     .fillMaxSize()
@@ -236,6 +239,7 @@ private fun ExoPlayerMediaVideoView(
                         resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
                         useController = false
+                        contentDescription = videoDescription
                     }
                 },
                 onRelease = { playerView ->

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/local/video/MediaVideoView.kt
@@ -77,6 +77,7 @@ fun MediaVideoView(
     localMedia: LocalMedia?,
     autoplay: Boolean,
     audioFocus: AudioFocus?,
+    forPreview: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val exoPlayer = rememberExoPlayer(forAudioOnly = false)
@@ -88,6 +89,7 @@ fun MediaVideoView(
         localMedia = localMedia,
         autoplay = autoplay,
         audioFocus = audioFocus,
+        forPreview = forPreview,
         modifier = modifier,
     )
 }
@@ -102,6 +104,7 @@ private fun ExoPlayerMediaVideoView(
     localMedia: LocalMedia?,
     autoplay: Boolean,
     audioFocus: AudioFocus?,
+    forPreview: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var mediaPlayerControllerState: MediaPlayerControllerState by remember {
@@ -220,7 +223,11 @@ private fun ExoPlayerMediaVideoView(
                 text = "A Video Player will render here",
             )
         } else {
-            val videoDescription = stringResource(CommonStrings.a11y_video_preview)
+            val videoDescription = if (forPreview) {
+                stringResource(CommonStrings.a11y_video_preview)
+            } else {
+                stringResource(CommonStrings.common_video)
+            }
             AndroidView(
                 modifier = Modifier
                     .fillMaxSize()
@@ -359,5 +366,6 @@ internal fun MediaVideoViewPreview() = ElementPreview {
         localMedia = null,
         audioFocus = null,
         autoplay = false,
+        forPreview = false,
     )
 }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -396,6 +396,7 @@ private fun MediaViewerPage(
                     onOpenWith = onOpenWith,
                     isUserSelected = isUserSelected,
                     audioFocus = audioFocus,
+                    forPreview = false,
                 )
                 if (showThumbnail) {
                     ThumbnailView(


### PR DESCRIPTION
## Summary

- Sets `contentDescription = stringResource(CommonStrings.a11y_video_preview)` on the ExoPlayer `PlayerView` in `MediaVideoView` so TalkBack announces the video to screen reader users instead of skipping it (fixes #6382)

## Test plan

- [ ] Attach a video to a message and open the attachment preview screen with TalkBack
- [ ] Verify TalkBack announces "Video preview" when focused on the video player area