### PR TITLE
Fix logging via QR code when using MDM-configured homeserver

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
@@ -97,13 +97,6 @@ class QrCodeScanPresenter(
                 val data = qrCodeLoginDataFactory.parseQrCodeData(code).onFailure {
                     Timber.e(it, "Error parsing QR code data")
                 }.getOrThrow()
-                val serverName = data.serverName()
-                if (serverName != null) {
-                    defaultAccountProviderAccessControl.assertIsAllowedToConnectToAccountProvider(
-                        title = serverName,
-                        accountProviderUrl = serverName,
-                    )
-                }
                 data
             }.runCatchingUpdatingState(codeScannedAction)
         }.invokeOnCompletion {

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import dev.zacsweers.metro.Inject
-import io.element.android.features.login.impl.accesscontrol.DefaultAccountProviderAccessControl
 import io.element.android.features.login.impl.qrcode.QrCodeLoginManager
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.architecture.Presenter

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenter.kt
@@ -39,7 +39,6 @@ class QrCodeScanPresenter(
     private val qrCodeLoginDataFactory: MatrixQrCodeLoginDataFactory,
     private val qrCodeLoginManager: QrCodeLoginManager,
     private val coroutineDispatchers: CoroutineDispatchers,
-    private val defaultAccountProviderAccessControl: DefaultAccountProviderAccessControl,
 ) : Presenter<QrCodeScanState> {
     private var isScanning by mutableStateOf(true)
 

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
@@ -67,44 +67,6 @@ class QrCodeScanPresenterTest {
     }
 
     @Test
-    fun `present - scanned QR code successfully, but homeserver not allowed`() = runTest {
-        val qrCodeLoginDataFactory = FakeMatrixQrCodeLoginDataFactory(
-            parseQrCodeLoginDataResult = {
-                Result.success(
-                    FakeMatrixQrCodeLoginData(
-                        serverNameResult = { "example.com" }
-                    )
-                )
-            }
-        )
-        val presenter = createQrCodeScanPresenter(
-            qrCodeLoginDataFactory = qrCodeLoginDataFactory,
-            enterpriseService = FakeEnterpriseService(
-                isAllowedToConnectToHomeserverResult = { false },
-                defaultHomeserverListResult = { listOf("element.io") },
-            )
-        )
-        presenter.test {
-            val initialState = awaitItem()
-            initialState.eventSink(QrCodeScanEvents.QrCodeScanned(byteArrayOf()))
-            assertThat(awaitItem().isScanning).isFalse()
-            assertThat(awaitItem().authenticationAction.isLoading()).isTrue()
-            awaitItem().also { state ->
-                assertThat(
-                    (state.authenticationAction
-                        .errorOrNull() as AccountProviderAccessException.UnauthorizedAccountProviderException).unauthorisedAccountProviderTitle
-                )
-                    .isEqualTo("example.com")
-                assertThat(
-                    (state.authenticationAction
-                        .errorOrNull() as AccountProviderAccessException.UnauthorizedAccountProviderException).authorisedAccountProviderTitles
-                )
-                    .containsExactly("element.io")
-            }
-        }
-    }
-
-    @Test
     fun `present - scanned QR code failed and can be retried`() = runTest {
         val qrCodeLoginDataFactory = FakeMatrixQrCodeLoginDataFactory(
             parseQrCodeLoginDataResult = { Result.failure(Exception("Failed to parse QR code")) }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
@@ -9,17 +9,12 @@
 package io.element.android.features.login.impl.screens.qrcode.scan
 
 import com.google.common.truth.Truth.assertThat
-import io.element.android.features.enterprise.api.EnterpriseService
-import io.element.android.features.enterprise.test.FakeEnterpriseService
-import io.element.android.features.login.impl.accesscontrol.DefaultAccountProviderAccessControl
 import io.element.android.features.login.impl.qrcode.FakeQrCodeLoginManager
-import io.element.android.features.wellknown.test.FakeWellknownRetriever
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.auth.qrlogin.QrCodeLoginStep
 import io.element.android.libraries.matrix.api.auth.qrlogin.QrLoginException
 import io.element.android.libraries.matrix.test.auth.qrlogin.FakeMatrixQrCodeLoginData
 import io.element.android.libraries.matrix.test.auth.qrlogin.FakeMatrixQrCodeLoginDataFactory
-import io.element.android.libraries.wellknown.api.WellknownRetriever
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.test
 import io.element.android.tests.testutils.testCoroutineDispatchers
@@ -52,9 +47,6 @@ class QrCodeScanPresenterTest {
         )
         val presenter = createQrCodeScanPresenter(
             qrCodeLoginDataFactory = qrCodeLoginDataFactory,
-            enterpriseService = FakeEnterpriseService(
-                isAllowedToConnectToHomeserverResult = { true },
-            )
         )
         presenter.test {
             val initialState = awaitItem()
@@ -114,15 +106,9 @@ class QrCodeScanPresenterTest {
         qrCodeLoginDataFactory: FakeMatrixQrCodeLoginDataFactory = FakeMatrixQrCodeLoginDataFactory(),
         coroutineDispatchers: CoroutineDispatchers = testCoroutineDispatchers(),
         qrCodeLoginManager: FakeQrCodeLoginManager = FakeQrCodeLoginManager(),
-        enterpriseService: EnterpriseService = FakeEnterpriseService(),
-        wellknownRetriever: WellknownRetriever = FakeWellknownRetriever(),
     ) = QrCodeScanPresenter(
         qrCodeLoginDataFactory = qrCodeLoginDataFactory,
         qrCodeLoginManager = qrCodeLoginManager,
         coroutineDispatchers = coroutineDispatchers,
-        defaultAccountProviderAccessControl = DefaultAccountProviderAccessControl(
-            enterpriseService = enterpriseService,
-            wellknownRetriever = wellknownRetriever,
-        ),
     )
 }

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/qrcode/scan/QrCodeScanPresenterTest.kt
@@ -12,7 +12,6 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.features.enterprise.test.FakeEnterpriseService
 import io.element.android.features.login.impl.accesscontrol.DefaultAccountProviderAccessControl
-import io.element.android.features.login.impl.changeserver.AccountProviderAccessException
 import io.element.android.features.login.impl.qrcode.FakeQrCodeLoginManager
 import io.element.android.features.wellknown.test.FakeWellknownRetriever
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

When logging in via QR Code, it is checked that the homeserver the user is logging in to, is the same as configured by MDM. This check has a bug (e.g. comparing https://example.com vs example.com). The same check is applied when the homeserver is pre-configured via custom app.

For now, we remove this check because of the following:
* Even if in some cases the check can be easily fixed by ensuring there is always protocol there, it could be that we end up comparing server/domain name (e.g. https://example.com with the homeserver URL https://element.example.com/) and the check fails again for another reason.
* The primary purpose of the feature MDM-configured homeserver was to simplify sign in (not necessarily to block users to sign in any other homeserver).
* However, since in some cases there is interest that no other homeserver than configured by MDM is used (even when using QR code login), then there will be a project soon to add the check back and work robustly.

On iOS the check was already removed before.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
