### PR TITLE
Hide the forward action on live location shares

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/model/event/TimelineItemEventContent.kt
@@ -58,10 +58,12 @@ fun TimelineItemEventContent.canBeForwarded(): Boolean =
         is TimelineItemFileContent,
         is TimelineItemAudioContent,
         is TimelineItemVideoContent,
-        is TimelineItemLocationContent,
         is TimelineItemVoiceContent,
         is TimelineItemGalleryContent,
         is TimelineItemAttachmentsContent -> true
+        // Live location shares can't be forwarded, the SDK rejects them, so we only show the option for static locations
+        // See https://github.com/element-hq/element-x-android/issues/7190
+        is TimelineItemLocationContent -> mode is TimelineItemLocationContent.Mode.Static
         // Stickers can't be forwarded (yet) so we don't show the option
         // See https://github.com/element-hq/element-x-android/issues/2161
         is TimelineItemStickerContent -> false

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/actionlist/ActionListPresenterTest.kt
@@ -21,7 +21,10 @@ import io.element.android.features.messages.impl.timeline.model.event.RtcNotific
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemRedactedContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemRtcNotificationContent
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextContent
+import io.element.android.features.messages.impl.timeline.model.event.aLiveLocationMode
+import io.element.android.features.messages.impl.timeline.model.event.aStaticLocationMode
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemImageContent
+import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemLocationContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemPollContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemStateEventContent
 import io.element.android.features.messages.impl.timeline.model.event.aTimelineItemVoiceContent
@@ -598,6 +601,123 @@ class ActionListPresenterTest {
             )
             initialState.eventSink.invoke(ActionListEvent.Clear)
             assertThat(awaitItem().target).isEqualTo(ActionListState.Target.None)
+        }
+    }
+
+    @Test
+    fun `present - compute for a static location item`() = runTest {
+        val presenter = createActionListPresenter(isDeveloperModeEnabled = true)
+        presenter.test {
+            val initialState = awaitItem()
+            val messageEvent = aMessageEvent(
+                isMine = true,
+                isEditable = false,
+                content = aTimelineItemLocationContent(mode = aStaticLocationMode()),
+            )
+            initialState.eventSink.invoke(
+                ActionListEvent.ComputeForMessage(
+                    event = messageEvent,
+                    userEventPermissions = aUserEventPermissions(
+                        canRedactOwn = true,
+                        canRedactOther = false,
+                        canSendMessage = true,
+                        canSendReaction = true,
+                        canPinUnpin = true,
+                    ),
+                )
+            )
+            val successState = awaitItem()
+            assertThat(successState.target).isEqualTo(
+                ActionListState.Target.Success(
+                    event = messageEvent,
+                    sentTimeFull = "0 Full true",
+                    displayEmojiReactions = true,
+                    verifiedUserSendFailure = VerifiedUserSendFailure.None,
+                    actions = persistentListOf(
+                        TimelineItemAction.Reply,
+                        TimelineItemAction.Forward,
+                        TimelineItemAction.CopyLink,
+                        TimelineItemAction.Pin,
+                        TimelineItemAction.ViewSource,
+                        TimelineItemAction.Redact,
+                    ),
+                    recentEmojis = suggestedEmojis,
+                )
+            )
+            initialState.eventSink.invoke(ActionListEvent.Clear)
+            assertThat(awaitItem().target).isEqualTo(ActionListState.Target.None)
+        }
+    }
+
+    @Test
+    fun `present - compute for a live location item does not offer to forward it`() = runTest {
+        val presenter = createActionListPresenter(isDeveloperModeEnabled = true)
+        presenter.test {
+            val initialState = awaitItem()
+            val messageEvent = aMessageEvent(
+                isMine = true,
+                isEditable = false,
+                content = aTimelineItemLocationContent(mode = aLiveLocationMode(isActive = true)),
+            )
+            initialState.eventSink.invoke(
+                ActionListEvent.ComputeForMessage(
+                    event = messageEvent,
+                    userEventPermissions = aUserEventPermissions(
+                        canRedactOwn = true,
+                        canRedactOther = false,
+                        canSendMessage = true,
+                        canSendReaction = true,
+                        canPinUnpin = true,
+                    ),
+                )
+            )
+            val successState = awaitItem()
+            assertThat(successState.target).isEqualTo(
+                ActionListState.Target.Success(
+                    event = messageEvent,
+                    sentTimeFull = "0 Full true",
+                    displayEmojiReactions = true,
+                    verifiedUserSendFailure = VerifiedUserSendFailure.None,
+                    actions = persistentListOf(
+                        TimelineItemAction.Reply,
+                        TimelineItemAction.CopyLink,
+                        TimelineItemAction.Pin,
+                        TimelineItemAction.ViewSource,
+                        TimelineItemAction.Redact,
+                    ),
+                    recentEmojis = suggestedEmojis,
+                )
+            )
+            initialState.eventSink.invoke(ActionListEvent.Clear)
+            assertThat(awaitItem().target).isEqualTo(ActionListState.Target.None)
+        }
+    }
+
+    @Test
+    fun `present - compute for an ended live location item does not offer to forward it`() = runTest {
+        val presenter = createActionListPresenter(isDeveloperModeEnabled = true)
+        presenter.test {
+            val initialState = awaitItem()
+            val messageEvent = aMessageEvent(
+                isMine = true,
+                isEditable = false,
+                content = aTimelineItemLocationContent(mode = aLiveLocationMode(isActive = false)),
+            )
+            initialState.eventSink.invoke(
+                ActionListEvent.ComputeForMessage(
+                    event = messageEvent,
+                    userEventPermissions = aUserEventPermissions(
+                        canRedactOwn = true,
+                        canRedactOther = false,
+                        canSendMessage = true,
+                        canSendReaction = true,
+                        canPinUnpin = true,
+                    ),
+                )
+            )
+            val successState = awaitItem()
+            assertThat((successState.target as ActionListState.Target.Success).actions)
+                .doesNotContain(TimelineItemAction.Forward)
         }
     }
 


### PR DESCRIPTION
## Content

### Problem

The timeline action sheet offers **Forward** on a live location share, but forwarding one always
fails: the SDK rejects that event kind outright, so the user gets an error every time. The action is
therefore visible for exactly the set of events on which it cannot work.

### Fix

- `TimelineItemEventContent.canBeForwarded()` now returns `true` for a location event only when its
  mode is `Static`. Live shares — active or ended — are excluded, so the action is not offered.
- No change is needed in `ActionListPresenter`: its `timelineItem.isRemote &&
  timelineItem.content.canBeForwarded()` check is the function's only call site in the repo, so this
  single gate covers the timeline sheet, the threaded timeline and the pinned-messages list at once.

## Motivation and context

`Mode.Live` corresponds to the SDK's `MsgLikeKind.LiveLocation`, which `RoomContentForwarder`
rejects with `ForwardEventException`. Hiding the action mirrors both Element Web's behaviour and the
existing sticker exclusion in the same function, where an action that cannot succeed is not shown.

Relates to #7190.

## Tests

- `ActionListPresenterTest` — new `compute for a static location item` asserts the full expected
  action list for a static location share and confirms **Forward is still offered** there, so the
  change cannot over-reach.
- New `compute for a live location item does not offer to forward it` asserts the full action list
  for an active live share: Reply, CopyLink, Pin, ViewSource, Redact — with Forward absent, and
  emoji reactions still enabled.
- New `compute for an ended live location item does not offer to forward it` covers the
  `isActive = false` case, which is still `Mode.Live`.

What these do not prove: they assert what the action list contains, not that the SDK would have
rejected the forward — the `RoomContentForwarder` failure path is unchanged and untested here.

### Scope

**This is not an attempt to make live location shares forwardable.** Converting a live share into a
static `m.location` on forward is a product decision, not a defect fix, and is deliberately out of
scope.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes have been tested on an Android device or Android emulator with API 30
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a sign off
- [x] You've made a self-review of your changes

