### PR TITLE
Add item count text as the placeholder for in reply to box for galleries

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadata.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadata.kt
@@ -10,12 +10,15 @@ package io.element.android.libraries.matrix.ui.messages.reply
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.CallNotifyContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FailedToParseMessageLikeContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FailedToParseStateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FileMessageType
+import io.element.android.libraries.matrix.api.timeline.item.event.GalleryItemType
+import io.element.android.libraries.matrix.api.timeline.item.event.GalleryMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.ImageMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.LegacyCallInviteContent
 import io.element.android.libraries.matrix.api.timeline.item.event.LiveLocationContent
@@ -35,6 +38,7 @@ import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailInfo
 import io.element.android.libraries.matrix.ui.components.AttachmentThumbnailType
 import io.element.android.libraries.matrix.ui.messages.reply.InReplyToMetadata.Text
 import io.element.android.libraries.matrix.ui.messages.reply.InReplyToMetadata.Thumbnail
+import io.element.android.libraries.ui.strings.CommonPlurals
 import io.element.android.libraries.ui.strings.CommonStrings
 
 @Immutable
@@ -104,6 +108,44 @@ internal fun InReplyToDetails.Ready.metadata(hideImage: Boolean): InReplyToMetad
                 type = AttachmentThumbnailType.Voice,
             )
         )
