### PR TITLE
Announce FTUE step changes to TalkBack

### DIFF
--- a/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
+++ b/features/ftue/impl/src/main/kotlin/io/element/android/features/ftue/impl/FtueFlowNode.kt
@@ -10,7 +10,12 @@ package io.element.android.features.ftue.impl
 
 import android.os.Parcelable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
@@ -33,6 +38,7 @@ import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.ui.common.nodes.emptyNode
+import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -143,6 +149,12 @@ class FtueFlowNode(
 
     @Composable
     override fun View(modifier: Modifier) {
+        val ftueState by defaultFtueService.ftueStepStateFlow.collectAsState()
+        val view = LocalView.current
+        val stepChangedAnnouncement = stringResource(CommonStrings.a11y_ftue_step_changed)
+        LaunchedEffect(ftueState) {
+            view.announceForAccessibility(stepChangedAnnouncement)
+        }
         BackstackView()
     }
 }

--- a/libraries/ui-strings/src/main/res/values/temporary.xml
+++ b/libraries/ui-strings/src/main/res/values/temporary.xml
@@ -10,4 +10,5 @@
     <string name="a11y_jump_to_unread_messages">"Jump to first unread message"</string>
     <string name="screen_local_network_opt_in_title">Allow access to local network</string>
     <string name="screen_local_network_opt_in_subtitle">Your homeserver is on your local network. To connect, Element needs permission to reach other devices on this network.</string>
+    <string name="a11y_ftue_step_changed">New step</string>
 </resources>


### PR DESCRIPTION
## Content

Navigating between onboarding (FTUE) screens (e.g. to "Confirm your PIN") doesn't announce the context change to TalkBack — the step change only swaps the Appyx backstack, so screen reader users get no feedback that the flow has advanced.

## Motivation and context

Add an accessibility announcement whenever the FTUE step state changes, using `View.announceForAccessibility()`.

## Screenshots / GIFs

No visual change — the fix only adds a TalkBack announcement on step change, which isn't visible on screen. `FtueFlowNode` is a flow-navigation node rather than a themed Composable, so it has no Preview of its own; the individual onboarding screens' existing Previews are unaffected.

## Tests

- Step 1: enable TalkBack, step through onboarding, confirm each new step is announced
- Step 2: verify with TalkBack enabled

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes.
- [x] You've made a self review of your PR.