### PR TITLE
Backfill room history into the search index in the background so older messages become findable

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/initializer/PlatformInitializer.kt
+++ b/app/src/main/kotlin/io/element/android/x/initializer/PlatformInitializer.kt
@@ -22,6 +22,14 @@ import timber.log.Timber
 
 private const val ELEMENT_X_TARGET = "elementx"
 
+// The SDK sets no global log level, and `matrix_sdk_search` is absent from its default target list,
+// so without this directive every log line from the message search index is silently dropped.
+// The indexing task itself lives under `matrix_sdk::event_cache`, so enable the Event Cache trace
+// log pack as well to follow a message from sync into the index.
+// Debuggable builds only: the SDK logs the full message body at debug level, and release logs can be
+// uploaded via rageshake.
+private const val MATRIX_SDK_SEARCH_TARGET = "matrix_sdk_search"
+
 class PlatformInitializer : Initializer<Unit> {
     override fun create(context: Context) {
         val appBindings = context.bindings<AppBindings>()
@@ -36,7 +44,12 @@ class PlatformInitializer : Initializer<Unit> {
             writesToLogcat = runBlocking { featureFlagService.isFeatureEnabled(FeatureFlags.PrintLogsToLogcat) },
             writesToFilesConfiguration = bugReporter.createWriteToFilesConfiguration(),
             logLevel = logLevel,
-            extraTargets = listOf(ELEMENT_X_TARGET),
+            extraTargets = buildList {
+                add(ELEMENT_X_TARGET)
+                if (appBindings.buildMeta().isDebuggable) {
+                    add(MATRIX_SDK_SEARCH_TARGET)
+                }
+            },
             traceLogPacks = runBlocking { preferencesStore.getTracingLogPacksFlow().first() },
             sdkSentryDsn = appBindings.sentrySdkDsn()?.value?.takeIf { it.isNotBlank() },
         )

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -162,7 +162,7 @@ enum class FeatureFlags(
     MessageSearch(
         key = "feature.message_search",
         title = "Message search",
-        description = "Index messages locally so they can be searched. Only messages received while enabled are indexed.",
+        description = "Index messages locally so they can be searched. Older history is backfilled in the background.",
         defaultValue = { false },
         isFinished = false,
     ),

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -159,4 +159,11 @@ enum class FeatureFlags(
         defaultValue = { false },
         isFinished = false,
     ),
+    MessageSearch(
+        key = "feature.message_search",
+        title = "Message search",
+        description = "Index messages locally so they can be searched. Only messages received while enabled are indexed.",
+        defaultValue = { false },
+        isFinished = false,
+    ),
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -39,6 +39,7 @@ import io.element.android.libraries.matrix.api.room.location.BeaconInfoUpdate
 import io.element.android.libraries.matrix.api.roomdirectory.RoomDirectoryService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.scanner.ContentScanner
+import io.element.android.libraries.matrix.api.search.MessageSearchService
 import io.element.android.libraries.matrix.api.spaces.SpaceService
 import io.element.android.libraries.matrix.api.sync.SlidingSyncVersion
 import io.element.android.libraries.matrix.api.sync.SyncService
@@ -70,6 +71,10 @@ interface MatrixClient {
     val notificationSettingsService: NotificationSettingsService
     val encryptionService: EncryptionService
     val roomDirectoryService: RoomDirectoryService
+
+    /** Whether this live client was built with an encrypted message search index. */
+    val isMessageSearchAvailable: Boolean
+    val messageSearchService: MessageSearchService
     val mediaPreviewService: MediaPreviewService
     val matrixMediaLoader: MatrixMediaLoader
     val sessionCoroutineScope: CoroutineScope

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearch.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearch.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A single, stateful message search cursor: one query at a time, with paginated results.
+ *
+ * Obtain an instance via [MessageSearchService.createMessageSearch]. The instance is tied to the
+ * [kotlinx.coroutines.CoroutineScope] it was created with; cancelling that scope releases the
+ * underlying SDK resources, so there is no `close()` to call.
+ */
+interface MessageSearch {
+    /**
+     * The current result set for the active query, in the order supplied by the SDK.
+     */
+    val results: StateFlow<ImmutableList<MessageSearchResult>>
+
+    /**
+     * Whether a page is currently loading, and whether the end has been reached.
+     */
+    val paginationState: StateFlow<MessageSearchPaginationState>
+
+    /**
+     * Set (or update) the search query. Clears the current results, restarts pagination from
+     * scratch and loads the first page. Call [paginate] to load any further pages.
+     */
+    suspend fun setQuery(query: String): Result<Unit>
+
+    /**
+     * Load the next page of results. No-ops if a page is already loading or the end was reached.
+     */
+    suspend fun paginate(): Result<Unit>
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchPaginationState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchPaginationState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+/**
+ * Whether the search is currently loading a page of results.
+ */
+sealed interface MessageSearchPaginationState {
+    /**
+     * Not currently paginating. [endReached] is true once every source has been
+     * exhausted for the current query.
+     */
+    data class Idle(val endReached: Boolean) : MessageSearchPaginationState
+
+    /**
+     * A page of results is currently being loaded.
+     */
+    data object Loading : MessageSearchPaginationState
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchResult.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchResult.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.timeline.item.event.EventContent
+import io.element.android.libraries.matrix.api.timeline.item.event.ProfileDetails
+
+/**
+ * A single message matching a search query, with its content and sender resolved.
+ */
+data class MessageSearchResult(
+    val roomId: RoomId,
+    val eventId: EventId,
+    val senderId: UserId,
+    val senderProfile: ProfileDetails,
+    val content: EventContent,
+    /** Origin server timestamp, in milliseconds since the epoch. */
+    val timestamp: Long,
+)

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchService.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/MessageSearchService.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import kotlinx.coroutines.CoroutineScope
+
+interface MessageSearchService {
+    /**
+     * Create a new, independent search cursor.
+     *
+     * The underlying SDK service is stateful (one query at a time), so create one per search
+     * screen — never one per keystroke, and never a shared singleton.
+     *
+     * @param scope the lifetime of the search session. The returned [MessageSearch] observes and
+     * emits results on this scope, and the underlying SDK service is closed once the scope
+     * completes, so there is nothing to release by hand. Pass the scope of the screen that owns the
+     * search, not a longer-lived one.
+     * @param roomId when null, the search is session-wide and results from every room the user is
+     * in are exposed; when non-null, only results from that room are. Note that the SDK searches
+     * and ranks across every room regardless, so this is a client-side filter, not a pushdown: a
+     * room with few matches may need several [MessageSearch.paginate] calls before any of its
+     * results surface.
+     */
+    fun createMessageSearch(scope: CoroutineScope, roomId: RoomId? = null): MessageSearch
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/SearchBackfillState.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/SearchBackfillState.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import kotlinx.serialization.Serializable
+
+/**
+ * How a single room's backfill ended.
+ *
+ * Note what is deliberately missing: an outcome meaning "this room is fully indexed". The app cannot
+ * know that. Back-paginating a room whose history is already in the local event-cache store
+ * re-hydrates it from disk, the SDK drops those updates before the indexer sees them, and nothing is
+ * indexed — yet pagination reports exactly the same success as a network fetch that indexed
+ * everything. [REACHED_START] therefore means "there was nothing left to ask for", not "it is all
+ * searchable".
+ */
+@Serializable
+enum class RoomSweepOutcome {
+    /** Pagination reported the start of the room. Says nothing about how much was indexed. */
+    REACHED_START,
+
+    /**
+     * Stopped at the per-room page cap or time limit. More history exists.
+     *
+     * There is deliberately no age-horizon outcome. A "stop at N days old" rule needs the timestamp
+     * of the oldest loaded event, and the only app-side source for that is the timeline item list —
+     * the same signal that reads highest exactly when nothing was indexed. Cost is bounded by pages
+     * instead, which is a number the app can actually trust.
+     */
+    PAGE_CAP,
+
+    /** Pagination failed repeatedly for this room. */
+    FAILED,
+
+    /** The room was no longer joined by the time its turn came. */
+    NOT_JOINED,
+}
+
+/**
+ * Durable position of the sweep, so it survives process death and does not restart from zero.
+ *
+ * [queue] is frozen when a sweep generation starts. It is deliberately not recomputed as the sweep
+ * runs: it is ordered by the room's latest event timestamp, which changes on every incoming message,
+ * so recomputing mid-sweep would reshuffle rooms underneath the cursor and could starve a room
+ * forever.
+ */
+@Serializable
+data class SearchBackfillCursor(
+    val generation: Int = 0,
+    val queue: List<String> = emptyList(),
+    val index: Int = 0,
+    val pagesDone: Map<String, Int> = emptyMap(),
+    val failures: Map<String, Int> = emptyMap(),
+    val outcomes: Map<String, RoomSweepOutcome> = emptyMap(),
+    val pagesIssued: Int = 0,
+    val startedAt: Long = 0L,
+    val finishedAt: Long? = null,
+    val stoppedByBudget: Boolean = false,
+) {
+    val isDrained: Boolean get() = index >= queue.size
+
+    /**
+     * True when another execution is needed to make progress: rooms remain unvisited, or the
+     * queue was empty when the generation started — typically because the room list had not
+     * synced yet in a headless start — and nothing was swept at all.
+     */
+    val needsAnotherExecution: Boolean get() = !isDrained || queue.isEmpty()
+
+    fun roomAt(position: Int): RoomId? = queue.getOrNull(position)?.let(::RoomId)
+}
+
+/**
+ * What the UI is allowed to know about the sweep.
+ *
+ * There is no `Complete` member, and that absence is load-bearing rather than an oversight: draining
+ * the queue proves the sweep ran out of work, not that the user's history is searchable. A state the
+ * presenter could render as "indexing finished" would be a claim the app has no way to justify, so
+ * the type makes it unrepresentable.
+ */
+sealed interface SearchBackfillStatus {
+    data object NotStarted : SearchBackfillStatus
+
+    data class Running(
+        val roomsAttempted: Int,
+        val roomsQueued: Int,
+    ) : SearchBackfillStatus
+
+    data class Stopped(
+        val roomsAttempted: Int,
+        val roomsCapped: Int,
+        val roomsFailed: Int,
+        val stoppedByBudget: Boolean,
+    ) : SearchBackfillStatus
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/SearchBackfillStore.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/search/SearchBackfillStore.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.search
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Durable state for the message search backfill.
+ *
+ * Kept apart from `SessionPreferencesStore`: that holds user-facing settings, this holds machine
+ * state with a different lifetime, which must be independently resettable without touching anything
+ * the user chose.
+ */
+interface SearchBackfillStore {
+    /** Emits the current cursor, or null when no sweep has ever been recorded. */
+    fun cursorFlow(): Flow<SearchBackfillCursor?>
+
+    /** Reads the cursor once. Returns null if absent or unreadable — never throws. */
+    suspend fun getCursor(): SearchBackfillCursor?
+
+    suspend fun setCursor(cursor: SearchBackfillCursor)
+
+    suspend fun clear()
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -81,6 +81,7 @@ import io.element.android.libraries.matrix.impl.roomdirectory.map
 import io.element.android.libraries.matrix.impl.roomlist.RoomListFactory
 import io.element.android.libraries.matrix.impl.roomlist.RustRoomListService
 import io.element.android.libraries.matrix.impl.roomlist.roomOrNull
+import io.element.android.libraries.matrix.impl.search.RustMessageSearchService
 import io.element.android.libraries.matrix.impl.spaces.RustSpaceService
 import io.element.android.libraries.matrix.impl.sync.RustSyncService
 import io.element.android.libraries.matrix.impl.sync.map
@@ -155,6 +156,7 @@ class RustMatrixClient(
     private val analyticsService: AnalyticsService,
     private val workManagerScheduler: WorkManagerScheduler,
     override val contentScanner: ContentScanner?,
+    override val isMessageSearchAvailable: Boolean,
 ) : MatrixClient {
     override val sessionId: UserId = UserId(innerClient.userId())
     override val deviceId: DeviceId = DeviceId(innerClient.deviceId())
@@ -190,6 +192,11 @@ class RustMatrixClient(
     )
 
     override val roomDirectoryService = RustRoomDirectoryService(
+        client = innerClient,
+        sessionDispatcher = sessionDispatcher,
+    )
+
+    override val messageSearchService = RustMessageSearchService(
         client = innerClient,
         sessionDispatcher = sessionDispatcher,
     )
@@ -876,7 +883,11 @@ class RustMatrixClient(
                 File(sessionPaths.fileDirectory, fileName)
             }.sumOf { file ->
                 file.length()
-            }
+            } +
+                // The message search index. Like the state database above it lives in the file
+                // directory and so survives a cache clear, but it can grow without bound and must
+                // not be invisible in the storage figures. Returns 0 when the index is disabled.
+                File(sessionPaths.fileDirectory, SEARCH_INDEX_DIRECTORY).getSizeOfFiles()
         }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -82,6 +82,7 @@ import io.element.android.libraries.matrix.impl.roomlist.RoomListFactory
 import io.element.android.libraries.matrix.impl.roomlist.RustRoomListService
 import io.element.android.libraries.matrix.impl.roomlist.roomOrNull
 import io.element.android.libraries.matrix.impl.search.RustMessageSearchService
+import io.element.android.libraries.matrix.impl.search.backfill.SearchBackfillRequestBuilder
 import io.element.android.libraries.matrix.impl.spaces.RustSpaceService
 import io.element.android.libraries.matrix.impl.sync.RustSyncService
 import io.element.android.libraries.matrix.impl.sync.map
@@ -320,6 +321,10 @@ class RustMatrixClient(
 
         // Schedule regular database vacuuming to ensure DB performance remains optimal
         scheduleDatabaseVacuum()
+
+        // Bring older history into the search index in the background, so search covers more than
+        // what happens to have been synced since the index was created.
+        scheduleSearchBackfill()
     }
 
     override fun userIdServerName(): String {
@@ -902,6 +907,23 @@ class RustMatrixClient(
 
         Timber.i("Scheduling periodic database vacuuming for session $sessionId")
         val request = PerformDatabaseVacuumRequestBuilder(sessionId)
+        sessionCoroutineScope.launch { workManagerScheduler.submit(request) }
+    }
+
+    /**
+     * Starts the background backfill so old history reaches the search index without the user having
+     * to ask for it or wait on it.
+     *
+     * Gated on [isMessageSearchAvailable], not on the feature flag: the index is attached at
+     * client-build time, so a flag toggled mid-session has no index to write into and sweeping would
+     * be pure cost. The worker re-checks the live flag itself before doing any work.
+     */
+    private fun scheduleSearchBackfill() {
+        if (!isMessageSearchAvailable) return
+        if (workManagerScheduler.hasPendingWork(sessionId, WorkManagerRequestType.SEARCH_BACKFILL)) return
+
+        Timber.i("Scheduling message search backfill for session $sessionId")
+        val request = SearchBackfillRequestBuilder(sessionId)
         sessionCoroutineScope.launch { workManagerScheduler.submit(request) }
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -81,11 +81,34 @@ class RustMatrixClientFactory(
     suspend fun create(sessionData: SessionData): RustMatrixClient = withContext(coroutineDispatchers.io) {
         // This secret is called 'passphrase' for historical reasons, but it can be a raw key or an actual passphrase
         val clientSecret = sessionData.passphrase?.let(ClientSecret::fromString)
-        val client = getBaseClientBuilder(
+        val sessionPaths = sessionData.getSessionPaths()
+        val isMessageSearchAvailable = isMessageSearchAvailable(clientSecret)
+        val indexDirectory = File(sessionPaths.fileDirectory, SEARCH_INDEX_DIRECTORY)
+
+        if (!isMessageSearchAvailable && indexDirectory.exists()) {
+            // With search off, events reach the event cache unindexed and the index can never
+            // catch up on them. Delete it so the next enable rebuilds it from a state where
+            // coverage can actually be guaranteed, instead of resuming a silently stale index.
+            Timber.tag("RustMatrixClient").i("Message search is unavailable, deleting the stale search index")
+            indexDirectory.deleteRecursively()
+        }
+
+        val client = buildAndRestoreClient(sessionData, clientSecret, isMessageSearchAvailable)
+        create(client, sessionData, isMessageSearchAvailable)
+    }
+
+    private suspend fun buildAndRestoreClient(
+        sessionData: SessionData,
+        clientSecret: ClientSecret?,
+        isMessageSearchAvailable: Boolean,
+    ): Client {
+        val baseClientBuilder = getBaseClientBuilder(
             sessionPaths = sessionData.getSessionPaths(),
             clientSecret = clientSecret,
             slidingSyncType = ClientBuilderSlidingSync.Restored,
+            isMessageSearchAvailable = isMessageSearchAvailable,
         )
+        val client = baseClientBuilder.clientBuilder
             .homeserverUrl(sessionData.homeserverUrl)
             .username(sessionData.userId)
             .use { it.build() }
@@ -104,11 +127,14 @@ class RustMatrixClientFactory(
         )
 
         client.restoreSession(sessionData.toSession())
-
-        create(client, sessionData)
+        return client
     }
 
-    suspend fun create(client: Client, sessionData: SessionData): RustMatrixClient {
+    suspend fun create(
+        client: Client,
+        sessionData: SessionData,
+        isMessageSearchAvailable: Boolean,
+    ): RustMatrixClient {
         val (anonymizedAccessToken, anonymizedRefreshToken) = client.session().anonymizedTokens()
 
         // Must be called before creating the sync service, timelines etc.
@@ -155,17 +181,26 @@ class RustMatrixClientFactory(
             analyticsService = analyticsService,
             workManagerScheduler = workManagerScheduler,
             contentScanner = contentScanner,
+            isMessageSearchAvailable = isMessageSearchAvailable,
         ).also {
             Timber.tag("RustMatrixClient").i("Creating Client with access token '$anonymizedAccessToken' and refresh token '$anonymizedRefreshToken'")
         }
     }
 
+    private suspend fun isMessageSearchAvailable(clientSecret: ClientSecret?): Boolean =
+        featureFlagService.isFeatureEnabled(FeatureFlags.MessageSearch) && clientSecret != null
+
     internal suspend fun getBaseClientBuilder(
         sessionPaths: SessionPaths,
         clientSecret: ClientSecret?,
         slidingSyncType: ClientBuilderSlidingSync,
-    ): ClientBuilder {
-        return clientBuilderProvider.provide()
+        // Null reads the live flag; the restore path passes its own snapshot instead, so a flag
+        // flipped mid-restore cannot make the coverage bookkeeping and the built client disagree
+        // about whether an index exists.
+        isMessageSearchAvailable: Boolean? = null,
+    ): BaseClientBuilder {
+        val messageSearchAvailable = isMessageSearchAvailable ?: isMessageSearchAvailable(clientSecret)
+        val clientBuilder = clientBuilderProvider.provide()
             .run {
                 sqliteStoreBuilderProvider.provide(sessionPaths)
                     .secret(clientSecret)
@@ -193,6 +228,22 @@ class RustMatrixClientFactory(
             )
             .enableShareHistoryOnInvite(true)
             .threadsEnabled(featureFlagService.isFeatureEnabled(FeatureFlags.Threads), threadSubscriptions = false)
+            .run {
+                // Note: every ClientBuilder call returns a NEW reference, so this must stay in
+                // expression position — using `if (flag) withSearchIndexStore(...)` as a statement
+                // would silently drop the result and leave the index disabled.
+                if (messageSearchAvailable) {
+                    // The index is encrypted at rest with the session secret, reusing the exact
+                    // string the SDK's SQLite stores already use. When there is no secret we skip
+                    // indexing entirely rather than writing message bodies to disk in plaintext.
+                    withSearchIndexStore(
+                        path = File(sessionPaths.fileDirectory, SEARCH_INDEX_DIRECTORY).absolutePath,
+                        password = checkNotNull(clientSecret).formattedAsString(),
+                    )
+                } else {
+                    this
+                }
+            }
             .dmRoomDefinition(DmRoomDefinition.TWO_MEMBERS)
             .requestConfig(
                 RequestConfig(
@@ -218,8 +269,23 @@ class RustMatrixClientFactory(
                 // Workaround for non-nullable proxy parameter in the SDK, since each call to the ClientBuilder returns a new reference we need to keep
                 proxyProvider.provides()?.let { proxy(it) } ?: this
             }
+        return BaseClientBuilder(
+            clientBuilder = clientBuilder,
+            isMessageSearchAvailable = messageSearchAvailable,
+        )
     }
 }
+
+internal data class BaseClientBuilder(
+    val clientBuilder: ClientBuilder,
+    val isMessageSearchAvailable: Boolean,
+)
+
+/**
+ * Directory holding the local message search index, under the session's file directory.
+ * Not the cache directory: the index is not disposable, and a cache wipe should not destroy it.
+ */
+internal const val SEARCH_INDEX_DIRECTORY = "search-index"
 
 sealed interface ClientBuilderSlidingSync {
     // The proxy will be supplied when restoring the Session.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -81,6 +81,7 @@ class RustMatrixAuthenticationService(
     // Ideally it would be possible to get the sessionPath from the Client to avoid doing this.
     private var sessionPaths: SessionPaths? = null
     private var currentClient: Client? = null
+    private var currentClientIsMessageSearchAvailable = false
 
     private val newMatrixClientObservers = mutableListOf<(MatrixClient) -> Unit>()
     override fun listenToNewMatrixClients(lambda: (MatrixClient) -> Unit) {
@@ -160,7 +161,7 @@ class RustMatrixAuthenticationService(
                         passphrase = pendingKey.formattedAsString(),
                         sessionPaths = currentSessionPaths,
                     )
-                val matrixClient = rustMatrixClientFactory.create(client, sessionData)
+                val matrixClient = rustMatrixClientFactory.create(client, sessionData, currentClientIsMessageSearchAvailable)
                 newMatrixClientObservers.forEach { it.invoke(matrixClient) }
                 sessionStore.addSession(sessionData)
 
@@ -235,7 +236,7 @@ class RustMatrixAuthenticationService(
 
                 // We restore the client using the just retrieved session data
                 client.restoreSession(sessionData.toSession())
-                val matrixClient = rustMatrixClientFactory.create(client, sessionData)
+                val matrixClient = rustMatrixClientFactory.create(client, sessionData, currentClientIsMessageSearchAvailable)
 
                 // We wait for the verification state to be known
                 matrixClient.waitForKnownVerificationState()
@@ -325,7 +326,7 @@ class RustMatrixAuthenticationService(
                     passphrase = pendingKey.formattedAsString(),
                     sessionPaths = currentSessionPaths,
                 )
-                val matrixClient = rustMatrixClientFactory.create(client, sessionData)
+                val matrixClient = rustMatrixClientFactory.create(client, sessionData, currentClientIsMessageSearchAvailable)
                 matrixClient.waitForKnownVerificationState()
 
                 newMatrixClientObservers.forEach { it.invoke(matrixClient) }
@@ -390,7 +391,7 @@ class RustMatrixAuthenticationService(
                         passphrase = pendingKey.formattedAsString(),
                         sessionPaths = emptySessionPaths,
                     )
-                val matrixClient = rustMatrixClientFactory.create(client, sessionData)
+                val matrixClient = rustMatrixClientFactory.create(client, sessionData, currentClientIsMessageSearchAvailable)
                 newMatrixClientObservers.forEach { it.invoke(matrixClient) }
                 sessionStore.addSession(sessionData)
 
@@ -417,12 +418,13 @@ class RustMatrixAuthenticationService(
         config: suspend ClientBuilder.() -> ClientBuilder,
     ): Client {
         Timber.d("Creating client with simplified sliding sync")
-        return rustMatrixClientFactory
-            .getBaseClientBuilder(
-                sessionPaths = sessionPaths,
-                clientSecret = pendingKey,
-                slidingSyncType = ClientBuilderSlidingSync.Discovered,
-            )
+        val baseClientBuilder = rustMatrixClientFactory.getBaseClientBuilder(
+            sessionPaths = sessionPaths,
+            clientSecret = pendingKey,
+            slidingSyncType = ClientBuilderSlidingSync.Discovered,
+        )
+        currentClientIsMessageSearchAvailable = baseClientBuilder.isMessageSearchAvailable
+        return baseClientBuilder.clientBuilder
             .config()
             .build()
     }
@@ -449,12 +451,13 @@ class RustMatrixAuthenticationService(
             throw HumanQrLoginException.Unknown()
         }
 
-        return rustMatrixClientFactory
-            .getBaseClientBuilder(
-                sessionPaths = sessionPaths,
-                clientSecret = pendingKey,
-                slidingSyncType = ClientBuilderSlidingSync.Discovered,
-            )
+        val baseClientBuilder = rustMatrixClientFactory.getBaseClientBuilder(
+            sessionPaths = sessionPaths,
+            clientSecret = pendingKey,
+            slidingSyncType = ClientBuilderSlidingSync.Discovered,
+        )
+        currentClientIsMessageSearchAvailable = baseClientBuilder.isMessageSearchAvailable
+        return baseClientBuilder.clientBuilder
             .serverNameOrHomeserverUrl(baseUrlOrServerName)
             .build()
     }
@@ -462,6 +465,7 @@ class RustMatrixAuthenticationService(
     private fun clear() {
         currentClient?.close()
         currentClient = null
+        currentClientIsMessageSearchAvailable = false
     }
 
     private suspend fun MatrixClient.waitForKnownVerificationState() {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultMapper.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.search.MessageSearchResult
+import io.element.android.libraries.matrix.impl.timeline.item.event.TimelineEventContentMapper
+import io.element.android.libraries.matrix.impl.timeline.item.event.map
+import org.matrix.rustcomponents.sdk.SearchServiceResult
+
+class MessageSearchResultMapper(
+    private val contentMapper: TimelineEventContentMapper = TimelineEventContentMapper(),
+) {
+    /**
+     * Note: [TimelineEventContentMapper.map] consumes (and destroys) the content, so each result
+     * must be mapped exactly once.
+     */
+    fun map(result: SearchServiceResult): MessageSearchResult {
+        // Exhaustive on purpose, with no `else`: a new SDK result kind must fail compilation here
+        // rather than being silently dropped, which would desync our list from the SDK's indices.
+        return when (result) {
+            is SearchServiceResult.Message -> MessageSearchResult(
+                roomId = RoomId(result.roomId),
+                eventId = EventId(result.result.eventId),
+                senderId = UserId(result.result.sender),
+                senderProfile = result.result.senderProfile.map(),
+                content = contentMapper.map(result.result.content),
+                timestamp = result.result.timestamp.toLong(),
+            )
+        }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultsProcessor.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultsProcessor.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import io.element.android.libraries.matrix.api.search.MessageSearchResult
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.matrix.rustcomponents.sdk.SearchServiceResultsUpdate
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Applies the SDK's diff stream to a local list of search results.
+ *
+ * The local list is kept strictly index-parallel to the SDK's: every result is mapped, nothing is
+ * filtered or dropped, so the positional updates ([SearchServiceResultsUpdate.Insert],
+ * [SearchServiceResultsUpdate.Set], [SearchServiceResultsUpdate.Remove],
+ * [SearchServiceResultsUpdate.Truncate]) always address the slot the SDK meant. Filtering for
+ * display, if ever needed, belongs at render time — not here.
+ */
+class MessageSearchResultsProcessor(
+    private val results: MutableSharedFlow<List<MessageSearchResult>>,
+    private val coroutineContext: CoroutineContext,
+    private val mapper: MessageSearchResultMapper = MessageSearchResultMapper(),
+) {
+    private val mutex = Mutex()
+
+    suspend fun postUpdates(updates: List<SearchServiceResultsUpdate>) = withContext(coroutineContext) {
+        mutex.withLock {
+            val current = results.replayCache.lastOrNull().orEmpty().toMutableList()
+            updates.forEach { update ->
+                current.applyUpdate(update)
+            }
+            results.emit(current)
+        }
+    }
+
+    private fun MutableList<MessageSearchResult>.applyUpdate(update: SearchServiceResultsUpdate) {
+        // Exhaustive on purpose, with no `else`: a future SDK bump adding a variant must fail
+        // compilation rather than silently dropping updates and corrupting the list.
+        when (update) {
+            is SearchServiceResultsUpdate.Append -> {
+                addAll(update.values.map(mapper::map))
+            }
+            is SearchServiceResultsUpdate.PushBack -> {
+                add(mapper.map(update.value))
+            }
+            is SearchServiceResultsUpdate.PushFront -> {
+                add(0, mapper.map(update.value))
+            }
+            is SearchServiceResultsUpdate.Set -> {
+                this[update.index.toInt()] = mapper.map(update.value)
+            }
+            is SearchServiceResultsUpdate.Insert -> {
+                add(update.index.toInt(), mapper.map(update.value))
+            }
+            is SearchServiceResultsUpdate.Remove -> {
+                removeAt(update.index.toInt())
+            }
+            is SearchServiceResultsUpdate.Truncate -> {
+                subList(update.length.toInt(), size).clear()
+            }
+            is SearchServiceResultsUpdate.Reset -> {
+                clear()
+                addAll(update.values.map(mapper::map))
+            }
+            SearchServiceResultsUpdate.PopBack -> {
+                removeLastOrNull()
+            }
+            SearchServiceResultsUpdate.PopFront -> {
+                removeFirstOrNull()
+            }
+            SearchServiceResultsUpdate.Clear -> {
+                clear()
+            }
+        }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearch.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearch.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import io.element.android.libraries.core.extensions.runCatchingExceptions
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.search.MessageSearch
+import io.element.android.libraries.matrix.api.search.MessageSearchPaginationState
+import io.element.android.libraries.matrix.api.search.MessageSearchResult
+import io.element.android.libraries.matrix.impl.util.TaskHandleBag
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.job
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.matrix.rustcomponents.sdk.SearchServiceInterface
+import org.matrix.rustcomponents.sdk.SearchServicePaginationStateListener
+import org.matrix.rustcomponents.sdk.SearchServiceResultsListener
+import org.matrix.rustcomponents.sdk.SearchServiceResultsUpdate
+import uniffi.matrix_sdk_ui.SearchServicePaginationState
+
+/**
+ * Wraps the SDK's stateful [SearchServiceInterface] as a single search cursor.
+ *
+ * Lifecycle: the caller's [CoroutineScope] owns this instance. When that scope completes, both
+ * subscription [org.matrix.rustcomponents.sdk.TaskHandle]s are cancelled and [onClose] releases the
+ * underlying service — the handles must be retained until then, or the Rust side drops the
+ * subscription.
+ *
+ * PII: search queries and message bodies are never logged.
+ */
+class RustMessageSearch(
+    private val inner: SearchServiceInterface,
+    private val onClose: () -> Unit,
+    scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+    private val roomId: RoomId? = null,
+) : MessageSearch {
+    private val innerResults = MutableStateFlow<List<MessageSearchResult>>(emptyList())
+    private val processor = MessageSearchResultsProcessor(
+        results = innerResults,
+        coroutineContext = dispatcher,
+    )
+    private val taskHandles = TaskHandleBag()
+    private val subscriptionMutex = Mutex()
+    private var subscribedToResults = false
+
+    /**
+     * The SDK listener is not a suspend function, so batches are handed to a single consumer
+     * coroutine. An unlimited channel keeps them strictly in arrival order — applying diffs out of
+     * order would corrupt the list just as surely as dropping them.
+     */
+    private val updates = Channel<List<SearchServiceResultsUpdate>>(Channel.UNLIMITED)
+
+    override val results: StateFlow<ImmutableList<MessageSearchResult>> = innerResults
+        .map { results ->
+            // Room scoping is applied HERE, at the exposure boundary, and nowhere else.
+            // [innerResults] must stay index-parallel to the SDK's own list, because the positional
+            // diffs (Insert/Set/Remove/Truncate) address the SDK's indices. Filtering inside
+            // MessageSearchResultsProcessor instead is precisely the element-x-ios desync bug.
+            when (roomId) {
+                null -> results.toImmutableList()
+                else -> results.filter { it.roomId == roomId }.toImmutableList()
+            }
+        }
+        .stateIn(scope, SharingStarted.Eagerly, persistentListOf())
+
+    private val mutablePaginationState = MutableStateFlow(inner.paginationState().map())
+    override val paginationState: StateFlow<MessageSearchPaginationState> = mutablePaginationState.asStateFlow()
+
+    init {
+        updates.consumeAsFlow()
+            .onEach { processor.postUpdates(it) }
+            .launchIn(scope)
+
+        taskHandles += inner.subscribeToPaginationStateUpdates(
+            object : SearchServicePaginationStateListener {
+                override fun onUpdate(paginationState: SearchServicePaginationState) {
+                    mutablePaginationState.value = paginationState.map()
+                }
+            }
+        )
+
+        scope.coroutineContext.job.invokeOnCompletion {
+            taskHandles.dispose()
+            updates.close()
+            onClose()
+        }
+    }
+
+    override suspend fun setQuery(query: String): Result<Unit> = withContext(dispatcher) {
+        runCatchingExceptions {
+            // Subscribe lazily, so a search screen that is opened but never used costs nothing.
+            subscribeToResultsIfNeeded()
+            // The SDK contract for setQuery is "clears the current results, restarts pagination from
+            // scratch". Whatever endReached we are holding describes the PREVIOUS query — or, on the
+            // very first search, a cursor that was never queried at all and reports endReached=true
+            // because there is nothing to page through yet. Carrying it over makes every search look
+            // finished before it starts, so callers never paginate and an empty result is reported as
+            // a definitive "no results". Reset before handing the query over; the subscription
+            // corrects this the moment the SDK reports its real state.
+            mutablePaginationState.value = MessageSearchPaginationState.Idle(endReached = false)
+            // The SDK parses this with tantivy's strict query parser, where `:` and friends are
+            // syntax rather than text — a pasted URL fails the whole search. Escape so the query is
+            // searched literally. The caller keeps the raw string; only the SDK sees the escaped one.
+            inner.setQuery(query.escapeForTantivy())
+        }
+    }
+
+    override suspend fun paginate(): Result<Unit> = withContext(dispatcher) {
+        runCatchingExceptions {
+            inner.paginate()
+        }
+    }
+
+    private suspend fun subscribeToResultsIfNeeded() {
+        subscriptionMutex.withLock {
+            if (subscribedToResults) return@withLock
+            taskHandles += inner.subscribeToResults(
+                object : SearchServiceResultsListener {
+                    override fun onUpdate(updates: List<SearchServiceResultsUpdate>) {
+                        this@RustMessageSearch.updates.trySend(updates)
+                    }
+                }
+            )
+            subscribedToResults = true
+        }
+    }
+}
+
+internal fun SearchServicePaginationState.map(): MessageSearchPaginationState = when (this) {
+    is SearchServicePaginationState.Idle -> MessageSearchPaginationState.Idle(endReached = endReached)
+    SearchServicePaginationState.Loading -> MessageSearchPaginationState.Loading
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearchService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearchService.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.search.MessageSearch
+import io.element.android.libraries.matrix.api.search.MessageSearchService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import org.matrix.rustcomponents.sdk.Client
+
+class RustMessageSearchService(
+    private val client: Client,
+    private val sessionDispatcher: CoroutineDispatcher,
+) : MessageSearchService {
+    override fun createMessageSearch(scope: CoroutineScope, roomId: RoomId?): MessageSearch {
+        // Each searchService() call mints a new Rust object, so this instance owns the one it
+        // creates and closes it when the caller's scope completes.
+        val searchService = client.searchService()
+        return RustMessageSearch(
+            inner = searchService,
+            onClose = { searchService.close() },
+            scope = scope,
+            dispatcher = sessionDispatcher,
+            roomId = roomId,
+        )
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/TantivyQueryEscaper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/TantivyQueryEscaper.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+/**
+ * Characters that terminate a bare word wherever they appear in it. Escaping them keeps the token a
+ * single literal word. `\` is included so a backslash the user typed cannot escape one of ours, and
+ * `*` is the prefix/all-documents operator rather than a word breaker.
+ */
+private val ESCAPED_ANYWHERE = charArrayOf('\\', '^', '`', ':', '{', '}', '"', '\'', '[', ']', '(', ')', '*')
+
+/**
+ * Characters that are operators only in the first position of a term: `-`/`+` occurrence, `/` regex,
+ * `>`/`<` elastic range, `!` field separator, `~` slop. Inside a word they are ordinary text, so
+ * escaping them there would be over-broad — `C++` and `1/2/2024` must survive untouched.
+ */
+private val ESCAPED_WHEN_LEADING = charArrayOf('-', '+', '/', '>', '<', '!', '~')
+
+/**
+ * Bare-word operators, neutralised so the query stays literal text end to end: `a AND b` searches
+ * for the three words rather than silently switching to a boolean AND. Mid-query these change
+ * meaning rather than failing; only a dangling operator is a syntax error.
+ */
+private val OPERATOR_WORDS = setOf("AND", "OR", "NOT", "IN", "TO")
+
+private val WHITESPACE_REGEX = Regex("\\s+")
+
+private const val ESCAPE_HEADROOM = 8
+
+/**
+ * Escapes a user-typed search string so tantivy's query parser reads it as literal text, and makes
+ * every word of it mandatory.
+ *
+ * **Escaping.** `matrix-sdk-search` hands the query to the **strict** `QueryParser::parse_query` with
+ * `body` as the only default field, so an unescaped `:` sends tantivy looking for a field named
+ * `https` and the whole search fails — pasting a link finds nothing at all. Unbalanced quotes and
+ * brackets, a leading `-`, and elastic ranges like `>5` fail the same way, and the error arrives as
+ * an opaque `ClientError` string we cannot tell apart from an I/O failure.
+ *
+ * Escaping is per token rather than wrapping the whole query in quotes: whitespace stays the term
+ * separator, and only a token that actually contained an operator changes shape. Wrapping instead
+ * would turn `design review notes` into one ordered phrase and quietly break every ordinary search.
+ *
+ * **Conjunction.** tantivy's parser is OR-by-default and the FFI takes a bare string, so
+ * `set_conjunction_by_default()` is unreachable from here — `check the photo` matched every message
+ * containing `the`, and buried the wanted one under hundreds of unrelated hits ranked by relevance.
+ * Prefixing each token with `+` makes it a Must clause, which parses to exactly the query
+ * `set_conjunction_by_default()` would have built.
+ *
+ * The `+` goes on **after** escaping, never before: `+` is escaped in leading position, so prefixing
+ * first would hand the escaper its own operator and produce a literal `\+`. That parses cleanly and
+ * silently restores OR, so it cannot be caught by anything but an assertion on the exact string.
+ *
+ * The costs, stated plainly: deliberate `"phrase"`, `-exclude` and boolean syntax stop working as
+ * operators; and a query is now only as good as its worst word — one typo, or one word the user
+ * misremembers, empties the result set where before it degraded to partial matches.
+ *
+ * Pinned to tantivy 0.26.1 grammar. PII: the query is never logged.
+ */
+internal fun String.escapeForTantivy(): String =
+    split(WHITESPACE_REGEX)
+        .filter { it.isNotEmpty() }
+        .joinToString(separator = " ") { token ->
+            // tantivy's default tokenizer splits on non-alphanumerics, so a token like `:)` or an
+            // emoji indexes no terms at all. Required, such a token could only ever subtract, and a
+            // single emoji beside real words would silently empty the results. Optional, it is
+            // inert — which is what it was before conjunctions too.
+            if (token.any(Char::isLetterOrDigit)) "+${token.escapeToken()}" else token.escapeToken()
+        }
+
+private fun String.escapeToken(): String = buildString(length + ESCAPE_HEADROOM) {
+    if (this@escapeToken in OPERATOR_WORDS) append('\\')
+    this@escapeToken.forEachIndexed { index, char ->
+        // One forward pass: chained replace() calls would re-escape the backslashes they just added.
+        if (char in ESCAPED_ANYWHERE || index == 0 && char in ESCAPED_WHEN_LEADING) {
+            append('\\')
+        }
+        append(char)
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/DataStoreSearchBackfillStore.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/DataStoreSearchBackfillStore.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import io.element.android.libraries.androidutils.hash.hash
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.search.SearchBackfillCursor
+import io.element.android.libraries.matrix.api.search.SearchBackfillStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Stores the backfill cursor as a JSON blob in its own DataStore file.
+ *
+ * Deliberately not part of `SessionPreferencesStore`: that holds settings the user chose, this holds
+ * machine state that we must be free to reset without touching anything of theirs.
+ */
+class DataStoreSearchBackfillStore(
+    context: Context,
+    sessionId: SessionId,
+    sessionCoroutineScope: CoroutineScope,
+) : SearchBackfillStore {
+    companion object {
+        fun storeFile(context: Context, sessionId: SessionId): File {
+            val hashedUserId = sessionId.value.hash().take(16)
+            return context.preferencesDataStoreFile("search_backfill_$hashedUserId")
+        }
+    }
+
+    private val cursorKey = stringPreferencesKey("cursor")
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private val dataStoreFile = storeFile(context, sessionId)
+    private val store = PreferenceDataStoreFactory.create(scope = sessionCoroutineScope) { dataStoreFile }
+
+    override fun cursorFlow(): Flow<SearchBackfillCursor?> = store.data.map { preferences ->
+        preferences[cursorKey]?.let(::decode)
+    }
+
+    override suspend fun getCursor(): SearchBackfillCursor? = cursorFlow().first()
+
+    override suspend fun setCursor(cursor: SearchBackfillCursor) {
+        store.edit { preferences ->
+            preferences[cursorKey] = json.encodeToString(cursor)
+        }
+    }
+
+    override suspend fun clear() {
+        store.edit { it.remove(cursorKey) }
+    }
+
+    /**
+     * A cursor we cannot read is treated as absent, not as an error: the sweep then starts a fresh
+     * generation. Losing progress is cheap; crashing a background worker on a schema change is not.
+     */
+    private fun decode(raw: String): SearchBackfillCursor? = try {
+        json.decodeFromString<SearchBackfillCursor>(raw)
+    } catch (error: IllegalArgumentException) {
+        Timber.w(error, "Discarding unreadable search backfill cursor")
+        null
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillBudget.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillBudget.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Cost limits for one execution of the backfill.
+ *
+ * Budgets are denominated in **pages and rooms, never events**. `Timeline.paginate` returns only
+ * "did we reach the start", so the app has no trustworthy event count: inferring one from the
+ * timeline item count would report its largest numbers precisely in the case where nothing was
+ * indexed at all (history re-hydrated from the local store), which is exactly backwards.
+ *
+ * The numbers below are deliberately conservative starting points, not measurements. Each page is a
+ * network round trip of up to 50 events, so one execution costs at most [maxPagesPerExecution]
+ * requests. They should be re-tuned against a real device measurement of index growth per page.
+ */
+internal data class SearchBackfillBudget(
+    /**
+     * Pages for a single room before moving on, so one huge room cannot starve the rest.
+     *
+     * Deliberately looser than [maxRoomDuration], which is the effective per-room bound
+     * (~180 pages at [delayBetweenPages]). Every generation walks a room from its live end, and
+     * pages served from the already-cached history are charged here while indexing nothing — a
+     * tight page cap therefore walls each room at `cap × cached-chunk-size` events forever, which
+     * at the previous value of 20 meant nothing older than ~2560 events could ever be indexed.
+     */
+    val maxPagesPerRoom: Int = 200,
+    /** Pages across the whole execution. The dominant cost control. */
+    val maxPagesPerExecution: Int = 300,
+    /** Wall-clock ceiling, kept well inside WorkManager's ~10 minute kill. */
+    val executionDeadline: Duration = 5.minutes,
+    /** Time spent on any one room, so a slow server cannot consume the whole execution. */
+    val maxRoomDuration: Duration = 45.seconds,
+    /** Consecutive failures before a room is abandoned for this generation. */
+    val maxFailuresPerRoom: Int = 2,
+    /** Breathing room between requests so the sweep does not monopolise the network. */
+    val delayBetweenPages: Duration = 250.milliseconds,
+    /** Longer pause between rooms; the sweep is never in a hurry. */
+    val delayBetweenRooms: Duration = 1_000.milliseconds,
+)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillPlanner.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillPlanner.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.roomlist.RoomSummary
+
+/**
+ * Rooms visited in one sweep generation. Bounds the work for an account with a very large room list;
+ * beyond this the tail is almost always rooms the user does not read.
+ */
+internal const val ROOM_QUEUE_LIMIT = 200
+
+/**
+ * Decides which rooms to back-paginate, and in what order.
+ *
+ * Pure on purpose: this is the one part of the sweep whose behaviour a unit test can fully pin down,
+ * so all the judgement lives here and the runner stays a dumb loop.
+ *
+ * Ordering is most-recently-active first, so the rooms a user is most likely to search become
+ * searchable soonest. The sort is explicit and not inherited: the room list replays the SDK's diffs
+ * verbatim and applies no app-side ordering, so relying on incoming order would be relying on an
+ * accident.
+ */
+internal fun planSearchBackfill(summaries: List<RoomSummary>): List<RoomId> {
+    return summaries
+        .asSequence()
+        .filter { it.info.currentUserMembership == CurrentUserMembership.JOINED }
+        // Spaces are containers and hold no messages to index.
+        .filter { !it.info.isSpace }
+        // A tombstoned room's history is frozen and lives on under the predecessor's id, so
+        // paginating the successor spends network on nothing.
+        .filter { it.info.successorRoom == null }
+        // No latest event means nothing has ever arrived here; there is no history to walk back into.
+        .filter { it.latestEventTimestamp != null }
+        .sortedWith(
+            // Low priority last, then most recently active first.
+            compareBy<RoomSummary> { it.info.isLowPriority }
+                .thenByDescending { it.latestEventTimestamp ?: 0L }
+        )
+        .map { it.roomId }
+        .distinct()
+        .take(ROOM_QUEUE_LIMIT)
+        .toList()
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRequestBuilder.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRequestBuilder.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.impl.search.backfill.SearchBackfillWorker.Companion.SESSION_ID_PARAM
+import io.element.android.libraries.workmanager.api.WorkManagerRequestBuilder
+import io.element.android.libraries.workmanager.api.WorkManagerRequestType
+import io.element.android.libraries.workmanager.api.WorkManagerRequestWrapper
+import io.element.android.libraries.workmanager.api.WorkManagerWorkerType
+import io.element.android.libraries.workmanager.api.workManagerTag
+import java.util.concurrent.TimeUnit
+
+class SearchBackfillRequestBuilder(
+    private val sessionId: SessionId,
+) : WorkManagerRequestBuilder {
+    override suspend fun build(): Result<List<WorkManagerRequestWrapper>> {
+        val tag = workManagerTag(sessionId, WorkManagerRequestType.SEARCH_BACKFILL)
+        // One sweep per session at a time. The sweep is enqueued from every client start, and all
+        // of its progress lives in a single stored cursor — two of them running at once would
+        // interleave writes to it and pay twice for the same pages. KEEP rather than REPLACE
+        // because a sweep already in flight is strictly more useful than restarting it.
+        val type = WorkManagerWorkerType.Unique(name = tag, policy = ExistingWorkPolicy.KEEP)
+        val data = Data.Builder().putString(SESSION_ID_PARAM, sessionId.value).build()
+        val workRequest = OneTimeWorkRequest.Builder(SearchBackfillWorker::class)
+            // Load-bearing and unenforced by the compiler: without this tag the sweep keeps
+            // downloading a signed-out user's history, because cancel-on-logout works by tag.
+            .addTag(tag)
+            .setInputData(data)
+            .setConstraints(
+                Constraints.Builder()
+                    // Never on cellular. The user did not ask for this download, so it must not
+                    // arrive on their data plan.
+                    .setRequiredNetworkType(NetworkType.UNMETERED)
+                    .setRequiresBatteryNotLow(true)
+                    // The index grows as history lands; do not fill a nearly-full device.
+                    .setRequiresStorageNotLow(true)
+                    .build()
+            )
+            // Deliberately not expedited: this is entirely background work with no user waiting on it.
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+
+        return Result.success(listOf(WorkManagerRequestWrapper(workRequest, type)))
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRunner.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRunner.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.search.RoomSweepOutcome
+import io.element.android.libraries.matrix.api.search.SearchBackfillCursor
+import io.element.android.libraries.matrix.api.search.SearchBackfillStore
+import io.element.android.libraries.matrix.api.timeline.Timeline
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import timber.log.Timber
+
+private const val LOG_TAG = "SearchBackfill"
+
+/**
+ * Walks rooms backwards so their history reaches the local message search index.
+ *
+ * The app never touches the index directly — no such API is exposed. Indexing is a side effect of
+ * events passing through the SDK's event cache, so "backfill" here means nothing more than asking
+ * for old pages and letting the SDK index what the network returns.
+ *
+ * **What this cannot do, stated where the code lives.** A room whose history is already in the local
+ * event-cache store re-hydrates from disk on pagination, and the SDK drops those updates before the
+ * indexer sees them. The sweep gets the same "success" back either way, so it will record a clean
+ * outcome for a room into which it indexed exactly nothing. Nothing here can detect that; it is why
+ * no state in this package can ever report completeness.
+ *
+ * Deliberately a plain suspend class rather than a Worker: budgets and loop shape are then testable
+ * without Robolectric, and the host decides scheduling.
+ */
+internal class SearchBackfillRunner(
+    private val client: MatrixClient,
+    private val store: SearchBackfillStore,
+    private val roomsProvider: suspend () -> List<RoomId>,
+    private val budget: SearchBackfillBudget = SearchBackfillBudget(),
+    private val currentTimeMillis: () -> Long = System::currentTimeMillis,
+) {
+    /**
+     * Runs one execution: resumes the stored cursor, or starts a new generation when there is none
+     * or the previous one drained. Returns the cursor as persisted at the end.
+     */
+    suspend fun runOnce(): SearchBackfillCursor {
+        val startedAt = currentTimeMillis()
+        var cursor = resumeOrStartGeneration(startedAt)
+
+        if (cursor.queue.isEmpty()) {
+            Timber.tag(LOG_TAG).d("Nothing to sweep")
+            return cursor.copy(finishedAt = currentTimeMillis()).also { store.setCursor(it) }
+        }
+
+        var pagesThisExecution = 0
+        var stopped = false
+
+        while (!stopped && !cursor.isDrained) {
+            when (val step = sweepNextRoom(cursor, startedAt, pagesThisExecution)) {
+                is SweepStep.Stop -> {
+                    cursor = step.cursor
+                    stopped = true
+                }
+                is SweepStep.Continue -> {
+                    cursor = step.cursor
+                    pagesThisExecution += step.pagesIssued
+                }
+            }
+        }
+
+        val finished = cursor.copy(finishedAt = currentTimeMillis())
+        store.setCursor(finished)
+        Timber.tag(LOG_TAG).d(
+            "Execution finished: %d/%d rooms visited, %d pages issued",
+            finished.index,
+            finished.queue.size,
+            finished.pagesIssued,
+        )
+        return finished
+    }
+
+    /**
+     * One iteration of the sweep: the budget and cancellation guards, then at most one room.
+     *
+     * Extracted so the loop above is a single decision — carry on, or stop with this cursor — instead
+     * of a stack of early exits. The guards keep the order they had inline: cancellation, then the
+     * page budget, then the deadline, so the clock is read exactly once per surviving iteration.
+     */
+    private suspend fun sweepNextRoom(
+        cursor: SearchBackfillCursor,
+        startedAt: Long,
+        pagesThisExecution: Int,
+    ): SweepStep {
+        if (!currentCoroutineContext().isActive) {
+            Timber.tag(LOG_TAG).d("Cancelled, stopping at index ${cursor.index}")
+            return SweepStep.Stop(cursor)
+        }
+        if (pagesThisExecution >= budget.maxPagesPerExecution) {
+            Timber.tag(LOG_TAG).d("Page budget spent after $pagesThisExecution pages")
+            return SweepStep.Stop(cursor.copy(stoppedByBudget = true))
+        }
+        if (currentTimeMillis() - startedAt >= budget.executionDeadline.inWholeMilliseconds) {
+            Timber.tag(LOG_TAG).d("Execution deadline reached")
+            return SweepStep.Stop(cursor.copy(stoppedByBudget = true))
+        }
+
+        val roomId = cursor.roomAt(cursor.index) ?: return SweepStep.Stop(cursor)
+        val result = sweepRoom(roomId, remainingPages = budget.maxPagesPerExecution - pagesThisExecution)
+
+        val updated = cursor.copy(
+            index = cursor.index + 1,
+            pagesDone = cursor.pagesDone + (roomId.value to result.pagesIssued),
+            outcomes = cursor.outcomes + (roomId.value to result.outcome),
+            failures = if (result.outcome == RoomSweepOutcome.FAILED) {
+                cursor.failures + (roomId.value to (cursor.failures[roomId.value] ?: 0) + 1)
+            } else {
+                cursor.failures
+            },
+            pagesIssued = cursor.pagesIssued + result.pagesIssued,
+        )
+        // Persisted after every room so process death costs at most one room of progress.
+        store.setCursor(updated)
+
+        if (!updated.isDrained) {
+            delay(budget.delayBetweenRooms)
+        }
+        return SweepStep.Continue(updated, result.pagesIssued)
+    }
+
+    private suspend fun resumeOrStartGeneration(startedAt: Long): SearchBackfillCursor {
+        val stored = store.getCursor()
+        if (stored != null && !stored.isDrained) {
+            Timber.tag(LOG_TAG).d("Resuming generation ${stored.generation} at index ${stored.index}")
+            return stored
+        }
+        val queue = roomsProvider()
+        Timber.tag(LOG_TAG).d("Starting generation with ${queue.size} rooms")
+        return SearchBackfillCursor(
+            generation = (stored?.generation ?: 0) + 1,
+            queue = queue.map { it.value },
+            startedAt = startedAt,
+        )
+    }
+
+    private suspend fun sweepRoom(roomId: RoomId, remainingPages: Int): RoomResult {
+        val room = client.getJoinedRoom(roomId)
+        if (room == null) {
+            Timber.tag(LOG_TAG).d("Room $roomId is no longer joined, skipping")
+            return RoomResult(RoomSweepOutcome.NOT_JOINED, pagesIssued = 0)
+        }
+
+        val roomStartedAt = currentTimeMillis()
+        var pages = 0
+        var failures = 0
+
+        return try {
+            val timeline = room.liveTimeline
+            while (pages < budget.maxPagesPerRoom && pages < remainingPages) {
+                if (!currentCoroutineContext().isActive) break
+                if (currentTimeMillis() - roomStartedAt >= budget.maxRoomDuration.inWholeMilliseconds) {
+                    return RoomResult(RoomSweepOutcome.PAGE_CAP, pages)
+                }
+                // Mandatory: paginate() throws CannotPaginate when the timeline says it cannot, so
+                // calling it unguarded turns "nothing left to fetch" into a spurious failure.
+                if (!timeline.backwardPaginationStatus.value.canPaginate) {
+                    return RoomResult(RoomSweepOutcome.REACHED_START, pages)
+                }
+
+                val outcome = timeline.paginate(Timeline.PaginationDirection.BACKWARDS)
+                pages++
+
+                outcome.fold(
+                    onSuccess = { reachedStart ->
+                        failures = 0
+                        if (reachedStart) {
+                            return RoomResult(RoomSweepOutcome.REACHED_START, pages)
+                        }
+                    },
+                    onFailure = { error ->
+                        failures++
+                        // Room ids are safe to log; message content never is.
+                        Timber.tag(LOG_TAG).w(error, "Pagination failed for $roomId (%d)", failures)
+                        if (failures >= budget.maxFailuresPerRoom) {
+                            return RoomResult(RoomSweepOutcome.FAILED, pages)
+                        }
+                    },
+                )
+
+                delay(budget.delayBetweenPages)
+            }
+            RoomResult(RoomSweepOutcome.PAGE_CAP, pages)
+        } finally {
+            // 200 rooms of un-closed Rust handles would be a slow leak, so this is not optional.
+            room.close()
+        }
+    }
+
+    private data class RoomResult(
+        val outcome: RoomSweepOutcome,
+        val pagesIssued: Int,
+    )
+
+    /** Outcome of one sweep iteration: the loop either carries on with [cursor], or ends on it. */
+    private sealed interface SweepStep {
+        val cursor: SearchBackfillCursor
+
+        data class Continue(override val cursor: SearchBackfillCursor, val pagesIssued: Int) : SweepStep
+
+        data class Stop(override val cursor: SearchBackfillCursor) : SweepStep
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillWorker.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillWorker.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.binding
+import io.element.android.libraries.core.extensions.runCatchingExceptions
+import io.element.android.libraries.di.annotations.ApplicationContext
+import io.element.android.libraries.featureflag.api.FeatureFlagService
+import io.element.android.libraries.featureflag.api.FeatureFlags
+import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.MatrixClientProvider
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.workmanager.api.di.MetroWorkerFactory
+import io.element.android.libraries.workmanager.api.di.WorkerKey
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+
+/**
+ * Hosts [SearchBackfillRunner] on WorkManager so the sweep survives the app being backgrounded and
+ * resumes under its constraints rather than running whenever the user happens to be looking.
+ *
+ * The worker owns scheduling concerns only. All loop and budget logic lives in the runner, which is a
+ * plain suspend class precisely so it stays testable without Robolectric.
+ */
+@AssistedInject
+class SearchBackfillWorker(
+    @Assisted params: WorkerParameters,
+    @ApplicationContext private val context: Context,
+    private val matrixClientProvider: MatrixClientProvider,
+    private val featureFlagService: FeatureFlagService,
+) : CoroutineWorker(context, params) {
+    companion object {
+        const val SESSION_ID_PARAM = "session_id"
+    }
+
+    override suspend fun doWork(): Result {
+        val sessionId = inputData.getString(SESSION_ID_PARAM)?.let(::SessionId) ?: return Result.failure()
+
+        // Re-checked LIVE rather than trusting the value frozen at enqueue time: a user who turned
+        // message search off should stop paying for history downloads at the next execution.
+        if (!featureFlagService.isFeatureEnabled(FeatureFlags.MessageSearch)) {
+            Timber.tag("SearchBackfill").d("Message search disabled, skipping sweep")
+            return Result.success()
+        }
+
+        val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return Result.failure()
+
+        // The index only exists when it was attached at client-build time; without it, paginating
+        // would spend network on history that nothing is going to index.
+        if (!client.isMessageSearchAvailable) {
+            Timber.tag("SearchBackfill").d("No search index for this session, skipping sweep")
+            return Result.success()
+        }
+
+        val store = DataStoreSearchBackfillStore(
+            context = context,
+            sessionId = sessionId,
+            sessionCoroutineScope = client.sessionCoroutineScope,
+        )
+
+        val runner = SearchBackfillRunner(
+            client = client,
+            store = store,
+            roomsProvider = { client.roomQueue() },
+        )
+
+        return runCatchingExceptions { runner.runOnce() }
+            .fold(
+                onSuccess = { cursor ->
+                    Timber.tag("SearchBackfill").d(
+                        "Sweep execution done: %d/%d rooms, %d pages",
+                        cursor.index,
+                        cursor.queue.size,
+                        cursor.pagesIssued,
+                    )
+                    // More rooms left — or a queue that came up empty because the room list had
+                    // not synced yet — means another execution is wanted, not that this one failed.
+                    if (cursor.needsAnotherExecution) Result.retry() else Result.success()
+                },
+                onFailure = { error ->
+                    Timber.tag("SearchBackfill").w(error, "Sweep execution failed")
+                    Result.retry()
+                },
+            )
+    }
+
+    /**
+     * Room summaries come from the sliding-sync room list, which needs a running sync — and this
+     * worker is headless, so it may never populate. We wait briefly and fall back to the flat joined
+     * room list rather than sweeping nothing.
+     *
+     * The fallback is logged at WARN on purpose: it is unordered, so "the most recent rooms first"
+     * silently becomes "an arbitrary 200 rooms". If that branch turns out to be the one production
+     * always takes, the prioritisation story is fiction and the log is how anyone would find out.
+     */
+    private suspend fun MatrixClient.roomQueue(): List<RoomId> {
+        val summaries = withTimeoutOrNull(ROOM_LIST_TIMEOUT_MILLIS) {
+            roomListService.allRooms.summaries.firstOrNull { it.isNotEmpty() }
+        }
+        if (!summaries.isNullOrEmpty()) {
+            return planSearchBackfill(summaries)
+        }
+        Timber.tag("SearchBackfill").w("Room list unavailable headless; falling back to unordered joined rooms")
+        return getJoinedRoomIds().getOrNull().orEmpty().take(ROOM_QUEUE_LIMIT)
+    }
+
+    @ContributesIntoMap(AppScope::class, binding = binding<MetroWorkerFactory.WorkerInstanceFactory<*>>())
+    @WorkerKey(SearchBackfillWorker::class)
+    @AssistedFactory
+    interface Factory : MetroWorkerFactory.WorkerInstanceFactory<SearchBackfillWorker>
+}
+
+private const val ROOM_LIST_TIMEOUT_MILLIS = 30_000L

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientTest.kt
@@ -160,5 +160,6 @@ class RustMatrixClientTest {
         analyticsService = FakeAnalyticsService(),
         workManagerScheduler = FakeWorkManagerScheduler(submitLambda = {}),
         contentScanner = FakeContentScanner(),
+        isMessageSearchAvailable = false,
     )
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/SearchServiceResult.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/factories/SearchServiceResult.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.fixtures.factories
+
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_USER_ID
+import org.matrix.rustcomponents.sdk.MessageSearchResult
+import org.matrix.rustcomponents.sdk.ProfileDetails
+import org.matrix.rustcomponents.sdk.SearchServiceResult
+
+internal fun aRustSearchServiceResult(
+    eventId: String,
+    roomId: String = A_ROOM_ID.value,
+    sender: String = A_USER_ID.value,
+    body: String = "Hello",
+    timestamp: ULong = 0uL,
+) = SearchServiceResult.Message(
+    roomId = roomId,
+    result = MessageSearchResult(
+        eventId = eventId,
+        sender = sender,
+        senderProfile = ProfileDetails.Unavailable,
+        content = aRustTimelineItemContentMsgLike(body = body),
+        timestamp = timestamp,
+    ),
+)

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiSearchService.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiSearchService.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.fixtures.fakes
+
+import org.matrix.rustcomponents.sdk.NoHandle
+import org.matrix.rustcomponents.sdk.SearchService
+import org.matrix.rustcomponents.sdk.SearchServicePaginationStateListener
+import org.matrix.rustcomponents.sdk.SearchServiceResultsListener
+import org.matrix.rustcomponents.sdk.TaskHandle
+import uniffi.matrix_sdk_ui.SearchServicePaginationState
+
+class FakeFfiSearchService(
+    private val initialPaginationState: SearchServicePaginationState = SearchServicePaginationState.Idle(endReached = false),
+    private val setQueryLambda: (String) -> Unit = {},
+    private val paginateLambda: () -> Unit = {},
+) : SearchService(NoHandle) {
+    var resultsListener: SearchServiceResultsListener? = null
+        private set
+    var paginationStateListener: SearchServicePaginationStateListener? = null
+        private set
+    var subscribeToResultsCallCount = 0
+        private set
+
+    override suspend fun paginate() = paginateLambda()
+
+    override fun paginationState(): SearchServicePaginationState = initialPaginationState
+
+    override suspend fun setQuery(query: String) = setQueryLambda(query)
+
+    override fun subscribeToPaginationStateUpdates(listener: SearchServicePaginationStateListener): TaskHandle {
+        paginationStateListener = listener
+        return FakeFfiTaskHandle()
+    }
+
+    override suspend fun subscribeToResults(listener: SearchServiceResultsListener): TaskHandle {
+        subscribeToResultsCallCount++
+        resultsListener = listener
+        return FakeFfiTaskHandle()
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultsProcessorTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/MessageSearchResultsProcessorTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.search.MessageSearchResult
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustSearchServiceResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.matrix.rustcomponents.sdk.SearchServiceResultsUpdate
+
+class MessageSearchResultsProcessorTest {
+    private val results = MutableStateFlow<List<MessageSearchResult>>(emptyList())
+
+    private fun createProcessor() = MessageSearchResultsProcessor(
+        results = results,
+        coroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+    )
+
+    private fun eventIds() = results.value.map { it.eventId.value }
+
+    @Test
+    fun `Append adds entries at the end of the list`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2")))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$2"))
+    }
+
+    @Test
+    fun `PushBack adds an entry at the end of the list`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.PushBack(aRustSearchServiceResult("\$2"))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$2"))
+    }
+
+    @Test
+    fun `PushFront inserts an entry at the start of the list`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.PushFront(aRustSearchServiceResult("\$0"))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$0", "\$1"))
+    }
+
+    @Test
+    fun `PopBack removes the last entry`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.PopBack))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1"))
+    }
+
+    @Test
+    fun `PopFront removes the first entry`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.PopFront))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$2"))
+    }
+
+    @Test
+    fun `Insert puts an entry at the given index`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$3")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Insert(1u, aRustSearchServiceResult("\$2"))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$2", "\$3"))
+    }
+
+    @Test
+    fun `Set replaces the entry at the given index`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Set(1u, aRustSearchServiceResult("\$9"))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$9"))
+    }
+
+    @Test
+    fun `Remove drops the entry at the given index`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(
+            listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2"), aRustSearchServiceResult("\$3"))))
+        )
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Remove(1u)))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$3"))
+    }
+
+    @Test
+    fun `Truncate keeps only the first N entries`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(
+            listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2"), aRustSearchServiceResult("\$3"))))
+        )
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Truncate(2u)))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$1", "\$2"))
+    }
+
+    @Test
+    fun `Clear empties the list`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Clear))
+
+        assertThat(eventIds()).isEmpty()
+    }
+
+    @Test
+    fun `Reset replaces the whole list`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2")))))
+        processor.postUpdates(listOf(SearchServiceResultsUpdate.Reset(listOf(aRustSearchServiceResult("\$7")))))
+
+        assertThat(eventIds()).isEqualTo(listOf("\$7"))
+    }
+
+    /**
+     * Regression test for the index-desync bug present in the element-x-ios bridge, where positional
+     * updates from the SDK were applied to a list that had already been filtered, so every index
+     * landed in the wrong slot. Our list must stay index-parallel to the SDK's throughout a batch.
+     */
+    @Test
+    fun `positional updates in one batch stay index-parallel with the SDK`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(
+            listOf(
+                SearchServiceResultsUpdate.Append(
+                    listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2"), aRustSearchServiceResult("\$3"))
+                ),
+                SearchServiceResultsUpdate.Insert(1u, aRustSearchServiceResult("\$b")),
+                SearchServiceResultsUpdate.Remove(0u),
+                SearchServiceResultsUpdate.Set(0u, aRustSearchServiceResult("\$z")),
+                SearchServiceResultsUpdate.PushFront(aRustSearchServiceResult("\$a")),
+                SearchServiceResultsUpdate.Truncate(3u),
+            )
+        )
+
+        // Append      -> [1, 2, 3]
+        // Insert(1,b) -> [1, b, 2, 3]
+        // Remove(0)   -> [b, 2, 3]
+        // Set(0,z)    -> [z, 2, 3]
+        // PushFront(a)-> [a, z, 2, 3]
+        // Truncate(3) -> [a, z, 2]
+        assertThat(eventIds()).isEqualTo(listOf("\$a", "\$z", "\$2"))
+    }
+
+    @Test
+    fun `a result carries roomId, sender and timestamp through the mapping`() = runTest {
+        val processor = createProcessor()
+        processor.postUpdates(
+            listOf(
+                SearchServiceResultsUpdate.Append(
+                    listOf(aRustSearchServiceResult(eventId = "\$1", roomId = "!room:server", sender = "@bob:server", timestamp = 1234uL))
+                )
+            )
+        )
+
+        val result = results.value.single()
+        assertThat(result.roomId.value).isEqualTo("!room:server")
+        assertThat(result.senderId.value).isEqualTo("@bob:server")
+        assertThat(result.timestamp).isEqualTo(1234L)
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearchTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/RustMessageSearchTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.search.MessageSearchPaginationState
+import io.element.android.libraries.matrix.impl.fixtures.factories.aRustSearchServiceResult
+import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeFfiSearchService
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_ROOM_ID_2
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.matrix.rustcomponents.sdk.SearchServiceResultsUpdate
+import uniffi.matrix_sdk_ui.SearchServicePaginationState
+
+class RustMessageSearchTest {
+    @Test
+    fun `paginationState is seeded from the SDK and reflects later updates`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService(initialPaginationState = SearchServicePaginationState.Idle(endReached = true))
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        assertThat(search.paginationState.value).isEqualTo(MessageSearchPaginationState.Idle(endReached = true))
+
+        service.paginationStateListener!!.onUpdate(SearchServicePaginationState.Loading)
+        assertThat(search.paginationState.value).isEqualTo(MessageSearchPaginationState.Loading)
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `setQuery failure surfaces as Result failure without throwing`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService(setQueryLambda = { error("boom") })
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        val result = search.setQuery("hello")
+
+        assertThat(result.isFailure).isTrue()
+        scope.cancel()
+    }
+
+    @Test
+    fun `the query handed to the SDK is escaped and made conjunctive for tantivy`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        var queryReceived: String? = null
+        val service = FakeFfiSearchService(setQueryLambda = { queryReceived = it })
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        // Unescaped, tantivy reads `https` as a field name and fails the entire search. The `+`
+        // makes the term mandatory: without it tantivy is OR-by-default and a multi-word query
+        // matches anything containing any one of its words.
+        search.setQuery("https://github.com/foo")
+
+        assertThat(queryReceived).isEqualTo("+https\\://github.com/foo")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `paginate failure surfaces as Result failure without throwing`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService(paginateLambda = { error("boom") })
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        val result = search.paginate()
+
+        assertThat(result.isFailure).isTrue()
+        scope.cancel()
+    }
+
+    @Test
+    fun `results are not subscribed to until the first setQuery, and only once`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService()
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        assertThat(service.subscribeToResultsCallCount).isEqualTo(0)
+
+        search.setQuery("hello")
+        assertThat(service.subscribeToResultsCallCount).isEqualTo(1)
+
+        search.setQuery("world")
+        assertThat(service.subscribeToResultsCallCount).isEqualTo(1)
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `updates pushed by the SDK reach the results flow`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService()
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher)
+
+        search.setQuery("hello")
+        service.resultsListener!!.onUpdate(
+            listOf(SearchServiceResultsUpdate.Append(listOf(aRustSearchServiceResult("\$1"), aRustSearchServiceResult("\$2"))))
+        )
+        advanceUntilIdle()
+
+        assertThat(search.results.value.map { it.eventId.value }).isEqualTo(listOf("\$1", "\$2"))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a room filter hides other rooms without disturbing SDK indexing`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService()
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher, roomId = A_ROOM_ID)
+
+        search.setQuery("hello")
+        // SDK list: [$1@room1, $2@room2, $3@room1, $4@room2]
+        service.resultsListener!!.onUpdate(
+            listOf(
+                SearchServiceResultsUpdate.Append(
+                    listOf(
+                        aRustSearchServiceResult("\$1", roomId = A_ROOM_ID.value),
+                        aRustSearchServiceResult("\$2", roomId = A_ROOM_ID_2.value),
+                        aRustSearchServiceResult("\$3", roomId = A_ROOM_ID.value),
+                        aRustSearchServiceResult("\$4", roomId = A_ROOM_ID_2.value),
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(search.results.value.map { it.eventId.value }).isEqualTo(listOf("\$1", "\$3"))
+
+        // Index 2 in the SDK's list is $3. Had the filter been applied inside the processor, the
+        // filtered list would be [$1, $3] and index 2 would be out of bounds — the iOS bug.
+        service.resultsListener!!.onUpdate(
+            listOf(SearchServiceResultsUpdate.Set(index = 2u, value = aRustSearchServiceResult("\$3edited", roomId = A_ROOM_ID.value)))
+        )
+        advanceUntilIdle()
+
+        assertThat(search.results.value.map { it.eventId.value }).isEqualTo(listOf("\$1", "\$3edited"))
+
+        // Removing index 1 ($2, a room we filter out) must not shift anything the user can see.
+        service.resultsListener!!.onUpdate(listOf(SearchServiceResultsUpdate.Remove(index = 1u)))
+        advanceUntilIdle()
+
+        assertThat(search.results.value.map { it.eventId.value }).isEqualTo(listOf("\$1", "\$3edited"))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `no room filter exposes every room`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val service = FakeFfiSearchService()
+        val search = RustMessageSearch(inner = service, onClose = {}, scope = scope, dispatcher = dispatcher, roomId = null)
+
+        search.setQuery("hello")
+        service.resultsListener!!.onUpdate(
+            listOf(
+                SearchServiceResultsUpdate.Append(
+                    listOf(
+                        aRustSearchServiceResult("\$1", roomId = A_ROOM_ID.value),
+                        aRustSearchServiceResult("\$2", roomId = A_ROOM_ID_2.value),
+                    )
+                )
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(search.results.value.map { it.eventId.value }).isEqualTo(listOf("\$1", "\$2"))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `cancelling the scope closes the underlying service`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        var closed = false
+        val service = FakeFfiSearchService()
+        RustMessageSearch(inner = service, onClose = { closed = true }, scope = scope, dispatcher = dispatcher)
+
+        assertThat(closed).isFalse()
+
+        scope.cancel()
+        advanceUntilIdle()
+
+        assertThat(closed).isTrue()
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/TantivyQueryEscaperTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/TantivyQueryEscaperTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Expectations here were checked against tantivy 0.26.1's own `QueryParser` — the version
+ * `matrix-sdk-search` compiles against — not inferred from the grammar. Each case notes the query it
+ * parses to, because "does not throw" is not the same as "searches for what the user typed".
+ */
+class TantivyQueryEscaperTest {
+    @Test
+    fun `an ordinary multi-word query becomes a conjunction`() {
+        // The headline behaviour. Without the `+`s tantivy is OR-by-default, so searching
+        // `check the photo` returned every message containing `the` — measured on device: a list of
+        // unrelated hits ranked by relevance, with the message actually wanted nowhere in it.
+        // Each `+` is a Must clause, which is what `set_conjunction_by_default()` would produce if
+        // the FFI let us call it.
+        assertThat("design review notes".escapeForTantivy()).isEqualTo("+design +review +notes")
+    }
+
+    @Test
+    fun `a single word query is a conjunction of one`() {
+        assertThat("photo".escapeForTantivy()).isEqualTo("+photo")
+    }
+
+    @Test
+    fun `the plus is prepended after escaping, never before`() {
+        // Load-bearing and silent when wrong: `-` is escaped only in leading position, so prefixing
+        // first would hand the escaper our own `+` to escape and produce `\+\-cats` — a literal
+        // plus, no Must clause, no parse error, and OR behaviour restored without a single failing
+        // assertion anywhere.
+        assertThat("-cats".escapeForTantivy()).isEqualTo("+\\-cats")
+    }
+
+    @Test
+    fun `a pasted URL no longer parses as a field lookup`() {
+        // The bug: unescaped, tantivy resolves `https` as a field name and fails the WHOLE search
+        // with FieldDoesNotExist. Only the colon needs escaping; the slashes are not leading.
+        assertThat("https://github.com/foo".escapeForTantivy()).isEqualTo("+https\\://github.com/foo")
+    }
+
+    @Test
+    fun `a real indexed field name is escaped too`() {
+        // `date` IS in the schema, as a DATE field, so this fails differently and more confusingly:
+        // DateFormatError rather than FieldDoesNotExist. The fix is not only about unknown fields.
+        assertThat("date:2020".escapeForTantivy()).isEqualTo("+date\\:2020")
+    }
+
+    @Test
+    fun `a matrix id is escaped`() {
+        // The second most likely paste after a URL. `@` and `.` are ordinary characters.
+        assertThat("@alice:matrix.org".escapeForTantivy()).isEqualTo("+@alice\\:matrix.org")
+    }
+
+    @Test
+    fun `a colon separated from its field name by a space is still escaped`() {
+        // The grammar allows whitespace between a field name and its colon, so `time: 12` would also
+        // be read as a field access. Per-token escaping defeats the spaced form as well.
+        assertThat("time: 12:30".escapeForTantivy()).isEqualTo("+time\\: +12\\:30")
+    }
+
+    @Test
+    fun `an elastic range operator is escaped`() {
+        // A genuine second failure class the desktop colon-only fix would have missed: unescaped,
+        // `>5` fails with UnsupportedQuery("Range query need to target a specific field.").
+        assertThat(">5".escapeForTantivy()).isEqualTo("+\\>5")
+    }
+
+    @Test
+    fun `quotes are escaped, which deliberately drops phrase search`() {
+        // Documents the cost: a typed phrase search becomes two AND'd terms. Accepted because a
+        // MISbalanced quote is a hard failure and the UI never advertised phrase syntax. Since the
+        // change to conjunctions this is much closer to a phrase search than it used to be — the
+        // words must all be present, only their order and adjacency are lost.
+        assertThat("\"quoted phrase\"".escapeForTantivy()).isEqualTo("+\\\"quoted +phrase\\\"")
+    }
+
+    @Test
+    fun `an unclosed quote no longer fails the search`() {
+        // Why quotes are escaped at all: an odd number of quotes is a syntax error today, and
+        // half-typed quotes happen constantly on a mobile keyboard.
+        assertThat("\"unclosed phrase".escapeForTantivy()).isEqualTo("+\\\"unclosed +phrase")
+    }
+
+    @Test
+    fun `parentheses are escaped`() {
+        // An unbalanced paren is a hard parse failure, and parens are common in ordinary prose.
+        assertThat("(a b)".escapeForTantivy()).isEqualTo("+\\(a +b\\)")
+    }
+
+    @Test
+    fun `a backslash the user typed is doubled`() {
+        // Guards the escaper against itself: without this the user's backslash would escape the one
+        // we appended and shift the whole token. This is why escaping is a single forward pass.
+        assertThat("foo\\bar".escapeForTantivy()).isEqualTo("+foo\\\\bar")
+    }
+
+    @Test
+    fun `a plus is left alone when it is not leading`() {
+        // `+` is only an operator in leading position. Confirms the escaper is not over-broad.
+        assertThat("C++".escapeForTantivy()).isEqualTo("+C++")
+    }
+
+    @Test
+    fun `a date with slashes is left alone`() {
+        // Slashes are only escaped when leading, where they would open a regex literal.
+        assertThat("1/2/2024".escapeForTantivy()).isEqualTo("+1/2/2024")
+    }
+
+    @Test
+    fun `a bare-word boolean operator is neutralised`() {
+        // A uniformity choice rather than purely an error fix: the query is literal text, so
+        // `a AND b` searches for two words instead of silently switching to boolean AND — which is
+        // now what every query does anyway.
+        assertThat("hello NOT".escapeForTantivy()).isEqualTo("+hello +\\NOT")
+    }
+
+    @Test
+    fun `a token with no letters or digits is never made mandatory`() {
+        // tantivy's default tokenizer splits on non-alphanumerics, so `:)` and emoji tokenise to
+        // nothing. As a Must clause a token that indexes no terms can only ever subtract, so an
+        // emoji typed alongside real words would silently empty the result set. Left as a Should
+        // clause it is inert, which is what it was before this change too.
+        assertThat("photo :)".escapeForTantivy()).isEqualTo("+photo \\:\\)")
+        assertThat("fotoğraf 📷".escapeForTantivy()).isEqualTo("+fotoğraf 📷")
+    }
+
+    @Test
+    fun `a punctuation-only query behaves exactly as it did before`() {
+        // The residual cost, recorded honestly: this no longer errors, but it tokenises to nothing
+        // and becomes EmptyQuery — zero results, silently. Better than killing the search, not good.
+        assertThat(":::".escapeForTantivy()).isEqualTo("\\:\\:\\:")
+    }
+
+    @Test
+    fun `a lone star matches nothing instead of everything`() {
+        // A real behaviour delta: `*` alone is AllQuery today and EmptyQuery after this change.
+        // Neither is a sensible search, but the change should be pinned rather than discovered.
+        assertThat("*".escapeForTantivy()).isEqualTo("\\*")
+    }
+
+    @Test
+    fun `non-ascii words are mandatory like any other`() {
+        // The account this was built for is Turkish. Kotlin's isLetterOrDigit is Unicode-aware, so
+        // no accented or non-Latin word is mistaken for punctuation and demoted.
+        assertThat("fotoğrafa bak".escapeForTantivy()).isEqualTo("+fotoğrafa +bak")
+    }
+
+    @Test
+    fun `runs of whitespace collapse and the query is trimmed`() {
+        // Semantically neutral to tantivy — whitespace is only a separator — but it is an
+        // observable change to the string we hand over, so it is pinned.
+        assertThat("   spaced   out  ".escapeForTantivy()).isEqualTo("+spaced +out")
+    }
+
+    @Test
+    fun `an empty query stays empty`() {
+        assertThat("".escapeForTantivy()).isEqualTo("")
+        assertThat("   ".escapeForTantivy()).isEqualTo("")
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillPlannerTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillPlannerTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.tombstone.SuccessorRoom
+import io.element.android.libraries.matrix.api.roomlist.LatestEventValue
+import io.element.android.libraries.matrix.api.roomlist.RoomSummary
+import io.element.android.libraries.matrix.test.room.aRemoteLatestEvent
+import io.element.android.libraries.matrix.test.room.aRoomSummary
+import org.junit.Test
+
+class SearchBackfillPlannerTest {
+    @Test
+    fun `rooms are ordered most recently active first`() {
+        // Given SHUFFLED input, so a pass cannot come from the input already being in order. The
+        // room list replays SDK diffs verbatim and applies no app-side sort, so the ordering has to
+        // be the planner's own doing.
+        val summaries = listOf(
+            aRoom("!old:server", timestamp = 100L),
+            aRoom("!newest:server", timestamp = 900L),
+            aRoom("!middle:server", timestamp = 500L),
+        )
+
+        val plan = planSearchBackfill(summaries)
+
+        assertThat(plan).isEqualTo(
+            listOf(RoomId("!newest:server"), RoomId("!middle:server"), RoomId("!old:server"))
+        )
+    }
+
+    @Test
+    fun `spaces are excluded`() {
+        // A space is a container; it holds no messages to index.
+        val summaries = listOf(
+            aRoom("!space:server", timestamp = 900L, isSpace = true),
+            aRoom("!room:server", timestamp = 100L),
+        )
+
+        assertThat(planSearchBackfill(summaries)).isEqualTo(listOf(RoomId("!room:server")))
+    }
+
+    @Test
+    fun `tombstoned rooms are excluded`() {
+        // An upgraded room's history is frozen and lives under the predecessor's id, so paginating
+        // the successor spends network and returns nothing worth indexing.
+        val summaries = listOf(
+            aRoom("!upgraded:server", timestamp = 900L, successorRoom = SuccessorRoom(RoomId("!new:server"), null)),
+            aRoom("!room:server", timestamp = 100L),
+        )
+
+        assertThat(planSearchBackfill(summaries)).isEqualTo(listOf(RoomId("!room:server")))
+    }
+
+    @Test
+    fun `rooms the user has not joined are excluded`() {
+        val summaries = listOf(
+            aRoom("!invited:server", timestamp = 900L, membership = CurrentUserMembership.INVITED),
+            aRoom("!left:server", timestamp = 800L, membership = CurrentUserMembership.LEFT),
+            aRoom("!joined:server", timestamp = 100L),
+        )
+
+        assertThat(planSearchBackfill(summaries)).isEqualTo(listOf(RoomId("!joined:server")))
+    }
+
+    @Test
+    fun `rooms with no latest event are excluded`() {
+        // Nothing has ever arrived here, so there is no history to walk back into.
+        val summaries = listOf(
+            aRoom("!empty:server", latestEvent = LatestEventValue.None),
+            aRoom("!room:server", timestamp = 100L),
+        )
+
+        assertThat(planSearchBackfill(summaries)).isEqualTo(listOf(RoomId("!room:server")))
+    }
+
+    @Test
+    fun `low priority rooms are pushed to the tail regardless of recency`() {
+        val summaries = listOf(
+            aRoom("!lowButRecent:server", timestamp = 900L, isLowPriority = true),
+            aRoom("!normalButOld:server", timestamp = 100L),
+        )
+
+        assertThat(planSearchBackfill(summaries)).isEqualTo(
+            listOf(RoomId("!normalButOld:server"), RoomId("!lowButRecent:server"))
+        )
+    }
+
+    @Test
+    fun `the queue is truncated to the room limit, keeping the most recent`() {
+        val summaries = (1..ROOM_QUEUE_LIMIT + 50).map { index ->
+            aRoom("!room$index:server", timestamp = index.toLong())
+        }
+
+        val plan = planSearchBackfill(summaries)
+
+        assertThat(plan).hasSize(ROOM_QUEUE_LIMIT)
+        // Highest timestamp wins, so the newest room is first and the oldest 50 are dropped.
+        assertThat(plan.first()).isEqualTo(RoomId("!room${ROOM_QUEUE_LIMIT + 50}:server"))
+        assertThat(plan).doesNotContain(RoomId("!room1:server"))
+    }
+
+    @Test
+    fun `an empty room list yields an empty plan`() {
+        assertThat(planSearchBackfill(emptyList())).isEmpty()
+    }
+}
+
+private fun aRoom(
+    roomId: String,
+    timestamp: Long = 0L,
+    isSpace: Boolean = false,
+    isLowPriority: Boolean = false,
+    successorRoom: SuccessorRoom? = null,
+    membership: CurrentUserMembership = CurrentUserMembership.JOINED,
+    latestEvent: LatestEventValue = aRemoteLatestEvent(timestamp = timestamp),
+): RoomSummary = aRoomSummary(
+    roomId = RoomId(roomId),
+    isSpace = isSpace,
+    isLowPriority = isLowPriority,
+    successorRoom = successorRoom,
+    currentUserMembership = membership,
+    latestEvent = latestEvent,
+)

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRequestBuilderTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRequestBuilderTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.libraries.workmanager.api.WorkManagerRequestType
+import io.element.android.libraries.workmanager.api.WorkManagerWorkerType
+import io.element.android.libraries.workmanager.api.workManagerTag
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SearchBackfillRequestBuilderTest : RobolectricTest() {
+    @Test
+    fun `the sweep is unique per session and keeps one already in flight`() = runTest {
+        // The sweep is enqueued from every client start and keeps all of its progress in a single
+        // stored cursor, so two concurrent runs would interleave writes to it and re-fetch the same
+        // pages. Enqueued as ordinary work this would happen on the second launch.
+        val results = SearchBackfillRequestBuilder(A_SESSION_ID).build()
+
+        val wrapper = results.getOrThrow().single()
+        val type = wrapper.type as WorkManagerWorkerType.Unique
+        assertThat(type.name).isEqualTo(workManagerTag(A_SESSION_ID, WorkManagerRequestType.SEARCH_BACKFILL))
+        assertThat(type.policy).isEqualTo(ExistingWorkPolicy.KEEP)
+    }
+
+    @Test
+    fun `the request is tagged for logout cancellation and constrained to free network`() = runTest {
+        val results = SearchBackfillRequestBuilder(A_SESSION_ID).build()
+
+        val request = results.getOrThrow().single().request
+        assertThat(request).isInstanceOf(OneTimeWorkRequest::class.java)
+        // Cancel-on-logout works by tag: without it the sweep keeps downloading a signed-out user's
+        // history.
+        assertThat(request.tags).contains(workManagerTag(A_SESSION_ID, WorkManagerRequestType.SEARCH_BACKFILL))
+        // The user did not ask for this download, so it must not arrive on their data plan.
+        assertThat(request.workSpec.constraints.requiredNetworkType).isEqualTo(NetworkType.UNMETERED)
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRunnerTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/search/backfill/SearchBackfillRunnerTest.kt
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.search.backfill
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.search.RoomSweepOutcome
+import io.element.android.libraries.matrix.api.search.SearchBackfillCursor
+import io.element.android.libraries.matrix.api.search.SearchBackfillStore
+import io.element.android.libraries.matrix.api.timeline.Timeline
+import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.room.FakeBaseRoom
+import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
+import io.element.android.libraries.matrix.test.timeline.FakeTimeline
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * These tests pin the LOOP SHAPE and nothing more.
+ *
+ * They cannot show that a single message becomes searchable: the chain from `paginate()` through the
+ * SDK event cache into tantivy has no app-level observation point, and no index API exists over FFI.
+ * A fully green file here means the loop iterated correctly over fakes. It is not evidence the
+ * feature works, and it must never be cited as such.
+ */
+class SearchBackfillRunnerTest {
+    @Test
+    fun `each room is paginated until it reports the start of the room`() = runTest {
+        val timeline = fakeTimeline(reachStartAfter = 3)
+        val runner = runner(rooms = listOf(A_ROOM), timelines = mapOf(A_ROOM to timeline))
+
+        val cursor = runner.runOnce()
+
+        assertThat(timeline.paginateCallCount).isEqualTo(3)
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.REACHED_START)
+        assertThat(cursor.isDrained).isTrue()
+    }
+
+    @Test
+    fun `a room that cannot paginate is never asked to`() = runTest {
+        // The regression test for the silent no-op: paginate() THROWS CannotPaginate when the status
+        // says it cannot, so calling it unguarded would turn "nothing to fetch" into a fake failure.
+        val timeline = fakeTimeline(canPaginate = false)
+        val runner = runner(rooms = listOf(A_ROOM), timelines = mapOf(A_ROOM to timeline))
+
+        val cursor = runner.runOnce()
+
+        assertThat(timeline.paginateCallCount).isEqualTo(0)
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.REACHED_START)
+    }
+
+    @Test
+    fun `pagination stops at the per-room page cap`() = runTest {
+        val timeline = fakeTimeline(reachStartAfter = Int.MAX_VALUE)
+        val runner = runner(
+            rooms = listOf(A_ROOM),
+            timelines = mapOf(A_ROOM to timeline),
+            budget = SearchBackfillBudget(maxPagesPerRoom = 4),
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(timeline.paginateCallCount).isEqualTo(4)
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.PAGE_CAP)
+    }
+
+    @Test
+    fun `a room is abandoned after repeated failures and the sweep continues`() = runTest {
+        val failing = fakeTimeline(failEvery = true)
+        val healthy = fakeTimeline(reachStartAfter = 1)
+        val runner = runner(
+            rooms = listOf(A_ROOM, B_ROOM),
+            timelines = mapOf(A_ROOM to failing, B_ROOM to healthy),
+            budget = SearchBackfillBudget(maxFailuresPerRoom = 2),
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(failing.paginateCallCount).isEqualTo(2)
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.FAILED)
+        // The important half: one bad room must not sink the sweep.
+        assertThat(cursor.outcomes[B_ROOM.value]).isEqualTo(RoomSweepOutcome.REACHED_START)
+    }
+
+    @Test
+    fun `a room that is no longer joined is skipped without paginating`() = runTest {
+        val runner = runner(rooms = listOf(A_ROOM), timelines = emptyMap())
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.NOT_JOINED)
+    }
+
+    @Test
+    fun `an empty queue asks for another execution instead of reporting completion`() = runTest {
+        // A headless start right after the caches were cleared can see an empty room list. Reading
+        // that as "all done" would park the sweep until the next app start with nothing indexed.
+        val runner = runner(rooms = emptyList(), timelines = emptyMap())
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.needsAnotherExecution).isTrue()
+    }
+
+    @Test
+    fun `a drained queue with visited rooms does not ask for another execution`() = runTest {
+        val runner = runner(
+            rooms = listOf(A_ROOM),
+            timelines = mapOf(A_ROOM to fakeTimeline(reachStartAfter = 1)),
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.needsAnotherExecution).isFalse()
+    }
+
+    @Test
+    fun `the room is always released, including when pagination fails`() = runTest {
+        // 200 rooms of un-closed Rust handles would be a slow leak with no symptom until it hurts.
+        val baseRoom = FakeBaseRoom()
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM, FakeJoinedRoom(baseRoom = baseRoom, liveTimeline = fakeTimeline(failEvery = true)))
+        }
+        val runner = SearchBackfillRunner(
+            client = client,
+            store = InMemoryStore(),
+            roomsProvider = { listOf(A_ROOM) },
+            budget = SearchBackfillBudget(maxFailuresPerRoom = 1),
+            currentTimeMillis = { 0L },
+        )
+
+        runner.runOnce()
+
+        baseRoom.assertDestroyed()
+    }
+
+    @Test
+    fun `the execution page budget stops the sweep early and is recorded`() = runTest {
+        val timelines = (1..5).associate { index ->
+            RoomId("!room$index:server") to fakeTimeline(reachStartAfter = Int.MAX_VALUE)
+        }
+        val runner = runner(
+            rooms = timelines.keys.toList(),
+            timelines = timelines,
+            budget = SearchBackfillBudget(maxPagesPerRoom = 10, maxPagesPerExecution = 15),
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.pagesIssued).isAtMost(15)
+        assertThat(cursor.stoppedByBudget).isTrue()
+        assertThat(cursor.isDrained).isFalse()
+    }
+
+    @Test
+    fun `a stored cursor resumes where it stopped and does not revisit earlier rooms`() = runTest {
+        val first = fakeTimeline(reachStartAfter = 1)
+        val second = fakeTimeline(reachStartAfter = 1)
+        val store = InMemoryStore(
+            SearchBackfillCursor(
+                generation = 1,
+                queue = listOf(A_ROOM.value, B_ROOM.value),
+                index = 1,
+            )
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM, FakeJoinedRoom(baseRoom = FakeBaseRoom(), liveTimeline = first))
+            givenGetRoomResult(B_ROOM, FakeJoinedRoom(baseRoom = FakeBaseRoom(), liveTimeline = second))
+        }
+        val runner = SearchBackfillRunner(
+            client = client,
+            store = store,
+            roomsProvider = { error("must not rebuild the queue while one is in progress") },
+            currentTimeMillis = { 0L },
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(first.paginateCallCount).isEqualTo(0)
+        assertThat(second.paginateCallCount).isEqualTo(1)
+        assertThat(cursor.isDrained).isTrue()
+    }
+
+    @Test
+    fun `a drained cursor starts a new generation`() = runTest {
+        val store = InMemoryStore(
+            SearchBackfillCursor(generation = 4, queue = listOf(A_ROOM.value), index = 1)
+        )
+        val runner = SearchBackfillRunner(
+            client = FakeMatrixClient(),
+            store = store,
+            roomsProvider = { listOf(B_ROOM) },
+            currentTimeMillis = { 0L },
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.generation).isEqualTo(5)
+        assertThat(cursor.queue).isEqualTo(listOf(B_ROOM.value))
+    }
+
+    @Test
+    fun `progress is persisted after every room`() = runTest {
+        val store = InMemoryStore()
+        val timelines = mapOf(
+            A_ROOM to fakeTimeline(reachStartAfter = 1),
+            B_ROOM to fakeTimeline(reachStartAfter = 1),
+        )
+        val runner = runner(rooms = listOf(A_ROOM, B_ROOM), timelines = timelines, store = store)
+
+        runner.runOnce()
+
+        // Two rooms plus the final write: process death costs at most one room of progress.
+        assertThat(store.writes).isAtLeast(3)
+        assertThat(store.getCursor()?.isDrained).isTrue()
+    }
+
+    @Test
+    fun `the execution deadline stops the sweep between rooms`() = runTest {
+        // Every other test freezes the clock, so without this the time budgets are never exercised
+        // at all and a wrong comparison would pass silently.
+        val timelines = (1..5).associate { index ->
+            RoomId("!room$index:server") to fakeTimeline(reachStartAfter = 1)
+        }
+        // Advances 40s per reading, so the 1-minute deadline trips after the first room.
+        var now = 0L
+        val runner = SearchBackfillRunner(
+            client = FakeMatrixClient().apply {
+                timelines.forEach { (roomId, timeline) ->
+                    givenGetRoomResult(roomId, FakeJoinedRoom(baseRoom = FakeBaseRoom(), liveTimeline = timeline))
+                }
+            },
+            store = InMemoryStore(),
+            roomsProvider = { timelines.keys.toList() },
+            budget = SearchBackfillBudget(executionDeadline = 1.minutes),
+            currentTimeMillis = { now.also { now += 40_000 } },
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.stoppedByBudget).isTrue()
+        assertThat(cursor.isDrained).isFalse()
+        // Later rooms must be left untouched for the next execution to resume into.
+        assertThat(timelines.values.count { it.paginateCallCount > 0 }).isLessThan(timelines.size)
+    }
+
+    @Test
+    fun `the per-room time limit stops that room and moves on`() = runTest {
+        val slow = fakeTimeline(reachStartAfter = Int.MAX_VALUE)
+        var now = 0L
+        val runner = SearchBackfillRunner(
+            client = FakeMatrixClient().apply {
+                givenGetRoomResult(A_ROOM, FakeJoinedRoom(baseRoom = FakeBaseRoom(), liveTimeline = slow))
+            },
+            store = InMemoryStore(),
+            roomsProvider = { listOf(A_ROOM) },
+            budget = SearchBackfillBudget(maxPagesPerRoom = 100, maxRoomDuration = 10.seconds),
+            currentTimeMillis = { now.also { now += 4_000 } },
+        )
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.outcomes[A_ROOM.value]).isEqualTo(RoomSweepOutcome.PAGE_CAP)
+        // Time, not the page cap of 100, is what stopped it.
+        assertThat(slow.paginateCallCount).isLessThan(100)
+    }
+
+    @Test
+    fun `an empty room list finishes without touching any room`() = runTest {
+        val runner = runner(rooms = emptyList(), timelines = emptyMap())
+
+        val cursor = runner.runOnce()
+
+        assertThat(cursor.queue).isEmpty()
+        assertThat(cursor.finishedAt).isNotNull()
+    }
+}
+
+private val A_ROOM = RoomId("!a:server")
+private val B_ROOM = RoomId("!b:server")
+
+private fun runner(
+    rooms: List<RoomId>,
+    timelines: Map<RoomId, CountingTimeline>,
+    budget: SearchBackfillBudget = SearchBackfillBudget(),
+    store: SearchBackfillStore = InMemoryStore(),
+): SearchBackfillRunner {
+    val client = FakeMatrixClient().apply {
+        timelines.forEach { (roomId, timeline) ->
+            givenGetRoomResult(roomId, FakeJoinedRoom(baseRoom = FakeBaseRoom(), liveTimeline = timeline))
+        }
+    }
+    return SearchBackfillRunner(
+        client = client,
+        store = store,
+        roomsProvider = { rooms },
+        budget = budget,
+        // Fixed clock: these tests assert page counts, never elapsed time.
+        currentTimeMillis = { 0L },
+    )
+}
+
+private fun fakeTimeline(
+    reachStartAfter: Int = 1,
+    canPaginate: Boolean = true,
+    failEvery: Boolean = false,
+): CountingTimeline = CountingTimeline(reachStartAfter, canPaginate, failEvery)
+
+/**
+ * Wraps [FakeTimeline] to count pagination calls, which is the only thing these tests can observe.
+ */
+private class CountingTimeline(
+    private val reachStartAfter: Int,
+    canPaginate: Boolean,
+    private val failEvery: Boolean,
+) : Timeline by FakeTimeline() {
+    var paginateCallCount = 0
+        private set
+
+    override val backwardPaginationStatus = MutableStateFlow(
+        Timeline.PaginationStatus(isPaginating = false, hasMoreToLoad = canPaginate)
+    )
+
+    override suspend fun paginate(direction: Timeline.PaginationDirection): Result<Boolean> {
+        paginateCallCount++
+        if (failEvery) return Result.failure(IllegalStateException("network"))
+        return Result.success(paginateCallCount >= reachStartAfter)
+    }
+}
+
+private class InMemoryStore(
+    private var cursor: SearchBackfillCursor? = null,
+) : SearchBackfillStore {
+    var writes = 0
+        private set
+
+    private val flow = MutableStateFlow(cursor)
+
+    override fun cursorFlow(): Flow<SearchBackfillCursor?> = flow
+
+    override suspend fun getCursor(): SearchBackfillCursor? = cursor
+
+    override suspend fun setCursor(cursor: SearchBackfillCursor) {
+        writes++
+        this.cursor = cursor
+        flow.value = cursor
+    }
+
+    override suspend fun clear() {
+        cursor = null
+        flow.value = null
+    }
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -39,6 +39,7 @@ import io.element.android.libraries.matrix.api.room.location.BeaconInfoUpdate
 import io.element.android.libraries.matrix.api.roomdirectory.RoomDirectoryService
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.scanner.ContentScanner
+import io.element.android.libraries.matrix.api.search.MessageSearchService
 import io.element.android.libraries.matrix.api.spaces.SpaceService
 import io.element.android.libraries.matrix.api.sync.SlidingSyncVersion
 import io.element.android.libraries.matrix.api.sync.SyncService
@@ -55,6 +56,7 @@ import io.element.android.libraries.matrix.test.notificationsettings.FakeNotific
 import io.element.android.libraries.matrix.test.pushers.FakePushersService
 import io.element.android.libraries.matrix.test.roomdirectory.FakeRoomDirectoryService
 import io.element.android.libraries.matrix.test.roomlist.FakeRoomListService
+import io.element.android.libraries.matrix.test.search.FakeMessageSearchService
 import io.element.android.libraries.matrix.test.spaces.FakeSpaceService
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.verification.FakeSessionVerificationService
@@ -91,6 +93,8 @@ class FakeMatrixClient(
     override val syncService: SyncService = FakeSyncService(),
     override val encryptionService: EncryptionService = FakeEncryptionService(),
     override val roomDirectoryService: RoomDirectoryService = FakeRoomDirectoryService(),
+    override val isMessageSearchAvailable: Boolean = false,
+    override val messageSearchService: MessageSearchService = FakeMessageSearchService(),
     override val mediaPreviewService: MediaPreviewService = FakeMediaPreviewService(),
     override val roomMembershipObserver: RoomMembershipObserver = RoomMembershipObserver(),
     private val homeserverCapabilitiesProvider: FakeHomeserverCapabilitiesProvider = FakeHomeserverCapabilitiesProvider(),

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/search/FakeMessageSearch.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/search/FakeMessageSearch.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.test.search
+
+import io.element.android.libraries.matrix.api.search.MessageSearch
+import io.element.android.libraries.matrix.api.search.MessageSearchPaginationState
+import io.element.android.libraries.matrix.api.search.MessageSearchResult
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeMessageSearch(
+    private val setQueryResult: suspend (String) -> Result<Unit> = { Result.success(Unit) },
+    private val paginateResult: suspend () -> Result<Unit> = { Result.success(Unit) },
+    private val controllablePagination: Boolean = false,
+) : MessageSearch {
+    private val mutableResults = MutableStateFlow<ImmutableList<MessageSearchResult>>(persistentListOf())
+    override val results: StateFlow<ImmutableList<MessageSearchResult>> = mutableResults
+
+    private val mutablePaginationState = MutableStateFlow<MessageSearchPaginationState>(
+        MessageSearchPaginationState.Idle(endReached = false)
+    )
+    override val paginationState: StateFlow<MessageSearchPaginationState> = mutablePaginationState
+
+    var lastQuery: String? = null
+        private set
+
+    var setQueryCallCount = 0
+        private set
+
+    var paginateCallCount = 0
+        private set
+
+    var completedPaginateCallCount = 0
+        private set
+
+    var cancelledPaginateCallCount = 0
+        private set
+
+    private var pendingPagination = CompletableDeferred<PaginationCompletion>()
+
+    override suspend fun setQuery(query: String): Result<Unit> {
+        lastQuery = query
+        setQueryCallCount++
+        return setQueryResult(query)
+    }
+
+    override suspend fun paginate(): Result<Unit> {
+        paginateCallCount++
+        if (!controllablePagination) {
+            return paginateResult()
+        }
+
+        mutablePaginationState.value = MessageSearchPaginationState.Loading
+        return try {
+            val completion = pendingPagination.await()
+            completedPaginateCallCount++
+            mutablePaginationState.value = MessageSearchPaginationState.Idle(endReached = completion.endReached)
+            completion.result
+        } catch (exception: CancellationException) {
+            cancelledPaginateCallCount++
+            mutablePaginationState.value = MessageSearchPaginationState.Idle(endReached = false)
+            throw exception
+        } finally {
+            pendingPagination = CompletableDeferred()
+        }
+    }
+
+    fun emitResults(results: ImmutableList<MessageSearchResult>) {
+        mutableResults.value = results
+    }
+
+    fun emitPaginationState(state: MessageSearchPaginationState) {
+        mutablePaginationState.value = state
+    }
+
+    fun completePagination(
+        result: Result<Unit> = Result.success(Unit),
+        endReached: Boolean = false,
+    ) {
+        check(pendingPagination.complete(PaginationCompletion(result, endReached))) {
+            "There is no pending pagination to complete."
+        }
+    }
+
+    private data class PaginationCompletion(
+        val result: Result<Unit>,
+        val endReached: Boolean,
+    )
+}

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/search/FakeMessageSearchService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/search/FakeMessageSearchService.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.test.search
+
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.search.MessageSearch
+import io.element.android.libraries.matrix.api.search.MessageSearchService
+import kotlinx.coroutines.CoroutineScope
+
+class FakeMessageSearchService(
+    private val messageSearch: MessageSearch = FakeMessageSearch(),
+) : MessageSearchService {
+    /** The room the search was scoped to on the last call — null means all rooms. */
+    var lastRoomId: RoomId? = null
+        private set
+
+    var createMessageSearchCallCount = 0
+        private set
+
+    override fun createMessageSearch(scope: CoroutineScope, roomId: RoomId?): MessageSearch {
+        lastRoomId = roomId
+        createMessageSearchCallCount++
+        return messageSearch
+    }
+}

--- a/libraries/workmanager/api/src/main/kotlin/io/element/android/libraries/workmanager/api/WorkManagerScheduler.kt
+++ b/libraries/workmanager/api/src/main/kotlin/io/element/android/libraries/workmanager/api/WorkManagerScheduler.kt
@@ -32,6 +32,7 @@ fun workManagerTag(sessionId: SessionId, requestType: WorkManagerRequestType): S
     val prefix = when (requestType) {
         WorkManagerRequestType.NOTIFICATION_SYNC -> "notifications"
         WorkManagerRequestType.DB_VACUUM -> "db_vacuum"
+        WorkManagerRequestType.SEARCH_BACKFILL -> "search_backfill"
     }
     return "$prefix-$sessionId"
 }
@@ -39,4 +40,13 @@ fun workManagerTag(sessionId: SessionId, requestType: WorkManagerRequestType): S
 enum class WorkManagerRequestType {
     NOTIFICATION_SYNC,
     DB_VACUUM,
+
+    /**
+     * Back-paginates rooms so their history reaches the local message search index.
+     *
+     * Work of this type keeps fetching history in the background, so it MUST be cancelled when the
+     * session goes away — see the cancel-by-tag test. Any request builder for this type has to call
+     * `addTag(workManagerTag(sessionId, SEARCH_BACKFILL))`; nothing enforces that at compile time.
+     */
+    SEARCH_BACKFILL,
 }

--- a/libraries/workmanager/impl/src/test/kotlin/io/element/android/libraries/workmanager/impl/DefaultWorkManagerSchedulerTest.kt
+++ b/libraries/workmanager/impl/src/test/kotlin/io/element/android/libraries/workmanager/impl/DefaultWorkManagerSchedulerTest.kt
@@ -49,6 +49,31 @@ class DefaultWorkManagerSchedulerTest {
 
         // The session is now gone and work associated with the session is cancelled
         verify { workManager.cancelAllWorkByTag("notifications-$sessionId") }
+        // Search backfill keeps fetching room history in the background, so leaving it running after
+        // logout would keep pulling a signed-out user's messages down. Pinned explicitly rather than
+        // relying on the enum loop, because nothing else fails if the tag stops matching.
+        verify { workManager.cancelAllWorkByTag("search_backfill-$sessionId") }
+    }
+
+    @Test
+    fun `every request type is cancelled when a session is deleted`() = runTest {
+        // Guards the enum loop in cancel(): a new WorkManagerRequestType that is never cancelled on
+        // logout would leak background work for a signed-out session, and no other test would notice.
+        val sessionId = "@session1:matrix.org"
+        val sessionObserver = FakeSessionObserver()
+        val workManager = spyk<WorkManager>()
+
+        DefaultWorkManagerScheduler(
+            lazyWorkManager = lazy { workManager },
+            sessionObserver = sessionObserver,
+        )
+
+        sessionObserver.onSessionDeleted(sessionId)
+        runCurrent()
+
+        for (requestType in WorkManagerRequestType.entries) {
+            verify { workManager.cancelAllWorkByTag(workManagerTag(SessionId(sessionId), requestType)) }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Content

### Problem

The local index is attached at `ClientBuilder` time and is written only as a side effect of events
passing through the SDK's **event cache**, so it holds exactly what arrived after it was created.
Nothing in the app ever asks the SDK for anything older on the index's behalf — `Timeline.paginate`
is driven by foreground screens the user is looking at, and only as far back as they scroll. A user
who enables search on an existing account therefore searches an index that starts at the moment
they enabled it, gets an empty result set for every message they actually remember, and reasonably
concludes that search does not work.

### Fix

- Add `planSearchBackfill` in `SearchBackfillPlanner.kt`, which turns the room-list summaries into
  an ordered queue — low-priority rooms last, then most recently active first — capped at
  `ROOM_QUEUE_LIMIT` (200) so a very large account cannot produce an unbounded plan.
- Add `SearchBackfillRunner`, a plain suspend class that walks that queue and back-paginates each
  room from its live end, checking `backwardPaginationStatus.value.canPaginate` before every call
  because `paginate()` returns a failed `Result` wrapping `TimelineException.CannotPaginate` when it
  cannot, which would otherwise record *"nothing left to fetch"* as a failure.
- Bound every execution with `SearchBackfillBudget`: `maxPagesPerRoom = 200`,
  `maxPagesPerExecution = 300`, `executionDeadline = 5.minutes`, `maxRoomDuration = 45.seconds`,
  `maxFailuresPerRoom = 2`, `delayBetweenPages = 250.milliseconds` and
  `delayBetweenRooms = 1_000.milliseconds` — pages and rooms, never events, because `paginate()`
  reports only whether it reached the start.
- Persist the position in `SearchBackfillCursor` through `DataStoreSearchBackfillStore`, written
  after every room so process death costs at most one room of progress, in its own DataStore file
  keyed on the hashed session id rather than in `SessionPreferencesStore`.
- Treat a cursor that fails to deserialise as absent and start a fresh generation, so a schema
  change loses progress instead of crashing a background worker.
- Host the runner on WorkManager as `SearchBackfillWorker`, so the sweep survives the app being
  backgrounded rather than running only while the user is watching.
- Re-read `FeatureFlags.MessageSearch` *live* inside `doWork()` rather than trusting the value
  frozen at enqueue time, so a user who turns message search off stops paying for history
  downloads at the next execution.
- Return early from `doWork()` when `client.isMessageSearchAvailable` is false, since without an
  index attached at build time the sweep would spend network on history that nothing will index.
- Constrain the request in `SearchBackfillRequestBuilder` to `NetworkType.UNMETERED`,
  `setRequiresBatteryNotLow(true)` and `setRequiresStorageNotLow(true)`, with
  `BackoffPolicy.LINEAR` at 10 minutes and deliberately not expedited — the user did not ask for
  this download, so it must not arrive on their data plan.
- Enqueue it as `WorkManagerWorkerType.Unique` with `ExistingWorkPolicy.KEEP`, because all sweep
  progress lives in one stored cursor and two concurrent runs would interleave writes to it and
  pay twice for the same pages.
- Add `WorkManagerRequestType.SEARCH_BACKFILL` and tag the request with
  `workManagerTag(sessionId, SEARCH_BACKFILL)`, which is what makes cancel-on-logout reach it —
  without the tag the sweep keeps downloading a signed-out user's history, and nothing fails at
  compile time if it is omitted.
- Schedule the sweep from `RustMatrixClient` on client start, gated on `isMessageSearchAvailable`
  and on `hasPendingWork`, so a flag toggled mid-session does not schedule a sweep with no index
  to write into.
- Fall back to `getJoinedRoomIds().getOrNull().orEmpty().take(ROOM_QUEUE_LIMIT)` when the
  sliding-sync room list has not populated within 30s.
- Raise `maxPagesPerRoom` from 20 to 200 (`179a4f90`): each generation walks a room from its live
  end and pages served from already-cached history are charged against the cap while indexing
  nothing, so the old value walled every room at roughly 2560 events forever — `maxRoomDuration`
  is now the effective per-room bound and the per-execution budgets remain the cost governors.
- Return `Result.retry()` rather than `Result.success()` for an empty queue (`179a4f90`), so a
  headless start that sees a room list which has not synced yet is re-run within the same session
  instead of parking until the next app start with nothing indexed.
- Replace `runCatching` with `runCatchingExceptions` in `SearchBackfillWorker` (`b60a6669`):
  `runCatching` catches `Throwable`, so a `CancellationException` raised while the runner was
  suspended was folded into `Result.failure` and then into `Result.retry()` — the worker swallowed
  its own cancellation and asked WorkManager to run the sweep again. Cancellation now propagates
  and only real failures become a retry.
- No behaviour change anywhere outside message search: with `feature.message_search` off, nothing
  is scheduled, no pagination is issued and every other WorkManager request type keeps its
  existing tag, constraints and cancellation behaviour.

## Motivation and context

In-room search has been asked for repeatedly, and the reports are specific about what is missing:
that search is present in unencrypted rooms and absent in encrypted ones, and that what users want
is keyword search with timestamps and a jump to the matching message. This pull request is one
layer underneath that surface — it makes older messages reachable by the index at all — so it
closes nothing on its own.

Part of element-hq/element-x-android#3709
Relates to element-hq/element-x-android#6557
Relates to element-hq/element-x-android#4149
Relates to element-hq/element-x-android#7072

## Screenshots / GIFs

No UI change in this pull request.

## Tests

There is nothing here for a user to click, so the coverage is unit tests rather than manual steps.

- `SearchBackfillRunnerTest` — JUnit with `kotlinx-coroutines-test` `runTest` and Truth over
  `FakeMatrixClient`/`FakeJoinedRoom`/`FakeTimeline`, no Robolectric; 15 cases pinning the loop
  shape: each room is paginated until it reports the start of the room; a room that cannot
  paginate is never asked to; pagination stops at the per-room page cap; a room is abandoned after
  repeated failures and the sweep continues; a room that is no longer joined is skipped without
  paginating; an empty queue asks for another execution instead of reporting completion; a drained
  queue with visited rooms does not ask for another execution; the room is always released,
  including when pagination fails; the execution page budget stops the sweep early and is
  recorded; a stored cursor resumes where it stopped and does not revisit earlier rooms; a drained
  cursor starts a new generation; progress is persisted after every room; the execution deadline
  stops the sweep between rooms; the per-room time limit stops that room and moves on; an empty
  room list finishes without touching any room.
- `SearchBackfillPlannerTest` — plain JUnit with Truth; 8 cases, mostly negative: rooms are
  ordered most recently active first; spaces are excluded; tombstoned rooms are excluded; rooms
  the user has not joined are excluded; rooms with no latest event are excluded; low priority
  rooms are pushed to the tail regardless of recency; the queue is truncated to the room limit,
  keeping the most recent; an empty room list yields an empty plan.
- `SearchBackfillRequestBuilderTest` — Robolectric (`RobolectricTest`), because `OneTimeWorkRequest`
  needs a real `Constraints` object; 2 cases: the sweep is unique per session and keeps one
  already in flight; the request is tagged for logout cancellation and constrained to free network.
- `DefaultWorkManagerSchedulerTest` — one new case, *every request type is cancelled when a session
  is deleted*, which walks `WorkManagerRequestType.entries` so a future type that leaks background
  work after logout fails here, plus an added assertion in the existing logout case pinning the
  literal `search_backfill-$sessionId` tag.
- `RustMatrixClientTest` is touched only to pass the new `isMessageSearchAvailable` constructor
  argument; it asserts nothing new.
- The runner test file carries a header saying what it does *not* prove: the chain from
  `paginate()` through the SDK event cache into tantivy has no app-level observation point and no
  index API over FFI, so a green file means the loop iterated correctly over fakes and is not
  evidence that a single message became searchable. That was checked on a device instead — a
  closed room produced 108 index writes carrying send dates up to three weeks old where none
  arrived before, and a fresh login swept 9/9 rooms over 112 pages and made messages from 23 days
  before the session existed searchable.

### Scope

**This sweep is not a completeness guarantee, and nothing here should be read as one.** The
budgets and constraints listed above are hard ceilings rather than targets, and a room that hits
its failure limit is abandoned for the rest of that generation. A user on cellular with a low
battery gets no backfill at all.

Beyond the budgets, there are things the app structurally cannot know or has deliberately not
done:

- **Nothing can ever report that history is fully searchable.** A room whose history is already in
  the local event-cache store re-hydrates from disk on pagination and the SDK drops those updates
  before the indexer sees them, while `paginate()` returns the same success as a network fetch that
  indexed everything. `SearchBackfillStatus` therefore has no `Complete` member — the absence is
  load-bearing, not an oversight — and `RoomSweepOutcome.REACHED_START` means *"there was nothing
  left to ask for"*, not *"it is all searchable"*.
- The planner silently skips spaces, tombstoned rooms (`successorRoom != null`), rooms whose
  membership is not `JOINED`, and rooms with no `latestEventTimestamp`. None of that is surfaced
  anywhere.
- The headless fallback is a real hole in the prioritisation story: that path is **unordered**, so
  *"the most recently active rooms become searchable first"* does not hold whenever the worker
  takes it. It logs at WARN precisely so that anyone can find out whether production always does.
- Background pagination may contend with the displayed timeline's own back-pagination — manuroe
  raised exactly this on matrix-org/matrix-rust-sdk#5350, that only a single room timeline
  instance exists at a time. The runner takes `client.getJoinedRoom` and closes it in a `finally`,
  but it deserves a reviewer's eye rather than an assurance here.
- **matrix-org/matrix-rust-sdk#6772 is open and is not handled here.** `matrix-sdk-search` writes
  the raw `origin_server_ts` into the tantivy schema and panics on a malformed value
  (`tantivy-common` `datetime.rs`, *attempt to multiply with overflow*). Because this sweep feeds
  real room history to the indexer, one malformed event in any indexed room can panic it on
  device. The fix has to be SDK-side; the app cannot filter what it never sees.
- `SearchBackfillStatus` (`NotStarted`/`Running`/`Stopped`) currently has no producer and no
  consumer — sweep progress is entirely invisible to the user, who has nothing to reconcile an
  empty result set against. The intent is to wire it to a real indicator or remove it in a
  follow-up rather than guess at the surface here.
- There is no age horizon on the sweep at all: bounding it by message age needs the oldest loaded
  event's timestamp, and the only app-side source is the timeline item list, which reads highest
  exactly when nothing was indexed. That gap, the size of the room queue and the choice of a
  `OneTimeWorkRequest` with retry over a periodic batch are all policy rather than design, as is
  battery-not-low rather than charging, the weaker of those two conditions; every one of them can
  be moved to whatever the team prefers.
- Not attempted here: sender filtering, space scoping, stemming, partial-word matching and edits.
  Tokenisation is English-first, so a query in a language the default analyser does not segment
  will behave worse than the same query in English.

The bounded shape is a direct response to an earlier Android search proof-of-concept that
OOM-crashed on unbounded room-data loading; that is why the budgets are counted in pages and rooms
and why the queue is frozen when a generation starts. Happy to file a linked tracking issue for the
unwired `SearchBackfillStatus` and for the matrix-org/matrix-rust-sdk#6772 exposure if that is more
useful than carrying them in this description.

### Notes for reviewers

PR 3 of a four-PR stack. It depends on PR 1 for `MatrixClient.isMessageSearchAvailable` and the
index attachment; it is independent of PRs 2 and 4, and can be reviewed without them.

Size honesty: this is roughly 1,300 additions across 15 files, well over the 500-addition guidance
in `AGENTS.md`. It is the smallest unit that does anything — planner, runner, budget, store,
worker, scheduling and their tests — and splitting it further would land a runner nothing calls, or
a worker with no loop. 567 of those lines are test files. The reviewable delta is `bffc690c`, which
is the whole design; `7f246e33`, `179a4f90`, `b60a6669` and the `SearchBackfillRunner` part of
`a8854f85` are corrections on top and read quickly on their own.

Targets `develop`, labelled `PR-Wip`. The flag everything sits behind is
`FeatureFlags.MessageSearch` (`feature.message_search`, `defaultValue = { false }`,
`isFinished = false`).

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 16 (API 36), Pixel 10 Pro emulator (arm64-v8a)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
