### PR TITLE
Live location sharing timeout

### DIFF
--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManager.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManager.kt
@@ -141,6 +141,18 @@ class DefaultActiveLiveLocationShareManager(
     }
 
     override suspend fun onLocationUpdate(location: Location) {
+        val active = stopExpiredShares()
+        Timber.d("ActiveLiveLocationShareManager received location update for ${active.size} active share(s)")
+        active.forEach { roomId ->
+            Timber.d("ActiveLiveLocationShareManager sending location to room $roomId")
+            sendLiveLocation(roomId, location)
+                .onFailure {
+                    Timber.e(it, "ActiveLiveLocationShareManager failed to send location to room $roomId")
+                }
+        }
+    }
+
+    private suspend fun stopExpiredShares(): List<RoomId> {
         val nowMillis = clock.epochMillis()
         val (expired, active) = localSharingRoomIds.value.partition { roomId ->
             val timeout = timeouts[roomId] ?: return@partition false
@@ -150,15 +162,7 @@ class DefaultActiveLiveLocationShareManager(
             Timber.d("ActiveLiveLocationShareManager location tick detected expired share for room $roomId, stopping")
             stopShare(roomId)
         }
-        val activeSharesCount = active.size
-        Timber.d("ActiveLiveLocationShareManager received location update for $activeSharesCount active share(s)")
-        active.forEach { roomId ->
-            Timber.d("ActiveLiveLocationShareManager sending location to room $roomId")
-            sendLiveLocation(roomId, location)
-                .onFailure {
-                    Timber.e(it, "ActiveLiveLocationShareManager failed to send location to room $roomId")
-                }
-        }
+        return active
     }
 
     private suspend fun sendLiveLocation(roomId: RoomId, location: Location): Result<Unit> {

--- a/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManager.kt
+++ b/features/location/impl/src/main/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManager.kt
@@ -52,9 +52,11 @@ class DefaultActiveLiveLocationShareManager(
     private val clock: SystemClock,
     private val sessionObserver: SessionObserver,
 ) : ActiveLiveLocationShareManager, LiveLocationReceiver {
+    private data class Timeout(val expiresAt: Instant, val job: Job)
+
     private val isSetup = AtomicBoolean(false)
     private val cachedRooms = ConcurrentHashMap<RoomId, JoinedRoom>()
-    private val timeoutJobs = ConcurrentHashMap<RoomId, Job>()
+    private val timeouts = ConcurrentHashMap<RoomId, Timeout>()
     private val syncedActiveShareIds = MutableStateFlow<Set<BeaconId>>(emptySet())
     private val localSharingRoomIds = MutableStateFlow<Set<RoomId>>(emptySet())
     override val sharingRoomIds: StateFlow<Set<RoomId>> = localSharingRoomIds
@@ -139,9 +141,18 @@ class DefaultActiveLiveLocationShareManager(
     }
 
     override suspend fun onLocationUpdate(location: Location) {
-        val activeSharesCount = localSharingRoomIds.value.size
+        val nowMillis = clock.epochMillis()
+        val (expired, active) = localSharingRoomIds.value.partition { roomId ->
+            val timeout = timeouts[roomId] ?: return@partition false
+            timeout.expiresAt.toEpochMilliseconds() <= nowMillis
+        }
+        expired.forEach { roomId ->
+            Timber.d("ActiveLiveLocationShareManager location tick detected expired share for room $roomId, stopping")
+            stopShare(roomId)
+        }
+        val activeSharesCount = active.size
         Timber.d("ActiveLiveLocationShareManager received location update for $activeSharesCount active share(s)")
-        localSharingRoomIds.value.forEach { roomId ->
+        active.forEach { roomId ->
             Timber.d("ActiveLiveLocationShareManager sending location to room $roomId")
             sendLiveLocation(roomId, location)
                 .onFailure {
@@ -192,20 +203,21 @@ class DefaultActiveLiveLocationShareManager(
     }
 
     private fun scheduleTimeout(roomId: RoomId, expiresAt: Instant) {
-        timeoutJobs.remove(roomId)?.cancel()
+        timeouts.remove(roomId)?.job?.cancel()
         val delayMillis = expiresAt.toEpochMilliseconds() - clock.epochMillis()
-        timeoutJobs[roomId] = matrixClient.sessionCoroutineScope.launch {
+        val job = matrixClient.sessionCoroutineScope.launch {
             delay(delayMillis)
             stopShare(roomId)
                 .onFailure { error ->
                     Timber.e(error, "ActiveLiveLocationShareManager failed to stop timed out share for room $roomId")
                 }
         }
+        timeouts[roomId] = Timeout(expiresAt = expiresAt, job = job)
     }
 
     private suspend fun stopLocalShare(roomId: RoomId) {
         Timber.d("ActiveLiveLocationShareManager stop local share in $roomId")
-        timeoutJobs.remove(roomId)?.cancel()
+        timeouts.remove(roomId)?.job?.cancel()
         val wasSharing = localSharingRoomIds.getAndUpdate { it - roomId }.isNotEmpty()
         cachedRooms.remove(roomId)?.close()
         liveLocationStore.removeLiveLocationExpiry(roomId)
@@ -220,11 +232,11 @@ class DefaultActiveLiveLocationShareManager(
         sessionObserver.removeListener(sessionListener)
         coordinator.unregister(matrixClient.sessionId)
         liveLocationStore.clear()
+        timeouts.values.forEach { it.job.cancel() }
+        timeouts.clear()
         for (room in cachedRooms.values) {
             room.close()
-            timeoutJobs[room.roomId]?.cancel()
         }
-        timeoutJobs.clear()
         cachedRooms.clear()
         localSharingRoomIds.value = emptySet()
         syncedActiveShareIds.value = emptySet()

--- a/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManagerTest.kt
+++ b/features/location/impl/src/test/kotlin/io/element/android/features/location/impl/live/DefaultActiveLiveLocationShareManagerTest.kt
@@ -374,6 +374,53 @@ class DefaultActiveLiveLocationShareManagerTest {
     }
 
     @Test
+    fun `location update after expiry stops the share and does not send location`() = runTest {
+        val liveLocationStore = createInMemoryLiveLocationStore()
+        val beaconInfoUpdates = MutableSharedFlow<BeaconInfoUpdate>(replay = 1)
+        val stopLiveLocationShareResult = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val sendLiveLocationResult = lambdaRecorder<String, Result<Unit>> { _ -> Result.success(Unit) }
+        val clock = FakeSystemClock(epochMillisResult = 1_000L)
+        val manager = createManager(
+            client = FakeMatrixClient(
+                sessionId = A_SESSION_ID,
+                sessionCoroutineScope = backgroundScope,
+                ownBeaconInfoUpdates = beaconInfoUpdates,
+            ).apply {
+                givenGetRoomResult(
+                    A_ROOM_ID,
+                    FakeJoinedRoom(
+                        startLiveLocationShareResult = { Result.success(AN_EVENT_ID) },
+                        stopLiveLocationShareResult = stopLiveLocationShareResult,
+                        sendLiveLocationResult = sendLiveLocationResult,
+                    ),
+                )
+            },
+            coordinator = createCoordinator(),
+            liveLocationStore = liveLocationStore,
+            clock = clock,
+        )
+        advanceUntilIdle()
+
+        val startResult = async { manager.startShare(A_ROOM_ID, 1.minutes) }
+        beaconInfoUpdates.emit(BeaconInfoUpdate(roomId = A_ROOM_ID, beaconId = AN_EVENT_ID, isLive = true))
+        assertThat(startResult.await().isSuccess).isTrue()
+
+        // Advance the clock past the expiry so the next location tick is beyond the deadline.
+        clock.epochMillisResult = 1_000L + 1.minutes.inWholeMilliseconds + 1_000L
+
+        manager.sharingRoomIds.test {
+            assertThat(awaitItem()).containsExactly(A_ROOM_ID)
+            manager.onLocationUpdate(io.element.android.features.location.api.Location(lat = 0.0, lon = 0.0, accuracy = null))
+            assertThat(awaitItem()).isEmpty()
+            advanceUntilIdle()
+        }
+        assertThat(liveLocationStore.getLiveLocationExpiries()).doesNotContainKey(A_ROOM_ID)
+        assert(sendLiveLocationResult).isNeverCalled()
+        // stopLiveLocationShare is called twice: once defensively in startShare, once from the tick-triggered stopShare.
+        assert(stopLiveLocationShareResult).isCalledExactly(2)
+    }
+
+    @Test
     fun `session deleted clears local state`() = runTest {
         val startServiceRecorder = lambdaRecorder<Unit> { }
         val stopServiceRecorder = lambdaRecorder<Unit> { }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->

  Live Location Sharing wasn't stopping at the user-selected expiry when the device was in in background for long, probably because of Doze. The coroutine `delay` used as the timeout trigger doesn't reliably fire while the process is CPU-throttled. 

  The fix adds a secondary trigger: since `FOREGROUND_SERVICE_TYPE_LOCATION` keeps delivering location updates during Doze, `onLocationUpdate` now checks the stored expiry and stops any share whose deadline has passed before dispatching the send. 
## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #7028.
## Screenshots / GIFs
No change
<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
