### PR TITLE
Use a dedicated string for the Mute room notification mode

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsItem.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsItem.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import io.element.android.features.roomdetails.impl.R
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
-import io.element.android.libraries.ui.strings.CommonStrings
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -36,7 +35,7 @@ fun roomNotificationSettingsItems(): ImmutableList<RoomNotificationSettingsItem>
                 )
                 RoomNotificationMode.MUTE -> RoomNotificationSettingsItem(
                     mode = it,
-                    title = stringResource(CommonStrings.common_mute),
+                    title = stringResource(R.string.screen_room_notification_settings_mode_mute),
                 )
             }
         }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/notificationsettings/RoomNotificationSettingsView.kt
@@ -34,7 +34,6 @@ import io.element.android.libraries.designsystem.text.buildAnnotatedStringWithSt
 import io.element.android.libraries.designsystem.theme.components.Scaffold
 import io.element.android.libraries.designsystem.theme.components.TopAppBar
 import io.element.android.libraries.matrix.api.room.RoomNotificationMode
-import io.element.android.libraries.ui.strings.CommonStrings
 
 @Composable
 fun RoomNotificationSettingsView(
@@ -118,7 +117,7 @@ private fun RoomSpecificNotificationSettingsView(
                             RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY -> {
                                 stringResource(id = R.string.screen_room_notification_settings_mode_mentions_and_keywords)
                             }
-                            RoomNotificationMode.MUTE -> stringResource(id = CommonStrings.common_mute)
+                            RoomNotificationMode.MUTE -> stringResource(id = R.string.screen_room_notification_settings_mode_mute)
                         }
                         val displayMentionsOnlyDisclaimer = state.displayMentionsOnlyDisclaimer &&
                             state.defaultRoomNotificationMode == RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY

--- a/features/roomdetails/impl/src/main/res/values/temporary.xml
+++ b/features/roomdetails/impl/src/main/res/values/temporary.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 Element Creations Ltd.
+  ~
+  ~ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  ~ Please see LICENSE files in the repository root for full details.
+  -->
+
+<resources>
+    <string name="screen_room_notification_settings_mode_mute">Mute</string>
+</resources>


### PR DESCRIPTION
## Content

The room notification settings screen offers three mutually exclusive modes. Two of them already had
screen-scoped string keys, but the third reused the shared `common_mute`, which also labels the Mute
action button on the room details screen. A translator could not fix one occurrence without breaking
the other, and in French the option reads as a verb phrase where the list needs a noun phrase.

This adds `screen_room_notification_settings_mode_mute` and uses it at both places on that screen: the
option list and the read-only default-setting row. The English value is unchanged, so nothing renders
differently and no screenshot needs re-recording.

The Mute action button on the room details screen keeps `common_mute`, which is the one context where
the generic verb is correct.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/2925

The issue also asks for translator context to be added on Localazy for the four strings of this screen,
and suggests the English wording of this option could be reconsidered now that it has its own key. Both
are core-team actions that cannot be done from a fork.

## Tests

- The English value is identical, so the existing screenshot tests for the room notification settings
  screen and the existing presenter tests all pass unchanged, which is what proves the rendering did not
  move.
- No test asserts on the old key for this screen.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
