### PR TITLE
Do not fail the screenshot recording job when there is nothing to commit

### DIFF
--- a/.github/workflows/scripts/recordScreenshots.sh
+++ b/.github/workflows/scripts/recordScreenshots.sh
@@ -78,6 +78,10 @@ else
   git config --local user.name "${INPUT_AUTHOR_EMAIL}"
 fi
 git add -A
+if git diff --cached --quiet; then
+  echo "Screenshots are already up to date, nothing to commit."
+  exit 0
+fi
 git commit -m "Update screenshots"
 
 GITHUB_REPO="https://$GITHUB_ACTOR:$TOKEN@github.com/$REPO.git"


### PR DESCRIPTION
## Content

`recordScreenshots.sh` runs under `set -e` and ends with an unconditional
`git commit -m "Update screenshots"`. When a recording run produces no diff — the common case once
the snapshots are already up to date — `git commit` exits 1 with "nothing to commit, working tree
clean" and takes the whole workflow down with it, reporting a red job for a successful run.

This stages as before, then returns early when the staged diff is empty. `set -e` is left in place:
it was added deliberately so a failed Gradle run cannot push a commit that deletes every snapshot.
Using `git diff --cached --quiet` as an `if` condition is `set -e`-safe, because its non-zero "there
are changes" status is consumed by the condition. The early return also skips the push, which had
nothing to send.

The unrelated `user.name`/`user.email` mix-up a few lines above is left alone to keep this
single-purpose.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/822

## Tests

- Exercised the commit tail of the script in a scratch repository, against a clean tree and a dirty
  one: the current script exits 1 on a clean tree, the patched one prints "Screenshots are already up
  to date, nothing to commit." and exits 0, and a dirty tree still produces the "Update screenshots"
  commit and reaches the push.
- These do not prove the workflow itself: `recordScreenshots.yml` is `workflow_dispatch`/label gated
  and needs a repository secret, so it cannot run on a fork pull request.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s): n/a, CI script only

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR


