### PR TITLE
Let users enter their full Matrix user ID when searching for a homeserver

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/resolver/HomeserverResolver.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/resolver/HomeserverResolver.kt
@@ -14,6 +14,8 @@ import io.element.android.libraries.core.coroutine.parallelMap
 import io.element.android.libraries.core.uri.ensureProtocol
 import io.element.android.libraries.core.uri.isValidUrl
 import io.element.android.libraries.matrix.api.auth.HomeServerLoginCompatibilityChecker
+import io.element.android.libraries.matrix.api.core.MatrixPatterns
+import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.permissions.api.localnetwork.LocalNetworkPermissionAdvisor
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
@@ -34,8 +36,13 @@ class HomeserverResolver(
     fun resolve(userInput: String): Flow<List<HomeserverData>> = flow {
         val flowContext = currentCoroutineContext()
         val trimmedUserInput = userInput.trim()
-        if (trimmedUserInput.length < 4) return@flow
-        val candidateBase = trimmedUserInput.ensureProtocol().removeSuffix("/")
+        val searchTerm = when {
+            MatrixPatterns.isUserId(trimmedUserInput) -> UserId(trimmedUserInput).domainName.orEmpty()
+            trimmedUserInput.startsWith("@") -> return@flow
+            else -> trimmedUserInput
+        }
+        if (searchTerm.length < 4) return@flow
+        val candidateBase = searchTerm.ensureProtocol().removeSuffix("/")
         val list = getUrlCandidates(candidateBase)
         val currentList = Collections.synchronizedList(mutableListOf<HomeserverData>())
         // Run all the requests in parallel

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/resolver/HomeserverResolverTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/resolver/HomeserverResolverTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.login.impl.resolver
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.test.auth.FakeHomeServerLoginCompatibilityChecker
+import io.element.android.libraries.permissions.test.FakeLocalNetworkPermissionAdvisor
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
+import io.element.android.tests.testutils.testCoroutineDispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class HomeserverResolverTest {
+    @Test
+    fun `resolve - a server name is used as is`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(it == "https://example.org") }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("example.org").test {
+            assertThat(awaitItem()).isEqualTo(listOf(HomeserverData(homeserverUrl = "https://example.org")))
+            awaitComplete()
+        }
+        checkResult.assertions().isCalledExactly(1)
+            .withSequence(
+                listOf(value("https://example.org")),
+            )
+    }
+
+    @Test
+    fun `resolve - an url is used as is`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(it == "https://example.org") }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("https://example.org").test {
+            assertThat(awaitItem()).isEqualTo(listOf(HomeserverData(homeserverUrl = "https://example.org")))
+            awaitComplete()
+        }
+        checkResult.assertions().isCalledExactly(1)
+            .withSequence(
+                listOf(value("https://example.org")),
+            )
+    }
+
+    @Test
+    fun `resolve - a user id resolves the server name of the user id`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(it == "https://example.org") }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("@alice:example.org").test {
+            assertThat(awaitItem()).isEqualTo(listOf(HomeserverData(homeserverUrl = "https://example.org")))
+            awaitComplete()
+        }
+        checkResult.assertions().isCalledExactly(1)
+            .withSequence(
+                listOf(value("https://example.org")),
+            )
+    }
+
+    @Test
+    fun `resolve - a user id with a port resolves the server name of the user id`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(it == "https://example.org:8448") }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("@alice:example.org:8448").test {
+            assertThat(awaitItem()).isEqualTo(listOf(HomeserverData(homeserverUrl = "https://example.org:8448")))
+            awaitComplete()
+        }
+        checkResult.assertions().isCalledExactly(1)
+            .withSequence(
+                listOf(value("https://example.org:8448")),
+            )
+    }
+
+    @Test
+    fun `resolve - an incomplete user id does not resolve anything`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(true) }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("@alice").test {
+            awaitComplete()
+        }
+        sut.resolve("@alice:").test {
+            awaitComplete()
+        }
+        checkResult.assertions().isNeverCalled()
+    }
+
+    @Test
+    fun `resolve - a user id with a too short server name does not resolve anything`() = runTest {
+        val checkResult = lambdaRecorder<String, Result<Boolean>> { Result.success(true) }
+        val sut = createHomeserverResolver(checkResult)
+        sut.resolve("@alice:a.b").test {
+            awaitComplete()
+        }
+        checkResult.assertions().isNeverCalled()
+    }
+
+    private fun TestScope.createHomeserverResolver(
+        checkResult: (String) -> Result<Boolean>,
+    ) = HomeserverResolver(
+        dispatchers = testCoroutineDispatchers(),
+        homeServerLoginCompatibilityChecker = FakeHomeServerLoginCompatibilityChecker(checkResult = checkResult),
+        localNetworkPermissionAdvisor = FakeLocalNetworkPermissionAdvisor(),
+    )
+}


### PR DESCRIPTION
## Content

Typing a full Matrix user ID into the account provider search did not find the homeserver. The
resolver treated the whole string as a host, so `@alice:example.org` was probed as
`https://@alice:example.org`, which never resolves; the permissive URL fallback then offered that
invalid address as an account provider.

The resolver now recognises a complete user ID and resolves the homeserver from its server name, so
`@alice:example.org` finds `example.org`. Ports are preserved, so `@alice:example.org:8448` resolves
`example.org:8448`. Input that starts with `@` but is not yet a complete user ID no longer produces a
candidate while the user is still typing.

Detection reuses the existing `MatrixPatterns.isUserId` and `UserId.domainName` rather than a new
pattern. Bare server names and full URLs are unaffected.

## Motivation and context

Part of https://github.com/element-hq/element-x-android/issues/3444

The issue also asks for fewer taps to reach the account provider screen, which is not addressed here.

## Tests

- `features/login/impl/src/test/.../resolver/HomeserverResolverTest.kt` — a user ID resolves its
  server name, a user ID with a port keeps the port, an incomplete user ID resolves nothing, a server
  name that is too short is still filtered, and bare server names and URLs still resolve exactly as
  before. Each case asserts both the emitted result and the exact URLs handed to the compatibility
  checker.
- These do not cover the `.well-known` delegation itself, which is performed by the SDK.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
