### PR TITLE
Set custom status emoji

### DIFF
--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusEvent.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusEvent.kt
@@ -19,4 +19,5 @@ sealed interface UserStatusEvent {
     data object OpenEmojiPicker : UserStatusEvent
     data object DismissEmojiPicker : UserStatusEvent
     data object ClearStatus : UserStatusEvent
+    data class OpenCustomInputWithValues(val emoji: String, val text: String) : UserStatusEvent
 }

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusPresenter.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusPresenter.kt
@@ -67,6 +67,15 @@ class UserStatusPresenter(
                         emojiPickerSheetState = EmojiPickerSheetState.Hidden,
                     )
                 }
+                is UserStatusEvent.OpenCustomInputWithValues -> {
+                    customTextFieldState.setTextAndPlaceCursorAtEnd(event.text)
+                    isEmojiPickerVisible = true
+                    pickerState = UserStatusPickerState.CustomInput(
+                        emoji = event.emoji,
+                        textFieldState = customTextFieldState,
+                        emojiPickerSheetState = EmojiPickerSheetState.Hidden,
+                    )
+                }
                 // Custom-input mutations
                 is UserStatusEvent.UpdateCustomEmoji -> {
                     isEmojiPickerVisible = false

--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusView.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusView.kt
@@ -94,6 +94,9 @@ fun UserStatusView(
                     onDismiss = { state.eventSink(UserStatusEvent.DismissPicker) },
                     onSelectPredefinedStatus = { status -> state.eventSink(UserStatusEvent.SetStatus(status)) },
                     onSelectCustomStatus = { state.eventSink(UserStatusEvent.OpenCustomInput) },
+                    onCustomizePredefinedStatusEmoji = { emoji, text ->
+                        state.eventSink(UserStatusEvent.OpenCustomInputWithValues(emoji, text))
+                    },
                 )
             }
         }
@@ -191,6 +194,7 @@ private fun UserStatusPickerBottomSheet(
     onDismiss: () -> Unit,
     onSelectPredefinedStatus: (UserStatus) -> Unit,
     onSelectCustomStatus: () -> Unit,
+    onCustomizePredefinedStatusEmoji: (emoji: String, text: String) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberBottomSheetState(
@@ -210,7 +214,15 @@ private fun UserStatusPickerBottomSheet(
             val isSelected = currentRawStatus == predefinedUserStatus
             ListItem(
                 headlineContent = { Text(text = label) },
-                leadingContent = ListItemContent.Custom { EmojiText(predefined.emoji) },
+                leadingContent = ListItemContent.Custom({
+                    Box(modifier = Modifier.clickable {
+                        sheetState.hide(coroutineScope) {
+                            onCustomizePredefinedStatusEmoji(predefined.emoji, label)
+                        }
+                    }) {
+                        EmojiText(predefined.emoji)
+                    }
+                }),
                 trailingContent = if (isSelected) {
                     ListItemContent.Icon(IconSource.Vector(CompoundIcons.Check()), tintColor = ElementTheme.colors.iconAccentPrimary)
                 } else {

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusPresenterTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/userstatus/UserStatusPresenterTest.kt
@@ -111,6 +111,18 @@ class UserStatusPresenterTest {
     }
 
     @Test
+    fun `OpenCustomInputWithValues pre-fills values and opens emoji picker`() = runTest {
+        createPresenter().test {
+            awaitItem().eventSink(UserStatusEvent.OpenCustomInputWithValues("🚀", "My custom text"))
+            val state = awaitItem()
+            val pickerState = state.pickerState as UserStatusPickerState.CustomInput
+            assertThat(pickerState.emoji).isEqualTo("🚀")
+            assertThat(pickerState.textFieldState.text.toString()).isEqualTo("My custom text")
+            assertThat(pickerState.emojiPickerSheetState).isInstanceOf(EmojiPickerSheetState.Shown::class.java)
+        }
+    }
+
+    @Test
     fun `Clear event calls clearUserStatus and clears displayed status`() = runTest {
         val client = FakeMatrixClient()
         createPresenter(client).test {


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Wire the Emoji picker for the custom Emoji status button

## Motivation and context

Didn't work before

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Try to set a custom status
- Click on the Emoji button

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
