### PR TITLE
Add default `OAUTH_CLIENT_URL_PATH` alternative

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OAuthConfig.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/auth/OAuthConfig.kt
@@ -11,6 +11,8 @@ package io.element.android.libraries.matrix.api.auth
 import io.element.android.libraries.matrix.api.BuildConfig
 
 object OAuthConfig {
+    // This *can* be null if the build time config field is not set
+    @Suppress("UNNECESSARY_SAFE_CALL")
     val CLIENT_URI = BuildConfig.OAUTH_CLIENT_URI_PATH?.let {
         // Concatenate the base URI and the path, ensuring there is exactly one '/' between them
         "${BuildConfig.CLIENT_URI.trimEnd('/')}/${it.trimStart('/')}"

--- a/plugins/src/main/kotlin/config/BuildTimeConfig.kt
+++ b/plugins/src/main/kotlin/config/BuildTimeConfig.kt
@@ -22,7 +22,7 @@ object BuildTimeConfig {
     val URL_ACCEPTABLE_USE: String? = null
     val URL_PRIVACY: String? = null
     val URL_POLICY: String? = null
-    val OAUTH_CLIENT_URL_PATH: String? = null
+    val OAUTH_CLIENT_URL_PATH: String? = "apps/android"
     val SERVICES_MAPTILER_BASE_URL: String? = null
     val SERVICES_MAPTILER_APIKEY: String? = null
     val SERVICES_MAPTILER_LIGHT_MAPID: String? = null


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Previously this was `null`, but we want to use `apps/android` instead to identify Element X Android. Element Pro will override this value with its own custom value.

## Motivation and context

This will allow MAS to identify Element X Android clients. It's not useful yet AFAICT, but it might come handy in the future.

## Tests

Not much, I guess? You could try checking if the request to `https://account.matrix.org/oauth2/registration` contains the path in the `client_uri` field.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
