### PR TITLE
Route existing backups to recovery key entry

### DIFF
--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootState.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootState.kt
@@ -24,6 +24,9 @@ data class SecureBackupRootState(
     val snackbarMessage: SnackbarMessage?,
     val eventSink: (SecureBackupRootEvents) -> Unit,
 ) {
+    val shouldEnterRecoveryKeyWhenDisabled: Boolean
+        get() = recoveryState == RecoveryState.DISABLED && doesBackupExistOnServer.dataOrNull() == true
+
     val isKeyStorageEnabled: Boolean
         get() = when (backupState) {
             BackupState.UNKNOWN -> doesBackupExistOnServer.dataOrNull() == true

--- a/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
+++ b/features/securebackup/impl/src/main/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootView.kt
@@ -139,12 +139,22 @@ fun SecureBackupRootView(
                 ListItem(
                     headlineContent = {
                         Text(
-                            text = stringResource(id = R.string.screen_chat_backup_recovery_action_setup),
+                            text = stringResource(
+                                id = if (state.shouldEnterRecoveryKeyWhenDisabled) {
+                                    R.string.screen_chat_backup_recovery_action_confirm
+                                } else {
+                                    R.string.screen_chat_backup_recovery_action_setup
+                                }
+                            ),
                         )
                     },
                     supportingContent = {
                         Text(
-                            text = stringResource(id = R.string.screen_chat_backup_recovery_action_setup_description, state.appName),
+                            text = if (state.shouldEnterRecoveryKeyWhenDisabled) {
+                                stringResource(id = R.string.screen_chat_backup_recovery_action_confirm_description)
+                            } else {
+                                stringResource(id = R.string.screen_chat_backup_recovery_action_setup_description, state.appName)
+                            },
                         )
                     },
                     trailingContent = ListItemContent.Badge,
@@ -152,7 +162,11 @@ fun SecureBackupRootView(
                     alwaysClickable = true,
                     onClick = {
                         if (state.isKeyStorageEnabled) {
-                            onSetupClick()
+                            if (state.shouldEnterRecoveryKeyWhenDisabled) {
+                                onConfirmRecoveryKeyClick()
+                            } else {
+                                onSetupClick()
+                            }
                         } else {
                             state.eventSink.invoke(SecureBackupRootEvents.DisplayKeyStorageDisabledError)
                         }

--- a/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootStateTest.kt
+++ b/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootStateTest.kt
@@ -11,10 +11,31 @@ package io.element.android.features.securebackup.impl.root
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.encryption.BackupState
+import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import org.junit.Test
 
 class SecureBackupRootStateTest {
+    @Test
+    fun `shouldEnterRecoveryKeyWhenDisabled is true when recovery is disabled and a backup exists on the server`() {
+        assertThat(
+            aSecureBackupRootState(
+                recoveryState = RecoveryState.DISABLED,
+                doesBackupExistOnServer = AsyncData.Success(true),
+            ).shouldEnterRecoveryKeyWhenDisabled
+        ).isTrue()
+    }
+
+    @Test
+    fun `shouldEnterRecoveryKeyWhenDisabled is false when recovery is disabled and no backup exists on the server`() {
+        assertThat(
+            aSecureBackupRootState(
+                recoveryState = RecoveryState.DISABLED,
+                doesBackupExistOnServer = AsyncData.Success(false),
+            ).shouldEnterRecoveryKeyWhenDisabled
+        ).isFalse()
+    }
+
     @Test
     fun `isKeyStorageEnabled should be true for all these backup states`() {
         listOf(

--- a/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootViewTest.kt
+++ b/features/securebackup/impl/src/test/kotlin/io/element/android/features/securebackup/impl/root/SecureBackupRootViewTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.element.android.features.securebackup.impl.root
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.AndroidComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import io.element.android.features.securebackup.impl.R
+import io.element.android.libraries.architecture.AsyncData
+import io.element.android.libraries.matrix.api.encryption.BackupState
+import io.element.android.libraries.matrix.api.encryption.RecoveryState
+import io.element.android.tests.testutils.EnsureNeverCalled
+import io.element.android.tests.testutils.clickOn
+import io.element.android.tests.testutils.ensureCalledOnce
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+
+class SecureBackupRootViewTest : RobolectricTest() {
+    @Test
+    fun `disabled recovery with remote backup routes to enter recovery key`() = runAndroidComposeUiTest {
+        ensureCalledOnce { callback ->
+            setSecureBackupRootView(
+                state = disabledRecoveryState(doesBackupExistOnServer = true),
+                onConfirmRecoveryKeyClick = callback,
+            )
+            clickOn(R.string.screen_chat_backup_recovery_action_confirm)
+        }
+    }
+
+    @Test
+    fun `disabled recovery without remote backup presents setup recovery`() = runAndroidComposeUiTest {
+        setSecureBackupRootView(state = disabledRecoveryState(doesBackupExistOnServer = false))
+
+        onNodeWithText(activity!!.getString(R.string.screen_chat_backup_recovery_action_setup)).assertExists()
+    }
+
+    private fun disabledRecoveryState(doesBackupExistOnServer: Boolean) = aSecureBackupRootState(
+        backupState = BackupState.UNKNOWN,
+        doesBackupExistOnServer = AsyncData.Success(doesBackupExistOnServer),
+        recoveryState = RecoveryState.DISABLED,
+    )
+
+    private fun AndroidComposeUiTest<ComponentActivity>.setSecureBackupRootView(
+        state: SecureBackupRootState,
+        onSetupClick: () -> Unit = EnsureNeverCalled(),
+        onConfirmRecoveryKeyClick: () -> Unit = EnsureNeverCalled(),
+    ) {
+        setContent {
+            SecureBackupRootView(
+                state = state,
+                onBackClick = EnsureNeverCalled(),
+                onSetupClick = onSetupClick,
+                onChangeClick = EnsureNeverCalled(),
+                onDisableClick = EnsureNeverCalled(),
+                onConfirmRecoveryKeyClick = onConfirmRecoveryKeyClick,
+                onLearnMoreClick = EnsureNeverCalled(),
+            )
+        }
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/encryption/RustEncryptionService.kt
@@ -47,7 +47,6 @@ import org.matrix.rustcomponents.sdk.UserIdentity
 import timber.log.Timber
 import org.matrix.rustcomponents.sdk.BackupUploadState as RustBackupUploadState
 import org.matrix.rustcomponents.sdk.EnableRecoveryProgress as RustEnableRecoveryProgress
-import org.matrix.rustcomponents.sdk.RecoveryException as RustRecoveryException
 import org.matrix.rustcomponents.sdk.SteadyStateException as RustSteadyStateException
 
 class RustEncryptionService(
@@ -224,12 +223,8 @@ class RustEncryptionService(
     override suspend fun recover(recoveryKey: String): Result<Unit> = withContext(dispatchers.io) {
         runCatchingExceptions {
             service.recoverAndFixBackup(recoveryKey)
-        }.recoverCatching {
-            when (it) {
-                // We ignore import errors because the user will be notified about them via the "Key storage out of sync" detection.
-                is RustRecoveryException.Import -> Unit
-                else -> throw it.mapRecoveryException()
-            }
+        }.mapFailure {
+            it.mapRecoveryException()
         }
     }
 

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/encryption/RecoveryExceptionMapperTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/encryption/RecoveryExceptionMapperTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.encryption
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.encryption.RecoveryException
+import org.junit.Test
+import org.matrix.rustcomponents.sdk.RecoveryException as RustRecoveryException
+
+class RecoveryExceptionMapperTest {
+    @Test
+    fun `Import exception is mapped to the application boundary`() {
+        val result = RustRecoveryException.Import("Failed to import room keys").mapRecoveryException()
+
+        assertThat(result).isInstanceOf(RecoveryException.Import::class.java)
+        assertThat(result.message).isEqualTo("Failed to import room keys")
+    }
+}


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- When a server backup exists while local recovery is `DISABLED`, show and route to the existing enter-recovery-key flow instead of offering to set up new recovery.
- Map `RustRecoveryException.Import` through the application recovery-exception boundary instead of treating the import failure as a successful recovery.
- Add focused state, view-routing, and exception-mapping tests.

## Motivation and context

Users with an existing server backup can reach a locally disabled recovery state. Offering setup-new recovery in that state sends them down the wrong path; the existing key-entry flow is the appropriate route.

Separately, an SDK room-key import failure must remain a failure so the UI can report it rather than proceeding as though recovery succeeded.

Related symptom report: #7283. This change may improve routing and import-error reporting for overlapping “key storage out of sync” cases, but it does not claim to fix that issue's reported incorrect-key cause or every historical Megolm restore failure.

## Screenshots / GIFs

Not provided. The change reuses the existing recovery-key confirmation content and flow.

## Tests

Focused tests were added for the new routing decision, its click target, and import-exception mapping.

Local tests were not run because the required Android toolchain was unavailable. GitHub-hosted PR CI is requested as the test substrate.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s): Not tested locally

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
