### PR TITLE
Expand the emoji picker to full height when the keyboard is shown

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
@@ -26,7 +27,7 @@ import io.element.android.libraries.designsystem.theme.components.hide
 import io.element.android.libraries.emoji.api.picker.EmojiPickerRenderer
 import io.element.android.libraries.matrix.api.timeline.item.event.EventOrTransactionId
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomReactionBottomSheet(
     state: CustomReactionState,
@@ -58,12 +59,7 @@ fun CustomReactionBottomSheet(
                 modifier = modifier,
                 scrollable = false,
             ) {
-                val isImeVisible = WindowInsets.isImeVisible
-                LaunchedEffect(isImeVisible) {
-                    if (isImeVisible) {
-                        sheetState.expand()
-                    }
-                }
+                ExpandSheetWhenImeIsVisible(sheetState)
                 emojiPickerRenderer.Render(
                     state = state.target.emojiPickerState,
                     onSelectEmoji = ::onEmojiSelectedDismiss,
@@ -74,6 +70,17 @@ fun CustomReactionBottomSheet(
                     },
                 )
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+internal fun ExpandSheetWhenImeIsVisible(sheetState: SheetState) {
+    val isImeVisible = WindowInsets.isImeVisible
+    LaunchedEffect(isImeVisible) {
+        if (isImeVisible) {
+            sheetState.expand()
         }
     }
 }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/CustomReactionBottomSheet.kt
@@ -8,11 +8,15 @@
 
 package io.element.android.features.messages.impl.timeline.components.customreaction
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import io.element.android.emojibasebindings.Emoji
@@ -22,7 +26,7 @@ import io.element.android.libraries.designsystem.theme.components.hide
 import io.element.android.libraries.emoji.api.picker.EmojiPickerRenderer
 import io.element.android.libraries.matrix.api.timeline.item.event.EventOrTransactionId
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun CustomReactionBottomSheet(
     state: CustomReactionState,
@@ -54,6 +58,12 @@ fun CustomReactionBottomSheet(
                 modifier = modifier,
                 scrollable = false,
             ) {
+                val isImeVisible = WindowInsets.isImeVisible
+                LaunchedEffect(isImeVisible) {
+                    if (isImeVisible) {
+                        sheetState.expand()
+                    }
+                }
                 emojiPickerRenderer.Render(
                     state = state.target.emojiPickerState,
                     onSelectEmoji = ::onEmojiSelectedDismiss,

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/ExpandSheetWhenImeIsVisibleTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/components/customreaction/ExpandSheetWhenImeIsVisibleTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+
+package io.element.android.features.messages.impl.timeline.components.customreaction
+
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.test.AndroidComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.common.truth.Truth.assertThat
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+
+class ExpandSheetWhenImeIsVisibleTest : RobolectricTest() {
+    @Test
+    fun `the sheet is left alone while the keyboard is hidden`() = runAndroidComposeUiTest<ComponentActivity> {
+        val sheetState = renderWithIme(isImeVisible = false)
+        assertThat(sheetState.currentValue).isEqualTo(SheetValue.PartiallyExpanded)
+    }
+
+    @Test
+    fun `the sheet is expanded when the keyboard is shown`() = runAndroidComposeUiTest<ComponentActivity> {
+        val sheetState = renderWithIme(isImeVisible = true)
+        assertThat(sheetState.currentValue).isEqualTo(SheetValue.Expanded)
+    }
+}
+
+private fun AndroidComposeUiTest<ComponentActivity>.renderWithIme(isImeVisible: Boolean): SheetState {
+    lateinit var sheetState: SheetState
+    lateinit var view: View
+    setContent {
+        view = LocalView.current
+        sheetState = rememberBottomSheetState(initialValue = SheetValue.PartiallyExpanded)
+        ExpandSheetWhenImeIsVisible(sheetState)
+    }
+    runOnIdle {
+        ViewCompat.dispatchApplyWindowInsets(
+            view,
+            WindowInsetsCompat.Builder()
+                .setVisible(WindowInsetsCompat.Type.ime(), isImeVisible)
+                .setInsets(WindowInsetsCompat.Type.ime(), if (isImeVisible) Insets.of(0, 0, 0, 300) else Insets.NONE)
+                .build()
+        )
+    }
+    waitForIdle()
+    return sheetState
+}

--- a/libraries/emoji/impl/build.gradle.kts
+++ b/libraries/emoji/impl/build.gradle.kts
@@ -36,5 +36,5 @@ dependencies {
     implementation(libs.matrix.emojibase.bindings)
 
     testImplementation(projects.libraries.matrix.test)
-    testCommonDependencies(libs)
+    testCommonDependencies(libs, includeTestComposeView = true)
 }

--- a/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/EmojiPickerView.kt
+++ b/libraries/emoji/impl/src/main/kotlin/io/element/android/libraries/emoji/impl/picker/EmojiPickerView.kt
@@ -62,7 +62,7 @@ internal fun EmojiPickerView(
 
     Column(modifier) {
         SearchBar(
-            modifier = Modifier.padding(bottom = 10.dp),
+            modifier = Modifier.padding(bottom = if (state.isSearchActive) 0.dp else 10.dp),
             queryState = state.searchQuery,
             resultState = state.searchResults,
             active = state.isSearchActive,

--- a/libraries/emoji/impl/src/test/kotlin/io/element/android/libraries/emoji/impl/picker/EmojiPickerViewTest.kt
+++ b/libraries/emoji/impl/src/test/kotlin/io/element/android/libraries/emoji/impl/picker/EmojiPickerViewTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.element.android.libraries.emoji.impl.picker
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.AndroidComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEqualTo
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import androidx.compose.ui.unit.dp
+import io.element.android.emojibasebindings.Emoji
+import io.element.android.libraries.designsystem.theme.components.SearchBarResultState
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+private val PICKER_HEIGHT = 600.dp
+
+class EmojiPickerViewTest : RobolectricTest() {
+    @Config(qualifiers = "w400dp-h800dp")
+    @Test
+    fun `the search results reach the bottom of the picker`() = runAndroidComposeUiTest<ComponentActivity> {
+        setEmojiPickerView()
+        onNode(hasScrollToIndexAction())
+            .getBoundsInRoot()
+            .bottom
+            .assertIsEqualTo(PICKER_HEIGHT, "emoji grid bottom")
+    }
+}
+
+private fun AndroidComposeUiTest<ComponentActivity>.setEmojiPickerView() {
+    setContent {
+        Box(Modifier.size(400.dp, PICKER_HEIGHT)) {
+            EmojiPickerView(
+                state = aDefaultEmojiPickerState(
+                    isSearchActive = true,
+                    searchQuery = "smile",
+                    searchResults = SearchBarResultState.Results(
+                        persistentListOf(
+                            Emoji(
+                                hexcode = "0x00",
+                                label = "grinning face",
+                                tags = persistentListOf("grinning"),
+                                shortcodes = persistentListOf("smile"),
+                                unicode = "😀",
+                                skins = null,
+                            ),
+                        )
+                    ),
+                ),
+                onSelectEmoji = {},
+                selectedEmojis = persistentSetOf(),
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Content

The emoji picker bottom sheet now expands to full height while the soft keyboard is visible, so search
results are laid out above the keyboard instead of behind it.

The picker content is rendered with `fillMaxSize`, so the sheet measures itself to the full window
height. That makes the partially expanded anchor available, and the modal sheet auto-shows at that
anchor — half way down the screen. The sheet does reserve the IME inset through its content window
insets, but it applies that padding at its own bottom edge, which is off-screen while the sheet rests
half way down. The band that is both on screen and above the keyboard is then about a tenth of the
screen: enough for the search field and little else.

Expanding the sheet while the keyboard is up puts its bottom edge back at the screen edge, so the inset
it already reserves lands exactly on top of the keyboard.

`Modifier.imePadding()` on the sheet content is not an option here: the sheet applies the insets with
`windowInsetsPadding`, which consumes them, so a nested `imePadding()` reads zero.

Expanding the sheet also brought a blank strip between the results and the keyboard into view.
`EmojiPickerView` pads its search bar with `Modifier.padding(bottom = 10.dp)` to separate the collapsed
field from the category tabs underneath it, and that padding stayed applied once the search bar
expanded to fill the picker, so the picker stopped 10dp short of its own bottom edge. Until now that
strip sat below the visible part of a half-height sheet; against the keyboard it reads as a gap. The
padding is now applied only while the search bar is collapsed, which is the only state that has
anything below it.

This covers the reaction emoji picker, which is the one reported. The emoji picker on the user status
screen resolves its sheet height the same way and has the same problem; it is left for a separate
change because the sheet there is configured differently.

## Motivation and context

Closes https://github.com/element-hq/element-x-android/issues/7270

## Tests

- Long press a message, open the emoji picker and tap the search field: the sheet expands and the
  matching emoji are visible and tappable above the keyboard.
- Open the picker without searching: it still opens at its usual height.
- `features/messages/impl/src/test/.../customreaction/ExpandSheetWhenImeIsVisibleTest.kt` — dispatching
  IME insets to the composition expands the sheet, and leaves it at its resting height while the
  keyboard is hidden.
- `libraries/emoji/impl/src/test/.../picker/EmojiPickerViewTest.kt` — with the search active, the
  results grid reaches the bottom of the picker. It fails against the previous code, where the grid
  stopped 10dp short.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
