### PR TITLE
Expose current/max progress values to accessibility services

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/LinearProgressIndicator.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/LinearProgressIndicator.kt
@@ -16,6 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,7 +35,9 @@ fun LinearProgressIndicator(
     strokeCap: StrokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
 ) {
     androidx.compose.material3.LinearProgressIndicator(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            progressBarRangeInfo = ProgressBarRangeInfo(progress(), 0f..1f)
+        },
         progress = progress,
         gapSize = gapSize,
         color = color,
@@ -63,7 +68,9 @@ fun LinearProgressIndicator(
         )
     } else {
         androidx.compose.material3.LinearProgressIndicator(
-            modifier = modifier,
+            modifier = modifier.semantics {
+                progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
+            },
             color = color,
             gapSize = gapSize,
             trackColor = trackColor,


### PR DESCRIPTION
## Content

The multi-step onboarding progress indicator shows steps visually but sets no `progressBarRangeInfo` semantics, so TalkBack users have no way to tell which step they're on or how many steps remain.

## Motivation and context

Add `progressBarRangeInfo` with the current step and total step count so TalkBack can announce progress.

## Screenshots / GIFs

No visual change — this is an accessibility-semantics-only fix (`progressBarRangeInfo` is not rendered). The component's appearance is already covered by the existing `LinearProgressIndicatorPreview` Composable Preview in this file.

## Tests

- Step 1: enable TalkBack, navigate the onboarding flow, confirm current/total step is announced
- Step 2: verify with TalkBack enabled

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes.
- [x] You've made a self review of your PR.