### PR TITLE
Never re-encode a video at a higher bitrate than the source

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
@@ -36,11 +36,6 @@ internal object VideoCompressorConfigFactory {
         // If we need to resize the video, we also want to recalculate the bitrate
         val optimalBitrate = resizer.calculateOptimalBitrate(Size(width, height), newFrameRate).toInt()
 
-        // Never ask the encoder for more than the source already carries: re-encoding a video that is
-        // already efficiently encoded at a low bitrate otherwise inflates it, making the upload both
-        // slower and bigger than sending the original. METADATA_KEY_BITRATE is the container total,
-        // video plus audio, so it is a safe upper bound for the video track alone.
-        // See https://github.com/element-hq/element-x-android/issues/4191
         val sourceBitrate = metadata?.bitrate?.takeIf { it > 0 }
         val newBitrate = sourceBitrate?.let { min(optimalBitrate.toLong(), it).toInt() } ?: optimalBitrate
 

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfig.kt
@@ -34,11 +34,19 @@ internal object VideoCompressorConfigFactory {
         val newFrameRate = min(originalFrameRate, DEFAULT_FRAME_RATE)
 
         // If we need to resize the video, we also want to recalculate the bitrate
-        val newBitrate = resizer.calculateOptimalBitrate(Size(width, height), newFrameRate)
+        val optimalBitrate = resizer.calculateOptimalBitrate(Size(width, height), newFrameRate).toInt()
+
+        // Never ask the encoder for more than the source already carries: re-encoding a video that is
+        // already efficiently encoded at a low bitrate otherwise inflates it, making the upload both
+        // slower and bigger than sending the original. METADATA_KEY_BITRATE is the container total,
+        // video plus audio, so it is a safe upper bound for the video track alone.
+        // See https://github.com/element-hq/element-x-android/issues/4191
+        val sourceBitrate = metadata?.bitrate?.takeIf { it > 0 }
+        val newBitrate = sourceBitrate?.let { min(optimalBitrate.toLong(), it).toInt() } ?: optimalBitrate
 
         return VideoCompressorConfig(
             videoCompressorHelper = resizer,
-            newBitRate = newBitrate.toInt(),
+            newBitRate = newBitrate,
             newFrameRate = newFrameRate,
         )
     }

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfigFactoryTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfigFactoryTest.kt
@@ -35,8 +35,6 @@ class VideoCompressorConfigFactoryTest : RobolectricTest() {
 
     @Test
     fun `the bitrate is clamped to the source bitrate when the source is already low`() {
-        // A 720x720 clip encoded at 615 kbps: the calculated optimal is far higher, which would
-        // re-encode it into a much bigger file.
         val metadata = VideoFileMetadata(width = 720, height = 720, bitrate = 615_000, frameRate = 25, rotation = 0)
 
         val videoCompressorConfig = VideoCompressorConfigFactory.create(

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfigFactoryTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressorConfigFactoryTest.kt
@@ -34,6 +34,48 @@ class VideoCompressorConfigFactoryTest : RobolectricTest() {
     }
 
     @Test
+    fun `the bitrate is clamped to the source bitrate when the source is already low`() {
+        // A 720x720 clip encoded at 615 kbps: the calculated optimal is far higher, which would
+        // re-encode it into a much bigger file.
+        val metadata = VideoFileMetadata(width = 720, height = 720, bitrate = 615_000, frameRate = 25, rotation = 0)
+
+        val videoCompressorConfig = VideoCompressorConfigFactory.create(
+            metadata = metadata,
+            preset = VideoCompressionPreset.STANDARD,
+        )
+
+        assertThat(videoCompressorConfig.newBitRate).isEqualTo(615_000)
+    }
+
+    @Test
+    fun `the bitrate is not raised for a high bitrate source`() {
+        val metadata = VideoFileMetadata(width = 1920, height = 1080, bitrate = 20_000_000, frameRate = 30, rotation = 0)
+
+        val videoCompressorConfig = VideoCompressorConfigFactory.create(
+            metadata = metadata,
+            preset = VideoCompressionPreset.STANDARD,
+        )
+
+        assertThat(videoCompressorConfig.newBitRate).isLessThan(20_000_000)
+        assertThat(videoCompressorConfig.newBitRate).isGreaterThan(0)
+    }
+
+    @Test
+    fun `an unknown bitrate falls back to the calculated optimal`() {
+        val unknown = VideoCompressorConfigFactory.create(
+            metadata = VideoFileMetadata(width = 1280, height = 720, bitrate = -1, frameRate = 30, rotation = 0),
+            preset = VideoCompressionPreset.STANDARD,
+        )
+        val zero = VideoCompressorConfigFactory.create(
+            metadata = VideoFileMetadata(width = 1280, height = 720, bitrate = 0, frameRate = 30, rotation = 0),
+            preset = VideoCompressionPreset.STANDARD,
+        )
+
+        assertThat(unknown.newBitRate).isGreaterThan(0)
+        assertThat(zero.newBitRate).isEqualTo(unknown.newBitRate)
+    }
+
+    @Test
     fun `if the video should be compressed and is larger than 720p it will be resized`() {
         // Given
         val metadata = VideoFileMetadata(width = 1920, height = 1080, bitrate = 1_000_000, frameRate = 50, rotation = 0)


### PR DESCRIPTION
## Content

The compression config computed a target bitrate purely from the output resolution and frame rate,
ignoring the bitrate already extracted from the source. A clip that is small because it was
efficiently encoded, rather than because it is short, was therefore re-encoded upwards: the upload
got slower and the resulting file was larger than the original.

The target is now clamped to the source bitrate when that is known. `METADATA_KEY_BITRATE` is the
container total, video plus audio, so it is a safe upper bound for the video track alone. An unknown
or zero bitrate still falls back to the calculated value, and a high-bitrate source is still
compressed exactly as before.

## Motivation and context

Compression that makes the file bigger is worse than no compression, and the user waits
longer for it.

Fixes #4191

## Tests

- `VideoCompressorConfigFactoryTest` — new case for the reported shape, a 720x720 clip at 615 kbps,
  asserting the target is the source bitrate rather than the much higher calculated optimum.
- New case asserting a high-bitrate 1080p source is still compressed downwards.
- New case asserting an unknown (-1) and a zero bitrate both fall back to the calculated value, so a
  bogus metadata read cannot produce a zero-bitrate encode.
- The four existing resize tests are unchanged.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
