### PR TITLE
Do not offer to start a call in a DM with no other member

### DIFF
--- a/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
+++ b/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
@@ -60,10 +60,18 @@ class RoomCallStatePresenter(
                         isUserLocallyInTheCall = isUserLocallyInTheCall,
                         isAudioCall = roomInfo.activeCallIntentConsensus.isAudio(),
                     )
-                    else -> RoomCallState.StandBy(
-                        canStartCall = canJoinCall,
-                        isDM = roomInfo.isDm
-                    )
+                    else -> {
+                        // Nobody would ever join a call started in a DM whose other member has left,
+                        // and the call screen has no way out of that state.
+                        // activeMembersCount counts joined and invited members, so a DM whose peer
+                        // has been invited but has not joined yet can still start a call.
+                        // See https://github.com/element-hq/element-x-android/issues/6189
+                        val isEmptyDm = roomInfo.isDm && roomInfo.activeMembersCount <= 1
+                        RoomCallState.StandBy(
+                            canStartCall = canJoinCall && !isEmptyDm,
+                            isDM = roomInfo.isDm
+                        )
+                    }
                 }
             }
         }

--- a/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
+++ b/features/roomcall/impl/src/main/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenter.kt
@@ -61,11 +61,6 @@ class RoomCallStatePresenter(
                         isAudioCall = roomInfo.activeCallIntentConsensus.isAudio(),
                     )
                     else -> {
-                        // Nobody would ever join a call started in a DM whose other member has left,
-                        // and the call screen has no way out of that state.
-                        // activeMembersCount counts joined and invited members, so a DM whose peer
-                        // has been invited but has not joined yet can still start a call.
-                        // See https://github.com/element-hq/element-x-android/issues/6189
                         val isEmptyDm = roomInfo.isDm && roomInfo.activeMembersCount <= 1
                         RoomCallState.StandBy(
                             canStartCall = canJoinCall && !isEmptyDm,

--- a/features/roomcall/impl/src/test/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenterTest.kt
+++ b/features/roomcall/impl/src/test/kotlin/io/element/android/features/roomcall/impl/RoomCallStatePresenterTest.kt
@@ -50,6 +50,42 @@ class RoomCallStatePresenterTest {
     }
 
     @Test
+    fun `present - a DM with no other member cannot start a call`() = runTest {
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                initialRoomInfo = aRoomInfo(isDm = true, activeMembersCount = 1, joinedMembersCount = 1),
+                roomPermissions = roomPermissions(true),
+            )
+        )
+        val presenter = createRoomCallStatePresenter(joinedRoom = room)
+        presenter.test {
+            skipItems(1)
+            assertThat(awaitItem()).isEqualTo(
+                RoomCallState.StandBy(
+                    canStartCall = false,
+                    isDM = true
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `present - a DM becomes callable once the other member is active`() = runTest {
+        val baseRoom = FakeBaseRoom(
+            initialRoomInfo = aRoomInfo(isDm = true, activeMembersCount = 1, joinedMembersCount = 1),
+            roomPermissions = roomPermissions(true),
+        )
+        val room = FakeJoinedRoom(baseRoom = baseRoom)
+        val presenter = createRoomCallStatePresenter(joinedRoom = room)
+        presenter.test {
+            skipItems(1)
+            assertThat(awaitItem()).isEqualTo(RoomCallState.StandBy(canStartCall = false, isDM = true))
+            baseRoom.givenRoomInfo(aRoomInfo(isDm = true, activeMembersCount = 2, joinedMembersCount = 2))
+            assertThat(awaitItem()).isEqualTo(RoomCallState.StandBy(canStartCall = true, isDM = true))
+        }
+    }
+
+    @Test
     fun `present - element call not available`() = runTest {
         val room = FakeJoinedRoom(
             baseRoom = FakeBaseRoom(


### PR DESCRIPTION
## Content

A DM whose other member has left still offered the call button. Starting that call put the user
alone in a room nobody could join, with no way out of the call screen.

The presenter now clears `canStartCall` for a DM with no other active member. `activeMembersCount`
counts joined and invited members, so a fresh DM whose peer has been invited but has not joined yet
can still start a call. Joining an already ongoing call is untouched, so a call started before the
other member left stays reachable.

## Motivation and context

There is nobody to call, and the call screen offers no way back once it is entered.

Fixes #6189

## Tests

- `RoomCallStatePresenterTest` — new case asserting a DM with one active member yields
  `StandBy(canStartCall = false)`.
- New reactive case: the same room becomes callable as soon as the member count rises, which proves
  the guard follows room info rather than being computed once.
- The existing DM and permission cases are unchanged and still assert `canStartCall = true`, since
  the fixture defaults to two active members.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
