### PR TITLE
feat: Add copy button for code blocks in text messages

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/event/TimelineItemTextView.kt
@@ -8,19 +8,34 @@
 
 package io.element.android.features.messages.impl.timeline.components.event
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.text.SpannedString
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
+import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.timeline.components.layout.ContentAvoidingLayout
 import io.element.android.features.messages.impl.timeline.components.layout.ContentAvoidingLayoutData
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextBasedContent
@@ -63,8 +78,57 @@ fun TimelineItemTextView(
                 onTextLayout = ContentAvoidingLayout.measureLegacyLastTextLine(onContentLayoutChange = onContentLayoutChange),
                 releaseOnDetach = false,
             )
+            CodeBlockCopyButton(content = content)
         }
     }
+}
+
+/**
+ * Extracts the text from all `<pre><code>` blocks in the message.
+ */
+private fun extractCodeBlocks(content: TimelineItemTextBasedContent): List<String> {
+    val doc = content.htmlDocument ?: return emptyList()
+    val codeElements = doc.select("pre > code")
+    if (codeElements.isEmpty()) return emptyList()
+    return codeElements.map { it.text() }
+}
+
+/**
+ * A small copy button that appears on messages containing code blocks.
+ * Tapping it copies all code block content to the clipboard.
+ */
+@Composable
+private fun CodeBlockCopyButton(content: TimelineItemTextBasedContent) {
+    val codeTexts = remember(content) { extractCodeBlocks(content) }
+    if (codeTexts.isEmpty()) return
+
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+
+    IconButton(
+        onClick = {
+            val text = codeTexts.joinToString("\n")
+            copyToClipboard(context, text)
+            copied = true
+        },
+        modifier = Modifier
+            .align(Alignment.TopEnd)
+            .padding(2.dp)
+            .size(32.dp),
+    ) {
+        Icon(
+            imageVector = CompoundIcons.Copy(),
+            contentDescription = if (copied) "Copied" else "Copy code",
+            tint = ElementTheme.colors.textSecondary,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("code", text)
+    clipboard.setPrimaryClip(clip)
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)


### PR DESCRIPTION
## Description

Adds a copy-to-clipboard button on text messages that contain `<pre><code>` blocks. When tapped, all code content is copied to the clipboard.

## Changes

- `TimelineItemTextView.kt`: Added `extractCodeBlocks()` and `CodeBlockCopyButton()` composable
- The button uses `CompoundIcons.Copy()` and appears in the top-right corner of messages containing code blocks
- No modifications to the wysiwyg renderer — purely additive overlay in the message view

## Screenshots

<!-- Would need to add before/after screenshots -->

## Why this matters

Many messaging apps (Telegram, Discord, Slack, GitHub) provide a one-tap copy button on code blocks. This feature brings the same convenience to Element X Android, making it easier for users to copy code snippets shared in conversations.