### PR TITLE
Fix bug reports failing to send after the app has crashed

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/RageshakeConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/RageshakeConfig.kt
@@ -35,4 +35,11 @@ object RageshakeConfig {
      * The maximum number of log lines a rageshake can contain.
      */
     const val MAX_LOG_LINES_SIZE = 1_000_000
+
+    /**
+     * The maximum size of the description. The bug report server copies it verbatim into a GitHub issue body,
+     * which GitHub rejects above 65536 characters. The remaining budget is left to the other reported fields,
+     * mainly the list of the omitted log file names.
+     */
+    const val MAX_DESCRIPTION_SIZE = 40 * 1024
 }

--- a/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
+++ b/features/rageshake/impl/src/main/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporter.kt
@@ -152,7 +152,7 @@ class DefaultBugReporter(
                         append("\n\n\n\n--------------------------------- crash call stack ---------------------------------\n")
                         append(crashCallStack)
                     }
-                }
+                }.truncateDescription()
                 val gzippedFiles = mutableListOf<File>()
                 var filesTooBig = emptyList<String>()
 
@@ -493,5 +493,14 @@ class DefaultBugReporter(
 
     private fun countLogLines(file: File): Int {
         return file.reader().useLines { it.count() }
+    }
+
+    private fun String.truncateDescription(): String {
+        return if (length <= RageshakeConfig.MAX_DESCRIPTION_SIZE) {
+            this
+        } else {
+            take(RageshakeConfig.MAX_DESCRIPTION_SIZE) +
+                "\n\n--------------------------------- truncated, see the attached logs ---------------------------------"
+        }
     }
 }

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -309,6 +309,68 @@ class DefaultBugReporterTest : RobolectricTest() {
         assertThat(foundValues["label"]).isEqualTo("crash")
     }
 
+    @Test
+    fun `test sendBugReport truncates a description which is too long`() = runTest {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        server.start()
+        val hugeCrashCallStack = "a".repeat(RageshakeConfig.MAX_DESCRIPTION_SIZE * 2)
+        val sut = createDefaultBugReporter(
+            server = server,
+            crashDataStore = FakeCrashDataStore(hugeCrashCallStack, true),
+        )
+
+        sut.sendBugReport(
+            withDevicesLogs = true,
+            withCrashLogs = true,
+            withScreenshot = true,
+            problemDescription = "a bug occurred",
+            canContact = true,
+            listener = NoopBugReporterListener(),
+        )
+        val request = server.takeRequest()
+
+        val text = collectValuesFromFormData(request)["text"]!!
+        assertThat(text).startsWith("a bug occurred")
+        assertThat(text).contains("truncated")
+        assertThat(text.length).isAtMost(RageshakeConfig.MAX_DESCRIPTION_SIZE + TRUNCATION_MARKER_MAX_SIZE)
+        assertThat(text.length).isLessThan(GITHUB_MAX_ISSUE_BODY_SIZE)
+        server.shutdown()
+    }
+
+    @Test
+    fun `test sendBugReport does not truncate a description which fits`() = runTest {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        server.start()
+        val sut = createDefaultBugReporter(
+            server = server,
+            crashDataStore = FakeCrashDataStore("I did crash", true),
+        )
+
+        sut.sendBugReport(
+            withDevicesLogs = true,
+            withCrashLogs = true,
+            withScreenshot = true,
+            problemDescription = "a bug occurred",
+            canContact = true,
+            listener = NoopBugReporterListener(),
+        )
+        val request = server.takeRequest()
+
+        val text = collectValuesFromFormData(request)["text"]!!
+        assertThat(text).startsWith("a bug occurred")
+        assertThat(text).endsWith("I did crash")
+        assertThat(text).doesNotContain("truncated")
+        server.shutdown()
+    }
+
     private fun collectValuesFromFormData(request: RecordedRequest): HashMap<String, String> {
         val boundary = request.headers["Content-Type"]!!.split("=").last()
         val foundValues = HashMap<String, String>()
@@ -535,5 +597,7 @@ class DefaultBugReporterTest : RobolectricTest() {
 
     companion object {
         private const val EXPECTED_NUMBER_OF_PROGRESS_VALUE = 18
+        private const val GITHUB_MAX_ISSUE_BODY_SIZE = 65536
+        private const val TRUNCATION_MARKER_MAX_SIZE = 200
     }
 }

--- a/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
+++ b/features/rageshake/impl/src/test/kotlin/io/element/android/features/rageshake/impl/reporter/DefaultBugReporterTest.kt
@@ -597,7 +597,7 @@ class DefaultBugReporterTest : RobolectricTest() {
 
     companion object {
         private const val EXPECTED_NUMBER_OF_PROGRESS_VALUE = 18
-        private const val GITHUB_MAX_ISSUE_BODY_SIZE = 65536
+        private const val GITHUB_MAX_ISSUE_BODY_SIZE = 65_536
         private const val TRUNCATION_MARKER_MAX_SIZE = 200
     }
 }


### PR DESCRIPTION
## Content

Sending a bug report fails with the server error `Could not save report` when the app has previously
crashed and "Send log files" is enabled. The full crash call stack is appended to the report
description, and the bug report server copies that description verbatim into the GitHub issue it
opens. GitHub refuses an issue body over 65536 characters, so the server's save step fails and the
app surfaces the error it returns.

The description is now truncated before being sent. The user's own text and the GitHub issue link
come first, so only the tail of the crash stack is dropped, and a marker is appended in its place.
Nothing is lost: the uncaught exception handler already writes the full stack through Timber, so it
is present in the attached log files.

The stored crash data is only cleared after a report has been sent successfully, which is why a
report failing this way keeps failing on every retry until the cache is cleared.

## Motivation and context

Relates to https://github.com/element-hq/element-x-android/issues/7393, and to the earlier report of
the same error in https://github.com/element-hq/element-x-android/issues/5739, where the cause was
not identified.

The existing limits bound the uploaded logs — `MAX_LOG_CONTENT_SIZE` and `MAX_LOG_LINES_SIZE`, added
in #6003 and #6075 — and the server rejects those with a different error. Nothing bounded the
description itself.

## Tests

- `DefaultBugReporterTest` — a description over the limit is truncated, carries the marker, and
  stays below GitHub's issue body limit.
- `DefaultBugReporterTest` — a description within the limit is sent unchanged, with the crash call
  stack intact.
- Both were confirmed to fail with the change reverted.

These cover the payload the app builds; they do not exercise the real bug report server, so
end-to-end submission is not proven by them.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
