### PR TITLE
Update keyboard visibility to track hasFocus

### DIFF
--- a/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/BringIntoViewOnImeVisible.kt
+++ b/libraries/designsystem/src/main/kotlin/io/element/android/libraries/designsystem/modifiers/BringIntoViewOnImeVisible.kt
@@ -25,25 +25,28 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Keeps the focused field visible above the keyboard. Intended for a field inside a scrollable
- * container: the field is never clipped by a pinned footer, but the IME is shown only after focus
- * arrives, so we re-request bringIntoView once it is visible to scroll the field back into the
- * reduced viewport.
+ * Keeps a focused field visible above the keyboard. Intended for a field — or a group that wraps
+ * one — inside a scrollable container: the content is never clipped by a pinned footer, but the IME
+ * is shown only after focus arrives, so we re-request bringIntoView once it is visible to scroll the
+ * content back into the reduced viewport.
+ *
+ * Tracks focus via `hasFocus` rather than `isFocused`, so it also works when applied to a wrapper
+ * whose child — rather than the wrapper itself — takes focus.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun Modifier.bringIntoViewOnImeVisible(): Modifier {
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
-    var isFocused by remember { mutableStateOf(false) }
+    var hasFocus by remember { mutableStateOf(false) }
     val isImeVisible = WindowInsets.isImeVisible
-    LaunchedEffect(isImeVisible, isFocused) {
-        if (isImeVisible && isFocused) {
-            // Delay to ensure the keyboard is fully shown before scrolling the field into view.
+    LaunchedEffect(isImeVisible, hasFocus) {
+        if (isImeVisible && hasFocus) {
+            // Delay to ensure the keyboard is fully shown before scrolling the content into view.
             delay(100.milliseconds)
             bringIntoViewRequester.bringIntoView()
         }
     }
     return this
         .bringIntoViewRequester(bringIntoViewRequester)
-        .onFocusChanged { isFocused = it.isFocused }
+        .onFocusChanged { hasFocus = it.hasFocus }
 }


### PR DESCRIPTION
Generalizes `bringIntoViewOnImeVisible()` to track `hasFocus` instead of `isFocused`, so it can be applied to a container that *wraps* a focused field rather than only to the field itself. The existing direct-field callers are unaffected — `hasFocus == isFocused` when the field itself is focused.

This enables the enterprise-side fix for #7279, where the custom recovery passphrase strength indicator was hidden behind the keyboard

Part of the fix for #7279 
Enterprise companion PR: element-hq/element-android-enterprise#37.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 16 (Samsung Galaxy S24)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the main branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR