### PR TITLE
Do not linkify the server part of a fediverse handle as an email address

### DIFF
--- a/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
+++ b/libraries/androidutils/src/main/kotlin/io/element/android/libraries/androidutils/text/LinkifyHelper.kt
@@ -47,6 +47,11 @@ object LinkifyHelper {
                 val start = spannable.getSpanStart(urlSpan)
                 val end = spannable.getSpanEnd(urlSpan)
 
+                if (urlSpan !in oldURLSpans && spannable.isEmailInsideFediverseHandle(urlSpan, start)) {
+                    spannable.removeSpan(urlSpan)
+                    continue
+                }
+
                 // Try to avoid including trailing punctuation in the link.
                 // Since this might fail in some edge cases, we catch the exception and just use the original end index.
                 val newEnd = runCatchingExceptions {
@@ -80,6 +85,10 @@ object LinkifyHelper {
             spannable.setSpan(urlSpan, start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
         return spannable
+    }
+
+    private fun Spannable.isEmailInsideFediverseHandle(urlSpan: URLSpan, start: Int): Boolean {
+        return urlSpan.url.startsWith("mailto:") && start > 0 && this[start - 1] == '@'
     }
 
     private fun adjustLinkifiedUrlSpanEndIndex(spannable: Spannable, start: Int, end: Int): Int {

--- a/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
+++ b/libraries/androidutils/src/test/kotlin/io/element/android/libraries/androidutils/text/LinkifierHelperTest.kt
@@ -88,6 +88,45 @@ class LinkifierHelperTest : RobolectricTest() {
     }
 
     @Test
+    fun `linkification ignores fediverse handle`() {
+        val text = "Follow me at @name@server.tld"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans).isEmpty()
+    }
+
+    @Test
+    fun `linkification ignores fediverse handle at the start of the text`() {
+        val text = "@name@server.tld posted this"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans).isEmpty()
+    }
+
+    @Test
+    fun `linkification finds email next to a fediverse handle`() {
+        val text = "@name@server.tld and john@doe.com"
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("mailto:john@doe.com")
+    }
+
+    @Test
+    fun `linkification keeps an existing mailto span preceded by an at sign`() {
+        val text = buildSpannedString {
+            append("Mail me @")
+            inSpans(URLSpan("mailto:john@doe.com")) {
+                append("john@doe.com")
+            }
+        }
+        val result = LinkifyHelper.linkify(text)
+        val urlSpans = result.toSpannable().getSpans<URLSpan>()
+        assertThat(urlSpans.size).isEqualTo(1)
+        assertThat(urlSpans.first().url).isEqualTo("mailto:john@doe.com")
+    }
+
+    @Test
     fun `linkification handles trailing dot`() {
         val text = "A url https://matrix.org."
         val result = LinkifyHelper.linkify(text)


### PR DESCRIPTION
## Content

A fediverse handle such as `@name@server.tld` contains a substring that `Linkify.EMAIL_ADDRESSES`
recognises as a valid address, so the timeline renders `name@server.tld` as a tappable `mailto:`
link. Tapping it opens a mail composer addressed to an account that does not accept mail.

This drops a newly added `mailto:` span when the character immediately before it is `@`. It mirrors
what Android already does for web URLs, where `Linkify.sUrlMatchFilter` rejects a match preceded by
`@` — which is why the handle currently produces exactly one stray mailto span and no partial link is
left behind once it is removed.

Author-supplied links are unaffected: spans that were already present before linkification are
excluded from the check and restored as before. One deliberate trade-off: a genuine address written
directly after an `@` — "mail me @support@element.io" — is no longer linkified, which is the same
trade-off Android already makes for web URLs.

The issue also asks for a tap on the handle to offer a share or fediverse-app intent. That is a
separate, undesigned change and is not part of this.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/4008

## Tests

- `libraries/androidutils/src/test/.../text/LinkifierHelperTest.kt` — a handle mid-sentence and a
  handle at the start of the message both produce no spans; a handle next to a real address leaves
  exactly the `mailto:john@doe.com` span; an author-supplied `mailto:` span sitting after an `@` is
  preserved. The existing `linkification finds email` case stays green as the regression guard.
- These cover the span layer only. They do not prove the rendered timeline, which is not
  snapshot-testable here.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR


