### PR TITLE
Keep manually revealed media visible when re-entering a room

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenter.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -20,7 +19,6 @@ import io.element.android.features.contentscanner.api.ContentScannerService
 import io.element.android.libraries.architecture.Presenter
 import io.element.android.libraries.core.coroutine.mapState
 import io.element.android.libraries.di.RoomScope
-import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.media.MediaPreviewService
 import io.element.android.libraries.matrix.api.media.isPreviewEnabled
 import io.element.android.libraries.matrix.api.room.BaseRoom
@@ -32,9 +30,8 @@ class TimelineProtectionPresenter(
     private val mediaPreviewService: MediaPreviewService,
     private val room: BaseRoom,
     private val contentScannerService: ContentScannerService,
+    private val timelineProtectionStore: TimelineProtectionStore,
 ) : Presenter<TimelineProtectionState> {
-    private val allowedEvents = mutableStateSetOf<EventId>()
-
     @Composable
     override fun present(): TimelineProtectionState {
         val mediaPreviewValue = remember {
@@ -48,7 +45,7 @@ class TimelineProtectionPresenter(
                 if (isPreviewEnabled) {
                     ProtectionState.RenderAll
                 } else {
-                    ProtectionState.RenderOnly(eventIds = allowedEvents.toImmutableSet())
+                    ProtectionState.RenderOnly(eventIds = timelineProtectionStore.allowedEventIds.toImmutableSet())
                 }
             }
         }
@@ -56,7 +53,7 @@ class TimelineProtectionPresenter(
         fun handleEvent(event: TimelineProtectionEvent) {
             when (event) {
                 is TimelineProtectionEvent.ShowContent -> {
-                    allowedEvents += setOfNotNull(event.eventId)
+                    event.eventId?.let(timelineProtectionStore::allowEvent)
                 }
                 is TimelineProtectionEvent.ValidateContent -> {
                     contentScannerService.scan(event.mediaSources, event.validationState)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
@@ -7,25 +7,26 @@
 
 package io.element.android.features.messages.impl.timeline.protection
 
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.snapshots.SnapshotStateSet
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.core.EventId
 
 interface TimelineProtectionStore {
-    val allowedEventIds: Set<EventId>
+    val allowedEventIds: SnapshotStateSet<EventId>
     fun allowEvent(eventId: EventId)
 }
 
 @ContributesBinding(SessionScope::class)
 @SingleIn(SessionScope::class)
 class DefaultTimelineProtectionStore : TimelineProtectionStore {
-    private val allowedEvents = mutableStateOf(emptySet<EventId>())
+    private val allowedEvents = mutableStateSetOf<EventId>()
 
-    override val allowedEventIds: Set<EventId> get() = allowedEvents.value
+    override val allowedEventIds: SnapshotStateSet<EventId> = allowedEvents
 
     override fun allowEvent(eventId: EventId) {
-        allowedEvents.value = allowedEvents.value + eventId
+        allowedEvents += eventId
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
@@ -7,7 +7,7 @@
 
 package io.element.android.features.messages.impl.timeline.protection
 
-import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.mutableStateOf
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.di.SessionScope
@@ -21,11 +21,11 @@ interface TimelineProtectionStore {
 @ContributesBinding(SessionScope::class)
 @SingleIn(SessionScope::class)
 class DefaultTimelineProtectionStore : TimelineProtectionStore {
-    private val allowedEvents = mutableStateSetOf<EventId>()
+    private val allowedEvents = mutableStateOf(emptySet<EventId>())
 
-    override val allowedEventIds: Set<EventId> = allowedEvents
+    override val allowedEventIds: Set<EventId> get() = allowedEvents.value
 
     override fun allowEvent(eventId: EventId) {
-        allowedEvents += eventId
+        allowedEvents.value = allowedEvents.value + eventId
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionStore.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.timeline.protection
+
+import androidx.compose.runtime.mutableStateSetOf
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.matrix.api.core.EventId
+
+interface TimelineProtectionStore {
+    val allowedEventIds: Set<EventId>
+    fun allowEvent(eventId: EventId)
+}
+
+@ContributesBinding(SessionScope::class)
+@SingleIn(SessionScope::class)
+class DefaultTimelineProtectionStore : TimelineProtectionStore {
+    private val allowedEvents = mutableStateSetOf<EventId>()
+
+    override val allowedEventIds: Set<EventId> = allowedEvents
+
+    override fun allowEvent(eventId: EventId) {
+        allowedEvents += eventId
+    }
+}

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/protection/TimelineProtectionPresenterTest.kt
@@ -95,6 +95,24 @@ class TimelineProtectionPresenterTest {
         }
     }
 
+    @Test
+    fun `present - shown content is restored when the presenter is recreated`() = runTest {
+        val mediaPreviewConfig = MediaPreviewConfig(mediaPreviewValue = MediaPreviewValue.Off, hideInviteAvatar = false)
+        val mediaPreviewService = FakeMediaPreviewService(mediaPreviewConfigFlow = MutableStateFlow(mediaPreviewConfig))
+        val timelineProtectionStore = DefaultTimelineProtectionStore()
+        createPresenter(mediaPreviewService = mediaPreviewService, timelineProtectionStore = timelineProtectionStore).test {
+            val initialState = awaitItem()
+            assertThat(initialState.protectionState).isEqualTo(ProtectionState.RenderOnly(persistentSetOf()))
+            initialState.eventSink(TimelineProtectionEvent.ShowContent(eventId = AN_EVENT_ID))
+            val finalState = awaitItem()
+            assertThat(finalState.protectionState).isEqualTo(ProtectionState.RenderOnly(persistentSetOf(AN_EVENT_ID)))
+        }
+        createPresenter(mediaPreviewService = mediaPreviewService, timelineProtectionStore = timelineProtectionStore).test {
+            val initialState = awaitItem()
+            assertThat(initialState.protectionState).isEqualTo(ProtectionState.RenderOnly(persistentSetOf(AN_EVENT_ID)))
+        }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `present - validate media scans the media source`() = runTest {
@@ -134,9 +152,11 @@ class TimelineProtectionPresenterTest {
         room: BaseRoom = FakeBaseRoom(),
         mediaPreviewService: MediaPreviewService = FakeMediaPreviewService(),
         contentScannerService: ContentScannerService = ContentScannerService { _: List<MediaSource>, _: ContentValidationState -> },
+        timelineProtectionStore: TimelineProtectionStore = DefaultTimelineProtectionStore(),
     ) = TimelineProtectionPresenter(
         mediaPreviewService = mediaPreviewService,
         room = room,
         contentScannerService = contentScannerService,
+        timelineProtectionStore = timelineProtectionStore,
     )
 }


### PR DESCRIPTION
## Content

With media previews hidden, tapping "Show" on an individual image revealed it only until the room was
closed. The set of revealed event ids lived on `TimelineProtectionPresenter`, which is scoped to the
room graph, and that graph is rebuilt every time the room is opened — so on re-entry the set was empty
and every image was hidden again.

The set moves into a new session-scoped `TimelineProtectionStore`, so a reveal now survives leaving and
re-entering the room.

The store is deliberately in-memory rather than persisted. Revealing media is a privacy control and
there is no "hide again" action today, so keeping the reveals for the session leaves restarting the app
as a cheap way to undo one. Session scope also means the set is dropped on logout and never leaks
between accounts.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/6853

## Tests

- `features/messages/impl/src/test/.../timeline/protection/TimelineProtectionPresenterTest.kt` — a
  second presenter built over the same store already reports the previously revealed event on its first
  emission, which is the re-entering-the-room case. The existing cases are unchanged and now also pin
  that two presenters with separate stores stay isolated.
- These do not cover the DI wiring itself, which follows the existing session-scoped store idiom.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
