### PR TITLE
Group Element Pro changes into a dedicated release notes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -28,6 +28,10 @@ changelog:
       labels:
         - PR-Dependencies
 
+    - title: 💼 Element Pro
+      labels:
+        - PR-Element-Pro
+
     - title: Others
       labels:
         - PR-misc


### PR DESCRIPTION
Pro-only PRs (labelled PR-Element-Pro) leaked into Element X release notes, causing confusion. They now group into a single Element Pro section instead of scattering through Features/Bugfixes. Granularity is dropped on purpose for these changes.

Android equivalent of https://github.com/element-hq/element-x-ios/pull/5899.
The new tag is available in the project: https://github.com/element-hq/element-x-android/labels?q=pr-element-pro

