### PR TITLE
Render push notifications for live location share starts (MSC4505)

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
@@ -118,7 +118,7 @@ sealed interface NotificationContent {
         data class RoomTopic(val topic: String) : StateEvent
         data object SpaceChild : StateEvent
         data object SpaceParent : StateEvent
-        data object BeaconInfo : StateEvent
+        data class BeaconInfo(val senderId: UserId) : StateEvent
     }
 
     data class Invite(

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -40,11 +40,11 @@ class TimelineEventToNotificationContentMapper {
 private fun TimelineEventContent.toContent(senderId: UserId): NotificationContent {
     return when (this) {
         is TimelineEventContent.MessageLike -> content.toContent(senderId)
-        is TimelineEventContent.State -> content.toContent()
+        is TimelineEventContent.State -> content.toContent(senderId)
     }
 }
 
-private fun StateEventContent.toContent(): NotificationContent.StateEvent {
+private fun StateEventContent.toContent(senderId: UserId): NotificationContent.StateEvent {
     return when (this) {
         StateEventContent.PolicyRuleRoom -> NotificationContent.StateEvent.PolicyRuleRoom
         StateEventContent.PolicyRuleServer -> NotificationContent.StateEvent.PolicyRuleServer
@@ -71,7 +71,7 @@ private fun StateEventContent.toContent(): NotificationContent.StateEvent {
         is StateEventContent.RoomTopic -> NotificationContent.StateEvent.RoomTopic(topic)
         StateEventContent.SpaceChild -> NotificationContent.StateEvent.SpaceChild
         StateEventContent.SpaceParent -> NotificationContent.StateEvent.SpaceParent
-        StateEventContent.BeaconInfo -> NotificationContent.StateEvent.BeaconInfo
+        StateEventContent.BeaconInfo -> NotificationContent.StateEvent.BeaconInfo(senderId)
     }
 }
 

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -303,6 +303,24 @@ class DefaultNotifiableEventResolver(
                 Timber.tag(loggerTag.value).d("Ignoring notification for beacon")
                 throw NotificationResolverException.EventFilteredOut
             }
+            is NotificationContent.StateEvent.BeaconInfo -> {
+                val notifiableEventMessage = buildNotifiableMessageEvent(
+                    sessionId = userId,
+                    senderId = content.senderId,
+                    roomId = roomId,
+                    eventId = eventId,
+                    noisy = isNoisy,
+                    timestamp = this.timestamp,
+                    senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId),
+                    body = stringProvider.getString(R.string.notification_live_location_started_body),
+                    imageUriString = null,
+                    roomName = roomDisplayName,
+                    roomIsDm = isDm,
+                    roomAvatarPath = roomAvatarUrl,
+                    senderAvatarPath = senderAvatarUrl,
+                )
+                ResolvedPushEvent.Event(notifiableEventMessage)
+            }
             is NotificationContent.StateEvent.RoomMemberContent,
             NotificationContent.StateEvent.PolicyRuleRoom,
             NotificationContent.StateEvent.PolicyRuleServer,
@@ -322,8 +340,7 @@ class DefaultNotifiableEventResolver(
             NotificationContent.StateEvent.RoomTombstone,
             is NotificationContent.StateEvent.RoomTopic,
             NotificationContent.StateEvent.SpaceChild,
-            NotificationContent.StateEvent.SpaceParent,
-            NotificationContent.StateEvent.BeaconInfo -> {
+            NotificationContent.StateEvent.SpaceParent -> {
                 Timber.tag(loggerTag.value).d("Ignoring notification for state event ${content.javaClass.simpleName}")
                 throw NotificationResolverException.EventFilteredOut
             }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -417,6 +417,27 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
     }
 
     @Test
+    fun `resolve live location share start`() = runTest {
+        val sut = createDefaultNotifiableEventResolver(
+            notificationResult = Result.success(
+                mapOf(
+                    AN_EVENT_ID to Result.success(aNotificationData(
+                        content = NotificationContent.StateEvent.BeaconInfo(
+                            senderId = A_USER_ID_2,
+                        ),
+                    ))
+                )
+            )
+        )
+        val request = aPushRequest(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID, "firebase")
+        val result = sut.resolveEvents(A_SESSION_ID, listOf(request))
+        val expectedResult = ResolvedPushEvent.Event(
+            aNotifiableMessageEvent(body = "Started sharing their live location")
+        )
+        assertThat(result.getEvent(request)).isEqualTo(Result.success(expectedResult))
+    }
+
+    @Test
     fun `resolve RoomMemberContent invite room`() = runTest {
         val sut = createDefaultNotifiableEventResolver(
             notificationResult = Result.success(
@@ -829,6 +850,7 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
         testNoResults(NotificationContent.MessageLike.KeyVerificationDone)
         testNoResults(NotificationContent.MessageLike.ReactionContent(relatedEventId = AN_EVENT_ID_2.value))
         testNoResults(NotificationContent.MessageLike.Sticker)
+        testNoResults(NotificationContent.MessageLike.Beacon)
         testNoResults(NotificationContent.StateEvent.PolicyRuleRoom)
         testNoResults(NotificationContent.StateEvent.PolicyRuleServer)
         testNoResults(NotificationContent.StateEvent.PolicyRuleUser)


### PR DESCRIPTION
Bump the Rust SDK to 26.07.13, which exposes the new beacon FFI event variants (StateEventContent.BeaconInfo and MessageLikeEventContent.Beacon, matrix-rust-sdk 390f6c04e), and render a notification when a user starts sharing their live location (org.matrix.msc3672.beacon_info state event):

- Add NotificationContent.StateEvent.BeaconInfo (carrying the sender, who is the user sharing their location) and NotificationContent.MessageLike.Beacon.
- Map the new FFI variants in TimelineEventToNotificationContentMapper.
- Resolve BeaconInfo to a displayable message notification (sender as title, "Started sharing their live location" as body), mirroring the poll notification. Beacon location updates are explicitly filtered out, like other non-notifying event types.
- New string notification_live_location_start_body in temporary.xml.
- Absorb unrelated FFI drift in test fixtures: UserProfile gained the MSC4426 status and call fields.

<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

E2E Rig (Flow 8)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 17

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
