### PR TITLE
Try making `HeaderFooterView` more robust

### DIFF
--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/screens/desktop/DesktopNoticeView.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/screens/desktop/DesktopNoticeView.kt
@@ -67,6 +67,7 @@ fun DesktopNoticeView(
         title = stringResource(R.string.screen_link_new_device_desktop_title, appName),
         iconStyle = BigIcon.Style.Default(CompoundIcons.Computer()),
         modifier = modifier,
+        isScrollable = true,
         buttons = {
             Button(
                 text = stringResource(R.string.screen_link_new_device_desktop_submit),

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/organisms/NumberedListOrganism.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/organisms/NumberedListOrganism.kt
@@ -9,8 +9,7 @@
 package io.element.android.libraries.designsystem.atomic.organisms
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
@@ -23,11 +22,11 @@ fun NumberedListOrganism(
     items: ImmutableList<AnnotatedString>,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
+    Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
-        itemsIndexed(items) { index, item ->
+        for ((index, item) in items.withIndex()) {
             NumberedListMolecule(index = index + 1, text = item)
         }
     }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -63,33 +63,27 @@ fun HeaderFooterLayout(
             ) {
                 Layout(
                     content = {
-                        movableHeader()
-                        movableContent()
+                        Box { movableHeader() }
+                        Box { movableContent() }
                     },
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                     measurePolicy = { measurables, constraints ->
                         val actualConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxHeight = newHeight)
-                        val headerPlaceable = measurables.firstOrNull()?.measure(actualConstraints)
+                        val headerPlaceable = measurables[0].measure(actualConstraints)
 
-                        val contentPlaceable = if (headerPlaceable != null && measurables.size > 1) {
-                            val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
-                            val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
-                            measurables[1].measure(contentConstraints)
-                        } else {
-                            null
-                        }
+                        val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
+                        val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
+                        val contentPlaceable = measurables[1].measure(contentConstraints)
 
-                        val headerHeight = headerPlaceable?.height ?: 0
-                        val contentHeight = contentPlaceable?.height ?: 0
+                        val headerHeight = headerPlaceable.height
+                        val contentHeight = contentPlaceable.height
                         layout(actualConstraints.maxWidth, headerHeight + contentHeight) {
                             var yPosition = 0
 
-                            headerPlaceable?.let {
-                                it.placeRelative(0, yPosition)
-                                yPosition += it.height
-                            }
+                            headerPlaceable.placeRelative(0, yPosition)
+                            yPosition += headerPlaceable.height
 
-                            contentPlaceable?.placeRelative(0, yPosition)
+                            contentPlaceable.placeRelative(0, yPosition)
                         }
                     }
                 )

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -38,6 +37,7 @@ import kotlin.math.max
  * @param modifier Compose modifier.
  * @param content the main content composable.
  */
+@Suppress("ContentSlotReused")
 @Composable
 fun HeaderFooterLayout(
     header: @Composable () -> Unit,
@@ -47,8 +47,6 @@ fun HeaderFooterLayout(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val movableHeader = remember { movableContentOf(header) }
-    val movableContent = remember { movableContentOf(content) }
     Column(modifier = modifier) {
         if (isScrollable) {
             // This is a hack to make the content at least 1px high, otherwise the layout will crash
@@ -63,8 +61,8 @@ fun HeaderFooterLayout(
             ) {
                 Layout(
                     content = {
-                        Box { movableHeader() }
-                        Box { movableContent() }
+                        Box { header() }
+                        Box { content() }
                     },
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                     measurePolicy = { measurables, constraints ->
@@ -90,10 +88,10 @@ fun HeaderFooterLayout(
             }
         } else {
             Box(Modifier.padding(contentInsetsPadding)) {
-                movableHeader()
+                header()
             }
             Box(Modifier.weight(1f, fill = true)) {
-                movableContent()
+                content()
             }
         }
 

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -55,11 +55,11 @@ fun HeaderFooterLayout(
             var newHeight by remember { mutableIntStateOf(1) }
             Box(
                 modifier = Modifier
-                .weight(1f, fill = true)
-                .padding(contentInsetsPadding)
-                .onSizeChanged {
-                    newHeight = it.height
-                }
+                    .padding(contentInsetsPadding)
+                    .weight(1f, fill = true)
+                    .onSizeChanged {
+                        newHeight = it.height
+                    }
             ) {
                 Layout(
                     content = {
@@ -95,7 +95,9 @@ fun HeaderFooterLayout(
                 )
             }
         } else {
-            movableHeader()
+            Box(Modifier.padding(contentInsetsPadding)) {
+                movableHeader()
+            }
             Box(Modifier.weight(1f, fill = true)) {
                 movableContent()
             }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.designsystem.atomic.pages
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.Constraints
+import kotlin.math.max
+
+/**
+ * A layout with a [header], a [footer] and a [content] composables.
+ * The component can be scrollable or not, which will modify which layout is used internally to arrange the UI.
+ * In both cases, the [content] will use all the available space between the [header] and the [footer].
+ * The [footer] is always visible, the [header] and the [content] can be scrolled if [isScrollable] is true.
+ *
+ * @param header the header composable.
+ * @param footer the footer composable.
+ * @param isScrollable if the content should be scrollable.
+ * @param contentInsetsPadding padding values to apply to the content. This is useful to handle system insets.
+ * @param modifier Compose modifier.
+ * @param content the main content composable.
+ */
+@Composable
+fun HeaderFooterLayout(
+    header: @Composable () -> Unit,
+    footer: @Composable () -> Unit,
+    isScrollable: Boolean,
+    contentInsetsPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val movableHeader = remember { movableContentOf(header) }
+    val movableContent = remember { movableContentOf(content) }
+    Column(modifier = modifier) {
+        if (isScrollable) {
+            var newHeight by remember { mutableIntStateOf(1) }
+            Box(
+                modifier = Modifier
+                .weight(1f, fill = true)
+                .padding(contentInsetsPadding)
+                .onSizeChanged {
+                    newHeight = it.height
+                }
+            ) {
+                Layout(
+                    content = {
+                        movableHeader()
+                        movableContent()
+                    },
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    measurePolicy = { measurables, constraints ->
+                        val actualConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxHeight = newHeight)
+                        val headerPlaceable = measurables[0].measure(actualConstraints)
+
+                        val contentPlaceable = if (measurables.size > 1) {
+                            val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
+                            val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
+                            measurables[1].measure(contentConstraints)
+                        } else {
+                            null
+                        }
+
+                        layout(actualConstraints.maxWidth, headerPlaceable.height + (contentPlaceable?.height ?: 0)) {
+                            var yPosition = 0
+
+                            headerPlaceable.placeRelative(0, yPosition)
+                            yPosition += headerPlaceable.height
+
+                            contentPlaceable?.placeRelative(0, yPosition)
+                        }
+                    }
+                )
+            }
+        } else {
+            movableHeader()
+            Box(Modifier.weight(1f, fill = true)) {
+                movableContent()
+            }
+        }
+
+        footer()
+    }
+}

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -61,27 +61,33 @@ fun HeaderFooterLayout(
             ) {
                 Layout(
                     content = {
-                        Box { header() }
-                        Box { content() }
+                        header()
+                        content()
                     },
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                     measurePolicy = { measurables, constraints ->
                         val actualConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxHeight = newHeight)
-                        val headerPlaceable = measurables[0].measure(actualConstraints)
+                        val headerPlaceable = measurables.firstOrNull()?.measure(actualConstraints)
 
-                        val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
-                        val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
-                        val contentPlaceable = measurables[1].measure(contentConstraints)
+                        val contentPlaceable = if (headerPlaceable != null && measurables.size > 1) {
+                            val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
+                            val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
+                            measurables[1].measure(contentConstraints)
+                        } else {
+                            null
+                        }
 
-                        val headerHeight = headerPlaceable.height
-                        val contentHeight = contentPlaceable.height
+                        val headerHeight = headerPlaceable?.height ?: 0
+                        val contentHeight = contentPlaceable?.height ?: 0
                         layout(actualConstraints.maxWidth, headerHeight + contentHeight) {
                             var yPosition = 0
 
-                            headerPlaceable.placeRelative(0, yPosition)
-                            yPosition += headerPlaceable.height
+                            headerPlaceable?.let {
+                                it.placeRelative(0, yPosition)
+                                yPosition += it.height
+                            }
 
-                            contentPlaceable.placeRelative(0, yPosition)
+                            contentPlaceable?.placeRelative(0, yPosition)
                         }
                     }
                 )

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterLayout.kt
@@ -51,6 +51,7 @@ fun HeaderFooterLayout(
     val movableContent = remember { movableContentOf(content) }
     Column(modifier = modifier) {
         if (isScrollable) {
+            // This is a hack to make the content at least 1px high, otherwise the layout will crash
             var newHeight by remember { mutableIntStateOf(1) }
             Box(
                 modifier = Modifier
@@ -68,9 +69,9 @@ fun HeaderFooterLayout(
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                     measurePolicy = { measurables, constraints ->
                         val actualConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxHeight = newHeight)
-                        val headerPlaceable = measurables[0].measure(actualConstraints)
+                        val headerPlaceable = measurables.firstOrNull()?.measure(actualConstraints)
 
-                        val contentPlaceable = if (measurables.size > 1) {
+                        val contentPlaceable = if (headerPlaceable != null && measurables.size > 1) {
                             val availableContentHeight = max(1, actualConstraints.maxHeight - headerPlaceable.height)
                             val contentConstraints = actualConstraints.copy(minHeight = availableContentHeight, maxHeight = Constraints.Infinity)
                             measurables[1].measure(contentConstraints)
@@ -78,11 +79,15 @@ fun HeaderFooterLayout(
                             null
                         }
 
-                        layout(actualConstraints.maxWidth, headerPlaceable.height + (contentPlaceable?.height ?: 0)) {
+                        val headerHeight = headerPlaceable?.height ?: 0
+                        val contentHeight = contentPlaceable?.height ?: 0
+                        layout(actualConstraints.maxWidth, headerHeight + contentHeight) {
                             var yPosition = 0
 
-                            headerPlaceable.placeRelative(0, yPosition)
-                            yPosition += headerPlaceable.height
+                            headerPlaceable?.let {
+                                it.placeRelative(0, yPosition)
+                                yPosition += it.height
+                            }
 
                             contentPlaceable?.placeRelative(0, yPosition)
                         }

--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterPage.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/atomic/pages/HeaderFooterPage.kt
@@ -9,19 +9,14 @@
 package io.element.android.libraries.designsystem.atomic.pages
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -82,48 +77,27 @@ fun HeaderFooterPage(
         Box {
             background()
 
-            // Render in a Column
-            Column(
+            HeaderFooterLayout(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues = contentPadding)
                     .consumeWindowInsets(insetsPadding)
                     .imePadding(),
-            ) {
-                // Content
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .run {
-                            if (isScrollable) {
-                                verticalScroll(rememberScrollState())
-                                    // Make sure the scrollable content takes the full available height
-                                    .height(IntrinsicSize.Max)
-                            } else {
-                                Modifier
-                            }
-                        }
-                        // Apply insets here so if the content is scrollable it can get below the top app bar if needed
-                        .padding(contentInsetsPadding)
-                        .weight(1f, fill = true),
-                ) {
-                    // Header
-                    header()
-                    Box {
-                        content()
+                isScrollable = isScrollable,
+                contentInsetsPadding = contentInsetsPadding,
+                header = header,
+                content = content,
+                footer = {
+                    Box(
+                        modifier = Modifier
+                            .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                            .fillMaxWidth()
+                            .padding(footerInsetsPadding)
+                    ) {
+                        footer()
                     }
-                }
-
-                // Footer
-                Box(
-                    modifier = Modifier
-                        .padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                        .fillMaxWidth()
-                        .padding(footerInsetsPadding)
-                ) {
-                    footer()
-                }
-            }
+                },
+            )
         }
     }
 }

--- a/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da71297e7073c5c592dc154af7f137c4eb500bf528e1509b95da869a2c61cbd2
-size 30488
+oid sha256:5c79c83bde346bec65f67c34805407e46b351b2c91772c13e0a6c23ae09bf7e8
+size 30345

--- a/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48cafd6b98791b64e4cc6a16c602f17e3a886659698c3c93bc4acaf875337e0f
-size 31102
+oid sha256:e666d896f715b1e6a165514acbe603fc879c0495a2d7215ac7cabe7a8d165e09
+size 30961

--- a/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bbb94fdb717b2bcda3683d5833181c59d00e4c03a1860af66de6225c8df0756
-size 32482
+oid sha256:ff17ff66d5c92ab19ce8064e2e14326e9f2921c1b7313a3974547b2932cb7fb1
+size 32295

--- a/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.linknewdevice.impl.screens.qrcode_ShowQrCodeView_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f6f8d1282ae47a5240aec2b2c63a137b8e3e25ec8b746cf2d82d0fa7e0c0a34
-size 30287
+oid sha256:6a7786eecdd8f9f8ee2c7edb0d76a2fc09a960f6ca457445b35dc428539e5be6
+size 30102

--- a/tests/uitests/src/test/snapshots/images/features.login.impl.screens.classic.missingkeybackup_MissingKeyBackupView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.login.impl.screens.classic.missingkeybackup_MissingKeyBackupView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e97cab70b9ee3e870154ad4ae4cf1bf0bb413facf8253f5f9fe9429eddf76b1
-size 60303
+oid sha256:d70106c0e4d800aa34faa380d79b65ac29c6bc43e41cf874f31517f138e252f9
+size 60126

--- a/tests/uitests/src/test/snapshots/images/features.login.impl.screens.classic.missingkeybackup_MissingKeyBackupView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.login.impl.screens.classic.missingkeybackup_MissingKeyBackupView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:caaa2a0f4de455704a6b5c78e19c2f723be7deaeec470c77ff1e87df194dd95c
-size 58620
+oid sha256:75670dcefa55cf863d2c0dd608704d465b5c9ac74f4798b3503ce9a2d8e74417
+size 58518

--- a/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.pages_HeaderFooterPageScrollable_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.pages_HeaderFooterPageScrollable_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3874d6fa6ad92eac4ccfbbc2ea76cf8b1fbc869a725eb5e8131af52e78be7a4
-size 12427
+oid sha256:5d8630310d2c2f08aae23fe2e98b9b7b6dec253cbc0528804c999aa3d2d40658
+size 12439

--- a/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.pages_HeaderFooterPageScrollable_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.designsystem.atomic.pages_HeaderFooterPageScrollable_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60d3361163e9a846d0686e696ba25e35b6a8ca9b691d711ff0f5fdd3b1d5578d
-size 12091
+oid sha256:99e36471b02eedc24bf1a07ffc720fe18ca5482e7fc0f35316ab407fd485cb34
+size 12105


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Create a new custom layout `HeaderFooterLayout` and use it for `HeaderFooterView` when `isScrollable` is enabled. It ensures the content inside the scrollable column is at least as large as the available screen space.

When not using `isScrollable`, a similar strategy to what we had before is used, so nothing really changed there.

## Motivation and context

What we had before (creating a scrollable column with `height(IntrinsictSize.Max)` was needed to make the contents as large as possible, but it had weird side effects in some screens, where it allowed you to scroll up to twice the size of the content and you could just make it disappear and have a blank screen instead.

## Screenshots / GIFs

Not many, which is a good sign! The UI still looks the same, but it should work better.

## Tests

Try using different screens where this component is used, both scrollable and not.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ x Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
