### PR TITLE
Add a button role to clickable icons and text on the login/onboarding screens

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderOtherView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderOtherView.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -40,7 +41,7 @@ fun AccountProviderOtherView(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onClick() }
+            .clickable(role = Role.Button) { onClick() }
     ) {
         HorizontalDivider()
         Row(

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/accountprovider/AccountProviderView.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
@@ -45,7 +46,7 @@ fun AccountProviderView(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onClick() }
+            .clickable(role = Role.Button) { onClick() }
     ) {
         HorizontalDivider()
         Column(

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalAutofillManager
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
@@ -211,10 +212,15 @@ private fun LoginForm(
             singleLine = true,
             trailingIcon = if (loginFieldState.isNotEmpty()) {
                 {
-                    Box(Modifier.clickable {
-                        loginFieldState = ""
-                        eventSink(LoginPasswordEvents.SetLogin(""))
-                    }) {
+                    Box(
+                        Modifier.clickable(
+                            onClickLabel = stringResource(CommonStrings.action_clear),
+                            role = Role.Button,
+                        ) {
+                            loginFieldState = ""
+                            eventSink(LoginPasswordEvents.SetLogin(""))
+                        }
+                    ) {
                         Icon(
                             imageVector = CompoundIcons.Close(),
                             contentDescription = stringResource(CommonStrings.action_clear),

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/onboarding/OnBoardingView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -336,7 +337,7 @@ private fun OnBoardingButtons(
             } else {
                 Text(
                     modifier = Modifier
-                        .clickable {
+                        .clickable(role = Role.Button) {
                             state.eventSink(OnBoardingEvents.OnVersionClick)
                         }
                         .padding(16.dp),

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -125,10 +126,15 @@ fun SearchAccountProviderView(
                         singleLine = true,
                         trailingIcon = if (userInputState.isNotEmpty()) {
                             {
-                                Box(Modifier.clickable {
-                                    userInputState = ""
-                                    eventSink(SearchAccountProviderEvents.UserInput(""))
-                                }) {
+                                Box(
+                                    Modifier.clickable(
+                                        onClickLabel = stringResource(CommonStrings.action_clear),
+                                        role = Role.Button,
+                                    ) {
+                                        userInputState = ""
+                                        eventSink(SearchAccountProviderEvents.UserInput(""))
+                                    }
+                                ) {
                                     Icon(
                                         imageVector = CompoundIcons.Close(),
                                         contentDescription = stringResource(CommonStrings.action_clear)


### PR DESCRIPTION
## Content

Several clickable elements across the login and onboarding flow use a plain `Modifier.clickable {}` with no `role`, so TalkBack announces them as generic elements instead of buttons:

- The account-provider row in `AccountProviderOtherView.kt` and `AccountProviderView.kt`.
- The clear-input icon on the login password field (`LoginPasswordView.kt`) and on the account-provider search field (`SearchAccountProviderView.kt`).
- The hidden developer-mode version-tap text on the onboarding screen (`OnBoardingView.kt`).

## Motivation and context

Add `role = Role.Button` to each of these `clickable` modifiers so TalkBack announces them as buttons. For the two clear-input icons, also add an explicit `onClickLabel` (reusing the existing `CommonStrings.action_clear` string, already used for the icon's own `contentDescription`) so the action itself is announced, not just the icon.

## Screenshots / GIFs

No visual change — only `role`/`onClickLabel` semantics are added to existing clickable elements, nothing rendered differently on screen.

## Tests

- Step 1: enable TalkBack, navigate to the account-provider screen, focus the account-provider row, confirm it's announced as a button
- Step 2: enable TalkBack, focus the login password field's clear icon (after typing something), confirm it's announced as "Clear, button"
- Step 3: enable TalkBack, focus the account-provider search field's clear icon, same check
- Step 4: verify with TalkBack enabled

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes. (n/a — no visual change, see Screenshots section)
- [x] You've made a self review of your PR.