### PR TITLE
Fix banned mime type errors in `DefaultContentScannerService`

### DIFF
--- a/features/contentscanner/impl/src/main/kotlin/io/element/android/features/contentscanner/impl/DefaultContentScannerService.kt
+++ b/features/contentscanner/impl/src/main/kotlin/io/element/android/features/contentscanner/impl/DefaultContentScannerService.kt
@@ -10,6 +10,7 @@ package io.element.android.features.contentscanner.impl
 import io.element.android.features.contentscanner.api.ContentScannerService
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.exception.ClientException
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.scanner.ContentScanner
 import io.element.android.libraries.matrix.ui.media.contentvalidation.ContentValidationState
@@ -42,12 +43,19 @@ class DefaultContentScannerService(
                         contentValidationState.update(url, contentValidationValue)
                     }
                     .onFailure { exception ->
-                        if (exception is IOException) {
-                            // If it's an IO-related exception, we can retry later, so we don't store the error
-                            contentValidationState.update(url, ContentValidationValue.Unknown)
-                        } else {
-                            // For other exceptions, we cache the failure
-                            contentValidationState.update(url, ContentValidationValue.UnrecoverableError(exception))
+                        when (exception) {
+                            is IOException -> {
+                                // If it's an IO-related exception, we can retry later, so we don't store the error
+                                contentValidationState.update(url, ContentValidationValue.Unknown)
+                            }
+                            is ClientException.ContentScanner if exception.reason.isDangerous() -> {
+                                // It's a dangerous content (banned mime-type?), we mark it as invalid
+                                contentValidationState.update(url, ContentValidationValue.Invalid)
+                            }
+                            else -> {
+                                // For other exceptions, we cache the failure
+                                contentValidationState.update(url, ContentValidationValue.UnrecoverableError(exception))
+                            }
                         }
                     }
             }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/scanner/RustContentScanner.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/scanner/RustContentScanner.kt
@@ -7,9 +7,11 @@
 
 package io.element.android.libraries.matrix.impl.scanner
 
+import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.media.MediaSource
 import io.element.android.libraries.matrix.api.scanner.ContentScanner
+import io.element.android.libraries.matrix.impl.exception.mapClientException
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.NoHandle
 import org.matrix.rustcomponents.sdk.ContentScanner as RustScanner
@@ -22,6 +24,8 @@ class RustContentScanner(
     override suspend fun scan(mediaSource: MediaSource): Result<Boolean> {
         return runCatchingExceptions {
             rustScanner.scan(client, mediaSource.toRustMediaSource()).clean
+        }.mapFailure {
+            it.mapClientException()
         }
     }
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

The content scanner allows disabling certain mime types for files in the set up HS, but it turns out for the scan operation instead of returning an `"is_valid": false` result in that case, it returns an error with a `MCS_MIME_TYPE_FORBIDDEN` reason. We need to handle that case as if it had returned the false `isValid` value.

## Motivation and context

Stated in the content.

## Tests

You need a content scanner server running which disabled some mime types in their config. The errors in the timeline for those items should look as 'this file is not safe' instead of 'file not found'.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
