### PR TITLE
[WIP] FOSS infrastructure for X.509 signing and verification

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainActivity.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainActivity.kt
@@ -61,6 +61,10 @@ class MainActivity : NodeActivity() {
         setContent {
             MainContent(appBindings)
         }
+
+        lifecycleScope.launch {
+            appBindings.x509Provider().onAppStartup(this@MainActivity)
+        }
     }
 
     @Composable

--- a/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.di.identifiers.SentrySdkDsn
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.matrix.api.platform.InitPlatformService
 import io.element.android.libraries.matrix.api.tracing.TracingService
+import io.element.android.libraries.matrix.api.x509.X509Provider
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.services.analytics.api.AnalyticsService
 
@@ -51,4 +52,6 @@ interface AppBindings {
     fun buildMeta(): BuildMeta
 
     fun sentrySdkDsn(): SentrySdkDsn?
+
+    fun x509Provider(): X509Provider
 }

--- a/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/EnterpriseService.kt
+++ b/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/EnterpriseService.kt
@@ -34,6 +34,11 @@ interface EnterpriseService {
     fun firebasePushGateway(): String?
     fun unifiedPushDefaultPushGateway(): String?
 
+    /**
+     * Whether X.509 signing of cross-signing keys is enabled for this device, as reported by the device's MDM restrictions.
+     */
+    fun isX509SigningEnabled(): Boolean
+
     fun bugReportUrlFlow(sessionId: SessionId?): Flow<BugReportUrl>
 
     /**

--- a/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/DefaultEnterpriseService.kt
+++ b/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/DefaultEnterpriseService.kt
@@ -40,6 +40,8 @@ class DefaultEnterpriseService : EnterpriseService {
     override fun firebasePushGateway(): String? = null
     override fun unifiedPushDefaultPushGateway(): String? = null
 
+    override fun isX509SigningEnabled(): Boolean = false
+
     override fun bugReportUrlFlow(sessionId: SessionId?): Flow<BugReportUrl> {
         return flowOf(BugReportUrl.UseDefault)
     }

--- a/features/enterprise/test/src/main/kotlin/io/element/android/features/enterprise/test/FakeEnterpriseService.kt
+++ b/features/enterprise/test/src/main/kotlin/io/element/android/features/enterprise/test/FakeEnterpriseService.kt
@@ -31,6 +31,7 @@ class FakeEnterpriseService(
     private val unifiedPushDefaultPushGatewayResult: () -> String? = { lambdaError() },
     private val getNoisyNotificationChannelIdResult: (SessionId?) -> String? = { lambdaError() },
     private val tweakMasUrlResult: (String, String) -> String = { _, _ -> lambdaError() },
+    private val isX509SigningEnabledResult: () -> Boolean = { false },
 ) : EnterpriseService {
     private val brandColorState = MutableStateFlow(initialBrandColor)
     private val semanticColorsState = MutableStateFlow(initialSemanticColors)
@@ -69,6 +70,10 @@ class FakeEnterpriseService(
 
     override fun unifiedPushDefaultPushGateway(): String? {
         return unifiedPushDefaultPushGatewayResult()
+    }
+
+    override fun isX509SigningEnabled(): Boolean {
+        return isX509SigningEnabledResult()
     }
 
     val bugReportUrlMutableFlow = MutableStateFlow<BugReportUrl>(BugReportUrl.UseDefault)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signature.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signature.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+/**
+ * The object we receive from [`X509Sign`], and pass to
+ * [`X509Verify`].
+ *
+ * A simplified representation of the data in the signature object.
+ */
+data class RawX509Signature(
+    /**
+     * The PEM-encoded certificate chain, starting with the device's own
+     * certificate, followed by intermediate certificates.
+     */
+    val certificateChain: String,
+    /** The raw bytes of the signature. */
+    val signatureBytes: ByteArray,
+    /** The algorithm that the signer used to construct the signature. */
+    val signatureScheme: X509SignatureScheme,
+) {
+    // Overridden because the [signatureBytes] array must be compared by content, not by reference.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RawX509Signature) return false
+
+        return certificateChain == other.certificateChain &&
+            signatureBytes.contentEquals(other.signatureBytes) &&
+            signatureScheme == other.signatureScheme
+    }
+
+    override fun hashCode(): Int {
+        var result = certificateChain.hashCode()
+        result = 31 * result + signatureBytes.contentHashCode()
+        result = 31 * result + signatureScheme.hashCode()
+        return result
+    }
+}
+
+enum class X509SignatureScheme {
+    /**
+     * SHA-512 message digest, with RSASSA-PSS signature scheme (aka RSA-PSS),
+     * per [RFC 8017 § 8.1](https://www.rfc-editor.org/info/rfc8017/#section-8.1).
+     *
+     * Not to be confused with RSA-PKCS1, which is incompatible.
+     */
+    RSA_PSS_SHA512,
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+import android.app.Activity
+
+interface X509Provider {
+    suspend fun onAppStartup(parentActivity: Activity)
+    suspend fun getX509Sign(): X509Sign?
+    suspend fun getX509Verify(): X509Verify?
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Sign.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Sign.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+interface X509Sign {
+    fun sign(message: ByteArray): RawX509Signature
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Verify.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Verify.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+interface X509Verify {
+    /** Check that `sig` is a valid signature of `message`.
+     *
+     * Implementations must check:
+     *  * The certificate chain is issued via a trusted CA.
+     *  * The certificate is valid for today's date.
+     *  * The signature itself is a valid signature of `message`.
+     *
+     * @return `true` if the signature is valid, otherwise `false`.
+     */
+    fun verify(message: ByteArray, sig: RawX509Signature): Boolean
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.paths.SessionPaths
 import io.element.android.libraries.matrix.api.scanner.ContentScannerUrlProvider
+import io.element.android.libraries.matrix.api.x509.X509Provider
 import io.element.android.libraries.matrix.impl.analytics.UtdTracker
 import io.element.android.libraries.matrix.impl.paths.getSessionPaths
 import io.element.android.libraries.matrix.impl.proxy.ProxyProvider
@@ -27,6 +28,8 @@ import io.element.android.libraries.matrix.impl.room.TimelineEventFilterFactory
 import io.element.android.libraries.matrix.impl.scanner.RustContentScanner
 import io.element.android.libraries.matrix.impl.storage.SqliteStoreBuilderProvider
 import io.element.android.libraries.matrix.impl.util.anonymizedTokens
+import io.element.android.libraries.matrix.impl.x509.X509SignWrapper
+import io.element.android.libraries.matrix.impl.x509.X509VerifyWrapper
 import io.element.android.libraries.network.useragent.UserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.libraries.sessionstorage.api.SessionStore
@@ -71,6 +74,7 @@ class RustMatrixClientFactory(
     private val sqliteStoreBuilderProvider: SqliteStoreBuilderProvider,
     private val workManagerScheduler: WorkManagerScheduler,
     private val contentScannerUrlProvider: ContentScannerUrlProvider,
+    private val x509Provider: X509Provider,
 ) {
     private val sessionDelegate = RustClientSessionDelegate(
         sessionStore = sessionStore,
@@ -165,7 +169,7 @@ class RustMatrixClientFactory(
         clientSecret: ClientSecret?,
         slidingSyncType: ClientBuilderSlidingSync,
     ): ClientBuilder {
-        return clientBuilderProvider.provide()
+        var builder = clientBuilderProvider.provide()
             .run {
                 sqliteStoreBuilderProvider.provide(sessionPaths)
                     .secret(clientSecret)
@@ -206,7 +210,18 @@ class RustMatrixClientFactory(
             )
             // Make sure all built clients use the single process cross-process lock config
             .crossProcessLockConfig(CrossProcessLockConfig.SingleProcess)
-            .run {
+
+        val x509sign = x509Provider.getX509Sign()
+        if (x509sign != null) {
+            builder = builder.withX509Sign(X509SignWrapper(x509sign))
+        }
+
+        val x509verify = x509Provider.getX509Verify()
+        if (x509verify != null) {
+            builder = builder.withX509Verify(X509VerifyWrapper(x509verify))
+        }
+
+        return builder.run {
                 // Apply sliding sync version settings
                 when (slidingSyncType) {
                     ClientBuilderSlidingSync.Restored -> this

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import android.app.Activity
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.matrix.api.x509.X509Provider
+import io.element.android.libraries.matrix.api.x509.X509Sign
+import io.element.android.libraries.matrix.api.x509.X509Verify
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultX509Provider : X509Provider {
+    override suspend fun onAppStartup(parentActivity: Activity) {
+    }
+
+    override suspend fun getX509Sign(): X509Sign? {
+        return null
+    }
+
+    override suspend fun getX509Verify(): X509Verify? {
+        return null
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/X509SignWrapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/X509SignWrapper.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import io.element.android.libraries.matrix.api.x509.X509Sign
+import io.element.android.libraries.matrix.api.x509.X509SignatureScheme
+import uniffi.matrix_sdk_crypto.RawX509Signature
+
+/** A shim which maps from our own [X509Sign] interface to the rust-sdk's interface of the same name */
+class X509SignWrapper(private val x509Sign: X509Sign) : org.matrix.rustcomponents.sdk.X509Sign {
+    override fun sign(message: ByteArray): RawX509Signature {
+        val sig = x509Sign.sign(message)
+        val signatureScheme = when (sig.signatureScheme) {
+            X509SignatureScheme.RSA_PSS_SHA512 -> uniffi.matrix_sdk_crypto.X509SignatureScheme.RSA_PSS_SHA512
+        }
+        return RawX509Signature(sig.signatureBytes, sig.certificateChain, signatureScheme)
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/X509VerifyWrapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/X509VerifyWrapper.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import io.element.android.libraries.matrix.api.x509.X509Verify
+import uniffi.matrix_sdk_crypto.RawX509Signature
+import uniffi.matrix_sdk_crypto.X509SignatureScheme
+
+/** A shim which maps from our own [X509Verify] interface to the rust-sdk's interface of the same name */
+class X509VerifyWrapper(private val x509Verify: X509Verify) : org.matrix.rustcomponents.sdk.X509Verify {
+    override fun verify(message: ByteArray, sig: RawX509Signature): Boolean {
+        val signatureScheme = when (sig.signatureScheme) {
+            X509SignatureScheme.RSA_PSS_SHA512 -> io.element.android.libraries.matrix.api.x509.X509SignatureScheme.RSA_PSS_SHA512
+        }
+
+        val sig = io.element.android.libraries.matrix.api.x509.RawX509Signature(
+            sig.certificateChain,
+            sig.signatureBytes,
+            signatureScheme
+        )
+        return x509Verify.verify(message, sig)
+    }
+}


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->

This PR implements the Android-native side of the X.509 signing and verification work, introducing a signer and verifier implementation, as well as a startup hook to look for keychains on-device.

Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/6727 and a release of the Kotlin components, as well as the companion enterprise PR.

## Motivation and context

X.509 verification allows devices to be loaded with homeserver-origin certificates, and key chains signed by said certificate, allowing the device to be automatically verified.

This PR is based on the work by @andybalaam and @richvdh on the [`andyrich/x509`](https://github.com/element-hq/element-x-android/tree/andyrich/x509) branch and should be nearly identical, bar a few nits and a tidier commit history.

## Screenshots / GIFs

WIP

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 36.1

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
