### PR TITLE
Render <s> and <strike> as strikethrough instead of dropping the formatting

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -69,9 +69,6 @@ private object CustomHtmlToDomParser {
         val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
         val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)
         return Jsoup.parse(cleanHtml).also { document ->
-            // `del` is the only strikethrough tag the renderer knows about, so normalise the two
-            // others to it. Without this the content of the tag is dropped, not just its styling.
-            // See https://github.com/element-hq/element-x-android/issues/4328
             document.select("s, strike").forEach { it.tagName("del") }
         }
     }
@@ -85,7 +82,6 @@ private object CustomHtmlToDomParser {
             "em",
             "u",
             "del",
-            // Strikethrough aliases, normalised to `del` in [document]
             "s",
             "strike",
             "code",

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -68,7 +68,12 @@ private object CustomHtmlToDomParser {
     fun document(html: String): Document {
         val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
         val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)
-        return Jsoup.parse(cleanHtml)
+        return Jsoup.parse(cleanHtml).also { document ->
+            // `del` is the only strikethrough tag the renderer knows about, so normalise the two
+            // others to it. Without this the content of the tag is dropped, not just its styling.
+            // See https://github.com/element-hq/element-x-android/issues/4328
+            document.select("s, strike").forEach { it.tagName("del") }
+        }
     }
 
     private val safeList = Safelist()
@@ -80,6 +85,9 @@ private object CustomHtmlToDomParser {
             "em",
             "u",
             "del",
+            // Strikethrough aliases, normalised to `del` in [document]
+            "s",
+            "strike",
             "code",
             "ul",
             "ol",

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
@@ -60,6 +60,55 @@ class ToHtmlDocumentTest : RobolectricTest() {
     }
 
     @Test
+    fun `toHtmlDocument - a s tag is kept and normalised to del`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<s>gone</s>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+        assertThat(document?.selectFirst("del")?.text()).isEqualTo("gone")
+        assertThat(document?.text()).isEqualTo("gone")
+    }
+
+    @Test
+    fun `toHtmlDocument - a strike tag is kept and normalised to del`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<strike>gone</strike>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+        assertThat(document?.selectFirst("del")?.text()).isEqualTo("gone")
+        assertThat(document?.text()).isEqualTo("gone")
+    }
+
+    @Test
+    fun `toHtmlDocument - a del tag is left as is`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<del>gone</del>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+        assertThat(document?.selectFirst("del")?.text()).isEqualTo("gone")
+        assertThat(document?.text()).isEqualTo("gone")
+    }
+
+    @Test
+    fun `toHtmlDocument - a s tag nested in another tag is normalised too`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<p>Hello <s>world</s></p>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+        assertThat(document?.select("s, strike")).isEmpty()
+        assertThat(document?.selectFirst("del")?.text()).isEqualTo("world")
+        assertThat(document?.text()).isEqualTo("Hello world")
+    }
+
+    @Test
     fun `toHtmlDocument - if a mention is found without an '@' prefix, it will be added`() {
         val body = FormattedBody(
             format = MessageFormat.HTML,


### PR DESCRIPTION
## Content

### Problem

A message whose `formatted_body` uses `<s>` or `<strike>` for strikethrough renders as ordinary
text: the strikethrough is gone with no indication that the sender applied any formatting. Only
`<del>` works today. `<strike>` is part of the allowed tag list in the Matrix specification, and
several clients — Cinny among them — send `<s>`, so this affects real messages arriving from other
clients.

### Fix

- `CustomHtmlToDomParser` now allows `s` and `strike` through its Jsoup `Safelist`, so the sanitizer
  stops unwrapping them before the message is ever parsed.
- Immediately after sanitizing, both tags are renamed to `del` in the parsed document. This is what
  makes the fix safe: the span parser recognises `del` only, and its fallback branch does not
  recurse into the children of an unknown tag — so allowing the tags through *without* normalising
  them would drop the text itself, not just its styling.

## Motivation and context

`<strike>` is in the Matrix spec's list of permitted tags in `org.matrix.custom.html` bodies, so
discarding it loses information the sender deliberately included. `<s>` is not in that list, but
supporting it costs nothing here and fixes interoperability with clients that emit it.

Relates to #4328.

## Tests

- `ToHtmlDocumentTest` — new `a s tag is kept and normalised to del` and `a strike tag is kept and
  normalised to del`: each asserts the document contains `<del>gone</del>` **and** that
  `document.text()` is still `"gone"`. The second assertion is the regression guard against the span
  parser's fallback branch silently discarding children.
- New `a del tag is left as is` — proves the normalisation does not disturb the tag that already
  worked.
- New `a s tag nested in another tag is normalised too` — covers markup inside a `<p>`, and asserts
  no `s`/`strike` element survives anywhere in the document.

What these do not prove: they assert on the parsed `Document`, not on the rendered spans, so they
show the tag reaches the renderer in a form it understands — not that the pixels show a line through
the text.

### Scope

**This is not a change to the rich text editor or to what the composer sends.** Element X still
sends `<del>`; this only affects how incoming markup from other clients is interpreted.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 30
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a sign off
- [x] You've made a self-review of your changes

