### PR TITLE
Expose formatting toggle state to TalkBack

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/FormattingOption.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/FormattingOption.kt
@@ -23,14 +23,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.theme.components.Icon
+import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 internal fun FormattingOption(
@@ -52,6 +55,8 @@ internal fun FormattingOption(
         FormattingOptionState.Default -> ElementTheme.colors.iconSecondary
         FormattingOptionState.Disabled -> ElementTheme.colors.iconDisabled
     }
+    val activeStateDescription = stringResource(CommonStrings.a11y_active)
+    val inactiveStateDescription = stringResource(CommonStrings.a11y_inactive)
     Box(
         modifier = modifier
             .clickable(
@@ -77,6 +82,13 @@ internal fun FormattingOption(
             )
             .clearAndSetSemantics {
                 this.contentDescription = contentDescription
+                if (toggleable) {
+                    this.stateDescription = if (state == FormattingOptionState.Selected) {
+                        activeStateDescription
+                    } else {
+                        inactiveStateDescription
+                    }
+                }
             }
     ) {
         Box(

--- a/libraries/ui-strings/src/main/res/values/temporary.xml
+++ b/libraries/ui-strings/src/main/res/values/temporary.xml
@@ -10,4 +10,6 @@
     <string name="a11y_jump_to_unread_messages">"Jump to first unread message"</string>
     <string name="screen_local_network_opt_in_title">Allow access to local network</string>
     <string name="screen_local_network_opt_in_subtitle">Your homeserver is on your local network. To connect, Element needs permission to reach other devices on this network.</string>
+    <string name="a11y_active">Active</string>
+    <string name="a11y_inactive">Inactive</string>
 </resources>


### PR DESCRIPTION
## Content

The Bold/Italic/Underline formatting buttons in the rich text composer toolbar use `Modifier.toggleable()` combined with `clearAndSetSemantics { this.contentDescription = contentDescription }`. The `clearAndSetSemantics` block replaces all semantics produced further down the modifier chain — including the toggle state that `toggleable()` would otherwise expose — with only a static content description. As a result, TalkBack announces the button's label but never whether it is currently active or inactive, so screen reader users have no way to tell if Bold/Italic/Underline is currently applied.

## Motivation and context

Add an explicit `stateDescription` inside the same `clearAndSetSemantics` block, set to "Active" or "Inactive" depending on `FormattingOptionState.Selected`, applied only when the option is `toggleable`. This restores the state information that TalkBack needs without changing the existing content description or visuals.

## Screenshots / GIFs

No visual change — the fix only adds semantic state information for TalkBack; the on-screen appearance of the formatting buttons is unaffected.

## Tests

- Step 1: enable TalkBack, open the rich text composer, focus the Bold button
- Step 2: toggle Bold on and off, confirm TalkBack announces "Active"/"Inactive" alongside the existing label; repeat for Italic and Underline

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes. (n/a — no visual change, see Screenshots section)
- [x] You've made a self review of your PR.