### PR TITLE
Do not notify about a redaction whose target event is unknown

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -284,10 +284,6 @@ class DefaultNotifiableEventResolver(
                 // Note: this case will be handled below
                 val redactedEventId = content.redactedEventId
                 if (redactedEventId == null) {
-                    // Treat it as filtered out rather than as an error: an unknown error is turned
-                    // into a visible "you have N notifications" fallback plus a battery banner, so a
-                    // redaction we cannot map would notify about a message that was just deleted.
-                    // See https://github.com/element-hq/element-x-android/issues/5766
                     Timber.tag(loggerTag.value).w("Ignoring redaction notification with no redactedEventId.")
                     throw NotificationResolverException.EventFilteredOut
                 } else {

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolver.kt
@@ -284,8 +284,12 @@ class DefaultNotifiableEventResolver(
                 // Note: this case will be handled below
                 val redactedEventId = content.redactedEventId
                 if (redactedEventId == null) {
-                    Timber.tag(loggerTag.value).d("redactedEventId is null.")
-                    throw NotificationResolverException.UnknownError("redactedEventId is null")
+                    // Treat it as filtered out rather than as an error: an unknown error is turned
+                    // into a visible "you have N notifications" fallback plus a battery banner, so a
+                    // redaction we cannot map would notify about a message that was just deleted.
+                    // See https://github.com/element-hq/element-x-android/issues/5766
+                    Timber.tag(loggerTag.value).w("Ignoring redaction notification with no redactedEventId.")
+                    throw NotificationResolverException.EventFilteredOut
                 } else {
                     ResolvedPushEvent.Redaction(
                         sessionId = userId,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -818,7 +818,7 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
     }
 
     @Test
-    fun `resolve RoomRedaction with null redactedEventId should return null`() = runTest {
+    fun `resolve RoomRedaction with null redactedEventId is filtered out`() = runTest {
         val sut = createDefaultNotifiableEventResolver(
             notificationResult = Result.success(
                 mapOf(
@@ -834,6 +834,9 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
         val request = aPushRequest(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID, "firebase")
         val result = sut.resolveEvents(A_SESSION_ID, listOf(request))
         assertThat(result.getEvent(request)?.getOrNull()).isNull()
+        // Must be EventFilteredOut and not an error: the result processor renders a fallback
+        // notification for any other exception, which is the bug in #5766.
+        assertThat(result.getEvent(request)?.exceptionOrNull()).isEqualTo(NotificationResolverException.EventFilteredOut)
     }
 
     @Test

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotifiableEventResolverTest.kt
@@ -834,8 +834,6 @@ class DefaultNotifiableEventResolverTest : RobolectricTest() {
         val request = aPushRequest(A_SESSION_ID, A_ROOM_ID, AN_EVENT_ID, "firebase")
         val result = sut.resolveEvents(A_SESSION_ID, listOf(request))
         assertThat(result.getEvent(request)?.getOrNull()).isNull()
-        // Must be EventFilteredOut and not an error: the result processor renders a fallback
-        // notification for any other exception, which is the bug in #5766.
         assertThat(result.getEvent(request)?.exceptionOrNull()).isEqualTo(NotificationResolverException.EventFilteredOut)
     }
 


### PR DESCRIPTION
## Content

A redaction push whose `redacts` field the SDK could not map was reported as an unknown error. The
result processor only suppresses filtered-out and redacted events; every other exception becomes a
visible "you have N notifications" fallback and also raises the battery optimisation banner.

So a deleted message could produce a notification about itself, which is the opposite of what a
redaction means, plus an unrelated banner.

The branch now throws `EventFilteredOut`, which the processor already drops silently, and logs at
warning level so the SDK gap still shows up in push history.

## Motivation and context

A redaction exists to remove content. Turning a redaction the client cannot resolve into
a visible notification is strictly worse than doing nothing.

Fixes #5766

## Tests

- `DefaultNotifiableEventResolverTest` — the null-`redactedEventId` case now asserts the thrown
  exception **is** `EventFilteredOut`. It previously only asserted the result was null, which passed
  for either exception, so it could not have caught this.
- The existing `DefaultNotificationResultProcessor` tests already cover that `EventFilteredOut` is
  dropped and that other exceptions render a fallback.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
