### PR TITLE
Render an invite that arrives as a timeline member event as an invite push

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/notification/NotificationData.kt
@@ -103,6 +103,7 @@ sealed interface NotificationContent {
         data object RoomHistoryVisibility : StateEvent
         data object RoomJoinRules : StateEvent
         data class RoomMemberContent(
+            val senderId: UserId,
             val userId: UserId,
             val membershipState: RoomMembershipState
         ) : StateEvent

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/notification/TimelineEventToNotificationContentMapper.kt
@@ -58,6 +58,7 @@ private fun StateEventContent.toContent(): NotificationContent.StateEvent {
         StateEventContent.RoomJoinRules -> NotificationContent.StateEvent.RoomJoinRules
         is StateEventContent.RoomMemberContent -> {
             NotificationContent.StateEvent.RoomMemberContent(
+                senderId = senderId,
                 userId = UserId(userId),
                 membershipState = RoomMemberMapper.mapMembership(membershipState),
             )

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -36,6 +36,7 @@ import io.element.android.libraries.matrix.api.media.isPreviewEnabled
 import io.element.android.libraries.matrix.api.notification.NotificationContent
 import io.element.android.libraries.matrix.api.notification.NotificationData
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
+import io.element.android.libraries.matrix.api.room.RoomMembershipState
 import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.timeline.item.event.AudioMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.EmoteMessageType
@@ -299,7 +300,39 @@ class DefaultNotifiableEventResolver(
                 Timber.tag(loggerTag.value).d("Ignoring notification for sticker")
                 throw NotificationResolverException.EventFilteredOut
             }
-            is NotificationContent.StateEvent.RoomMemberContent,
+            is NotificationContent.StateEvent.RoomMemberContent -> {
+                if (content.membershipState == RoomMembershipState.INVITE && content.userId == userId) {
+                    // An invite for us can resolve as a timeline member event rather than a stripped
+                    // invite when the room has already advanced past the invited state — e.g. the
+                    // server auto-joined us because our knock was accepted (synapse#16307).
+                    val inviteNotifiableEvent = InviteNotifiableEvent(
+                        sessionId = userId,
+                        roomId = roomId,
+                        eventId = eventId,
+                        editedEventId = null,
+                        canBeReplaced = true,
+                        roomName = roomDisplayName,
+                        noisy = isNoisy,
+                        timestamp = this.timestamp,
+                        soundName = null,
+                        isRedacted = false,
+                        isUpdated = false,
+                        description = descriptionFromRoomMembershipInvite(
+                            senderDisambiguatedDisplayName = getDisambiguatedDisplayName(content.senderId),
+                            isDirectRoom = isDirect,
+                            isSpace = isSpace
+                        ),
+                        // TODO check if type is needed anymore
+                        type = null,
+                        // TODO check if title is needed anymore
+                        title = null,
+                    )
+                    ResolvedPushEvent.Event(inviteNotifiableEvent)
+                } else {
+                    Timber.tag(loggerTag.value).d("Ignoring notification for membership ${content.membershipState}")
+                    throw NotificationResolverException.EventFilteredOut
+                }
+            }
             NotificationContent.StateEvent.PolicyRuleRoom,
             NotificationContent.StateEvent.PolicyRuleServer,
             NotificationContent.StateEvent.PolicyRuleUser,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -41,6 +41,7 @@ import io.element.android.libraries.matrix.test.A_ROOM_NAME
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.A_SPACE_NAME
 import io.element.android.libraries.matrix.test.A_TIMESTAMP
+import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.libraries.matrix.test.A_USER_NAME_2
 import io.element.android.libraries.matrix.test.FakeMatrixClient
@@ -423,6 +424,7 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
                 mapOf(
                     AN_EVENT_ID to Result.success(aNotificationData(
                         content = NotificationContent.StateEvent.RoomMemberContent(
+                            senderId = A_USER_ID,
                             userId = A_USER_ID_2,
                             membershipState = RoomMembershipState.INVITE
                         ),
@@ -434,6 +436,45 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
         val request = aPushRequest(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID, "firebase")
         val result = sut.resolveEvents(A_SESSION_ID, listOf(request))
         assertThat(result.getEvent(request)?.getOrNull()).isNull()
+    }
+
+    @Test
+    fun `resolve RoomMemberContent invite room for me`() = runTest {
+        val sut = createDefaultNotifiableEventResolver(
+            notificationResult = Result.success(
+                mapOf(
+                    AN_EVENT_ID to Result.success(aNotificationData(
+                        content = NotificationContent.StateEvent.RoomMemberContent(
+                            senderId = A_USER_ID_2,
+                            userId = A_SESSION_ID,
+                            membershipState = RoomMembershipState.INVITE
+                        ),
+                        isDirect = false,
+                    ))
+                )
+            )
+        )
+        val request = aPushRequest(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID, "firebase")
+        val result = sut.resolveEvents(A_SESSION_ID, listOf(request))
+        val expectedResult = ResolvedPushEvent.Event(
+            InviteNotifiableEvent(
+                sessionId = A_SESSION_ID,
+                roomId = A_ROOM_ID,
+                eventId = AN_EVENT_ID,
+                editedEventId = null,
+                canBeReplaced = true,
+                roomName = A_ROOM_NAME,
+                noisy = false,
+                title = null,
+                description = "Bob invited you to join the room",
+                type = null,
+                timestamp = A_TIMESTAMP,
+                soundName = null,
+                isRedacted = false,
+                isUpdated = false,
+            )
+        )
+        assertThat(result.getEvent(request)).isEqualTo(Result.success(expectedResult))
     }
 
     @Test
@@ -634,6 +675,7 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
                 mapOf(
                     AN_EVENT_ID to Result.success(aNotificationData(
                         content = NotificationContent.StateEvent.RoomMemberContent(
+                            senderId = A_USER_ID_2,
                             userId = A_USER_ID_2,
                             membershipState = RoomMembershipState.JOIN
                         )


### PR DESCRIPTION
An invite for the current user can resolve as a timeline member event rather than a stripped invite when the room has already advanced past the invited state by notification-resolution time — e.g. the server auto-joined the user because their knock was accepted (element-hq/synapse#16307). Such invites were filtered out of notifications entirely; render them with the normal invite copy instead.

## Tests

e2e rig flow 10

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 17

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
