### PR TITLE
Fix `ContentErrorView` not calculating its text size synchronously

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/contentvalidation/ContentErrorView.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/media/contentvalidation/ContentErrorView.kt
@@ -9,26 +9,17 @@ package io.element.android.libraries.matrix.ui.media.contentvalidation
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.movableContentOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
@@ -41,7 +32,6 @@ internal fun ContentErrorView(
     contentPadding: PaddingValues = PaddingValues.Zero,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
-    val updatedOnTextLayout by rememberUpdatedState(onTextLayout)
     Row(
         modifier = modifier
             .background(color = ElementTheme.colors.bgCriticalSubtle)
@@ -61,33 +51,12 @@ internal fun ContentErrorView(
                 color = ElementTheme.colors.textCriticalPrimary,
                 style = ElementTheme.typography.fontBodyMdMedium,
             )
-            val textMeasurer = rememberTextMeasurer()
-            val textContent = remember(message) {
-                movableContentOf(
-                    @Composable {
-                        Text(
-                            text = message,
-                            color = ElementTheme.colors.textSecondary,
-                            style = ElementTheme.typography.fontBodySmRegular,
-                        )
-                    }
-                )
-            }
-
-            // BoxWithConstraints is needed to be able to calculate the text layout in the current constraints, so we can pass it to the onTextLayout callback.
-            // However, this can't be used inside a SubComposeLayout (like the one in the text composer), so we only use it when the onTextLayout callback
-            // is provided.
-            if (updatedOnTextLayout != null) {
-                BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                    LaunchedEffect(message) {
-                        updatedOnTextLayout?.invoke(textMeasurer.measure(message, overflow = TextOverflow.Visible, constraints = constraints))
-                    }
-
-                    textContent()
-                }
-            } else {
-                textContent()
-            }
+            Text(
+                text = message,
+                color = ElementTheme.colors.textSecondary,
+                style = ElementTheme.typography.fontBodySmRegular,
+                onTextLayout = onTextLayout,
+            )
         }
     }
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

It was using a `LaunchedEffect` instead of relying on the `Text(onTextLayout)` parameter.

## Motivation and context

In some cases, the content avoiding layout wasn't properly arranging the components causing an overlap and I believe it's caused by this:

<img width="476" height="186" alt="image" src="https://github.com/user-attachments/assets/b2959123-c1bd-4ac5-8f62-88351758b1ee" />

## Screenshots / GIFs

The shouldn't be screenshot changes I believe, except the known flaky ones.

## Tests

Not much to test if you weren't affected by this: if you are, running the `TimelineItemScanningContentFailedPreview` preview on your device would probably trigger different results with and without this patch.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
