### PR TITLE
Refactor SearchBarResultState.Initial/NoResultsFound to data objects

### DIFF
--- a/features/invitepeople/impl/src/main/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeoplePresenter.kt
+++ b/features/invitepeople/impl/src/main/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeoplePresenter.kt
@@ -88,7 +88,7 @@ class DefaultInvitePeoplePresenter(
     override fun present(): InvitePeopleState {
         val roomMembers = remember { mutableStateOf<AsyncData<ImmutableList<RoomMember>>>(AsyncData.Loading()) }
         val selectedUsers = remember { mutableStateOf<ImmutableList<MatrixUser>>(persistentListOf()) }
-        val searchResults = remember { mutableStateOf<SearchBarResultState<ImmutableList<InvitableUser>>>(SearchBarResultState.Initial()) }
+        val searchResults = remember { mutableStateOf<SearchBarResultState<ImmutableList<InvitableUser>>>(SearchBarResultState.Initial) }
         val queryState = rememberTextFieldState()
         var searchActive by rememberSaveable { mutableStateOf(false) }
         val showSearchLoader = rememberSaveable { mutableStateOf(false) }
@@ -332,15 +332,15 @@ class DefaultInvitePeoplePresenter(
         showSearchLoader: MutableState<Boolean>,
         searchQuery: String,
     ) = withContext(coroutineDispatchers.io) {
-        searchResults.value = SearchBarResultState.Initial()
+        searchResults.value = SearchBarResultState.Initial
         showSearchLoader.value = false
         val joinedMembers = roomMembers.value.dataOrNull().orEmpty()
 
         userRepository.search(searchQuery).onEach { state ->
             showSearchLoader.value = state.isSearching
             searchResults.value = when {
-                state.results.isEmpty() && state.isSearching -> SearchBarResultState.Initial()
-                state.results.isEmpty() && !state.isSearching -> SearchBarResultState.NoResultsFound()
+                state.results.isEmpty() && state.isSearching -> SearchBarResultState.Initial
+                state.results.isEmpty() && !state.isSearching -> SearchBarResultState.NoResultsFound
                 else -> SearchBarResultState.Results(state.results.map { result ->
                     val existingMembership = joinedMembers.firstOrNull { j -> j.userId == result.matrixUser.userId }?.membership
                     val isJoined = existingMembership == RoomMembershipState.JOIN

--- a/features/invitepeople/impl/src/main/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeopleStateProvider.kt
+++ b/features/invitepeople/impl/src/main/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeopleStateProvider.kt
@@ -33,7 +33,7 @@ internal class DefaultInvitePeopleStateProvider : PreviewParameterProvider<Defau
             aDefaultInvitePeopleState(canInvite = true, selectedUsers = aMatrixUserList().toImmutableList()),
             aDefaultInvitePeopleState(isSearchActive = true, searchQuery = "some query"),
             aDefaultInvitePeopleState(isSearchActive = true, searchQuery = "some query", selectedUsers = aMatrixUserList().toImmutableList()),
-            aDefaultInvitePeopleState(isSearchActive = true, searchQuery = "some query", searchResults = SearchBarResultState.NoResultsFound()),
+            aDefaultInvitePeopleState(isSearchActive = true, searchQuery = "some query", searchResults = SearchBarResultState.NoResultsFound),
             aDefaultInvitePeopleState(
                 isSearchActive = true,
                 canInvite = true,
@@ -115,7 +115,7 @@ private fun aDefaultInvitePeopleState(
     room: AsyncData<Unit> = AsyncData.Success(Unit),
     canInvite: Boolean = false,
     searchQuery: String = "",
-    searchResults: SearchBarResultState<ImmutableList<InvitableUser>> = SearchBarResultState.Initial(),
+    searchResults: SearchBarResultState<ImmutableList<InvitableUser>> = SearchBarResultState.Initial,
     selectedUsers: ImmutableList<MatrixUser> = persistentListOf(),
     isSearchActive: Boolean = false,
     showSearchLoader: Boolean = false,

--- a/features/invitepeople/impl/src/test/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeoplePresenterTest.kt
+++ b/features/invitepeople/impl/src/test/kotlin/io/element/android/features/invitepeople/impl/DefaultInvitePeoplePresenterTest.kt
@@ -95,7 +95,7 @@ internal class DefaultInvitePeoplePresenterTest {
             resultState.searchQuery.setTextAndPlaceCursorAtEnd("some query")
             assertThat(awaitItemAsDefault().searchQuery.text.toString()).isEqualTo("some query")
             resultState.eventSink(InvitePeopleEvents.CloseSearch)
-            skipItems(2)
+            skipItems(1)
             awaitItemAsDefault().also {
                 assertThat(it.isSearchActive).isFalse()
                 assertThat(it.searchQuery.text.toString()).isEmpty()
@@ -116,7 +116,7 @@ internal class DefaultInvitePeoplePresenterTest {
             initialState.searchQuery.setTextAndPlaceCursorAtEnd("some query")
             assertThat(repository.providedQuery).isEqualTo("some query")
             repository.emitState(UserSearchResultState(results = emptyList(), isSearching = true))
-            skipItems(3)
+            skipItems(2)
             awaitItemAsDefault().also { state ->
                 assertThat(state.searchResults).isInstanceOf(SearchBarResultState.Initial::class.java)
                 assertThat(state.showSearchLoader).isTrue()
@@ -145,7 +145,6 @@ internal class DefaultInvitePeoplePresenterTest {
 
             assertThat(repository.providedQuery).isEqualTo("some query")
             repository.emitStateWithUsers(users = aMatrixUserList())
-            skipItems(1)
 
             val resultState = awaitItemAsDefault()
             assertThat(resultState.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
@@ -198,7 +197,6 @@ internal class DefaultInvitePeoplePresenterTest {
 
             assertThat(repository.providedQuery).isEqualTo("some query")
             repository.emitStateWithUsers(users = aMatrixUserList())
-            skipItems(1)
 
             val resultState = awaitItemAsDefault()
             assertThat(resultState.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
@@ -265,7 +263,6 @@ internal class DefaultInvitePeoplePresenterTest {
                     it
                 )
             })
-            skipItems(1)
 
             val resultState = awaitItemAsDefault()
             assertThat(resultState.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
@@ -329,7 +326,7 @@ internal class DefaultInvitePeoplePresenterTest {
 
             assertThat(repository.providedQuery).isEqualTo("some query")
             repository.emitStateWithUsers(users = aMatrixUserList() + selectedUser)
-            skipItems(2)
+            skipItems(1)
 
             val resultState = awaitItemAsDefault()
             assertThat(resultState.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
@@ -366,7 +363,6 @@ internal class DefaultInvitePeoplePresenterTest {
 
             assertThat(repository.providedQuery).isEqualTo("some query")
             repository.emitStateWithUsers(users = aMatrixUserList() + selectedUser)
-            skipItems(1)
             awaitItemAsDefault().also { state ->
                 // selectedUser is not selected
                 assertThat(state.searchResults).isInstanceOf(SearchBarResultState.Results::class.java)
@@ -732,7 +728,7 @@ internal class DefaultInvitePeoplePresenterTest {
                     isSearching = true
                 )
             )
-            skipItems(3)
+            skipItems(2)
 
             awaitItemAsDefault().run {
                 assertThat(selectedUsers).containsExactly(alice, bob, charlie)

--- a/features/rolesandpermissions/impl/src/main/kotlin/io/element/android/features/rolesandpermissions/impl/roles/ChangeRolesPresenter.kt
+++ b/features/rolesandpermissions/impl/src/main/kotlin/io/element/android/features/rolesandpermissions/impl/roles/ChangeRolesPresenter.kt
@@ -77,7 +77,7 @@ class ChangeRolesPresenter(
         val queryState = rememberTextFieldState()
         var searchActive by rememberSaveable { mutableStateOf(false) }
         var searchResults by remember {
-            mutableStateOf<SearchBarResultState<MembersByRole>>(SearchBarResultState.Initial())
+            mutableStateOf<SearchBarResultState<MembersByRole>>(SearchBarResultState.Initial)
         }
         val selectedUsers = remember {
             mutableStateOf<ImmutableList<MatrixUser>>(persistentListOf())
@@ -118,7 +118,7 @@ class ChangeRolesPresenter(
                 .groupedByRole()
 
             searchResults = if (results.isEmpty()) {
-                SearchBarResultState.NoResultsFound()
+                SearchBarResultState.NoResultsFound
             } else {
                 SearchBarResultState.Results(results)
             }

--- a/features/rolesandpermissions/impl/src/main/kotlin/io/element/android/features/rolesandpermissions/impl/roles/ChangeRolesStateProvider.kt
+++ b/features/rolesandpermissions/impl/src/main/kotlin/io/element/android/features/rolesandpermissions/impl/roles/ChangeRolesStateProvider.kt
@@ -68,7 +68,7 @@ internal fun aChangeRolesState(
     role: RoomMember.Role = RoomMember.Role.Admin,
     searchQuery: String = "",
     isSearchActive: Boolean = false,
-    searchResults: SearchBarResultState<MembersByRole> = SearchBarResultState.NoResultsFound(),
+    searchResults: SearchBarResultState<MembersByRole> = SearchBarResultState.NoResultsFound,
     selectedUsers: ImmutableList<MatrixUser> = persistentListOf(),
     hasPendingChanges: Boolean = false,
     savingState: AsyncAction<Boolean> = AsyncAction.Uninitialized,

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpacePresenter.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpacePresenter.kt
@@ -66,8 +66,8 @@ class AddRoomToSpacePresenter(
             derivedStateOf {
                 when {
                     filteredRooms.isNotEmpty() -> SearchBarResultState.Results(filteredRooms)
-                    isSearchActive && searchQuery.text.isNotEmpty() -> SearchBarResultState.NoResultsFound<ImmutableList<SelectRoomInfo>>()
-                    else -> SearchBarResultState.Initial<ImmutableList<SelectRoomInfo>>()
+                    isSearchActive && searchQuery.text.isNotEmpty() -> SearchBarResultState.NoResultsFound
+                    else -> SearchBarResultState.Initial
                 }
             }
         }

--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceStateProvider.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceStateProvider.kt
@@ -40,7 +40,7 @@ internal class AddRoomToSpaceStateProvider : PreviewParameterProvider<AddRoomToS
             anAddRoomToSpaceState(
                 isSearchActive = true,
                 searchQuery = "unknown",
-                searchResults = SearchBarResultState.NoResultsFound(),
+                searchResults = SearchBarResultState.NoResultsFound,
             ),
             // With selected rooms
             anAddRoomToSpaceState(
@@ -62,7 +62,7 @@ internal class AddRoomToSpaceStateProvider : PreviewParameterProvider<AddRoomToS
 
 internal fun anAddRoomToSpaceState(
     searchQuery: String = "",
-    searchResults: SearchBarResultState<ImmutableList<SelectRoomInfo>> = SearchBarResultState.Initial(),
+    searchResults: SearchBarResultState<ImmutableList<SelectRoomInfo>> = SearchBarResultState.Initial,
     selectedRooms: ImmutableList<SelectRoomInfo> = persistentListOf(),
     isSearchActive: Boolean = false,
     saveAction: AsyncAction<Unit> = AsyncAction.Uninitialized,

--- a/features/startchat/impl/src/main/kotlin/io/element/android/features/startchat/impl/userlist/DefaultUserListPresenter.kt
+++ b/features/startchat/impl/src/main/kotlin/io/element/android/features/startchat/impl/userlist/DefaultUserListPresenter.kt
@@ -67,19 +67,19 @@ class DefaultUserListPresenter(
         val selectedUsers by userListDataStore.selectedUsers.collectAsState(emptyList())
         val queryState = rememberTextFieldState()
         var searchResults: SearchBarResultState<ImmutableList<UserSearchResult>> by remember {
-            mutableStateOf(SearchBarResultState.Initial())
+            mutableStateOf(SearchBarResultState.Initial)
         }
         var showSearchLoader by remember { mutableStateOf(false) }
 
         val searchQuery = queryState.text.toString()
         LaunchedEffect(searchQuery) {
-            searchResults = SearchBarResultState.Initial()
+            searchResults = SearchBarResultState.Initial
             showSearchLoader = false
             userRepository.search(searchQuery).onEach { state ->
                 showSearchLoader = state.isSearching
                 searchResults = when {
-                    state.results.isEmpty() && state.isSearching -> SearchBarResultState.Initial()
-                    state.results.isEmpty() && !state.isSearching -> SearchBarResultState.NoResultsFound()
+                    state.results.isEmpty() && state.isSearching -> SearchBarResultState.Initial
+                    state.results.isEmpty() && !state.isSearching -> SearchBarResultState.NoResultsFound
                     else -> SearchBarResultState.Results(state.results.toImmutableList())
                 }
             }.launchIn(this)

--- a/features/startchat/impl/src/main/kotlin/io/element/android/features/startchat/impl/userlist/UserListStateProvider.kt
+++ b/features/startchat/impl/src/main/kotlin/io/element/android/features/startchat/impl/userlist/UserListStateProvider.kt
@@ -47,7 +47,7 @@ open class UserListStateProvider : PreviewParameterProvider<UserListState> {
             aUserListState(
                 isSearchActive = true,
                 searchQuery = "something-with-no-results",
-                searchResults = SearchBarResultState.NoResultsFound()
+                searchResults = SearchBarResultState.NoResultsFound
             ),
             aUserListState(
                 isSearchActive = true,
@@ -63,7 +63,7 @@ open class UserListStateProvider : PreviewParameterProvider<UserListState> {
 fun aUserListState(
     searchQuery: String = "",
     isSearchActive: Boolean = false,
-    searchResults: SearchBarResultState<ImmutableList<UserSearchResult>> = SearchBarResultState.Initial(),
+    searchResults: SearchBarResultState<ImmutableList<UserSearchResult>> = SearchBarResultState.Initial,
     selectedUsers: List<MatrixUser> = emptyList(),
     showSearchLoader: Boolean = false,
     selectionMode: SelectionMode = SelectionMode.Single,

--- a/features/startchat/impl/src/test/kotlin/io/element/android/features/startchat/impl/userlist/DefaultUserListPresenterTest.kt
+++ b/features/startchat/impl/src/test/kotlin/io/element/android/features/startchat/impl/userlist/DefaultUserListPresenterTest.kt
@@ -40,7 +40,6 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
             assertThat(initialState.searchQuery.text.toString()).isEmpty()
             assertThat(initialState.isMultiSelectionEnabled).isFalse()
@@ -60,7 +59,6 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
             assertThat(initialState.searchQuery.text.toString()).isEmpty()
             assertThat(initialState.isMultiSelectionEnabled).isTrue()
@@ -80,7 +78,6 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
 
             initialState.eventSink(UserListEvents.OnSearchActiveChanged(true))
@@ -90,13 +87,11 @@ class DefaultUserListPresenterTest {
             initialState.searchQuery.setTextAndPlaceCursorAtEnd(matrixIdQuery)
             assertThat(awaitItem().searchQuery.text.toString()).isEqualTo(matrixIdQuery)
             assertThat(userRepository.providedQuery).isEqualTo(matrixIdQuery)
-            skipItems(1)
 
             val notMatrixIdQuery = "name"
             initialState.searchQuery.setTextAndPlaceCursorAtEnd(notMatrixIdQuery)
             assertThat(awaitItem().searchQuery.text.toString()).isEqualTo(notMatrixIdQuery)
             assertThat(userRepository.providedQuery).isEqualTo(notMatrixIdQuery)
-            skipItems(1)
 
             initialState.eventSink(UserListEvents.OnSearchActiveChanged(false))
             assertThat(awaitItem().isSearchActive).isFalse()
@@ -115,13 +110,12 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
 
             initialState.searchQuery.setTextAndPlaceCursorAtEnd("alice")
             assertThat(initialState.searchResults).isInstanceOf(SearchBarResultState.Initial::class.java)
             assertThat(userRepository.providedQuery).isEqualTo("alice")
-            skipItems(2)
+            skipItems(1)
 
             // When the user repository emits a result, it's copied to the state
             val result = UserSearchResultState(
@@ -166,13 +160,12 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
 
             initialState.searchQuery.setTextAndPlaceCursorAtEnd("alice")
             assertThat(initialState.searchResults).isInstanceOf(SearchBarResultState.Initial::class.java)
             assertThat(userRepository.providedQuery).isEqualTo("alice")
-            skipItems(2)
+            skipItems(1)
 
             // When the results list is empty, the state is set to NoResults
             userRepository.emitState(UserSearchResultState(results = emptyList(), isSearching = false))
@@ -190,7 +183,6 @@ class DefaultUserListPresenterTest {
                 FakeMatrixClient(),
             )
         presenter.test {
-            skipItems(1)
             val initialState = awaitItem()
 
             val userA = aMatrixUser("@userA:domain", "A")

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/SearchBar.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/theme/components/SearchBar.kt
@@ -59,7 +59,7 @@ fun <T> SearchBar(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     showBackButton: Boolean = true,
-    resultState: SearchBarResultState<T> = SearchBarResultState.Initial(),
+    resultState: SearchBarResultState<T> = SearchBarResultState.Initial,
     shape: Shape = SearchBarDefaults.inputFieldShape,
     tonalElevation: Dp = SearchBarDefaults.TonalElevation,
     windowInsets: WindowInsets = SearchBarDefaults.windowInsets,
@@ -134,7 +134,7 @@ fun <T> SearchBar(
                     resultHandler(resultState.results)
                 }
 
-                is SearchBarResultState.NoResultsFound<T> -> {
+                is SearchBarResultState.NoResultsFound -> {
                     // No results found, show a message
                     Spacer(Modifier.size(80.dp))
 
@@ -200,12 +200,12 @@ object ElementSearchBarDefaults {
 }
 
 @Immutable
-sealed interface SearchBarResultState<in T> {
+sealed interface SearchBarResultState<out T> {
     /** No search results are available yet (e.g. because the user hasn't entered a search term). */
-    class Initial<T> : SearchBarResultState<T>
+    data object Initial : SearchBarResultState<Nothing>
 
     /** The search has completed, but no results were found. */
-    class NoResultsFound<T> : SearchBarResultState<T>
+    data object NoResultsFound : SearchBarResultState<Nothing>
 
     /** The search has completed, and some matching users were found. */
     data class Results<T>(val results: T) : SearchBarResultState<T>
@@ -249,7 +249,7 @@ internal fun SearchBarActiveWithNoResultsPreview() = ElementThemedPreview {
     ContentToPreview(
         initialQuery = "search term",
         active = true,
-        resultState = SearchBarResultState.NoResultsFound<String>(),
+        resultState = SearchBarResultState.NoResultsFound,
     )
 }
 
@@ -293,7 +293,7 @@ private fun ContentToPreview(
     initialQuery: String = "",
     active: Boolean = false,
     showBackButton: Boolean = true,
-    resultState: SearchBarResultState<String> = SearchBarResultState.Initial(),
+    resultState: SearchBarResultState<String> = SearchBarResultState.Initial,
     contentPrefix: @Composable ColumnScope.() -> Unit = {},
     contentSuffix: @Composable ColumnScope.() -> Unit = {},
     resultHandler: @Composable ColumnScope.(String) -> Unit = {},

--- a/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/DefaultEmojiPickerPresenter.kt
+++ b/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/DefaultEmojiPickerPresenter.kt
@@ -55,7 +55,7 @@ class DefaultEmojiPickerPresenter(
     override fun present(): EmojiPickerState {
         val queryState = rememberTextFieldState()
         var isSearchActive by remember { mutableStateOf(false) }
-        var emojiResults by remember { mutableStateOf<SearchBarResultState<ImmutableList<Emoji>>>(SearchBarResultState.Initial()) }
+        var emojiResults by remember { mutableStateOf<SearchBarResultState<ImmutableList<Emoji>>>(SearchBarResultState.Initial) }
 
         val data by produceState(EmojiPickerData.Empty) {
             val storeDeferred = async { emojibaseProvider.getStore() }
@@ -93,11 +93,7 @@ class DefaultEmojiPickerPresenter(
         val searchQuery = queryState.text.toString()
         LaunchedEffect(searchQuery, data) {
             if (searchQuery.isEmpty() || data.allEmojis.isEmpty()) {
-                // `SearchBarResultState.Initial` has no `equals` override, so reassigning a new instance
-                // would trigger a redundant emission each time this effect re-runs while the query is empty.
-                if (emojiResults !is SearchBarResultState.Initial) {
-                    emojiResults = SearchBarResultState.Initial()
-                }
+                emojiResults = SearchBarResultState.Initial
                 return@LaunchedEffect
             }
             delay(100.milliseconds)

--- a/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/DefaultEmojiPickerStateProvider.kt
+++ b/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/DefaultEmojiPickerStateProvider.kt
@@ -62,7 +62,7 @@ internal fun aDefaultEmojiPickerState(
     }.toImmutableList(),
     searchQuery: String = "",
     isSearchActive: Boolean = false,
-    searchResults: SearchBarResultState<ImmutableList<Emoji>> = SearchBarResultState.Initial(),
+    searchResults: SearchBarResultState<ImmutableList<Emoji>> = SearchBarResultState.Initial,
     eventSink: (EmojiPickerEvent) -> Unit = {},
 ) = DefaultEmojiPickerState(
     categories = categories,

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectPresenter.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectPresenter.kt
@@ -65,8 +65,8 @@ class RoomSelectPresenter(
             derivedStateOf {
                 when {
                     roomSummaryDetailsList.isNotEmpty() -> SearchBarResultState.Results(roomSummaryDetailsList.toImmutableList())
-                    isSearchActive -> SearchBarResultState.NoResultsFound()
-                    else -> SearchBarResultState.Initial()
+                    isSearchActive -> SearchBarResultState.NoResultsFound
+                    else -> SearchBarResultState.Initial
                 }
             }
         }

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
@@ -52,7 +52,7 @@ open class RoomSelectStateProvider : PreviewParameterProvider<RoomSelectState> {
 internal fun aRoomSelectState(
     mode: RoomSelectMode = RoomSelectMode.Forward,
     maxNumberOfRooms: Int = 10,
-    resultState: SearchBarResultState<ImmutableList<SelectRoomInfo>> = SearchBarResultState.Initial(),
+    resultState: SearchBarResultState<ImmutableList<SelectRoomInfo>> = SearchBarResultState.Initial,
     searchQuery: String = "",
     isSearchActive: Boolean = false,
     selectedRooms: ImmutableList<SelectRoomInfo> = persistentListOf(),


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

-->

## Content
- Turns \`SearchBarResultState.Initial\` and \`SearchBarResultState.NoResultsFound\` into \`data object\`s (parameterised as \`SearchBarResultState<Nothing>\`), and flips the interface variance from \`in T\` to \`out T\`. Follows the existing \`AsyncData<out T>\` + \`Uninitialized : AsyncData<Nothing>\` pattern in \`libraries/architecture\`.
- Drops the \`if (emojiResults !is Initial)\` guard added in the previous PR — no longer needed now that \`Initial\` is a singleton and structural equality skips redundant assignments.
- Updates callsites: \`Initial()\` → \`Initial\`, \`NoResultsFound()\` → \`NoResultsFound\` (12 files).
- Adjusts \`skipItems(N)\` counts in \`DefaultInvitePeoplePresenterTest\` and \`DefaultUserListPresenterTest\` to reflect the emissions that no longer happen (each \`Initial\` reassignment inside \`performSearch\` used to emit a distinct instance; now it's a no-op).

## Motivation and context
Follow-up to https://github.com/element-hq/element-x-android/pull/7257 — [Jorge's inline comment](https://github.com/element-hq/element-x-android/pull/7257#discussion_r3636241667) about the redundant-emission guard.

## Tests
- [ ] Run unit tests for \`libraries:emoji:impl\`, \`libraries:designsystem\`, \`libraries:roomselect:impl\`, \`features:preferences:impl\`, \`features:messages:impl\`, \`features:invitepeople:impl\`, \`features:startchat:impl\`, \`features:rolesandpermissions:impl\`, \`features:space:impl\` — all green locally.

## Tested devices
- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR