### PR TITLE
Ignore a second voice recording start while one is already running

### DIFF
--- a/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
+++ b/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
@@ -72,11 +72,6 @@ class DefaultVoiceRecorder(
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
     override suspend fun startRecord() = lock.withLock {
-        // The composer can emit a second Start before the first recording has produced its first
-        // buffer, i.e. before the state flips away from Idle. Without this guard the second call
-        // orphans the first job and its AudioReader, which keeps the microphone open and keeps
-        // emitting Recording forever, so Stop and Delete appear to do nothing.
-        // See https://github.com/element-hq/element-x-android/issues/5780
         if (recordingJob != null) {
             Timber.w("Voice recorder is already recording, ignoring this start")
             return@withLock

--- a/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
+++ b/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
@@ -71,14 +71,22 @@ class DefaultVoiceRecorder(
     override val state: StateFlow<VoiceRecorderState> = _state
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
-    override suspend fun startRecord() {
+    override suspend fun startRecord() = lock.withLock {
+        // The composer can emit a second Start before the first recording has produced its first
+        // buffer, i.e. before the state flips away from Idle. Without this guard the second call
+        // orphans the first job and its AudioReader, which keeps the microphone open and keeps
+        // emitting Recording forever, so Stop and Delete appear to do nothing.
+        // See https://github.com/element-hq/element-x-android/issues/5780
+        if (recordingJob != null) {
+            Timber.w("Voice recorder is already recording, ignoring this start")
+            return@withLock
+        }
+
         Timber.i("Voice recorder started recording")
         outputFile = fileManager.createFile()
             .also(encoder::init)
 
-        lock.withLock {
-            levels.clear()
-        }
+        levels.clear()
 
         val audioRecorder = audioReaderFactory.create(config, dispatchers).also { audioReader = it }
 

--- a/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorderTest.kt
+++ b/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorderTest.kt
@@ -39,6 +39,7 @@ import kotlin.time.TestTimeSource
 class DefaultVoiceRecorderTest {
     private val fakeFileSystem = FakeFileSystem()
     private val timeSource = TestTimeSource()
+    private val audioReaderFactory = FakeAudioReaderFactory(audio = AUDIO)
 
     @Test
     fun `it emits the initial state`() = runTest {
@@ -110,6 +111,34 @@ class DefaultVoiceRecorderTest {
     }
 
     @Test
+    fun `when startRecord is called twice, the second call is ignored`() = runTest {
+        val voiceRecorder = createDefaultVoiceRecorder()
+        voiceRecorder.state.test {
+            assertThat(awaitItem()).isEqualTo(VoiceRecorderState.Idle)
+
+            // Two taps landing before the state has flipped away from Idle.
+            voiceRecorder.startRecord()
+            voiceRecorder.startRecord()
+            assertThat(audioReaderFactory.createdCount).isEqualTo(1)
+
+            skipItems(1)
+            timeSource += 5.seconds
+            skipItems(2)
+            voiceRecorder.stopRecord()
+            assertThat(awaitItem()).isEqualTo(
+                VoiceRecorderState.Finished(
+                    file = File(FILE_PATH),
+                    mimeType = MimeTypes.Ogg,
+                    waveform = List(100) { 1f },
+                    duration = 5.seconds,
+                )
+            )
+            // An orphaned recording job would keep emitting Recording after the stop.
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun `when cancelled, it deletes the file`() = runTest {
         val voiceRecorder = createDefaultVoiceRecorder()
         voiceRecorder.state.test {
@@ -128,9 +157,7 @@ class DefaultVoiceRecorderTest {
         return DefaultVoiceRecorder(
             dispatchers = testCoroutineDispatchers(),
             timeSource = timeSource,
-            audioReaderFactory = FakeAudioReaderFactory(
-                audio = AUDIO,
-            ),
+            audioReaderFactory = audioReaderFactory,
             encoder = FakeEncoder(fakeFileSystem),
             config = AudioConfig(
                 format = audioFormat,

--- a/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorderTest.kt
+++ b/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorderTest.kt
@@ -116,7 +116,6 @@ class DefaultVoiceRecorderTest {
         voiceRecorder.state.test {
             assertThat(awaitItem()).isEqualTo(VoiceRecorderState.Idle)
 
-            // Two taps landing before the state has flipped away from Idle.
             voiceRecorder.startRecord()
             voiceRecorder.startRecord()
             assertThat(audioReaderFactory.createdCount).isEqualTo(1)
@@ -133,7 +132,6 @@ class DefaultVoiceRecorderTest {
                     duration = 5.seconds,
                 )
             )
-            // An orphaned recording job would keep emitting Recording after the stop.
             expectNoEvents()
         }
     }

--- a/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/test/FakeAudioReaderFactory.kt
+++ b/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/test/FakeAudioReaderFactory.kt
@@ -16,7 +16,6 @@ import io.element.android.libraries.voicerecorder.impl.audio.AudioReader
 class FakeAudioReaderFactory(
     private val audio: List<Audio>
 ) : AudioReader.Factory {
-    /** Number of readers created so far, to assert that a second recording is never started. */
     var createdCount: Int = 0
         private set
 

--- a/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/test/FakeAudioReaderFactory.kt
+++ b/libraries/voicerecorder/impl/src/test/kotlin/io/element/android/libraries/voicerecorder/test/FakeAudioReaderFactory.kt
@@ -16,7 +16,12 @@ import io.element.android.libraries.voicerecorder.impl.audio.AudioReader
 class FakeAudioReaderFactory(
     private val audio: List<Audio>
 ) : AudioReader.Factory {
+    /** Number of readers created so far, to assert that a second recording is never started. */
+    var createdCount: Int = 0
+        private set
+
     override fun create(config: AudioConfig, dispatchers: CoroutineDispatchers): AudioReader {
+        createdCount++
         return FakeAudioReader(dispatchers, audio)
     }
 }


### PR DESCRIPTION
## Content

The composer emits Start whenever the voice message state is Idle, and the state only leaves Idle
once the recorder has produced its first audio buffer. A second tap inside that window started a
second recording, which overwrote the output file, re-initialised the encoder while the first one was
still encoding, and orphaned the first job together with its `AudioReader`.

The orphan kept the microphone open and kept emitting Recording for the rest of the session, so Stop
and Delete appeared to do nothing until the room was left and re-entered, and re-initialising the
encoder under an active encode could crash natively.

`DefaultVoiceRecorder.startRecord` now runs under the mutex it already owns and returns early when a
recording job exists, so the second start is a no-op: no file, no encoder re-init, no second
`AudioReader`. This is not a UX change; the button behaves as it always did.

## Motivation and context

A recording that cannot be stopped holds the microphone for the rest of the session, which
is worse than the visible symptom.

Fixes #5780

## Tests

- `DefaultVoiceRecorderTest` — new `when startRecord is called twice, the second call is ignored`
  calls start twice before the state has left Idle, asserts only one `AudioReader` was ever created,
  then stops and asserts the state settles on Finished with no further emission. An orphaned job fails
  the last assertion. This test fails without the guard.
- `FakeAudioReaderFactory` gained a `createdCount` so the first assertion is possible.
- The native crash path is not covered; no test can re-initialise the real encoder.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
