### PR TITLE
Bugfix/Retry session restore after cache clear

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -73,6 +73,8 @@ import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.api.watchers.AnalyticsColdStartWatcher
 import io.element.android.services.appnavstate.api.ROOM_OPENED_FROM_NOTIFICATION
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
@@ -109,6 +111,8 @@ class RootFlowNode(
     buildContext = buildContext,
     plugins = plugins
 ) {
+    private var restoreLatestSessionRetryJob: Job? = null
+
     override fun onBuilt() {
         analyticsColdStartWatcher.start()
         appCoroutineScope.launch {
@@ -140,18 +144,26 @@ class RootFlowNode(
                         if (navState.loggedInState.isTokenValid) {
                             val sessionId = SessionId(navState.loggedInState.sessionId)
                             if (matrixSessionCache.getOrNull(sessionId) != null) {
+                                cancelRestoreLatestSessionRetry()
                                 switchToLoggedInFlow(sessionId, navState.cacheIndex)
                             } else {
                                 tryToRestoreLatestSession(
-                                    onSuccess = { sessionId -> switchToLoggedInFlow(sessionId, navState.cacheIndex) },
-                                    onFailure = { switchToNotLoggedInFlow(null) }
+                                    onSuccess = { sessionId ->
+                                        cancelRestoreLatestSessionRetry()
+                                        switchToLoggedInFlow(sessionId, navState.cacheIndex)
+                                    },
+                                    onFailure = {
+                                        scheduleRestoreLatestSessionRetry(navState.cacheIndex)
+                                    }
                                 )
                             }
                         } else {
+                            cancelRestoreLatestSessionRetry()
                             switchToSignedOutFlow(SessionId(navState.loggedInState.sessionId))
                         }
                     }
                     LoggedInState.NotLoggedIn -> {
+                        cancelRestoreLatestSessionRetry()
                         switchToNotLoggedInFlow(null)
                     }
                 }
@@ -204,6 +216,29 @@ class RootFlowNode(
 
     private fun switchToSignedOutFlow(sessionId: SessionId) {
         backstack.safeRoot(NavTarget.SignedOutFlow(sessionId))
+    }
+
+    private fun scheduleRestoreLatestSessionRetry(cacheIndex: Int) {
+        if (restoreLatestSessionRetryJob?.isActive == true) return
+        Timber.w("Failed to restore logged-in session, will retry")
+        backstack.safeRoot(NavTarget.SplashScreen)
+        restoreLatestSessionRetryJob = lifecycleScope.launch {
+            delay(1_000)
+            restoreLatestSessionRetryJob = null
+            tryToRestoreLatestSession(
+                onSuccess = { sessionId ->
+                    switchToLoggedInFlow(sessionId, cacheIndex)
+                },
+                onFailure = {
+                    scheduleRestoreLatestSessionRetry(cacheIndex)
+                }
+            )
+        }
+    }
+
+    private fun cancelRestoreLatestSessionRetry() {
+        restoreLatestSessionRetryJob?.cancel()
+        restoreLatestSessionRetryJob = null
     }
 
     private suspend fun restoreSessionIfNeeded(


### PR DESCRIPTION
## Content

When a logged-in session fails try restoring the stored session instead of routing to onboarding.

## Motivation and context

When developing for the app, I was frequently routed to the onboarding page, after enabling Threads.

## Tests

- Enable Threads

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Graphene OS (latest)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
