### PR TITLE
Add a visible border to decorative avatar backgrounds

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/internal/TextAvatar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/components/avatar/internal/TextAvatar.kt
@@ -9,6 +9,7 @@
 package io.element.android.libraries.designsystem.components.avatar.internal
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -48,6 +49,7 @@ internal fun TextAvatar(
             .size(size)
             .clip(avatarShape)
             .background(color = colors.background)
+            .border(width = 1.dp, color = ElementTheme.colors.borderInteractivePrimary, shape = avatarShape)
     ) {
         val fontSize = size.toSp() / 2
         val originalFont = ElementTheme.typography.fontHeadingMdBold


### PR DESCRIPTION
## Content

The decorative background colors used behind avatar initials (the `bgDecorative1`–`bgDecorative6` tokens, e.g. `#E0F8D9`, `#E3F5F8`, `#FAEEFB`) have a contrast ratio of roughly 1.1–1.14:1 against a white canvas — far below the 3:1 minimum required for UI component boundaries (WCAG 1.4.11 Non-text Contrast). There is no border anywhere in the avatar render chain, so on light backgrounds the avatar shape itself can become nearly invisible for low-vision users, leaving only the initials/text as a visual anchor.

This adds a 1dp border to the avatar shape using `ElementTheme.colors.borderInteractivePrimary`, which has a contrast ratio of 3.50:1 against white and clears the 3:1 threshold, so the avatar boundary stays perceivable regardless of which decorative color is assigned.

## Motivation and context

Ensures avatar shapes remain visually distinguishable from their background for users with low vision, independent of the randomly-assigned decorative background color.

## Screenshots / GIFs

Adds a subtle 1dp border around the avatar's existing shape (matches whatever shape — circle, rounded square, etc. — is already used for the avatar's clip/background). No layout or sizing change.

## Tests

- Step 1: open any screen showing avatars with decorative background colors (e.g. a room list or member list with users who have no profile photo)
- Step 2: verify a subtle border is now visible around each avatar's initials background, improving the perceivable boundary of the shape on light backgrounds

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. Please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24.
- [ ] UI change has been tested on both light and dark themes.
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch.
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user.
- [x] Pull request includes screenshots or videos if containing UI changes. (n/a — no visual layout change, only a border addition; see Screenshots section)
- [x] You've made a self review of your PR.