### PR TITLE
Do not draw the media loading progress bar under the status bar

### DIFF
--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -414,6 +414,7 @@ private fun MediaViewerPage(
             if (showProgress) {
                 LinearProgressIndicator(
                     modifier = Modifier
+                        .padding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top).asPaddingValues())
                         .fillMaxWidth()
                         .height(2.dp)
                 )


### PR DESCRIPTION
## Content

The media viewer is drawn edge to edge, and the linear progress indicator shown while a media item
downloads was the top-most child of a container that only applied navigation bar padding. It was laid
out at y=0, so it rendered behind the status bar and, on a device with a camera cutout, partly behind
the notch.

It now carries `WindowInsets.safeDrawing` horizontal and top padding, reusing the same idiom already
used by `MediaViewerBottomBar` in this file.

The top inset deliberately comes from `safeDrawing` rather than from the scaffold content padding:
the top app bar lives inside an `AnimatedVisibility`, so that padding collapses to zero whenever the
user taps to hide the overlay, which would put the bar back under the cutout.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/3493

The issue also asks for a real 0-100% download progress bar. That still needs download progress to be
exposed by the SDK, as the existing note in `rememberShowProgress` explains, so it is not addressed
here.

## Tests

- Open an image or video that is not yet cached and check the loading bar is drawn below the status
  bar, including on a device with a display cutout and in landscape.
- Tap the media to toggle the overlay and check the bar does not move.
- No unit test accompanies this. Paparazzi supplies zero window insets, so a snapshot assertion would
  compare identical output before and after and prove nothing.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
