### PR TITLE
Announce timeline jump-to-bottom to TalkBack

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -365,19 +365,25 @@ private fun BoxScope.TimelineScrollHelper(
      * This fixes the issue where the user is seeing typing notification and so the read receipt is not sent
      * when a new message comes in.
      */
-    fun scrollToBottom(force: Boolean) {
+    fun scrollToBottom(force: Boolean, onComplete: (() -> Unit)? = null) {
         coroutineScope.launch {
             if (lazyListState.firstVisibleItemIndex > 10) {
                 lazyListState.scrollToItem(0)
             } else if (force || lazyListState.firstVisibleItemIndex != 0) {
                 lazyListState.animateScrollToItem(0)
             }
+            onComplete?.invoke()
         }
     }
 
+    val view = LocalView.current
+    val jumpedToBottomAnnouncement = stringResource(CommonStrings.a11y_timeline_jumped_to_bottom)
+
     fun jumpToBottom() {
         if (isLive) {
-            scrollToBottom(force = false)
+            scrollToBottom(force = false) {
+                view.announceForAccessibility(jumpedToBottomAnnouncement)
+            }
         } else {
             jumpToLiveHandled = false
             onJumpToLive()

--- a/libraries/ui-strings/src/main/res/values/temporary.xml
+++ b/libraries/ui-strings/src/main/res/values/temporary.xml
@@ -10,4 +10,5 @@
     <string name="a11y_jump_to_unread_messages">"Jump to first unread message"</string>
     <string name="screen_local_network_opt_in_title">Allow access to local network</string>
     <string name="screen_local_network_opt_in_subtitle">Your homeserver is on your local network. To connect, Element needs permission to reach other devices on this network.</string>
+    <string name="a11y_timeline_jumped_to_bottom">Jumped to newest message</string>
 </resources>


### PR DESCRIPTION
## Content

The "jump to bottom" action scrolls the timeline to the newest message (`lazyListState.scrollToItem(0)`) but never announces that the jump happened, so TalkBack users get no confirmation the scroll occurred.

## Motivation and context

Announce completion of the jump via `View.announceForAccessibility()` once the scroll animation finishes.

## Screenshots / GIFs

No visual change — the fix only announces once the existing scroll animation completes; the scroll behaviour and layout are unchanged. `TimelineView.kt`'s existing `@PreviewsDayNight` previews already cover its appearance.

## Tests

- Step 1: scroll up in a chat, trigger jump-to-bottom, with TalkBack confirm the jump is announced
- Step 2: verify with TalkBack enabled

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes.
- [x] You've made a self review of your PR.