### PR TITLE
Do not append the application MapTiler key to a custom map style url

### DIFF
--- a/features/location/api/src/main/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilder.kt
+++ b/features/location/api/src/main/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilder.kt
@@ -33,10 +33,6 @@ internal class MapTilerTileServerStyleUriBuilder(
             val mapId = if (darkMode) darkMapId else lightMapId
             "$baseUrl/$mapId/style.json?key=$apiKey"
         } else {
-            // A custom style url comes from the homeserver .well-known and is expected to be complete:
-            // it already carries the operator's own credentials, if any. Appending our api key to it
-            // adds a second query string and breaks the request.
-            // See https://github.com/element-hq/element-x-android/issues/7289
             customMapStyleUrl
         }
     }

--- a/features/location/api/src/main/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilder.kt
+++ b/features/location/api/src/main/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilder.kt
@@ -29,14 +29,15 @@ internal class MapTilerTileServerStyleUriBuilder(
         customMapStyleUrl: String?,
         darkMode: Boolean,
     ): String {
-        return buildString {
-            if (customMapStyleUrl.isNullOrBlank()) {
-                val mapId = if (darkMode) darkMapId else lightMapId
-                append("$baseUrl/$mapId/style.json")
-            } else {
-                append(customMapStyleUrl)
-            }
-            append("?key=$apiKey")
+        return if (customMapStyleUrl.isNullOrBlank()) {
+            val mapId = if (darkMode) darkMapId else lightMapId
+            "$baseUrl/$mapId/style.json?key=$apiKey"
+        } else {
+            // A custom style url comes from the homeserver .well-known and is expected to be complete:
+            // it already carries the operator's own credentials, if any. Appending our api key to it
+            // adds a second query string and breaks the request.
+            // See https://github.com/element-hq/element-x-android/issues/7289
+            customMapStyleUrl
         }
     }
 }

--- a/features/location/api/src/test/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilderTest.kt
+++ b/features/location/api/src/test/kotlin/io/element/android/features/location/api/internal/MapTilerTileServerStyleUriBuilderTest.kt
@@ -46,7 +46,7 @@ class MapTilerTileServerStyleUriBuilderTest {
                 customMapStyleUrl = "https://custom.url/style.json",
                 darkMode = false,
             )
-        ).isEqualTo("https://custom.url/style.json?key=anApiKey")
+        ).isEqualTo("https://custom.url/style.json")
     }
 
     @Test
@@ -56,6 +56,36 @@ class MapTilerTileServerStyleUriBuilderTest {
                 customMapStyleUrl = "https://custom.url/style.json",
                 darkMode = true,
             )
-        ).isEqualTo("https://custom.url/style.json?key=anApiKey")
+        ).isEqualTo("https://custom.url/style.json")
+    }
+
+    @Test
+    fun `custom map uri with its own api key is not altered`() {
+        assertThat(
+            builder.build(
+                customMapStyleUrl = "https://api.maptiler.com/maps/streets-v2/style.json?key=anOperatorKey",
+                darkMode = false,
+            )
+        ).isEqualTo("https://api.maptiler.com/maps/streets-v2/style.json?key=anOperatorKey")
+    }
+
+    @Test
+    fun `custom map uri with an existing query is not altered`() {
+        assertThat(
+            builder.build(
+                customMapStyleUrl = "https://self.hosted/style.json?foo=bar",
+                darkMode = true,
+            )
+        ).isEqualTo("https://self.hosted/style.json?foo=bar")
+    }
+
+    @Test
+    fun `blank custom map uri falls back to the built-in style`() {
+        assertThat(
+            builder.build(
+                customMapStyleUrl = "  ",
+                darkMode = false,
+            )
+        ).isEqualTo("https://base.url/aLightMapId/style.json?key=anApiKey")
     }
 }


### PR DESCRIPTION
## Content

### Problem

When a homeserver publishes a `map_style_url` in its `.well-known` file, the app appends its own
MapTiler API key to it before loading the style. The resulting URL has two query strings —
`https://tiles.example.org/style.json?key=operatorKey?key=applicationKey` — which the tile server
rejects, so the map fails to load for every user of that homeserver. There is no way for an operator
to opt out, because the key is appended unconditionally.

### Fix

- `MapTilerTileServerStyleUriBuilder.build()` now appends `?key=<application key>` only to the URL
  it composes itself from `MAPTILER_BASE_URL` and the light/dark map ids. A non-blank
  `customMapStyleUrl` is returned verbatim, so whatever credentials the operator put in it survive.
- The blank/`null` path is unchanged, so the bundled MapTiler configuration keeps working exactly as
  before.

## Motivation and context

A custom style URL is the mechanism an operator uses to point the app at their own tile server, and
it is expected to be self-sufficient — this is how Element Web treats it, and how the self-hosted
tile server documentation describes it. Injecting the application's key into a URL the app did not
build both breaks the request and leaks a credential to a third-party host.

Relates to #7289.

## Tests

- `MapTilerTileServerStyleUriBuilderTest` — `custom map uri light` / `custom map uri dark` now
  assert the custom URL is returned unchanged.
- New: `custom map uri with its own api key is not altered` reproduces the report — a MapTiler URL
  that already carries `?key=` must not gain a second one.
- New: `custom map uri with an existing query is not altered` covers a self-hosted URL with an
  unrelated query string.
- New: `blank custom map uri falls back to the built-in style`, and the untouched `light map uri` /
  `dark map uri` cases, guard that the built-in path still receives the application key.

What these do not prove: no test loads a real style document, so this verifies the URL that is
built, not that any particular tile server accepts it.

### Scope

**This is not a change to the static-map URL builder.** `MapTilerStaticMapUrlBuilder`, mentioned in
the same issue thread, has a different composition problem and is deliberately left alone.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 30
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a sign off
- [x] You've made a self-review of your changes

