### PR TITLE
Declare ACCESS_LOCAL_NETWORK permission so local homeservers work on Android 17

### DIFF
--- a/libraries/matrix/api/src/main/AndroidManifest.xml
+++ b/libraries/matrix/api/src/main/AndroidManifest.xml
@@ -8,5 +8,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required since targetSdk 37 (Android 17) to reach homeservers on the local network. -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
 </manifest>


### PR DESCRIPTION
## Content

Declare the `ACCESS_LOCAL_NETWORK` permission in the matrix api library manifest (next to `INTERNET`).

## Motivation and context

Since the targetSdk was raised to 37, Android 17's local network protections are enforced. Element X currently does not declare `ACCESS_LOCAL_NETWORK`, so:

- all traffic to homeservers on private addresses (192.168.x.x, 10.x.x.x, mDNS) is silently dropped — sync and push notifications stop working whenever the device is on the same LAN as a self-hosted homeserver,
- users cannot even grant the permission manually, because without the manifest declaration Android shows no toggle and `appops` rejects mode changes.

Declaring the permission makes the "Nearby devices" permission toggle available in the app settings, which is the minimal fix suggested in the discussion of #7077 ("devs can just add the permission to the manifest"). A follow-up could request the permission at runtime during server selection, as attempted in #7077, but this one-liner already unblocks affected self-hosters.

Fixes #7073

## Tests

- Reproduced on a Pixel 9a (Android 17, v26.06.x from the store) with a self-hosted Synapse on a private address: connection attempts are rejected by the system (visible via `appops get ... ACCESS_LOCAL_NETWORK` showing a fresh `rejectTime` on every app start), no permission toggle available.
- A build with the declared permission was already tested by a user in #7077 (comment by @pdc1): after manually granting "Nearby devices", connecting to a local homeserver works again. This PR applies exactly that declaration.

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 24 (see Tests above — reproduction verified on device, fixed build verified by community testing in #7077)
- [x] UI change has been tested on both light and dark themes (no UI change)
- [x] Accessibility has been taken into account. (no UI change)
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
