### PR TITLE
Keep playing a voice message when the screen turns off

### DIFF
--- a/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
+++ b/libraries/mediaplayer/impl/src/main/kotlin/io/element/android/libraries/mediaplayer/impl/SimplePlayer.kt
@@ -9,6 +9,7 @@
 package io.element.android.libraries.mediaplayer.impl
 
 import android.content.Context
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -49,7 +50,7 @@ object SimplePlayerModule {
     @Provides
     fun simplePlayerProvider(
         @ApplicationContext context: Context,
-    ): SimplePlayer = DefaultSimplePlayer(ExoPlayer.Builder(context).build())
+    ): SimplePlayer = DefaultSimplePlayer(ExoPlayer.Builder(context).setWakeMode(C.WAKE_MODE_LOCAL).build())
 }
 
 /**


### PR DESCRIPTION
## Content

Voice message playback stopped a few seconds after the screen turned off. The `ExoPlayer` backing
voice messages was built without a wake mode, so it defaulted to `C.WAKE_MODE_NONE` and held no wake
lock, and the CPU was free to suspend mid-message.

It is now built with `C.WAKE_MODE_LOCAL`, so a partial wake lock is held for the duration of playback
and released as soon as playback stops. The media is read from a local file, so no `WifiLock` is
needed. `android.permission.WAKE_LOCK` is already part of the merged manifest, declared both by the
`media3-exoplayer` artifact and by `features/call/impl`, so there is no manifest change.

The media viewer's audio and video players are deliberately left alone. Both already pause on
`Lifecycle.Event.ON_PAUSE`, and the video player additionally holds `KeepScreenOn` while playing, so
a wake lock there would keep the CPU awake for a player the user has intentionally backgrounded.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/7046

## Tests

- Set the device screen timeout to its shortest value, play a voice message longer than that timeout,
  and let the screen turn off: the audio now plays to the end.
- No unit test accompanies this. `ExoPlayer` exposes `setWakeMode` but no getter, the DI provider
  returns the `SimplePlayer` interface which has no wake-mode member, and media3 only acquires the
  lock once real playback starts, so nothing observable can be asserted without a device.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
