### PR TITLE
Ignore a room list filter that is incompatible with an already selected one

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
@@ -22,10 +22,6 @@ class DefaultFilterSelectionStrategy : FilterSelectionStrategy {
     override val filterSelectionStates = MutableStateFlow(buildFilters())
 
     override fun select(filter: RoomListFilter) {
-        // Incompatible filters are hidden from the UI rather than disabled, so a filter can still be
-        // selected while its chip is on its way out, typically when two chips are tapped in the same
-        // frame. Ignore it, the currently applied filters win.
-        // See https://github.com/element-hq/element-x-android/issues/5383
         if (selectedFilters.any { it in filter.incompatibleFilters }) return
         selectedFilters.add(filter)
         filterSelectionStates.value = buildFilters()

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
@@ -22,6 +22,11 @@ class DefaultFilterSelectionStrategy : FilterSelectionStrategy {
     override val filterSelectionStates = MutableStateFlow(buildFilters())
 
     override fun select(filter: RoomListFilter) {
+        // Incompatible filters are hidden from the UI rather than disabled, so a filter can still be
+        // selected while its chip is on its way out, typically when two chips are tapped in the same
+        // frame. Ignore it, the currently applied filters win.
+        // See https://github.com/element-hq/element-x-android/issues/5383
+        if (selectedFilters.any { it in filter.incompatibleFilters }) return
         selectedFilters.add(filter)
         filterSelectionStates.value = buildFilters()
     }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
@@ -78,8 +78,6 @@ class RoomListFiltersPresenterTest {
         val presenter = createRoomListFiltersPresenter()
         presenter.test {
             awaitItem().let { state ->
-                // Both events are sent on the same state, i.e. before any recomposition, which is what
-                // happens when the two chips are tapped simultaneously.
                 state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.Favourites))
                 state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.Invites))
             }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
@@ -74,6 +74,51 @@ class RoomListFiltersPresenterTest {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    fun `present - toggling two incompatible filters in the same frame keeps the first one`() = runTest {
+        val presenter = createRoomListFiltersPresenter()
+        presenter.test {
+            awaitItem().let { state ->
+                // Both events are sent on the same state, i.e. before any recomposition, which is what
+                // happens when the two chips are tapped simultaneously.
+                state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.Favourites))
+                state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.Invites))
+            }
+            advanceUntilIdle()
+            awaitLastSequentialItem().let { state ->
+                assertThat(state.selectedFilters()).containsExactly(RoomListFilter.Favourites)
+                assertThat(state.filterSelectionStates).containsExactly(
+                    filterSelectionState(RoomListFilter.Favourites, true),
+                    filterSelectionState(RoomListFilter.Unread, false),
+                    filterSelectionState(RoomListFilter.People, false),
+                    filterSelectionState(RoomListFilter.Rooms, false),
+                ).inOrder()
+            }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `present - toggling two incompatible categories in the same frame keeps the first one`() = runTest {
+        val presenter = createRoomListFiltersPresenter()
+        presenter.test {
+            awaitItem().let { state ->
+                state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.People))
+                state.eventSink.invoke(RoomListFiltersEvent.ToggleFilter(RoomListFilter.Rooms))
+            }
+            advanceUntilIdle()
+            awaitLastSequentialItem().let { state ->
+                assertThat(state.selectedFilters()).containsExactly(RoomListFilter.People)
+                assertThat(state.filterSelectionStates).containsExactly(
+                    filterSelectionState(RoomListFilter.People, true),
+                    filterSelectionState(RoomListFilter.Unread, false),
+                    filterSelectionState(RoomListFilter.Favourites, false),
+                ).inOrder()
+            }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun `present - clear filters event`() = runTest {
         val presenter = createRoomListFiltersPresenter()
         presenter.test {


### PR DESCRIPTION
## Content

### Problem

Some room list filters are mutually exclusive — *People* against *Rooms*, and *Invites* against
everything else. The UI expresses this by hiding the incompatible chips once a filter is selected,
but nothing prevents the selection itself. If two incompatible chips are tapped in the same frame,
before the list has had a chance to recompose, both filters are applied. The result is a room list
that can never match anything, and the offending chip is hidden, so the user cannot see what is
filtering their rooms or tap it again to undo it.

### Fix

- `DefaultFilterSelectionStrategy.select()` now ignores a filter that is incompatible with one
  already selected, so the write path enforces the same rule `buildFilters()` already applies when
  it decides which chips to show. The currently applied filters win; the late tap is dropped.
- `toggle()`, `deselect()` and `clear()` are unchanged, as is the `FilterSelectionStrategy`
  interface.

## Motivation and context

`RoomListFilter.incompatibleFilters` was only ever consulted when *rendering* the unselected chips.
Enforcing it where the selection is actually mutated closes the window between a tap and the
recomposition that hides the chip.

Relates to #5383.

## Tests

- `RoomListFiltersPresenterTest` — new `toggling two incompatible filters in the same frame keeps
  the first one` sends `ToggleFilter(Favourites)` and `ToggleFilter(Invites)` on the *same* state
  instance, which reproduces two taps landing before a recomposition, and asserts only *Favourites*
  survives and that the chip list is `Favourites` (selected), `Unread`, `People`, `Rooms`.
- New `toggling two incompatible categories in the same frame keeps the first one` covers the
  *People* / *Rooms* pair from the report.
- The existing `initial state`, `toggle rooms filter` and `clear filters event` cases are unchanged
  and guard that ordinary selection, deselection and clearing still behave.

What these do not prove: they exercise the presenter and the real selection strategy, not the
Compose chip row, so they do not prove two physical taps can actually be delivered in one frame on
a device — only that the selection layer is safe if they are.

### Scope

**This is not a change to which filters are mutually exclusive.** The `incompatibleFilters` table is
untouched; this only makes the existing table authoritative when a filter is selected.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 30
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a sign off
- [x] You've made a self-review of your changes

