### PR TITLE
Add direct to room share support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,11 @@
             android:launchMode="singleTask"
             android:theme="@style/Theme.ElementX.Splash"
             android:windowSoftInputMode="adjustResize">
+
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 Element Creations Ltd.
+  ~
+  ~ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  ~ Please see LICENSE files in the repository root for full details.
+  -->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <share-target android:targetClass="io.element.android.x.MainActivity">
+        <data android:mimeType="*/*" />
+        <category android:name="android.shortcut.conversation" />
+    </share-target>
+</shortcuts>

--- a/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/RootFlowNode.kt
@@ -426,25 +426,25 @@ class RootFlowNode(
     }
 
     private suspend fun onIncomingShare(shareIntentData: ShareIntentData) {
-        // Is there a session already?
-        val latestSessionId = sessionStore.getLatestSessionId()
-        if (latestSessionId == null) {
+        val targetSessionId = shareIntentData.targetSessionId
+        val sessionIdToUse = targetSessionId ?: sessionStore.getLatestSessionId()
+        if (sessionIdToUse == null) {
             // No session, open login
             switchToNotLoggedInFlow(null)
         } else {
             // wait for the current session to be restored
-            val loggedInFlowNode = attachSession(latestSessionId)
-            if (sessionStore.numberOfSessions() > 1) {
+            val loggedInFlowNode = attachSession(sessionIdToUse)
+            if (sessionStore.numberOfSessions() > 1 && targetSessionId == null) {
                 // Several accounts, let the user choose which one to use
                 backstack.push(
                     NavTarget.AccountSelect(
-                        currentSessionId = latestSessionId,
+                        currentSessionId = sessionIdToUse,
                         shareIntentData = shareIntentData,
                         permalinkData = null,
                     )
                 )
             } else {
-                // Only one account, directly attach the incoming share node.
+                // Directly attach the incoming share node.
                 loggedInFlowNode.attachIncomingShare(shareIntentData)
             }
         }

--- a/features/share/api/src/main/kotlin/io/element/android/features/share/api/ShareIntentData.kt
+++ b/features/share/api/src/main/kotlin/io/element/android/features/share/api/ShareIntentData.kt
@@ -11,21 +11,36 @@ import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+
 /**
  * Share intent data, mapped from the original [android.content.Intent].
  */
 sealed interface ShareIntentData : Parcelable {
+    val targetSessionId: SessionId?
+    val targetRoomId: RoomId?
+
     /**
      * A list of [Uri]s to share and their mime types, with an optional [text] to be used as caption.
      */
     @Parcelize
-    data class Uris(val text: String?, val uris: List<UriToShare>) : ShareIntentData
+    data class Uris(
+        val text: String?,
+        val uris: List<UriToShare>,
+        override val targetSessionId: SessionId? = null,
+        override val targetRoomId: RoomId? = null,
+    ) : ShareIntentData
 
     /**
      * A plain text to share.
      */
     @Parcelize
-    data class PlainText(val content: String) : ShareIntentData
+    data class PlainText(
+        val content: String,
+        override val targetSessionId: SessionId? = null,
+        override val targetRoomId: RoomId? = null,
+    ) : ShareIntentData
 }
 
 /**

--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultShareIntentHandler.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/DefaultShareIntentHandler.kt
@@ -31,6 +31,10 @@ import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
 import io.element.android.libraries.di.annotations.ApplicationContext
 import timber.log.Timber
 
+import androidx.core.content.pm.ShortcutManagerCompat
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.core.SessionId
+
 @ContributesBinding(AppScope::class)
 class DefaultShareIntentHandler(
     @ApplicationContext private val context: Context,
@@ -40,8 +44,9 @@ class DefaultShareIntentHandler(
     ): ShareIntentData? {
         val type = intent.resolveType(context) ?: return null
         val uris = getIncomingUris(intent, type)
+        val (targetSessionId, targetRoomId) = extractTargetShortcut(intent)
         return when {
-            uris.isEmpty() && type == MimeTypes.PlainText -> handlePlainText(intent)
+            uris.isEmpty() && type == MimeTypes.PlainText -> handlePlainText(intent, targetSessionId, targetRoomId)
             type.isMimeTypeImage() ||
                 type.isMimeTypeVideo() ||
                 type.isMimeTypeAudio() ||
@@ -52,18 +57,40 @@ class DefaultShareIntentHandler(
                 ShareIntentData.Uris(
                     text = intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()?.takeIf { it.isNotEmpty() },
                     uris = uris,
+                    targetSessionId = targetSessionId,
+                    targetRoomId = targetRoomId,
                 )
             }
             else -> null
         }
     }
 
-    private fun handlePlainText(intent: Intent): ShareIntentData.PlainText? {
+    private fun handlePlainText(
+        intent: Intent,
+        targetSessionId: SessionId?,
+        targetRoomId: RoomId?,
+    ): ShareIntentData.PlainText? {
         val content = intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
         return if (content?.isNotEmpty() == true) {
-            ShareIntentData.PlainText(content)
+            ShareIntentData.PlainText(
+                content = content,
+                targetSessionId = targetSessionId,
+                targetRoomId = targetRoomId,
+            )
         } else {
             null
+        }
+    }
+
+    private fun extractTargetShortcut(intent: Intent): Pair<SessionId?, RoomId?> {
+        val shortcutId = intent.getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID)
+            ?: intent.getStringExtra("android.intent.extra.shortcut.ID")
+            ?: return null to null
+        val parts = shortcutId.split("-", limit = 2)
+        return if (parts.size == 2) {
+            SessionId(parts[0]) to RoomId(parts[1])
+        } else {
+            null to null
         }
     }
 

--- a/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
+++ b/features/share/impl/src/main/kotlin/io/element/android/features/share/impl/SharePresenter.kt
@@ -9,6 +9,7 @@
 package io.element.android.features.share.impl
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import dev.zacsweers.metro.Assisted
@@ -55,6 +56,13 @@ class SharePresenter(
 
     @Composable
     override fun present(): ShareState {
+        val targetRoomId = shareIntentData.targetRoomId
+        LaunchedEffect(shareIntentData) {
+            if (targetRoomId != null && shareActionState.value is AsyncAction.Uninitialized) {
+                onRoomSelected(listOf(targetRoomId))
+            }
+        }
+
         fun handleEvent(event: ShareEvents) {
             when (event) {
                 ShareEvents.ClearError -> shareActionState.value = AsyncAction.Uninitialized

--- a/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/DefaultShareIntentHandlerTest.kt
+++ b/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/DefaultShareIntentHandlerTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.share.impl
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.pm.ShortcutManagerCompat
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.share.api.ShareIntentData
+import io.element.android.libraries.core.mimetype.MimeTypes
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_SESSION_ID
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+class DefaultShareIntentHandlerTest: RobolectricTest() {
+    private val context: Context = RuntimeEnvironment.getApplication()
+    private val handler = DefaultShareIntentHandler(context)
+
+    @Test
+    fun `handleIncomingShareIntent returns PlainText without target shortcut when extra is missing`() {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = MimeTypes.PlainText
+            putExtra(Intent.EXTRA_TEXT, "Hello world")
+        }
+
+        val result = handler.handleIncomingShareIntent(intent)
+        assertThat(result).isInstanceOf(ShareIntentData.PlainText::class.java)
+        val plainText = result as ShareIntentData.PlainText
+        assertThat(plainText.content).isEqualTo("Hello world")
+        assertThat(plainText.targetSessionId).isNull()
+        assertThat(plainText.targetRoomId).isNull()
+    }
+
+    @Test
+    fun `handleIncomingShareIntent returns PlainText with target shortcut when EXTRA_SHORTCUT_ID is present`() {
+        val shortcutId = "${A_SESSION_ID.value}-${A_ROOM_ID.value}"
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = MimeTypes.PlainText
+            putExtra(Intent.EXTRA_TEXT, "Hello world")
+            putExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID, shortcutId)
+        }
+
+        val result = handler.handleIncomingShareIntent(intent)
+        assertThat(result).isInstanceOf(ShareIntentData.PlainText::class.java)
+        val plainText = result as ShareIntentData.PlainText
+        assertThat(plainText.content).isEqualTo("Hello world")
+        assertThat(plainText.targetSessionId).isEqualTo(A_SESSION_ID)
+        assertThat(plainText.targetRoomId).isEqualTo(A_ROOM_ID)
+    }
+
+    @Test
+    fun `handleIncomingShareIntent returns Uris with target shortcut when EXTRA_SHORTCUT_ID is present`() {
+        val shortcutId = "${A_SESSION_ID.value}-${A_ROOM_ID.value}"
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = MimeTypes.Jpeg
+            putExtra(Intent.EXTRA_STREAM, Uri.parse("content://media/image.jpg"))
+            putExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID, shortcutId)
+        }
+
+        val result = handler.handleIncomingShareIntent(intent)
+        assertThat(result).isInstanceOf(ShareIntentData.Uris::class.java)
+        val urisData = result as ShareIntentData.Uris
+        assertThat(urisData.targetSessionId).isEqualTo(A_SESSION_ID)
+        assertThat(urisData.targetRoomId).isEqualTo(A_ROOM_ID)
+    }
+
+    @Test
+    fun `handleIncomingShareIntent ignores malformed shortcut ID`() {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = MimeTypes.PlainText
+            putExtra(Intent.EXTRA_TEXT, "Hello world")
+            putExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID, "invalid_shortcut_without_dash")
+        }
+
+        val result = handler.handleIncomingShareIntent(intent)
+        assertThat(result).isInstanceOf(ShareIntentData.PlainText::class.java)
+        val plainText = result as ShareIntentData.PlainText
+        assertThat(plainText.targetSessionId).isNull()
+        assertThat(plainText.targetRoomId).isNull()
+    }
+}

--- a/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/SharePresenterTest.kt
+++ b/features/share/impl/src/test/kotlin/io/element/android/features/share/impl/SharePresenterTest.kt
@@ -162,6 +162,35 @@ class SharePresenterTest : RobolectricTest() {
             sendMediaResult.assertions().isCalledOnce()
         }
     }
+
+    @Test
+    fun `present - auto-selects targetRoomId when present in shareIntentData`() = runTest {
+        val joinedRoom = FakeJoinedRoom(
+            liveTimeline = FakeTimeline().apply {
+                sendMessageLambda = { _, _, _, _, _ -> Result.success(Unit) }
+            },
+        )
+        val matrixClient = FakeMatrixClient().apply {
+            givenGetRoomResult(A_ROOM_ID, joinedRoom)
+        }
+        val presenter = createSharePresenter(
+            matrixClient = matrixClient,
+            shareIntentData = ShareIntentData.PlainText(
+                content = A_MESSAGE,
+                targetSessionId = io.element.android.libraries.matrix.test.A_SESSION_ID,
+                targetRoomId = A_ROOM_ID,
+            ),
+        )
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            val initialState = awaitItem()
+            val nextState = if (initialState.shareAction.isUninitialized()) awaitItem() else initialState
+            val success = if (nextState.shareAction.isLoading()) awaitItem() else nextState
+            assertThat(success.shareAction.isSuccess()).isTrue()
+            assertThat(success.shareAction).isEqualTo(AsyncAction.Success(listOf(A_ROOM_ID)))
+        }
+    }
 }
 
 internal fun TestScope.createSharePresenter(

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
@@ -11,6 +11,7 @@ package io.element.android.libraries.push.impl.notifications.conversations
 import android.content.Context
 import android.content.pm.ShortcutInfo
 import android.os.Build
+import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -86,7 +87,8 @@ class DefaultNotificationConversationService(
         }
 
         val categories = setOfNotNull(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION else null
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION else null,
+            "android.shortcut.conversation",
         )
 
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return
@@ -105,9 +107,17 @@ class DefaultNotificationConversationService(
             targetSize = defaultShortcutIconSize.toLong()
         )?.let(IconCompat::createWithBitmap)
 
+        val person = Person.Builder()
+            .setName(roomName)
+            .setIcon(icon)
+            .setKey(createShortcutId(sessionId, roomId))
+            .build()
+
         val shortcutInfo = ShortcutInfoCompat.Builder(context, createShortcutId(sessionId, roomId))
             .setShortLabel(name)
             .setIcon(icon)
+            .setPerson(person)
+            .setIsConversation()
             .setIntent(intentProvider.getViewRoomIntent(sessionId, roomId, threadId = null, eventId = null))
             .setCategories(categories)
             .setLongLived(true)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
@@ -50,6 +50,7 @@ class DefaultNotificationConversationServiceTest : RobolectricTest() {
 
         val shortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
         assertThat(shortcuts).isNotEmpty()
+        assertThat(shortcuts.first().categories).contains("android.shortcut.conversation")
     }
 
     @Test


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

I have added the correct handlers to directly share to a contact. Room names can now appear in the "person" row in the share dialog. When tapping on a room a 

## Motivation and context

The issue #3835 talks about it and I myself liked the feature in Element Classic. It's nice to share directly to a room.

## Screenshots / GIFs

<img width="1080" height="2424" alt="Screenshot_20260729_123737" src="https://github.com/user-attachments/assets/f6d2f2d6-6463-4146-8071-72e21eefe429" />

## Tests

- Unit tests
- Installed the app on an emulator
- Authenticated to a Server
- Wrote a message to a chat
- Found something to share
- Verified the room is in the top list
- Shared to the room and to see if it would send the element

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 7, 17

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
