### PR TITLE
Save microphone and camera state between group calls

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/DeviceMuteData.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/DeviceMuteData.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.impl.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Payload for Element Call's `device_mute` widget action.
+ *
+ * - `toWidget`: request a mute configuration (`null` fields keep the current EC value).
+ * - `fromWidget`: current mute state (or a reply to a request).
+ */
+@Serializable
+data class DeviceMuteData(
+    val audioEnabled: Boolean? = null,
+    val videoEnabled: Boolean? = null,
+)

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/WidgetMessage.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/data/WidgetMessage.kt
@@ -45,5 +45,8 @@ data class WidgetMessage(
 
         @SerialName("content_loaded")
         ContentLoaded,
+
+        @SerialName("device_mute")
+        DeviceMute,
     }
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -25,6 +25,7 @@ import im.vector.app.features.analytics.plan.MobileScreen
 import io.element.android.features.call.api.CallData
 import io.element.android.features.call.impl.data.WidgetMessage
 import io.element.android.features.call.impl.utils.ActiveCallManager
+import io.element.android.features.call.impl.utils.CallDeviceMuteController
 import io.element.android.features.call.impl.utils.CallWidgetProvider
 import io.element.android.features.call.impl.utils.WidgetMessageInterceptor
 import io.element.android.features.call.impl.utils.WidgetMessageSerializer
@@ -62,6 +63,7 @@ class CallScreenPresenter(
     private val activeCallManager: ActiveCallManager,
     private val languageTagProvider: LanguageTagProvider,
     private val appForegroundStateService: AppForegroundStateService,
+    private val callDeviceMuteController: CallDeviceMuteController,
     @AppCoroutineScope
     private val appCoroutineScope: CoroutineScope,
     private val widgetMessageSerializer: WidgetMessageSerializer,
@@ -98,7 +100,10 @@ class CallScreenPresenter(
                 )
             }
             onDispose {
-                appCoroutineScope.launch { activeCallManager.hangUpCall(callData) }
+                appCoroutineScope.launch {
+                    callDeviceMuteController.persistIfReady()
+                    activeCallManager.hangUpCall(callData)
+                }
             }
         }
         screenTracker.TrackScreen(screen = MobileScreen.ScreenName.RoomCall)
@@ -128,10 +133,25 @@ class CallScreenPresenter(
 
                         val parsedMessage = parseMessage(it)
                         if (parsedMessage?.direction == WidgetMessage.Direction.FromWidget) {
-                            if (parsedMessage.action == WidgetMessage.Action.Close) {
-                                close(callWidgetDriver.value, navigator)
-                            } else if (parsedMessage.action == WidgetMessage.Action.ContentLoaded) {
-                                isWidgetLoaded = true
+                            when (parsedMessage.action) {
+                                WidgetMessage.Action.Close -> {
+                                    callDeviceMuteController.persistIfReady()
+                                    close(callWidgetDriver.value, navigator)
+                                }
+                                WidgetMessage.Action.ContentLoaded -> {
+                                    isWidgetLoaded = true
+                                    callDeviceMuteController.onContentLoaded()
+                                }
+                                WidgetMessage.Action.DeviceMute -> {
+                                    callWidgetDriver.value?.id?.let { widgetId ->
+                                        callDeviceMuteController.onDeviceMuteFromWidget(
+                                            message = parsedMessage,
+                                            widgetId = widgetId,
+                                            messageInterceptor = interceptor,
+                                        )
+                                    }
+                                }
+                                else -> Unit
                             }
                         }
                     }
@@ -156,6 +176,7 @@ class CallScreenPresenter(
                 is CallScreenEvent.Hangup -> {
                     val widgetId = callWidgetDriver.value?.id
                     val interceptor = messageInterceptor.value
+                    coroutineScope.launch { callDeviceMuteController.persistIfReady() }
                     if (widgetId != null && interceptor != null && isWidgetLoaded) {
                         // If the call was joined, we need to hang up first. Then the UI will be dismissed automatically.
                         sendHangupMessage(widgetId, interceptor)
@@ -211,6 +232,7 @@ class CallScreenPresenter(
                 theme = theme,
             ).getOrThrow()
             callWidgetDriver.value = result.driver
+            callDeviceMuteController.setRememberLastMediaState(result.rememberLastMediaState)
             Timber.d("Call widget driver initialized for sessionId: ${callData.sessionId}, roomId: ${callData.roomId}")
             result.url
         }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/CallDeviceMuteController.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/CallDeviceMuteController.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.impl.utils
+
+import dev.zacsweers.metro.Inject
+import io.element.android.features.call.impl.data.DeviceMuteData
+import io.element.android.features.call.impl.data.WidgetMessage
+import io.element.android.libraries.androidutils.json.JsonProvider
+import io.element.android.libraries.core.extensions.runCatchingExceptions
+import io.element.android.libraries.preferences.api.store.AppPreferencesStore
+import io.element.android.services.toolbox.api.systemclock.SystemClock
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Remembers microphone/camera enabled state across group calls without fighting Element Call's lobby.
+ * Direct (1:1) calls do not restore or persist these preferences.
+ *
+ * Strategy:
+ * - Camera is applied up-front via CallIntent/URL (see [DefaultCallWidgetProvider]).
+ * - Microphone is only corrected via `device_mute` when it should start muted, and only after
+ *   Element Call reports that media devices are ready (avoids false/false startup spam).
+ * - Preferences are written only when the call ends, and only if media was ready at least once.
+ */
+@Inject
+class CallDeviceMuteController(
+    private val appPreferencesStore: AppPreferencesStore,
+    private val jsonProvider: JsonProvider,
+    private val widgetMessageSerializer: WidgetMessageSerializer,
+    private val clock: SystemClock,
+) {
+    private val rememberLastMediaState = AtomicBoolean(false)
+    private val mediaReady = AtomicBoolean(false)
+    private val microphoneMuteApplied = AtomicBoolean(false)
+    private val preferMicrophoneEnabled = AtomicReference(true)
+    private val lastMicrophoneEnabled = AtomicReference<Boolean?>(null)
+    private val lastCameraEnabled = AtomicReference<Boolean?>(null)
+
+    fun setRememberLastMediaState(enabled: Boolean) {
+        rememberLastMediaState.set(enabled)
+    }
+
+    suspend fun onContentLoaded() {
+        if (!rememberLastMediaState.get()) return
+        val microphoneEnabled = appPreferencesStore.isCallMicrophoneEnabledFlow().first()
+        val cameraEnabled = appPreferencesStore.isCallCameraEnabledFlow().first()
+        preferMicrophoneEnabled.set(microphoneEnabled)
+        lastMicrophoneEnabled.set(microphoneEnabled)
+        lastCameraEnabled.set(cameraEnabled)
+        Timber.d("Call media prefs loaded: microphoneEnabled=$microphoneEnabled, cameraEnabled=$cameraEnabled")
+    }
+
+    fun onDeviceMuteFromWidget(
+        message: WidgetMessage,
+        widgetId: String,
+        messageInterceptor: WidgetMessageInterceptor,
+    ) {
+        if (!rememberLastMediaState.get()) return
+        val muteData = parseDeviceMuteData(message) ?: return
+        val audioEnabled = muteData.audioEnabled
+        val videoEnabled = muteData.videoEnabled
+
+        if (!mediaReady.get()) {
+            // Element Call emits audio=false,video=false while capture devices are unavailable.
+            // Treat the first report with any device enabled as "media ready".
+            if (audioEnabled == true || videoEnabled == true) {
+                mediaReady.set(true)
+                Timber.d("Element Call media devices are ready")
+            } else {
+                return
+            }
+        }
+
+        audioEnabled?.let { lastMicrophoneEnabled.set(it) }
+        videoEnabled?.let { lastCameraEnabled.set(it) }
+
+        maybeMuteMicrophone(widgetId, messageInterceptor)
+    }
+
+    suspend fun persistIfReady() {
+        if (!rememberLastMediaState.get()) return
+        if (!mediaReady.get()) {
+            Timber.d("Skip persisting call media prefs: media was never ready")
+            return
+        }
+        val microphoneEnabled = lastMicrophoneEnabled.get()
+        val cameraEnabled = lastCameraEnabled.get()
+        microphoneEnabled?.let { appPreferencesStore.setCallMicrophoneEnabled(it) }
+        cameraEnabled?.let { appPreferencesStore.setCallCameraEnabled(it) }
+    }
+
+    private fun maybeMuteMicrophone(widgetId: String, messageInterceptor: WidgetMessageInterceptor) {
+        if (preferMicrophoneEnabled.get()) return
+        if (!mediaReady.get()) return
+        if (!microphoneMuteApplied.compareAndSet(false, true)) return
+
+        Timber.d("Muting microphone to match saved preference")
+        val message = WidgetMessage(
+            direction = WidgetMessage.Direction.ToWidget,
+            widgetId = widgetId,
+            requestId = "widgetapi-${clock.epochMillis()}",
+            action = WidgetMessage.Action.DeviceMute,
+            // Only touch the microphone. Camera is controlled by CallIntent.
+            data = jsonProvider().encodeToJsonElement(DeviceMuteData(audioEnabled = false)),
+        )
+        messageInterceptor.sendMessage(widgetMessageSerializer.serialize(message))
+        lastMicrophoneEnabled.set(false)
+    }
+
+    private fun parseDeviceMuteData(message: WidgetMessage): DeviceMuteData? {
+        val data = message.data ?: return null
+        return runCatchingExceptions {
+            jsonProvider().decodeFromJsonElement<DeviceMuteData>(data)
+        }.getOrElse {
+            Timber.w(it, "Failed to parse device mute payload")
+            null
+        }
+    }
+}

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/CallWidgetProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/CallWidgetProvider.kt
@@ -25,5 +25,6 @@ interface CallWidgetProvider {
     data class GetWidgetResult(
         val driver: MatrixWidgetDriver,
         val url: String,
+        val rememberLastMediaState: Boolean = false,
     )
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/DefaultCallWidgetProvider.kt
@@ -17,6 +17,7 @@ import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.widget.CallWidgetSettingsProvider
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.services.appnavstate.api.ActiveRoomsHolder
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 
 private const val EMBEDDED_CALL_WIDGET_BASE_URL = "https://appassets.androidplatform.net/element-call/index.html"
@@ -41,6 +42,14 @@ class DefaultCallWidgetProvider(
             ?: matrixClient.getJoinedRoom(roomId)
             ?: error("Room not found")
 
+        val isDm = room.isDm()
+        val rememberLastMediaState = !isDm
+        val treatAsAudioCall = if (rememberLastMediaState) {
+            isAudioCall || !appPreferencesStore.isCallCameraEnabledFlow().first()
+        } else {
+            isAudioCall
+        }
+
         val customBaseUrl = appPreferencesStore.getCustomElementCallBaseUrlFlow().firstOrNull()
         val baseUrl = customBaseUrl ?: EMBEDDED_CALL_WIDGET_BASE_URL
 
@@ -49,8 +58,8 @@ class DefaultCallWidgetProvider(
         val widgetSettings = callWidgetSettingsProvider.provide(
             baseUrl = baseUrl,
             encrypted = isEncrypted,
-            direct = room.isDm(),
-            isAudioCall = isAudioCall,
+            direct = isDm,
+            isAudioCall = treatAsAudioCall,
             hasActiveCall = roomInfo.hasRoomCall,
         )
         val callUrl = room.generateWidgetWebViewUrl(
@@ -58,13 +67,36 @@ class DefaultCallWidgetProvider(
             clientId = clientId,
             languageTag = languageTag,
             theme = theme,
-        ).getOrThrow()
+        ).getOrThrow().let { url ->
+            if (treatAsAudioCall && rememberLastMediaState) {
+                url.withNonDmVoiceCallIntent()
+            } else {
+                url
+            }
+        }
 
         val driver = room.getWidgetDriver(widgetSettings).getOrThrow()
 
         CallWidgetProvider.GetWidgetResult(
             driver = driver,
             url = callUrl,
+            rememberLastMediaState = rememberLastMediaState,
         )
+    }
+}
+
+/**
+ * Rewrites non-DM Element Call intents to their voice variants without touching DM intents(`start_call_dm`, `join_existing_dm`, …).
+ * Delete this and linked code when this intents will be added to SDK.
+ */
+internal fun String.withNonDmVoiceCallIntent(): String {
+    return when {
+        contains("intent=start_call_dm") || contains("intent=join_existing_dm") -> this
+        contains("intent=start_call_voice") || contains("intent=join_existing_voice") -> this
+        contains("intent=start_call") ->
+            replace("intent=start_call", "intent=start_call_voice")
+        contains("intent=join_existing") ->
+            replace("intent=join_existing", "intent=join_existing_voice")
+        else -> this
     }
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
@@ -17,6 +17,7 @@ import io.element.android.features.call.api.CallData
 import io.element.android.features.call.impl.ui.CallScreenEvent
 import io.element.android.features.call.impl.ui.CallScreenNavigator
 import io.element.android.features.call.impl.ui.CallScreenPresenter
+import io.element.android.features.call.impl.utils.CallDeviceMuteController
 import io.element.android.features.call.impl.utils.WidgetMessageSerializer
 import io.element.android.features.call.utils.FakeActiveCallManager
 import io.element.android.features.call.utils.FakeCallWidgetProvider
@@ -32,6 +33,7 @@ import io.element.android.libraries.matrix.test.FakeMatrixClientProvider
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.libraries.matrix.test.widget.FakeMatrixWidgetDriver
 import io.element.android.libraries.network.useragent.UserAgentProvider
+import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
 import io.element.android.services.analytics.api.ScreenTracker
 import io.element.android.services.analytics.test.FakeScreenTracker
 import io.element.android.services.appnavstate.test.FakeAppForegroundStateService
@@ -318,6 +320,7 @@ class CallScreenPresenterTest {
             }
         }
         val clock = SystemClock { 0 }
+        val jsonProvider = DefaultJsonProvider()
         return CallScreenPresenter(
             callData = callData,
             navigator = navigator,
@@ -331,7 +334,13 @@ class CallScreenPresenterTest {
             languageTagProvider = FakeLanguageTagProvider("en-US"),
             appForegroundStateService = appForegroundStateService,
             appCoroutineScope = backgroundScope,
-            widgetMessageSerializer = WidgetMessageSerializer(DefaultJsonProvider()),
+            callDeviceMuteController = CallDeviceMuteController(
+                appPreferencesStore = InMemoryAppPreferencesStore(),
+                jsonProvider = jsonProvider,
+                widgetMessageSerializer = WidgetMessageSerializer(jsonProvider),
+                clock = clock,
+            ),
+            widgetMessageSerializer = WidgetMessageSerializer(jsonProvider),
         )
     }
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/CallDeviceMuteControllerTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/CallDeviceMuteControllerTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.utils
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.call.impl.data.DeviceMuteData
+import io.element.android.features.call.impl.data.WidgetMessage
+import io.element.android.features.call.impl.utils.CallDeviceMuteController
+import io.element.android.features.call.impl.utils.WidgetMessageSerializer
+import io.element.android.libraries.androidutils.json.DefaultJsonProvider
+import io.element.android.libraries.preferences.test.InMemoryAppPreferencesStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.encodeToJsonElement
+import org.junit.Test
+
+class CallDeviceMuteControllerTest {
+    @Test
+    fun `ignores pre-ready false false device mute updates`() = runTest {
+        val preferences = InMemoryAppPreferencesStore(
+            callMicrophoneEnabled = true,
+            callCameraEnabled = true,
+        )
+        val interceptor = FakeWidgetMessageInterceptor()
+        val controller = createController(preferences)
+
+        controller.setRememberLastMediaState(true)
+        controller.onContentLoaded()
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = false, videoEnabled = false),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        controller.persistIfReady()
+
+        assertThat(interceptor.sentMessages).isEmpty()
+        assertThat(preferences.isCallMicrophoneEnabledFlow().first()).isTrue()
+        assertThat(preferences.isCallCameraEnabledFlow().first()).isTrue()
+    }
+
+    @Test
+    fun `tracks updates after media ready and persists on end`() = runTest {
+        val preferences = InMemoryAppPreferencesStore(
+            callMicrophoneEnabled = true,
+            callCameraEnabled = true,
+        )
+        val interceptor = FakeWidgetMessageInterceptor()
+        val controller = createController(preferences)
+
+        controller.setRememberLastMediaState(true)
+        controller.onContentLoaded()
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = true, videoEnabled = true),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = false, videoEnabled = true),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        controller.persistIfReady()
+
+        assertThat(interceptor.sentMessages).isEmpty()
+        assertThat(preferences.isCallMicrophoneEnabledFlow().first()).isFalse()
+        assertThat(preferences.isCallCameraEnabledFlow().first()).isTrue()
+    }
+
+    @Test
+    fun `mutes microphone once after media ready when preference is disabled`() = runTest {
+        val preferences = InMemoryAppPreferencesStore(
+            callMicrophoneEnabled = false,
+            callCameraEnabled = true,
+        )
+        val interceptor = FakeWidgetMessageInterceptor()
+        val controller = createController(preferences)
+
+        controller.setRememberLastMediaState(true)
+        controller.onContentLoaded()
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = true, videoEnabled = true),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        // Second ready update must not send another mute request.
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = true, videoEnabled = true),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+
+        assertThat(interceptor.sentMessages).hasSize(1)
+        val sent = interceptor.sentMessages.single()
+        assertThat(sent).contains("\"action\":\"device_mute\"")
+        assertThat(sent).contains("\"audio_enabled\":false")
+        assertThat(sent).doesNotContain("\"video_enabled\"")
+    }
+
+    @Test
+    fun `does not persist when media never became ready`() = runTest {
+        val preferences = InMemoryAppPreferencesStore(
+            callMicrophoneEnabled = true,
+            callCameraEnabled = false,
+        )
+        val controller = createController(preferences)
+
+        controller.setRememberLastMediaState(true)
+        controller.onContentLoaded()
+        controller.persistIfReady()
+
+        assertThat(preferences.isCallMicrophoneEnabledFlow().first()).isTrue()
+        assertThat(preferences.isCallCameraEnabledFlow().first()).isFalse()
+    }
+
+    @Test
+    fun `does nothing when rememberLastMediaState is disabled`() = runTest {
+        val preferences = InMemoryAppPreferencesStore(
+            callMicrophoneEnabled = false,
+            callCameraEnabled = false,
+        )
+        val interceptor = FakeWidgetMessageInterceptor()
+        val controller = createController(preferences)
+
+        controller.setRememberLastMediaState(false)
+        controller.onContentLoaded()
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = true, videoEnabled = true),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        controller.onDeviceMuteFromWidget(
+            message = deviceMuteMessage(audioEnabled = false, videoEnabled = false),
+            widgetId = "widget-1",
+            messageInterceptor = interceptor,
+        )
+        controller.persistIfReady()
+
+        assertThat(interceptor.sentMessages).isEmpty()
+        assertThat(preferences.isCallMicrophoneEnabledFlow().first()).isFalse()
+        assertThat(preferences.isCallCameraEnabledFlow().first()).isFalse()
+    }
+
+    private fun createController(
+        preferences: InMemoryAppPreferencesStore,
+    ): CallDeviceMuteController {
+        val jsonProvider = DefaultJsonProvider()
+        return CallDeviceMuteController(
+            appPreferencesStore = preferences,
+            jsonProvider = jsonProvider,
+            widgetMessageSerializer = WidgetMessageSerializer(jsonProvider),
+            clock = { 0 },
+        )
+    }
+
+    private fun deviceMuteMessage(
+        audioEnabled: Boolean?,
+        videoEnabled: Boolean?,
+    ): WidgetMessage {
+        val json = DefaultJsonProvider()
+        return WidgetMessage(
+            direction = WidgetMessage.Direction.FromWidget,
+            widgetId = "widget-1",
+            requestId = "1",
+            action = WidgetMessage.Action.DeviceMute,
+            data = json().encodeToJsonElement(
+                DeviceMuteData(
+                    audioEnabled = audioEnabled,
+                    videoEnabled = videoEnabled,
+                )
+            ),
+        )
+    }
+}

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/FakeCallWidgetProvider.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/FakeCallWidgetProvider.kt
@@ -16,6 +16,7 @@ import io.element.android.libraries.matrix.test.widget.FakeMatrixWidgetDriver
 class FakeCallWidgetProvider(
     private val widgetDriver: FakeMatrixWidgetDriver = FakeMatrixWidgetDriver(),
     private val url: String = "https://call.element.io",
+    private val rememberLastMediaState: Boolean = false,
 ) : CallWidgetProvider {
     var getWidgetCalled = false
         private set
@@ -33,6 +34,7 @@ class FakeCallWidgetProvider(
             CallWidgetProvider.GetWidgetResult(
                 driver = widgetDriver,
                 url = url,
+                rememberLastMediaState = rememberLastMediaState,
             )
         )
     }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/NonDmVoiceCallIntentTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/utils/NonDmVoiceCallIntentTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.call.utils
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.call.impl.utils.withNonDmVoiceCallIntent
+import org.junit.Test
+
+class NonDmVoiceCallIntentTest {
+    @Test
+    fun `rewrites start_call to start_call_voice`() {
+        val url = "https://call.example/#/?intent=start_call&roomId=!a:b"
+        assertThat(url.withNonDmVoiceCallIntent())
+            .isEqualTo("https://call.example/#/?intent=start_call_voice&roomId=!a:b")
+    }
+
+    @Test
+    fun `rewrites join_existing to join_existing_voice`() {
+        val url = "https://call.example/#/?intent=join_existing&roomId=!a:b"
+        assertThat(url.withNonDmVoiceCallIntent())
+            .isEqualTo("https://call.example/#/?intent=join_existing_voice&roomId=!a:b")
+    }
+
+    @Test
+    fun `does not rewrite DM intents`() {
+        val startDm = "https://call.example/#/?intent=start_call_dm&roomId=!a:b"
+        val joinDm = "https://call.example/#/?intent=join_existing_dm&roomId=!a:b"
+        assertThat(startDm.withNonDmVoiceCallIntent()).isEqualTo(startDm)
+        assertThat(joinDm.withNonDmVoiceCallIntent()).isEqualTo(joinDm)
+    }
+
+    @Test
+    fun `does not rewrite intents that are already voice`() {
+        val url = "https://call.example/#/?intent=start_call_voice&roomId=!a:b"
+        assertThat(url.withNonDmVoiceCallIntent()).isEqualTo(url)
+    }
+}

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/AppPreferencesStore.kt
@@ -63,5 +63,19 @@ interface AppPreferencesStore {
     /** Single-snapshot read of all sound prefs; used at boot to seed channels without N reads. */
     suspend fun getNotificationSoundChannelConfig(): NotificationSoundChannelConfig
 
+    /**
+     * Whether the microphone should be enabled when joining a call.
+     * Defaults to `true`. Stored on-device (not per Matrix account).
+     */
+    suspend fun setCallMicrophoneEnabled(enabled: Boolean)
+    fun isCallMicrophoneEnabledFlow(): Flow<Boolean>
+
+    /**
+     * Whether the camera should be enabled when joining a call.
+     * Defaults to `true`. Stored on-device (not per Matrix account).
+     */
+    suspend fun setCallCameraEnabled(enabled: Boolean)
+    fun isCallCameraEnabledFlow(): Flow<Boolean>
+
     suspend fun reset()
 }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultAppPreferencesStore.kt
