### PR TITLE
Show the alias or the direct message user's Matrix ID in the room picker

### DIFF
--- a/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceStateProvider.kt
+++ b/features/space/impl/src/main/kotlin/io/element/android/features/space/impl/addroom/AddRoomToSpaceStateProvider.kt
@@ -87,6 +87,7 @@ internal fun aSelectRoomInfoList(): ImmutableList<SelectRoomInfo> = listOf(
         canonicalAlias = null,
         avatarUrl = null,
         heroes = persistentListOf(),
+        isDm = false,
         isTombstoned = false,
     ),
     SelectRoomInfo(
@@ -95,6 +96,7 @@ internal fun aSelectRoomInfoList(): ImmutableList<SelectRoomInfo> = listOf(
         canonicalAlias = null,
         avatarUrl = null,
         heroes = persistentListOf(),
+        isDm = false,
         isTombstoned = false,
     ),
     SelectRoomInfo(
@@ -103,6 +105,7 @@ internal fun aSelectRoomInfoList(): ImmutableList<SelectRoomInfo> = listOf(
         canonicalAlias = null,
         avatarUrl = null,
         heroes = persistentListOf(),
+        isDm = false,
         isTombstoned = false,
     ),
 ).toImmutableList()

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SelectRoomInfoProvider.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/components/SelectRoomInfoProvider.kt
@@ -31,6 +31,7 @@ fun aSelectRoomInfo(
     canonicalAlias: RoomAlias? = null,
     avatarUrl: String? = null,
     heroes: ImmutableList<MatrixUser> = persistentListOf(),
+    isDm: Boolean = false,
     isTombstoned: Boolean = false,
 ) = SelectRoomInfo(
     roomId = roomId,
@@ -38,5 +39,6 @@ fun aSelectRoomInfo(
     canonicalAlias = canonicalAlias,
     avatarUrl = avatarUrl,
     heroes = heroes,
+    isDm = isDm,
     isTombstoned = isTombstoned,
 )

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/model/SelectRoomInfo.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/model/SelectRoomInfo.kt
@@ -23,6 +23,7 @@ data class SelectRoomInfo(
     val canonicalAlias: RoomAlias?,
     val avatarUrl: String?,
     val heroes: ImmutableList<MatrixUser>,
+    val isDm: Boolean,
     val isTombstoned: Boolean,
 ) {
     fun getAvatarData(size: AvatarSize) = AvatarData(
@@ -41,5 +42,6 @@ fun RoomInfo.toSelectRoomInfo() = SelectRoomInfo(
     avatarUrl = avatarUrl,
     heroes = heroes,
     canonicalAlias = canonicalAlias,
+    isDm = isDm,
     isTombstoned = successorRoom != null,
 )

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.ui.components.aMatrixUser
 import io.element.android.libraries.matrix.ui.components.aSelectRoomInfo
 import io.element.android.libraries.matrix.ui.model.SelectRoomInfo
 import io.element.android.libraries.roomselect.api.RoomSelectMode
@@ -79,5 +80,12 @@ internal fun aRoomSelectRoomList() = persistentListOf(
     ),
     aSelectRoomInfo(
         roomId = RoomId("!room3:domain"),
+        name = "Alice",
+        heroes = persistentListOf(
+            aMatrixUser(id = "@alice:example.org", displayName = "Alice"),
+        ),
+    ),
+    aSelectRoomInfo(
+        roomId = RoomId("!room4:domain"),
     ),
 )

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectStateProvider.kt
@@ -84,6 +84,7 @@ internal fun aRoomSelectRoomList() = persistentListOf(
         heroes = persistentListOf(
             aMatrixUser(id = "@alice:example.org", displayName = "Alice"),
         ),
+        isDm = true,
     ),
     aSelectRoomInfo(
         roomId = RoomId("!room4:domain"),

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
@@ -260,7 +260,8 @@ private fun RoomSummaryView(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            val subtitle = roomInfo.canonicalAlias?.value ?: roomInfo.heroes.singleOrNull()?.userId?.value
+            val otherUserId = roomInfo.heroes.singleOrNull()?.userId?.takeIf { roomInfo.isDm }
+            val subtitle = roomInfo.canonicalAlias?.value ?: otherUserId?.value
             if (subtitle != null) {
                 Text(
                     text = subtitle,

--- a/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
+++ b/libraries/roomselect/impl/src/main/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectView.kt
@@ -260,10 +260,10 @@ private fun RoomSummaryView(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            // Alias
-            roomInfo.canonicalAlias?.let { alias ->
+            val subtitle = roomInfo.canonicalAlias?.value ?: roomInfo.heroes.singleOrNull()?.userId?.value
+            if (subtitle != null) {
                 Text(
-                    text = alias.value,
+                    text = subtitle,
                     color = ElementTheme.colors.textSecondary,
                     style = ElementTheme.typography.fontBodySmRegular,
                     maxLines = 1,

--- a/libraries/roomselect/impl/src/test/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectViewTest.kt
+++ b/libraries/roomselect/impl/src/test/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectViewTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.element.android.libraries.roomselect.impl
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.AndroidComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.tests.testutils.EnsureNeverCalled
+import io.element.android.tests.testutils.EnsureNeverCalledWithParam
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+class RoomSelectViewTest : RobolectricTest() {
+    @Config(qualifiers = "h1024dp")
+    @Test
+    fun `a room with a canonical alias renders the alias`() = runAndroidComposeUiTest {
+        setRoomSelectView(
+            aRoomSelectState(
+                resultState = SearchBarResultState.Results(aRoomSelectRoomList()),
+            ),
+        )
+        onNodeWithText("Room with alias").assertIsDisplayed()
+        onNodeWithText("#alias:example.org").assertIsDisplayed()
+    }
+
+    @Config(qualifiers = "h1024dp")
+    @Test
+    fun `a direct message without alias renders the matrix id of the other user`() = runAndroidComposeUiTest {
+        setRoomSelectView(
+            aRoomSelectState(
+                resultState = SearchBarResultState.Results(aRoomSelectRoomList()),
+            ),
+        )
+        onNodeWithText("Alice").assertIsDisplayed()
+        onNodeWithText("@alice:example.org").assertIsDisplayed()
+    }
+}
+
+private fun AndroidComposeUiTest<ComponentActivity>.setRoomSelectView(
+    state: RoomSelectState,
+    onDismiss: () -> Unit = EnsureNeverCalled(),
+    onSubmit: (List<RoomId>) -> Unit = EnsureNeverCalledWithParam(),
+) {
+    setContent {
+        RoomSelectView(
+            state = state,
+            onDismiss = onDismiss,
+            onSubmit = onSubmit,
+        )
+    }
+}

--- a/libraries/roomselect/impl/src/test/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectViewTest.kt
+++ b/libraries/roomselect/impl/src/test/kotlin/io/element/android/libraries/roomselect/impl/RoomSelectViewTest.kt
@@ -17,9 +17,12 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.ui.components.aMatrixUser
+import io.element.android.libraries.matrix.ui.components.aSelectRoomInfo
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EnsureNeverCalledWithParam
 import io.element.android.tests.testutils.robolectric.RobolectricTest
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.Test
 import org.robolectric.annotation.Config
 
@@ -46,6 +49,28 @@ class RoomSelectViewTest : RobolectricTest() {
         )
         onNodeWithText("Alice").assertIsDisplayed()
         onNodeWithText("@alice:example.org").assertIsDisplayed()
+    }
+
+    @Config(qualifiers = "h1024dp")
+    @Test
+    fun `a room which is not a direct message does not render the matrix id of its hero`() = runAndroidComposeUiTest {
+        setRoomSelectView(
+            aRoomSelectState(
+                resultState = SearchBarResultState.Results(
+                    persistentListOf(
+                        aSelectRoomInfo(
+                            roomId = RoomId("!room:domain"),
+                            name = "Room with a single hero",
+                            heroes = persistentListOf(
+                                aMatrixUser(id = "@alice:example.org", displayName = "Alice"),
+                            ),
+                        ),
+                    )
+                ),
+            ),
+        )
+        onNodeWithText("Room with a single hero").assertIsDisplayed()
+        onNodeWithText("@alice:example.org").assertDoesNotExist()
     }
 }
 

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9dd0c6858e4cd885d05aedfa92797c9aae6d56fb0b60268ed59793524121465
-size 28962
+oid sha256:4bbd7ca482fe8e846b2748d25e429a5fffd2c0ecc88014942efb90ea312cb298
+size 34413

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f2601edb209c898a03dbbca33c963eb0ded0c8f1258f145d743b263e99b8418
-size 26945
+oid sha256:18eef832d5c341dbc7d9c6c5495464dd9bfbd5c9355c3fe74384e6b1fdb0fe40
+size 32481

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ec941914c0e4a5d4dfe376a6f13b4330b46eac3fc1c31708ac0122a3e6c1038
-size 31129
+oid sha256:9ebb9b7f9c8e657d8e5a7fae6a133449fbbbb7529260dc4feb6c5da176eb1103
+size 36481

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3663eff19bb6c270af51109248836b8ee8da778538406ae2b67d10a56263d05
-size 26639
+oid sha256:ae42acc9b1e77edee6c07f62a5c29a15b0e99b51622ebca8ba0b94943a1952b6
+size 32119

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Day_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6511dac276623acfccbdde7f8b3f79930107b5e386b8e60b3d3f5ec733a41202
-size 30781
+oid sha256:a4e584927a4aa9c6f85c667bed8c959cb4d525ea038d7c843db62cace4652d02
+size 36072

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:014b95f94a6a0c7711146df291fb22a49fde5e98c8584bdb69f3cb4f0b626e36
-size 28375
+oid sha256:0653e38a43b99d9b07e41cdccc1bdad0e1d22a1449fea87f3909c061dffeea1e
+size 34221

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cf02e53cfcc806cf02c04ecf275abc84265401e2a4e6ce4ebfa64e1c4e0f9d4
-size 26519
+oid sha256:396c1b84d656baefa9161221bbc82343d55552dd7ea6aa44d87b4fc1a294a769
+size 32436

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac935e780ea072953e6e15edb4a845605ca77776d6ad50c5782018ee5dd84d5e
-size 31120
+oid sha256:b5e5d889237d4e539e595c0dffd0f565b47b11257a8ef592567de0d302116f92
+size 36737

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52be506a4811614853b5c101907caddaeddde4a9147e0f6ac0a3ce31610a3612
-size 26020
+oid sha256:da64e7f3f820e4ad902fd989e41daf310d29a3b90833ae71ca1e3712cedf5075
+size 31883

--- a/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/libraries.roomselect.impl_RoomSelectView_Night_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a05353b7037ed03cdcdcd5821533d9cfd766e02260e9838eac8c7d86fc91e1a
-size 30328
+oid sha256:890ff1e4285f413dbbd6babe32d0c4e3f675a0567d3c2a827112a2336621f063
+size 36013


### PR DESCRIPTION
## Content

The forward and share room picker showed only a display name, so several direct messages, or rooms
sharing a name, were indistinguishable and it was easy to send to the wrong one.

Each row now carries a secondary line: the room's canonical alias when it has one, which is what was
already shown, and otherwise the other person's Matrix ID when the room is a direct message. Rooms that
are neither aliased nor a direct message keep showing the name alone.

`heroes` is populated for any room whose name is derived from its members, not only for direct
messages, so the single hero is not on its own proof of a peer: a two person room that is not a direct
message would have shown a member's Matrix ID. `SelectRoomInfo` therefore carries `isDm`, taken from
`RoomInfo`, and the hero is read only when it is set. Group rooms with no alias remain
indistinguishable, since they have no public identifier to show and the internal room id would be
noise.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/5428

## Tests

- `libraries/roomselect/impl/src/test/.../RoomSelectViewTest.kt` — an aliased room renders its alias,
  a direct message without an alias renders the other user's Matrix ID, which the previous alias-only
  branch could not do, and a room that has a single hero but is not a direct message renders no Matrix
  ID.
- The preview state provider gained a direct message entry so the new branch is covered by the
  screenshot tests as well.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR

