### PR TITLE
Fix timelines not loading after marking a room as read from notification when app was killed

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/di/DefaultSessionGraphFactory.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/DefaultSessionGraphFactory.kt
@@ -15,7 +15,7 @@ import io.element.android.libraries.matrix.api.MatrixClient
 
 @ContributesBinding(AppScope::class)
 class DefaultSessionGraphFactory(
-    private val appGraph: AppGraph
+    private val appGraph: AppGraph,
 ) : SessionGraphFactory {
     override fun create(client: MatrixClient): Any {
         return appGraph.sessionGraphFactory.create(client)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
@@ -105,13 +105,21 @@ class NotificationBroadcastReceiverHandler(
     @Suppress("unused")
     private fun handleMarkAsRead(sessionId: SessionId, roomId: RoomId, threadId: ThreadId?) = appCoroutineScope.launch {
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return@launch
-        val isSendPublicReadReceiptsEnabled = sessionPreferencesStore.get(sessionId, this).isSendPublicReadReceiptsEnabled().first()
+        val isSendPublicReadReceiptsEnabled = sessionPreferencesStore.get(
+            sessionId = sessionId,
+            // Make sure `sessionCoroutineScope` is used here, otherwise we'll have several instances using different coroutines,
+            // and it will not work as expected.
+            sessionCoroutineScope = client.sessionCoroutineScope,
+        ).isSendPublicReadReceiptsEnabled().first()
         val receiptType = if (isSendPublicReadReceiptsEnabled) {
             ReceiptType.READ
         } else {
             ReceiptType.READ_PRIVATE
         }
-        val room = client.getJoinedRoom(roomId) ?: return@launch
+
+        val (room, needsDestroy) = activeRoomsHolder.getActiveRoomMatching(sessionId, roomId)?.let { it to false }
+            ?: client.getJoinedRoom(roomId)?.let { it to true }
+            ?: return@launch
         val timeline = if (threadId != null) {
             room.createTimeline(CreateTimelineParams.Threaded(threadId)).getOrNull()
         } else {
@@ -130,6 +138,10 @@ class NotificationBroadcastReceiverHandler(
             }
         if (timeline?.mode != Timeline.Mode.Live) {
             timeline?.close()
+        }
+
+        if (needsDestroy) {
+            room.destroy()
         }
     }
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- When creating a new `SessionGraph`, make sure any `SessionPreferencesStore` that would be used in it is freshly created by removing existing ones.
- Try reusing an active room if it's present instead of instantiating a new one and its timeline, which is quite slow (this is just an optimization I added on top of the fix).

## Motivation and context

This can only happen when the app was killed by the OS and then you received some notification.

This 'mark as read' notification action creates a new `DefaultSessionPreferencesStore` when trying to fetch `isSendPublicReadReceiptsEnabled`, which would contain a different session coroutine scope than the one created when instantiating the navigation graph, resulting in flows that never emit any items and close automatically as 'completed'.

This in turn prevented the timeline items subscription in `TimelinePresenter` from progressing, since we're also checking `isRenderReadReceiptsEnabled` there, which is closed and in turn closes the timeline items flow.

## Tests

This is tricky to reproduce. With an unpatched version:

- Open the app, then send it to background.
- Simulate the OS killing the app with `adb shell am kill io.element.android.x.debug` and make sure it's not running anymore.
- With another account, send a message that will trigger a notification. This will wake the app, but without any UI or navigation graph (meaning no `SessionScope` or DI graph).
- Tap on 'mark as read' in the notification. This will trigger the problematic method call that caches a session prefs store.
- Then open the app and try opening any room. Check their timeline won't display any items, but the logs mention those items being received.

Then try the same with this branch, it should work.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
