### PR TITLE
Render heading tags as their own paragraph instead of dropping them

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -67,8 +67,23 @@ private fun fixMentions(
 private object CustomHtmlToDomParser {
     fun document(html: String): Document {
         val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
-        val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)
+        val cleanHtml = Jsoup.clean(html.withHeadingsAsBoldParagraphs(), "", safeList, outputSettings)
         return Jsoup.parse(cleanHtml)
+    }
+
+    private fun String.withHeadingsAsBoldParagraphs(): String {
+        val document = Jsoup.parseBodyFragment(this)
+        val headings = document.select("h1, h2, h3, h4, h5, h6")
+        if (headings.isEmpty()) return this
+        for (heading in headings) {
+            val bold = document.createElement("b")
+            for (child in heading.childNodes().toList()) {
+                bold.appendChild(child)
+            }
+            heading.appendChild(bold)
+            heading.tagName("p")
+        }
+        return document.body().html()
     }
 
     private val safeList = Safelist()

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
@@ -45,6 +45,34 @@ class ToHtmlDocumentTest : RobolectricTest() {
     }
 
     @Test
+    fun `toHtmlDocument - renders heading tags as bold paragraphs`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<h4>Title</h4>submitted by someone"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+
+        assertThat(document?.select("h1, h2, h3, h4, h5, h6")).isEmpty()
+        assertThat(document?.body()?.html()).contains("<p><b>Title</b></p>")
+        assertThat(document?.text()).isEqualTo("Title submitted by someone")
+    }
+
+    @Test
+    fun `toHtmlDocument - keeps the text of every heading level`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4><h5>Five</h5><h6>Six</h6>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+
+        assertThat(document?.select("h1, h2, h3, h4, h5, h6")).isEmpty()
+        assertThat(document?.select("p")).hasSize(6)
+        assertThat(document?.text()).isEqualTo("One Two Three Four Five Six")
+    }
+
+    @Test
     fun `toHtmlDocument - returns a Document with a prefix if provided`() {
         val body = FormattedBody(
             format = MessageFormat.HTML,

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
@@ -39,6 +39,16 @@ class ToPlainTextTest : RobolectricTest() {
     }
 
     @Test
+    fun `FormattedBody toPlainText - keeps a heading on a single preview line`() {
+        val formattedBody = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<h2>Header</h2>body"
+        )
+
+        assertThat(formattedBody.toPlainText(permalinkParser = FakePermalinkParser())).isEqualTo("Header body")
+    }
+
+    @Test
     fun `FormattedBody toPlainText - returns a plain text version of the HTML body`() {
         val formattedBody = FormattedBody(
             format = MessageFormat.HTML,


### PR DESCRIPTION
## Content

The safelist used to sanitise a formatted body allows no heading tag, so jsoup unwraps `<h1>`–`<h6>`
and their text is merged into whatever follows. A bridged message such as
`<h4>Title</h4>submitted by someone` renders as one run of text with no break, which is how the
reported Reddit and RSS bridge messages arrive.

This rewrites every heading into a `<p>` wrapping a `<b>` before sanitising, so the heading keeps its
own block and reads as emphasised. Adding the tags to the safelist instead would lose the text
outright: the span parser has no branch for a heading, and its default branch returns without
visiting the children. The rewrite is skipped entirely when a body contains no heading, so every
other message goes through the untouched path.

Two deliberate limits. Headings are approximated as bold body text rather than scaled type, because
the timeline has no heading typography to map onto. And `<div>` is left alone — it is a separate
spacing question and would widen the change.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/2870

## Tests

- `libraries/matrixui/src/test/.../messages/ToHtmlDocumentTest.kt` — the reported
  `<h4>Title</h4>submitted by someone` case now yields `<p><b>Title</b></p>` with no heading tag left
  in the document and the text intact; a second case walks `<h1>` through `<h6>` and asserts six
  paragraphs and no lost text, which is the guard against the parse-children trap described above.
- `libraries/matrixui/src/test/.../messages/ToPlainTextTest.kt` — pins that the plain-text form used
  for room-list previews and copy stays on one line.
- These assert the document the renderer is handed. The rendered spans themselves are not covered:
  `TimelineItemTextView` opts out of UI tests because of its View/Compose interop.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR


