### PR TITLE
Stop repeating messages that are already shown in a room notification

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -196,11 +196,12 @@ class DefaultNotificationCreator(
             isThread = threadId != null,
             roomIsGroup = !roomInfo.isDm,
         )
-        messagingStyle.addMessagesFromEvents(events, imageLoader)
+        val newEvents = messagingStyle.filterOutAlreadyDisplayedEvents(events)
+        messagingStyle.addMessagesFromEvents(newEvents, imageLoader)
         return builder
             .setCategory(category)
             .setNumber(events.size)
-            .setOnlyAlertOnce(roomInfo.isUpdated)
+            .setOnlyAlertOnce(roomInfo.isUpdated || newEvents.isEmpty())
             .setWhen(lastMessageTimestamp)
             // MESSAGING_STYLE sets title and content for API 16 and above devices.
             .setStyle(messagingStyle)
@@ -414,6 +415,15 @@ class DefaultNotificationCreator(
             .setAutoCancel(true)
             .setContentIntent(pendingIntentFactory.createOpenSessionPendingIntent(userId))
             .build()
+    }
+
+    private fun MessagingStyle.filterOutAlreadyDisplayedEvents(
+        events: List<NotifiableMessageEvent>,
+    ): List<NotifiableMessageEvent> {
+        val displayedEventIds = messages.mapNotNullTo(mutableSetOf()) { it.extras.getString(MESSAGE_EVENT_ID) }
+        return events.filter { event ->
+            event.isSmartReplyError() || displayedEventIds.add(event.eventId.value)
+        }
     }
 
     private suspend fun MessagingStyle.addMessagesFromEvents(

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -19,6 +19,7 @@ import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.features.enterprise.test.FakeEnterpriseService
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.AN_EVENT_ID_2
 import io.element.android.libraries.matrix.test.A_COLOR_INT
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
@@ -40,6 +41,7 @@ import io.element.android.libraries.push.impl.notifications.factories.action.Rej
 import io.element.android.libraries.push.impl.notifications.fixtures.aFallbackNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
 import io.element.android.libraries.push.impl.notifications.model.InviteNotifiableEvent
+import io.element.android.libraries.push.impl.notifications.model.NotifiableMessageEvent
 import io.element.android.libraries.push.impl.notifications.model.SimpleNotifiableEvent
 import io.element.android.services.toolbox.test.sdk.FakeBuildVersionSdkIntProvider
 import io.element.android.services.toolbox.test.strings.FakeStringProvider
@@ -300,6 +302,81 @@ class DefaultNotificationCreatorTest : RobolectricTest() {
             events = listOf(aNotifiableMessageEvent()),
         )
         result.commonAssertions()
+    }
+
+    @Test
+    fun `test createMessagesListNotification does not add an event which is already displayed`() = runTest {
+        val sut = createNotificationCreator()
+        val event = aNotifiableMessageEvent(body = "A message")
+        val existingNotification = sut.createRoomNotification(events = listOf(event))
+        assertThat(existingNotification.flags and Notification.FLAG_ONLY_ALERT_ONCE).isEqualTo(0)
+        val result = sut.createRoomNotification(events = listOf(event), existingNotification = existingNotification)
+        assertThat(result.messageTexts()).containsExactly("A message")
+        assertThat(result.flags and Notification.FLAG_ONLY_ALERT_ONCE).isNotEqualTo(0)
+    }
+
+    @Test
+    fun `test createMessagesListNotification adds a new event to the already displayed ones`() = runTest {
+        val sut = createNotificationCreator()
+        val existingNotification = sut.createRoomNotification(events = listOf(aNotifiableMessageEvent(body = "A message")))
+        val result = sut.createRoomNotification(
+            events = listOf(aNotifiableMessageEvent(eventId = AN_EVENT_ID_2, body = "Another message")),
+            existingNotification = existingNotification,
+        )
+        assertThat(result.messageTexts()).containsExactly("A message", "Another message").inOrder()
+    }
+
+    @Test
+    fun `test createMessagesListNotification adds the smart reply error of an already displayed event`() = runTest {
+        val sut = createNotificationCreator()
+        val event = aNotifiableMessageEvent(body = "A message").copy(outGoingMessage = true)
+        val existingNotification = sut.createRoomNotification(events = listOf(event))
+        val result = sut.createRoomNotification(
+            events = listOf(event.copy(outGoingMessageFailed = true)),
+            existingNotification = existingNotification,
+        )
+        assertThat(result.messageTexts()).containsExactly("A message", "test").inOrder()
+    }
+
+    @Test
+    fun `test createMessagesListNotification does not add an image and its caption twice`() = runTest {
+        val sut = createNotificationCreator()
+        val event = aNotifiableMessageEvent(body = "A caption").copy(
+            imageUriString = "aUri",
+            imageMimeType = "image/jpeg",
+        )
+        val existingNotification = sut.createRoomNotification(events = listOf(event))
+        assertThat(existingNotification.messageTexts()).containsExactly("test", "A caption").inOrder()
+        val result = sut.createRoomNotification(events = listOf(event), existingNotification = existingNotification)
+        assertThat(result.messageTexts()).containsExactly("test", "A caption").inOrder()
+    }
+
+    private suspend fun NotificationCreator.createRoomNotification(
+        events: List<NotifiableMessageEvent>,
+        existingNotification: Notification? = null,
+    ) = createMessagesListNotification(
+        notificationAccountParams = aNotificationAccountParams(),
+        roomInfo = RoomEventGroupInfo(
+            sessionId = A_SESSION_ID,
+            roomId = A_ROOM_ID,
+            roomDisplayName = "roomDisplayName",
+            hasSmartReplyError = false,
+            shouldBing = false,
+            customSound = null,
+            isUpdated = false,
+        ),
+        threadId = null,
+        largeIcon = null,
+        lastMessageTimestamp = 123_456L,
+        tickerText = "tickerText",
+        existingNotification = existingNotification,
+        imageLoader = FakeImageLoader(),
+        events = events,
+    )
+
+    private fun Notification.messageTexts(): List<String?> {
+        val messagingStyle = checkNotNull(NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(this))
+        return messagingStyle.messages.map { it.text?.toString() }
     }
 
     private fun Notification.commonAssertions(


### PR DESCRIPTION
## Content

When a room notification is rebuilt, the notification that is already on screen is used as the
accumulator: its messaging style is extracted and the incoming events are appended to it. Every event
was appended unconditionally, so an event that was re-delivered or re-resolved while its notification
was still showing was added a second time, and the same message appeared twice or more in the shade.
The notification also re-alerted each time.

Events whose id is already present in the existing messaging style are now skipped, and the
notification is posted with `onlyAlertOnce` when the incoming batch contained nothing new.

Two paths are deliberately exempt. Smart reply failures re-emit the same synthesised event id on
purpose in order to append the "message not sent" line, so they are still appended. Filtering happens
per event rather than per message, so an image and its caption — two messages for a single event — are
kept or skipped together.

This addresses the duplicated lines and the repeated alerts. It cannot help once the notification has
been dismissed, since there is then no existing notification to compare against, so it is a fix for the
visible duplication rather than for whatever causes the event to be delivered again.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/6253

## Tests

- `libraries/push/impl/src/test/.../factories/DefaultNotificationCreatorTest.kt` — an event that is
  already displayed is not added again and the rebuild no longer alerts; a genuinely new event is still
  added, in order; a smart reply failure for an already displayed event is still appended; and an image
  with a caption is not duplicated.
- These do not cover the re-delivery itself, which happens before this code runs.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
