### PR TITLE
Don't check enterprise previews in `KonsistPreviewTest`

### DIFF
--- a/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
+++ b/tests/konsist/src/test/kotlin/io/element/android/tests/konsist/KonsistPreviewTest.kt
@@ -11,6 +11,7 @@ package io.element.android.tests.konsist
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.google.common.truth.Truth.assertThat
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
 import com.lemonappdev.konsist.api.ext.list.withName
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
@@ -61,6 +62,8 @@ class KonsistPreviewTest {
             .scopeFromProject()
             .functions()
             .withAllAnnotationsOf(PreviewsDayNight::class)
+            // We can't check Enterprise previews because they are in a different repo, and they aren't present for FOSS
+            .withoutEnterpriseFunctions()
             .assertTrue {
                 it.text.contains("ElementPreview") ||
                     it.text.contains("ElementTimelineItemPreview")
@@ -88,8 +91,6 @@ class KonsistPreviewTest {
         "BackgroundVerticalGradientPreview",
         "ColorAliasesPreview",
         "EmojiItemWithPopupPreview",
-        "EnterpriseExtraDeveloperOptionsRendererBottomSheetPreview",
-        "EnterpriseExtraDeveloperOptionsRendererListItemPreview",
         "FocusedEventPreview",
         "GradientFloatingActionButtonCircleShapePreview",
         "HeaderFooterPageScrollablePreview",
@@ -189,7 +190,8 @@ class KonsistPreviewTest {
 
     @Test
     fun `previewNameExceptions only contains existing functions`() {
-        val names = previewNameExceptions.toMutableSet()
+        val names = previewNameExceptions
+            .toMutableSet()
         Konsist
             .scopeFromProject()
             .functions()
@@ -210,6 +212,8 @@ class KonsistPreviewTest {
             .functions()
             .withAllAnnotationsOf(PreviewsDayNight::class)
             .withoutName(previewNameExceptions)
+            // We can't check Enterprise previews because they are in a different repo, and they aren't present for FOSS
+            .withoutEnterpriseFunctions()
             .assertTrue(
                 additionalMessage = "Functions for Preview should be named like this: <ViewUnderPreview>Preview. " +
                     "Exception can be added to the test, for multiple Previews of the same view",
@@ -236,4 +240,8 @@ class KonsistPreviewTest {
                 additionalMessage = "Use '@PreviewsDayNight' instead of '@PreviewLightDark', or else screenshot(s) will not be generated.",
             )
     }
+}
+
+private fun List<KoFunctionDeclaration>.withoutEnterpriseFunctions() = filter { function ->
+    function.packagee?.hasNameStartingWith("io.element.android.enterprise") != true
 }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says.

## Motivation and context

These previews won't be present for FOSS/forked projects, so having them added to the list of name exceptions was wrong. We shouldn't check them at all, or if we want to, we should do it directly in some tests in the enterprise repo.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
