### PR TITLE
Hide space children you have left that can only be joined by invitation

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpacePresenter.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/root/SpacePresenter.kt
@@ -35,6 +35,7 @@ import io.element.android.libraries.matrix.api.core.toRoomIdOrAlias
 import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.join.JoinRoom
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.powerlevels.permissionsAsState
 import io.element.android.libraries.matrix.api.spaces.SpaceRoom
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
@@ -117,12 +118,14 @@ class SpacePresenter(
 
         val filteredChildren by remember {
             derivedStateOf {
-                val notRemoved = children.filterNot { it.roomId in removedRoomIds }
+                val visibleChildren = children
+                    .filterNot { it.roomId in removedRoomIds }
+                    .filterNot { it.cannotBeRejoined() }
                 if (isManageMode) {
                     // In manage mode, only show rooms (not spaces)
-                    notRemoved.filter { !it.isSpace }.toImmutableList()
+                    visibleChildren.filter { !it.isSpace }.toImmutableList()
                 } else {
-                    notRemoved.toImmutableList()
+                    visibleChildren.toImmutableList()
                 }
             }
         }
@@ -253,4 +256,8 @@ class SpacePresenter(
             setJoinActions(joinActions + mapOf(spaceRoom.roomId to AsyncAction.Failure(it)))
         }
     }
+}
+
+private fun SpaceRoom.cannotBeRejoined(): Boolean {
+    return state == CurrentUserMembership.LEFT && joinRule == JoinRule.Invite
 }

--- a/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/root/SpacePresenterTest.kt
+++ b/features/space/impl/src/test/kotlin/io/element/android/features/space/impl/root/SpacePresenterTest.kt
@@ -30,11 +30,13 @@ import io.element.android.libraries.matrix.api.room.BaseRoom
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.RoomType
 import io.element.android.libraries.matrix.api.room.join.JoinRoom
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.spaces.SpaceRoomList
 import io.element.android.libraries.matrix.test.AN_EXCEPTION
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID_2
 import io.element.android.libraries.matrix.test.A_ROOM_ID_3
+import io.element.android.libraries.matrix.test.A_ROOM_ID_4
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
 import io.element.android.libraries.matrix.test.room.join.FakeJoinRoom
@@ -534,6 +536,78 @@ class SpacePresenterTest {
             assertThat(manageModeState.children).hasSize(1)
             assertThat(manageModeState.children.first().roomId).isEqualTo(A_ROOM_ID)
             assertThat(manageModeState.children.first().isSpace).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - left children which can only be joined by invitation are filtered out`() = runTest {
+        val leftInviteOnlyRoom = aSpaceRoom(
+            roomId = A_ROOM_ID,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.LEFT,
+            joinRule = JoinRule.Invite,
+        )
+        val leftPublicRoom = aSpaceRoom(
+            roomId = A_ROOM_ID_2,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.LEFT,
+            joinRule = JoinRule.Public,
+        )
+        val leftKnockRoom = aSpaceRoom(
+            roomId = A_ROOM_ID_3,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.LEFT,
+            joinRule = JoinRule.Knock,
+        )
+        val leftRoomWithUnknownJoinRule = aSpaceRoom(
+            roomId = A_ROOM_ID_4,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.LEFT,
+            joinRule = null,
+        )
+        val fakeSpaceRoomList = FakeSpaceRoomList(
+            initialSpaceRoomsValue = listOf(leftInviteOnlyRoom, leftPublicRoom, leftKnockRoom, leftRoomWithUnknownJoinRule),
+            paginateResult = { Result.success(Unit) },
+        )
+        val presenter = createSpacePresenter(spaceRoomList = fakeSpaceRoomList)
+        presenter.test {
+            awaitItem()
+            advanceUntilIdle()
+            val stateWithChildren = expectMostRecentItem()
+            assertThat(stateWithChildren.children).containsExactly(leftPublicRoom, leftKnockRoom, leftRoomWithUnknownJoinRule)
+        }
+    }
+
+    @Test
+    fun `present - children which can only be joined by invitation are kept when not left`() = runTest {
+        val joinedRoom = aSpaceRoom(
+            roomId = A_ROOM_ID,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.JOINED,
+            joinRule = JoinRule.Invite,
+        )
+        val invitedRoom = aSpaceRoom(
+            roomId = A_ROOM_ID_2,
+            roomType = RoomType.Room,
+            state = CurrentUserMembership.INVITED,
+            joinRule = JoinRule.Invite,
+        )
+        val roomWithUnknownMembership = aSpaceRoom(
+            roomId = A_ROOM_ID_3,
+            roomType = RoomType.Room,
+            state = null,
+            joinRule = JoinRule.Invite,
+        )
+        val fakeSpaceRoomList = FakeSpaceRoomList(
+            initialSpaceRoomsValue = listOf(joinedRoom, invitedRoom, roomWithUnknownMembership),
+            paginateResult = { Result.success(Unit) },
+        )
+        val presenter = createSpacePresenter(spaceRoomList = fakeSpaceRoomList)
+        presenter.test {
+            awaitItem()
+            advanceUntilIdle()
+            val stateWithChildren = expectMostRecentItem()
+            assertThat(stateWithChildren.children).containsExactly(joinedRoom, invitedRoom, roomWithUnknownMembership)
         }
     }
 


### PR DESCRIPTION
## Content

After leaving a room listed in a space, the room stayed in the space's child list and was rendered with
a Join button, even though it can only be entered with a new invitation. Leaving the space and coming
back made it disappear, because the server omits it from the refetched hierarchy.

The presenter now applies the same rule locally: a child the current user has left and whose join rule
is `invite` is dropped from the list straight away.

The filter is deliberately narrow. It keys on the membership being `LEFT` combined with an `invite`
join rule, not on the derived visibility — that would collapse `knock` and unknown join rules into
"private" and would wrongly remove the Join button from knockable rooms and from any child whose join
rule the SDK did not populate. Public, knock, restricted and unknown join rules keep their Join button,
and joined or invited rooms are unaffected.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/6130

## Tests

- `features/space/impl/src/test/.../root/SpacePresenterTest.kt` — left children with `invite`, `public`,
  `knock` and absent join rules are emitted, and only the `invite` one is filtered out; a second case
  pins that `invite` children which are joined, invited or of unknown membership are all kept.
- The existing presenter and view tests are unchanged, and the space view snapshots are driven by the
  state provider rather than the presenter, so none are affected.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
