### PR TITLE
Make the password visibility toggle keyboard-focusable

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/PasswordVisibilityToggle.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/PasswordVisibilityToggle.kt
@@ -7,8 +7,6 @@
 
 package io.element.android.libraries.designsystem.theme.components
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -26,7 +24,7 @@ fun PasswordVisibilityToggle(
     onToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier.clickable(onClick = onToggle)) {
+    IconButton(onClick = onToggle, modifier = modifier) {
         Icon(
             imageVector = if (visible) CompoundIcons.VisibilityOn() else CompoundIcons.VisibilityOff(),
             contentDescription = stringResource(


### PR DESCRIPTION
## Content

The shared password-visibility toggle (used as the trailing icon on every password field, including login) is implemented as a plain `Box(modifier.clickable(...))` rather than an `IconButton`, so it doesn't reliably receive focus or a button role for external-keyboard and TalkBack users.

## Motivation and context

Use `IconButton` instead of a raw clickable `Box` so the toggle gets standard focus, sizing and semantics behaviour.

## Screenshots / GIFs

Switching the container from a plain `Box` to an `IconButton` may change the icon's touch-target size, padding and ripple effect slightly. `PasswordVisibilityToggle.kt` has no Composable Preview of its own today — adding a small `@PreviewsDayNight` preview for it as part of this change would let this table be filled in properly:

|Before|After|
|-|-|
|screenshot pending|screenshot pending|

## Tests

- Step 1: connect a hardware keyboard, tab through a password field, confirm the visibility toggle is reachable and operable
- Step 2: verify with TalkBack enabled

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [ ] Accessibility has been taken into account.
- [ ] Pull request is based on the develop branch.
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [ ] Pull request includes screenshots or videos if containing UI changes.
- [ ] You've made a self review of your PR.