### PR TITLE
Associate labels with password and report-reason text fields

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -233,6 +233,7 @@ private fun LoginForm(
         }
         Spacer(Modifier.height(20.dp))
         TextField(
+            label = stringResource(CommonStrings.common_password),
             value = passwordFieldState,
             enabled = !isLoading,
             modifier = Modifier

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/report/ReportMessageView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/report/ReportMessageView.kt
@@ -83,6 +83,7 @@ fun ReportMessageView(
             Spacer(modifier = Modifier.height(20.dp))
 
             TextField(
+                label = stringResource(R.string.screen_report_content_hint),
                 value = state.reason,
                 onValueChange = { state.eventSink(ReportMessageEvent.UpdateReason(it)) },
                 placeholder = stringResource(R.string.screen_report_content_hint),


### PR DESCRIPTION
## Content

Two text fields only expose their purpose through placeholder text, which disappears as soon as the user starts typing and isn't reliably surfaced to screen readers as the field's persistent label:

- The password field on the login screen (`LoginPasswordView.kt`) has no `label`, only a `placeholder`.
- The reason field on the "Report content" screen (`ReportMessageView.kt`) has no `label`, only a `placeholder`.

## Motivation and context

Add a `label` to both `TextField` calls, reusing existing string resources that already describe each field (`CommonStrings.common_password` for the password field, `R.string.screen_report_content_hint` for the report-reason field). This keeps the field's purpose visible and available to assistive technology at all times, not just before the user starts typing — addressing a WCAG 1.3.1 / 1.1.1 accessibility gap (labels/instructions not programmatically associated with inputs).

## Screenshots / GIFs

Label text appears above each field, in addition to the existing placeholder inside it. `LoginPasswordView`'s password field will show "Password" both above (label) and inside (placeholder, until typing starts); `ReportMessageView`'s reason field will show "Reason for reporting this content" the same way.


## Tests

- Step 1: enable TalkBack, focus the login password field, confirm "Password" is announced as the field's label
- Step 2: enable TalkBack, focus the report-content reason field, confirm "Reason for reporting this content" is announced as the field's label

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [ ] Pull request includes screenshots or videos if containing UI changes. (label text added above existing fields — see Screenshots section)
- [x] You've made a self review of your PR.