### PR TITLE
Hide legacy Jitsi call membership events from the timeline

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/TimelineConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/TimelineConfig.kt
@@ -13,11 +13,14 @@ import io.element.android.libraries.matrix.api.room.StateEventType
 object TimelineConfig {
     const val MAX_READ_RECEIPT_TO_DISPLAY = 3
 
+    private const val JITSI_CALL_MEMBER_EVENT_TYPE = "io.element.video.member"
+
     /**
      * Event types that will be filtered out from the timeline (i.e. not displayed).
      */
     val excludedEvents = listOf(
         StateEventType.CallMember,
+        StateEventType.Custom(JITSI_CALL_MEMBER_EVENT_TYPE),
         StateEventType.RoomCanonicalAlias,
         StateEventType.RoomGuestAccess,
         StateEventType.RoomHistoryVisibility,


### PR DESCRIPTION
## Content

Timelines for rooms that have been used with the older Jitsi-based video rooms show one
`Custom event io.element.video.member` row per participant joining or leaving. That event type is the
predecessor of `m.call.member`, which is already excluded from the timeline; because the newer type is
unknown to the app, the formatter falls through to its custom-state branch and renders the raw developer
string.

This adds the legacy type to the timeline's excluded events so it is filtered out by the SDK-level
timeline filter, exactly as the modern one already is. The room list preview was already unaffected,
since that rendering mode returns nothing for custom state events.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/1933

The original report was addressed for `m.call.member`; this covers the remaining legacy type reported
in the follow-up comment. The broader discussion in that issue, about deriving the call tile from call
membership rather than notify events, is not addressed here.

## Tests

- In a room carrying these events, the timeline no longer shows `Custom event io.element.video.member`
  rows.
- No unit test accompanies this. The value crosses the SDK boundary through
  `stateEventTypeFromString`, which is not available in JVM unit tests — the existing
  `StateEventTypeTest` already documents that limitation for custom state event types, and no other
  entry in this list is covered either.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
