### PR TITLE
Bump the default Gradle daemon heap to match what CI already uses

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseG1GC
+# Matches the heap size CI already uses for release builds (see GRADLE_OPTS in
+# .github/workflows/release.yml and nightly.yml) - a local `assembleRelease`/`bundleRelease`
+# runs R8 on the full app and can run out of heap well before 4g on this codebase's size.
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8 -XX:+UseG1GC
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
## Content

A local release build runs R8 over the full app and reliably runs out of heap at the checked-in 4g default. CI has used 8g for release builds all along via GRADLE_OPTS, so bring the local default in line with that.

Same reasoning as 6e55f2d7 (#1087), which bumped 2048m to 4g.

## Motivation and context

I was not able to build the app.

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