@@ -42,6 +42,8 @@ private val messageSoundDisplayNameKey = stringPreferencesKey("notificationMessa
 private val callRingtoneUriKey = stringPreferencesKey("notificationCallRingtoneUri")
 private val callRingtoneChannelVersionKey = intPreferencesKey("notificationCallRingtoneChannelVersion")
 private val callRingtoneDisplayNameKey = stringPreferencesKey("notificationCallRingtoneDisplayName")
+private val callMicrophoneEnabledKey = booleanPreferencesKey("callMicrophoneEnabled")
+private val callCameraEnabledKey = booleanPreferencesKey("callCameraEnabled")
 
 @ContributesBinding(AppScope::class)
 class DefaultAppPreferencesStore(
@@ -235,6 +237,22 @@ class DefaultAppPreferencesStore(
             callRingtoneVersion = prefs[callRingtoneChannelVersionKey] ?: 0,
             callRingtoneDisplayName = prefs[callRingtoneDisplayNameKey],
         )
+    }
+
+    override suspend fun setCallMicrophoneEnabled(enabled: Boolean) {
+        store.edit { prefs -> prefs[callMicrophoneEnabledKey] = enabled }
+    }
+
+    override fun isCallMicrophoneEnabledFlow(): Flow<Boolean> {
+        return store.data.map { prefs -> prefs[callMicrophoneEnabledKey] ?: true }
+    }
+
+    override suspend fun setCallCameraEnabled(enabled: Boolean) {
+        store.edit { prefs -> prefs[callCameraEnabledKey] = enabled }
+    }
+
+    override fun isCallCameraEnabledFlow(): Flow<Boolean> {
+        return store.data.map { prefs -> prefs[callCameraEnabledKey] ?: true }
     }
 
     override suspend fun reset() {

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemoryAppPreferencesStore.kt
@@ -33,6 +33,8 @@ class InMemoryAppPreferencesStore(
     callRingtone: NotificationSound = NotificationSound.SystemDefault,
     callRingtoneChannelVersion: Int = 0,
     callRingtoneDisplayName: String? = null,
+    callMicrophoneEnabled: Boolean = true,
+    callCameraEnabled: Boolean = true,
 ) : AppPreferencesStore {
     private val isDeveloperModeEnabled = MutableStateFlow(isDeveloperModeEnabled)
     private val customElementCallBaseUrl = MutableStateFlow(customElementCallBaseUrl)
@@ -48,6 +50,8 @@ class InMemoryAppPreferencesStore(
     private val callRingtone = MutableStateFlow(callRingtone)
     private val callRingtoneChannelVersion = MutableStateFlow(callRingtoneChannelVersion)
     private val callRingtoneDisplayName = MutableStateFlow(callRingtoneDisplayName)
+    private val callMicrophoneEnabled = MutableStateFlow(callMicrophoneEnabled)
+    private val callCameraEnabled = MutableStateFlow(callCameraEnabled)
 
     override suspend fun setDeveloperModeEnabled(enabled: Boolean) {
         isDeveloperModeEnabled.value = enabled
@@ -154,6 +158,22 @@ class InMemoryAppPreferencesStore(
             callRingtoneVersion = callRingtoneChannelVersion.value,
             callRingtoneDisplayName = callRingtoneDisplayName.value,
         )
+    }
+
+    override suspend fun setCallMicrophoneEnabled(enabled: Boolean) {
+        callMicrophoneEnabled.value = enabled
+    }
+
+    override fun isCallMicrophoneEnabledFlow(): Flow<Boolean> {
+        return callMicrophoneEnabled
+    }
+
+    override suspend fun setCallCameraEnabled(enabled: Boolean) {
+        callCameraEnabled.value = enabled
+    }
+
+    override fun isCallCameraEnabledFlow(): Flow<Boolean> {
+        return callCameraEnabled
     }
 
     override suspend fun reset() {


### PR DESCRIPTION
 ## Content

https://github.com/element-hq/element-meta/issues/3234
Saving camera and microphone state between group calls (for example if in last group call user used camera camera will be enabled by default on join call screen; if user was muted in last group call microphone will be disabled  by default on join call screen etc.)

## Motivation and context

In my organization on many meetings  some users don't use microphone or camera most of the time so they are manually turn off camera and microphone before each call and it's annoying.

## Screenshots / GIFs

UI doesn't change.

## Tests

- Join group call
- Enable|disable microphone and|or camera setting
- See that before joining next group call camera and microphone will be enabled/disabled as they were in last group call

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 16 (Samsung S25 Ultra), Android 7.0 (Emulator), Android 8.1 (Emulator)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR