### PR TITLE
Show the account a UnifiedPush registration belongs to in the distributor

### DIFF
--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/RegisterUnifiedPushUseCase.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/RegisterUnifiedPushUseCase.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.libraries.di.annotations.ApplicationContext
+import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.unifiedpush.registration.EndpointRegistrationHandler
 import kotlinx.coroutines.flow.filter
@@ -21,7 +22,7 @@ import org.unifiedpush.android.connector.UnifiedPush
 import kotlin.time.Duration.Companion.seconds
 
 interface RegisterUnifiedPushUseCase {
-    suspend fun execute(distributor: Distributor, clientSecret: String): Result<Unit>
+    suspend fun execute(distributor: Distributor, clientSecret: String, sessionId: SessionId): Result<Unit>
 }
 
 @ContributesBinding(AppScope::class)
@@ -29,11 +30,14 @@ class DefaultRegisterUnifiedPushUseCase(
     @ApplicationContext private val context: Context,
     private val endpointRegistrationHandler: EndpointRegistrationHandler,
 ) : RegisterUnifiedPushUseCase {
-    override suspend fun execute(distributor: Distributor, clientSecret: String): Result<Unit> {
+    override suspend fun execute(distributor: Distributor, clientSecret: String, sessionId: SessionId): Result<Unit> {
         UnifiedPush.saveDistributor(context, distributor.value)
         // This will trigger the callback
         // VectorUnifiedPushMessagingReceiver.onNewEndpoint
-        UnifiedPush.register(context = context, instance = clientSecret)
+        // The session id is passed as the message for the distributor, so that its UI can tell one
+        // registration from another when several accounts are registered.
+        // See https://github.com/element-hq/element-x-android/issues/6426
+        UnifiedPush.register(context = context, instance = clientSecret, messageForDistributor = sessionId.value)
         // Wait for VectorUnifiedPushMessagingReceiver.onNewEndpoint to proceed
         @Suppress("RunCatchingNotAllowed")
         return runCatching {

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/RegisterUnifiedPushUseCase.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/RegisterUnifiedPushUseCase.kt
@@ -34,9 +34,6 @@ class DefaultRegisterUnifiedPushUseCase(
         UnifiedPush.saveDistributor(context, distributor.value)
         // This will trigger the callback
         // VectorUnifiedPushMessagingReceiver.onNewEndpoint
-        // The session id is passed as the message for the distributor, so that its UI can tell one
-        // registration from another when several accounts are registered.
-        // See https://github.com/element-hq/element-x-android/issues/6426
         UnifiedPush.register(context = context, instance = clientSecret, messageForDistributor = sessionId.value)
         // Wait for VectorUnifiedPushMessagingReceiver.onNewEndpoint to proceed
         @Suppress("RunCatchingNotAllowed")

--- a/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
+++ b/libraries/pushproviders/unifiedpush/src/main/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProvider.kt
@@ -36,7 +36,7 @@ class UnifiedPushProvider(
 
     override suspend fun registerWith(matrixClient: MatrixClient, distributor: Distributor): Result<Unit> {
         val clientSecret = pushClientSecret.getSecretForUser(matrixClient.sessionId)
-        return registerUnifiedPushUseCase.execute(distributor, clientSecret)
+        return registerUnifiedPushUseCase.execute(distributor, clientSecret, matrixClient.sessionId)
             .onSuccess {
                 unifiedPushStore.setDistributorValue(matrixClient.sessionId, distributor.value)
             }

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultRegisterUnifiedPushUseCaseTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/DefaultRegisterUnifiedPushUseCaseTest.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_SECRET
+import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.libraries.pushproviders.unifiedpush.registration.EndpointRegistrationHandler
 import io.element.android.libraries.pushproviders.unifiedpush.registration.RegistrationResult
@@ -41,7 +42,7 @@ class DefaultRegisterUnifiedPushUseCaseTest : RobolectricTest() {
             delay(100)
             endpointRegistrationHandler.registrationDone(RegistrationResult(A_SECRET, Result.success(Unit)))
         }
-        val result = useCase.execute(aDistributor, A_SECRET)
+        val result = useCase.execute(aDistributor, A_SECRET, A_SESSION_ID)
         assertThat(result.isSuccess).isTrue()
     }
 
@@ -56,7 +57,7 @@ class DefaultRegisterUnifiedPushUseCaseTest : RobolectricTest() {
             delay(100)
             endpointRegistrationHandler.registrationDone(RegistrationResult(A_SECRET, Result.failure(AN_EXCEPTION)))
         }
-        val result = useCase.execute(aDistributor, A_SECRET)
+        val result = useCase.execute(aDistributor, A_SECRET, A_SESSION_ID)
         assertThat(result.isSuccess).isFalse()
     }
 
@@ -67,7 +68,7 @@ class DefaultRegisterUnifiedPushUseCaseTest : RobolectricTest() {
             endpointRegistrationHandler = endpointRegistrationHandler
         )
         val aDistributor = Distributor("aValue", "aName")
-        val result = useCase.execute(aDistributor, A_SECRET)
+        val result = useCase.execute(aDistributor, A_SECRET, A_SESSION_ID)
         assertThat(result.isSuccess).isFalse()
     }
 

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/FakeRegisterUnifiedPushUseCase.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/FakeRegisterUnifiedPushUseCase.kt
@@ -8,13 +8,14 @@
 
 package io.element.android.libraries.pushproviders.unifiedpush
 
+import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.pushproviders.api.Distributor
 import io.element.android.tests.testutils.lambda.lambdaError
 
 class FakeRegisterUnifiedPushUseCase(
-    private val result: (Distributor, String) -> Result<Unit> = { _, _ -> lambdaError() }
+    private val result: (Distributor, String, SessionId) -> Result<Unit> = { _, _, _ -> lambdaError() }
 ) : RegisterUnifiedPushUseCase {
-    override suspend fun execute(distributor: Distributor, clientSecret: String): Result<Unit> {
-        return result(distributor, clientSecret)
+    override suspend fun execute(distributor: Distributor, clientSecret: String, sessionId: SessionId): Result<Unit> {
+        return result(distributor, clientSecret, sessionId)
     }
 }

--- a/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProviderTest.kt
+++ b/libraries/pushproviders/unifiedpush/src/test/kotlin/io/element/android/libraries/pushproviders/unifiedpush/UnifiedPushProviderTest.kt
@@ -62,7 +62,7 @@ class UnifiedPushProviderTest {
     @Test
     fun `register ok`() = runTest {
         val getSecretForUserResultLambda = lambdaRecorder<SessionId, String> { A_SECRET }
-        val executeLambda = lambdaRecorder<Distributor, String, Result<Unit>> { _, _ -> Result.success(Unit) }
+        val executeLambda = lambdaRecorder<Distributor, String, SessionId, Result<Unit>> { _, _, _ -> Result.success(Unit) }
         val setDistributorValueResultLambda = lambdaRecorder<UserId, String, Unit> { _, _ -> }
         val unifiedPushProvider = createUnifiedPushProvider(
             pushClientSecret = FakePushClientSecret(
@@ -82,7 +82,7 @@ class UnifiedPushProviderTest {
             .with(value(A_SESSION_ID))
         executeLambda.assertions()
             .isCalledOnce()
-            .with(value(Distributor("value", "Name")), value(A_SECRET))
+            .with(value(Distributor("value", "Name")), value(A_SECRET), value(A_SESSION_ID))
         setDistributorValueResultLambda.assertions()
             .isCalledOnce()
             .with(value(A_SESSION_ID), value("value"))
@@ -91,7 +91,7 @@ class UnifiedPushProviderTest {
     @Test
     fun `register ko`() = runTest {
         val getSecretForUserResultLambda = lambdaRecorder<SessionId, String> { A_SECRET }
-        val executeLambda = lambdaRecorder<Distributor, String, Result<Unit>> { _, _ -> Result.failure(AN_EXCEPTION) }
+        val executeLambda = lambdaRecorder<Distributor, String, SessionId, Result<Unit>> { _, _, _ -> Result.failure(AN_EXCEPTION) }
         val setDistributorValueResultLambda = lambdaRecorder<UserId, String, Unit>(ensureNeverCalled = true) { _, _ -> }
         val unifiedPushProvider = createUnifiedPushProvider(
             pushClientSecret = FakePushClientSecret(
@@ -111,7 +111,7 @@ class UnifiedPushProviderTest {
             .with(value(A_SESSION_ID))
         executeLambda.assertions()
             .isCalledOnce()
-            .with(value(Distributor("value", "Name")), value(A_SECRET))
+            .with(value(Distributor("value", "Name")), value(A_SECRET), value(A_SESSION_ID))
     }
 
     @Test


### PR DESCRIPTION
## Content

A UnifiedPush distributor such as ntfy or DAVx5 lists every registration it holds, but Element
registered each one with no message for the distributor, so a second account was indistinguishable
from the first in that list.

`RegisterUnifiedPushUseCase.execute` now takes the session id and passes it as
`messageForDistributor`, which the connector has accepted since 3.x. The value is the raw Matrix ID,
which the project's logging rules treat as non-personal, so no new string resource is needed.

`UnifiedPushProvider` already has the `MatrixClient` in hand at the only call site, so the
`PushProvider` interface is unchanged and nothing outside the module moves.

## Motivation and context

With multiple accounts registered there is no way to tell from the distributor which
registration belongs to which account, so revoking the right one is guesswork.

Fixes #6426

## Tests

- `UnifiedPushProviderTest` — the `register ok` and `register ko` cases now assert the session id is
  forwarded from `registerWith` into the use case, alongside the distributor and client secret.
- `DefaultRegisterUnifiedPushUseCaseTest` follows the new arity; that Robolectric test cannot observe
  the argument handed to the static `UnifiedPush.register`, so it is a no-regression pass only.
- The value actually shown by a distributor's UI is not covered by any test.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
