### PR TITLE
Add a Mentions room list filter

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFilter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFilter.kt
@@ -18,9 +18,9 @@ import io.element.android.libraries.matrix.api.roomlist.RoomListFilter as Matrix
 enum class RoomListFilter(val stringResource: Int) {
     Unread(R.string.screen_roomlist_filter_unreads),
     Mentions(R.string.screen_roomlist_filter_mentions),
+    Favourites(R.string.screen_roomlist_filter_favourites),
     People(R.string.screen_roomlist_filter_people),
     Rooms(R.string.screen_roomlist_filter_rooms),
-    Favourites(R.string.screen_roomlist_filter_favourites),
     Invites(R.string.screen_roomlist_filter_invites);
 
     val incompatibleFilters: Set<RoomListFilter>

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFilter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFilter.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.matrix.api.roomlist.RoomListFilter as Matrix
  */
 enum class RoomListFilter(val stringResource: Int) {
     Unread(R.string.screen_roomlist_filter_unreads),
+    Mentions(R.string.screen_roomlist_filter_mentions),
     People(R.string.screen_roomlist_filter_people),
     Rooms(R.string.screen_roomlist_filter_rooms),
     Favourites(R.string.screen_roomlist_filter_favourites),
@@ -27,8 +28,9 @@ enum class RoomListFilter(val stringResource: Int) {
             Rooms -> setOf(People, Invites)
             People -> setOf(Rooms, Invites)
             Unread -> setOf(Invites)
+            Mentions -> setOf(Invites)
             Favourites -> setOf(Invites)
-            Invites -> setOf(Rooms, People, Unread, Favourites)
+            Invites -> setOf(Rooms, People, Unread, Mentions, Favourites)
         }
 }
 
@@ -37,6 +39,7 @@ fun RoomListFilter.into(): MatrixRoomListFilter {
         RoomListFilter.Rooms -> MatrixRoomListFilter.Category.Group
         RoomListFilter.People -> MatrixRoomListFilter.Category.People
         RoomListFilter.Unread -> MatrixRoomListFilter.Unread
+        RoomListFilter.Mentions -> MatrixRoomListFilter.Mentions
         RoomListFilter.Favourites -> MatrixRoomListFilter.Favorite
         RoomListFilter.Invites -> MatrixRoomListFilter.Invite
     }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersEmptyStateResources.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersEmptyStateResources.kt
@@ -37,6 +37,10 @@ data class RoomListFiltersEmptyStateResources(
                             title = R.string.screen_roomlist_filter_unreads_empty_state_title,
                             subtitle = R.string.screen_roomlist_filter_mixed_empty_state_subtitle
                         )
+                        RoomListFilter.Mentions -> RoomListFiltersEmptyStateResources(
+                            title = R.string.screen_roomlist_filter_mentions_empty_state_title,
+                            subtitle = R.string.screen_roomlist_filter_mixed_empty_state_subtitle
+                        )
                         RoomListFilter.People -> RoomListFiltersEmptyStateResources(
                             title = R.string.screen_roomlist_filter_people_empty_state_title,
                             subtitle = R.string.screen_roomlist_filter_mixed_empty_state_subtitle

--- a/features/home/impl/src/main/res/values/temporary.xml
+++ b/features/home/impl/src/main/res/values/temporary.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 Element Creations Ltd.
+  ~
+  ~ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  ~ Please see LICENSE files in the repository root for full details.
+  -->
+
+<resources>
+    <string name="screen_roomlist_filter_mentions">"Mentions"</string>
+    <string name="screen_roomlist_filter_mentions_empty_state_title">"You don’t have any unread mentions"</string>
+</resources>

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersEmptyStateResourcesTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersEmptyStateResourcesTest.kt
@@ -30,6 +30,15 @@ class RoomListFiltersEmptyStateResourcesTest {
     }
 
     @Test
+    fun `fromSelectedFilters should return exact RoomListFiltersEmptyStateResources when selectedFilters has only mentions filter`() {
+        val selectedFilters = listOf(RoomListFilter.Mentions)
+        val result = RoomListFiltersEmptyStateResources.fromSelectedFilters(selectedFilters, isSpaceFilterSelected = false)
+        assertThat(result).isNotNull()
+        assertThat(result?.title).isEqualTo(R.string.screen_roomlist_filter_mentions_empty_state_title)
+        assertThat(result?.subtitle).isEqualTo(R.string.screen_roomlist_filter_mixed_empty_state_subtitle)
+    }
+
+    @Test
     fun `fromSelectedFilters should return exact RoomListFiltersEmptyStateResources when selectedFilters has only people filter`() {
         val selectedFilters = listOf(RoomListFilter.People)
         val result = RoomListFiltersEmptyStateResources.fromSelectedFilters(selectedFilters, isSpaceFilterSelected = false)

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
@@ -29,9 +29,9 @@ class RoomListFiltersPresenterTest {
                 assertThat(state.filterSelectionStates).containsExactly(
                     filterSelectionState(RoomListFilter.Unread, false),
                     filterSelectionState(RoomListFilter.Mentions, false),
+                    filterSelectionState(RoomListFilter.Favourites, false),
                     filterSelectionState(RoomListFilter.People, false),
                     filterSelectionState(RoomListFilter.Rooms, false),
-                    filterSelectionState(RoomListFilter.Favourites, false),
                     filterSelectionState(RoomListFilter.Invites, false),
                 )
             }
@@ -65,9 +65,9 @@ class RoomListFiltersPresenterTest {
                 assertThat(state.filterSelectionStates).containsExactly(
                     filterSelectionState(RoomListFilter.Unread, false),
                     filterSelectionState(RoomListFilter.Mentions, false),
+                    filterSelectionState(RoomListFilter.Favourites, false),
                     filterSelectionState(RoomListFilter.People, false),
                     filterSelectionState(RoomListFilter.Rooms, false),
-                    filterSelectionState(RoomListFilter.Favourites, false),
                     filterSelectionState(RoomListFilter.Invites, false),
                 ).inOrder()
                 assertThat(state.selectedFilters()).isEmpty()

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
@@ -28,6 +28,7 @@ class RoomListFiltersPresenterTest {
                 assertThat(state.hasAnyFilterSelected).isFalse()
                 assertThat(state.filterSelectionStates).containsExactly(
                     filterSelectionState(RoomListFilter.Unread, false),
+                    filterSelectionState(RoomListFilter.Mentions, false),
                     filterSelectionState(RoomListFilter.People, false),
                     filterSelectionState(RoomListFilter.Rooms, false),
                     filterSelectionState(RoomListFilter.Favourites, false),
@@ -49,6 +50,7 @@ class RoomListFiltersPresenterTest {
                 assertThat(state.filterSelectionStates).containsExactly(
                     filterSelectionState(RoomListFilter.Rooms, true),
                     filterSelectionState(RoomListFilter.Unread, false),
+                    filterSelectionState(RoomListFilter.Mentions, false),
                     filterSelectionState(RoomListFilter.Favourites, false),
                 ).inOrder()
 
@@ -62,6 +64,7 @@ class RoomListFiltersPresenterTest {
                 assertThat(state.hasAnyFilterSelected).isFalse()
                 assertThat(state.filterSelectionStates).containsExactly(
                     filterSelectionState(RoomListFilter.Unread, false),
+                    filterSelectionState(RoomListFilter.Mentions, false),
                     filterSelectionState(RoomListFilter.People, false),
                     filterSelectionState(RoomListFilter.Rooms, false),
                     filterSelectionState(RoomListFilter.Favourites, false),

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
@@ -53,6 +53,11 @@ sealed interface RoomListFilter {
     data object Unread : RoomListFilter
 
     /**
+     * A filter that matches rooms with unread mentions.
+     */
+    data object Mentions : RoomListFilter
+
+    /**
      * A filter that matches rooms that are marked as favorite.
      */
     data object Favorite : RoomListFilter

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterMapper.kt
@@ -16,6 +16,7 @@ import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Deduplicat
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Favourite
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Identifiers
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Invite
+import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Mentions
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.NonLeft
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.NonSpace
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.None
@@ -68,6 +69,7 @@ internal object RoomListFilterMapper {
             RoomListFilter.Category.Space -> Space
             RoomListFilter.Favorite -> Favourite
             RoomListFilter.Unread -> Unread
+            RoomListFilter.Mentions -> Mentions
             is RoomListFilter.NormalizedMatchRoomName -> NormalizedMatchRoomName(
                 pattern = filter.pattern
             )


### PR DESCRIPTION
Adds a new filter chip to the room list that shows only rooms with unread mentions, using the new mentions room list filter from the Rust SDK (matrix-org/matrix-rust-sdk branch matthew/mentions-filter).

The SDK version needs bumping to a release that includes the new filter kind before this can build against the released components (https://github.com/matrix-org/matrix-rust-sdk/pull/6754).

Fixes https://github.com/element-hq/element-x-ios/issues/3952

## Tests

E2E Test Rig (Flow 11) - screenshots:

<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/c3ffd973-9e96-4a9a-a9f0-d9476204dbd6" /> <img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/f0ec1a4f-6912-4928-811a-5ff100fbab8c" />

## Tested devices

- [ ] Physical
- [x] Emulator 
- OS version(s): Android 17

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