+        is GalleryMessageType -> {
+            val caption = textContent?.takeIf { it.isNotBlank() }
+            val isMediaGallery = type.items.all { it is GalleryItemType.Image || it is GalleryItemType.Video }
+            val countPlural = if (isMediaGallery) {
+                CommonPlurals.common_gallery_reply_media_items
+            } else {
+                CommonPlurals.common_gallery_reply_attachments
+            }
+            val text = caption ?: pluralStringResource(countPlural, type.items.size, type.items.size)
+            if (isMediaGallery) {
+                val firstMediaItem = type.items.firstOrNull { it is GalleryItemType.Image || it is GalleryItemType.Video }
+                val thumbnailSource = when (firstMediaItem) {
+                    is GalleryItemType.Image -> (firstMediaItem.content.info?.thumbnailSource ?: firstMediaItem.content.source).takeUnless { hideImage }
+                    is GalleryItemType.Video -> firstMediaItem.content.info?.thumbnailSource?.takeUnless { hideImage }
+                    else -> null
+                }
+                val blurHash = when (firstMediaItem) {
+                    is GalleryItemType.Image -> firstMediaItem.content.info?.blurhash
+                    is GalleryItemType.Video -> firstMediaItem.content.info?.blurhash
+                    else -> null
+                }
+                Thumbnail(
+                    AttachmentThumbnailInfo(
+                        thumbnailSource = thumbnailSource,
+                        textContent = text,
+                        type = AttachmentThumbnailType.Image,
+                        blurHash = blurHash,
+                    )
+                )
+            } else {
+                Thumbnail(
+                    AttachmentThumbnailInfo(
+                        textContent = text,
+                        type = AttachmentThumbnailType.File,
+                    )
+                )
+            }
+        }
         else -> Text(textContent ?: eventContent.body)
     }
     is StickerContent -> Thumbnail(

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadata.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadata.kt
@@ -111,13 +111,12 @@ internal fun InReplyToDetails.Ready.metadata(hideImage: Boolean): InReplyToMetad
         is GalleryMessageType -> {
             val caption = textContent?.takeIf { it.isNotBlank() }
             val isMediaGallery = type.items.all { it is GalleryItemType.Image || it is GalleryItemType.Video }
-            val countPlural = if (isMediaGallery) {
-                CommonPlurals.common_gallery_reply_media_items
-            } else {
-                CommonPlurals.common_gallery_reply_attachments
-            }
-            val text = caption ?: pluralStringResource(countPlural, type.items.size, type.items.size)
             if (isMediaGallery) {
+                val text = caption ?: pluralStringResource(
+                    CommonPlurals.common_gallery_reply_media_items,
+                    type.items.size,
+                    type.items.size,
+                )
                 val firstMediaItem = type.items.firstOrNull { it is GalleryItemType.Image || it is GalleryItemType.Video }
                 val thumbnailSource = when (firstMediaItem) {
                     is GalleryItemType.Image -> (firstMediaItem.content.info?.thumbnailSource ?: firstMediaItem.content.source).takeUnless { hideImage }
@@ -129,15 +128,24 @@ internal fun InReplyToDetails.Ready.metadata(hideImage: Boolean): InReplyToMetad
                     is GalleryItemType.Video -> firstMediaItem.content.info?.blurhash
                     else -> null
                 }
+                val type = when (firstMediaItem) {
+                    is GalleryItemType.Video -> AttachmentThumbnailType.Video
+                    else -> AttachmentThumbnailType.Image
+                }
                 Thumbnail(
                     AttachmentThumbnailInfo(
                         thumbnailSource = thumbnailSource,
                         textContent = text,
-                        type = AttachmentThumbnailType.Image,
+                        type = type,
                         blurHash = blurHash,
                     )
                 )
             } else {
+                val text = caption ?: pluralStringResource(
+                    CommonPlurals.common_gallery_reply_attachments,
+                    type.items.size,
+                    type.items.size,
+                )
                 Thumbnail(
                     AttachmentThumbnailInfo(
                         textContent = text,

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.time.Duration.Companion.minutes
 
+@Suppress("LargeClass")
 class InReplyToMetadataKtTest : RobolectricTest() {
     @Test
     fun `any message content`() = runTest {

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/reply/InReplyToMetadataKtTest.kt
@@ -24,6 +24,8 @@ import io.element.android.libraries.matrix.api.timeline.item.event.EventContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FailedToParseMessageLikeContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FailedToParseStateContent
 import io.element.android.libraries.matrix.api.timeline.item.event.FileMessageType
+import io.element.android.libraries.matrix.api.timeline.item.event.GalleryItemType
+import io.element.android.libraries.matrix.api.timeline.item.event.GalleryMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.ImageMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.LocationMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherState
@@ -399,6 +401,226 @@ class InReplyToMetadataKtTest : RobolectricTest() {
                             thumbnailSource = null,
                             textContent = "Voice message",
                             type = AttachmentThumbnailType.Voice,
+                            blurHash = null,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a gallery message with all media items shows media count`() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            withConfigurationAndContext {
+                anInReplyToDetailsReady(
+                    eventContent = aMessageContent(
+                        messageType = GalleryMessageType(
+                            body = "",
+                            formatted = null,
+                            items = listOf(
+                                GalleryItemType.Image(
+                                    ImageMessageType(
+                                        filename = "image1.jpg",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = anImageInfo(),
+                                    )
+                                ),
+                                GalleryItemType.Image(
+                                    ImageMessageType(
+                                        filename = "image2.jpg",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = anImageInfo(),
+                                    )
+                                ),
+                            ),
+                        )
+                    ),
+                    textContent = "",
+                ).metadata(hideImage = false)
+            }
+        }.test {
+            awaitItem().let {
+                assertThat(it).isEqualTo(
+                    InReplyToMetadata.Thumbnail(
+                        attachmentThumbnailInfo = AttachmentThumbnailInfo(
+                            thumbnailSource = aMediaSource(),
+                            textContent = "2 media items…",
+                            type = AttachmentThumbnailType.Image,
+                            blurHash = A_BLUR_HASH,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a gallery message with attachment items shows attachment count`() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            withConfigurationAndContext {
+                anInReplyToDetailsReady(
+                    eventContent = aMessageContent(
+                        messageType = GalleryMessageType(
+                            body = "",
+                            formatted = null,
+                            items = listOf(
+                                GalleryItemType.File(
+                                    FileMessageType(
+                                        filename = "doc1.pdf",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = FileInfo(
+                                            mimetype = null,
+                                            size = null,
+                                            thumbnailInfo = null,
+                                            thumbnailSource = null,
+                                        ),
+                                    )
+                                ),
+                                GalleryItemType.File(
+                                    FileMessageType(
+                                        filename = "doc2.pdf",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = FileInfo(
+                                            mimetype = null,
+                                            size = null,
+                                            thumbnailInfo = null,
+                                            thumbnailSource = null,
+                                        ),
+                                    )
+                                ),
+                            ),
+                        )
+                    ),
+                    textContent = "",
+                ).metadata(hideImage = false)
+            }
+        }.test {
+            awaitItem().let {
+                assertThat(it).isEqualTo(
+                    InReplyToMetadata.Thumbnail(
+                        attachmentThumbnailInfo = AttachmentThumbnailInfo(
+                            thumbnailSource = null,
+                            textContent = "2 attachments…",
+                            type = AttachmentThumbnailType.File,
+                            blurHash = null,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a gallery message with caption shows caption instead of count`() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            withConfigurationAndContext {
+                anInReplyToDetailsReady(
+                    eventContent = aMessageContent(
+                        messageType = GalleryMessageType(
+                            body = "My vacation photos",
+                            formatted = null,
+                            items = listOf(
+                                GalleryItemType.Image(
+                                    ImageMessageType(
+                                        filename = "image1.jpg",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = anImageInfo(),
+                                    )
+                                ),
+                                GalleryItemType.Image(
+                                    ImageMessageType(
+                                        filename = "image2.jpg",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = anImageInfo(),
+                                    )
+                                ),
+                            ),
+                        )
+                    ),
+                    textContent = "My vacation photos",
+                ).metadata(hideImage = false)
+            }
+        }.test {
+            awaitItem().let {
+                assertThat(it).isEqualTo(
+                    InReplyToMetadata.Thumbnail(
+                        attachmentThumbnailInfo = AttachmentThumbnailInfo(
+                            thumbnailSource = aMediaSource(),
+                            textContent = "My vacation photos",
+                            type = AttachmentThumbnailType.Image,
+                            blurHash = A_BLUR_HASH,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a gallery message with attachment items and caption shows caption instead of count`() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            withConfigurationAndContext {
+                anInReplyToDetailsReady(
+                    eventContent = aMessageContent(
+                        messageType = GalleryMessageType(
+                            body = "My documents",
+                            formatted = null,
+                            items = listOf(
+                                GalleryItemType.File(
+                                    FileMessageType(
+                                        filename = "doc1.pdf",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = FileInfo(
+                                            mimetype = null,
+                                            size = null,
+                                            thumbnailInfo = null,
+                                            thumbnailSource = null,
+                                        ),
+                                    )
+                                ),
+                                GalleryItemType.File(
+                                    FileMessageType(
+                                        filename = "doc2.pdf",
+                                        caption = null,
+                                        formattedCaption = null,
+                                        source = aMediaSource(),
+                                        info = FileInfo(
+                                            mimetype = null,
+                                            size = null,
+                                            thumbnailInfo = null,
+                                            thumbnailSource = null,
+                                        ),
+                                    )
+                                ),
+                            ),
+                        )
+                    ),
+                    textContent = "My documents",
+                ).metadata(hideImage = false)
+            }
+        }.test {
+            awaitItem().let {
+                assertThat(it).isEqualTo(
+                    InReplyToMetadata.Thumbnail(
+                        attachmentThumbnailInfo = AttachmentThumbnailInfo(
+                            thumbnailSource = null,
+                            textContent = "My documents",
+                            type = AttachmentThumbnailType.File,
                             blurHash = null,
                         )
                     )

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -268,6 +268,14 @@ Reason: %1$s."</string>
   <string name="common_forward_message">"Forward message"</string>
   <string name="common_frequently_used">"Frequently used"</string>
   <string name="common_gallery">"Gallery"</string>
+  <plurals name="common_gallery_reply_attachments">
+    <item quantity="one">"%1$d attachment…"</item>
+    <item quantity="other">"%1$d attachments…"</item>
+  </plurals>
+  <plurals name="common_gallery_reply_media_items">
+    <item quantity="one">"%1$d media item…"</item>
+    <item quantity="other">"%1$d media items…"</item>
+  </plurals>
   <string name="common_gif">"GIF"</string>
   <string name="common_group_call_in_progress">"Group call in progress"</string>
   <string name="common_image">"Image"</string>

--- a/libraries/ui-strings/src/main/res/values/temporary.xml
+++ b/libraries/ui-strings/src/main/res/values/temporary.xml
@@ -8,10 +8,4 @@
 <resources>
     <string name="action_mark_as_read">"Mark as read"</string>
     <string name="a11y_jump_to_unread_messages">"Jump to first unread message"</string>
-    <plurals name="common_gallery_reply_media_items">
-        <item quantity="other">"%1$d media items…"</item>
-    </plurals>
-    <plurals name="common_gallery_reply_attachments">
-        <item quantity="other">"%1$d attachments…"</item>
-    </plurals>
 </resources>

--- a/libraries/ui-strings/src/main/res/values/temporary.xml
+++ b/libraries/ui-strings/src/main/res/values/temporary.xml
@@ -8,4 +8,10 @@
 <resources>
     <string name="action_mark_as_read">"Mark as read"</string>
     <string name="a11y_jump_to_unread_messages">"Jump to first unread message"</string>
+    <plurals name="common_gallery_reply_media_items">
+        <item quantity="other">"%1$d media items…"</item>
+    </plurals>
+    <plurals name="common_gallery_reply_attachments">
+        <item quantity="other">"%1$d attachments…"</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Fixes #7100

## Motivation and context

Overlooked the design screenshots while implementing.

## Screenshots / GIFs

I'll run CI

## Tests

<!-- Explain how you tested your development -->

- Reply to a gallery message
  - If there's no caption, "count media items..." or "count attachments..." should be shown.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR