### PR TITLE
Update DefaultMediaOptimizationSelectorPresenter.kt

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/video/DefaultMediaOptimizationSelectorPresenter.kt
@@ -45,6 +45,16 @@ class DefaultMediaOptimizationSelectorPresenter(
     private val videoCompressionPresetSelector: VideoCompressionPresetSelector,
     mediaExtractorFactory: VideoMetadataExtractor.Factory,
 ) : MediaOptimizationSelectorPresenter {
+    companion object {
+        /**
+         * Approximate bitrate (in bits per second) used by the AAC audio encoder for compressed videos.
+         * The video pre-processor doesn't override the audio encoder settings, so this should track
+         * whatever the platform default AAC bitrate ends up being. Used to avoid under-estimating the
+         * final file size, since the video bitrate alone doesn't account for the audio track.
+         */
+        private const val ASSUMED_AUDIO_BITRATE = 128_000
+    }
+
     @ContributesBinding(SessionScope::class)
     @AssistedFactory
     interface Factory : MediaOptimizationSelectorPresenter.Factory {
@@ -109,9 +119,12 @@ class DefaultMediaOptimizationSelectorPresenter(
 
             val sizeEstimations = VideoCompressionPreset.entries
                 .map { preset ->
-                    val bitRateAsBytes = preset.compressorHelper().calculateOptimalBitrate(videoDimensions, 30) / 8f
+                    val videoBitRate = preset.compressorHelper().calculateOptimalBitrate(videoDimensions, 30)
+                    // The output always includes an AAC audio track too; ignoring it made the estimate
+                    // systematically lower than the actual compressed file size.
+                    val combinedBitRateAsBytes = (videoBitRate + ASSUMED_AUDIO_BITRATE) / 8f
                     val durationInSeconds = duration.inWholeSeconds.toFloat()
-                    val calculatedSize = (bitRateAsBytes * durationInSeconds * 1.1f).roundToLong() // Adding 10% overhead for safety
+                    val calculatedSize = (combinedBitRateAsBytes * durationInSeconds * 1.1f).roundToLong() // Adding 10% overhead for safety
                     VideoUploadEstimation(
                         preset = preset,
                         sizeInBytes = calculatedSize,

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
@@ -1,5 +1,215 @@
 /*
  * Copyright (c) 2025 Element Creations Ltd.
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.attachments.video
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesBinding
+import io.element.android.libraries.architecture.AsyncData
+import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
+import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.featureflag.api.FeatureFlagService
+import io.element.android.libraries.featureflag.api.FeatureFlags
+import io.element.android.libraries.mediaupload.api.MaxUploadSizeProvider
+import io.element.android.libraries.mediaupload.api.MediaOptimizationConfigProvider
+import io.element.android.libraries.mediaupload.api.compressorHelper
+import io.element.android.libraries.mediaviewer.api.local.LocalMedia
+import io.element.android.libraries.preferences.api.store.VideoCompressionPreset
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
+import kotlin.math.roundToLong
+
+@AssistedInject
+class DefaultMediaOptimizationSelectorPresenter(
+    @Assisted private val index: Int,
+    @Assisted private val localMedia: LocalMedia,
+    @Assisted private val sendAsFile: Boolean,
+    private val maxUploadSizeProvider: MaxUploadSizeProvider,
+    private val featureFlagService: FeatureFlagService,
+    private val mediaOptimizationConfigProvider: MediaOptimizationConfigProvider,
+    private val videoCompressionPresetSelector: VideoCompressionPresetSelector,
+    mediaExtractorFactory: VideoMetadataExtractor.Factory,
+) : MediaOptimizationSelectorPresenter {
+    companion object {
+        /**
+         * Approximate bitrate (in bits per second) used by the AAC audio encoder for compressed videos.
+         * The video pre-processor doesn't override the audio encoder settings, so this should track
+         * whatever the platform default AAC bitrate ends up being. Used to avoid under-estimating the
+         * final file size, since the video bitrate alone doesn't account for the audio track.
+         */
+        private const val ASSUMED_AUDIO_BITRATE = 128_000
+    }
+
+    @ContributesBinding(SessionScope::class)
+    @AssistedFactory
+    interface Factory : MediaOptimizationSelectorPresenter.Factory {
+        override fun create(
+            index: Int,
+            localMedia: LocalMedia,
+            sendAsFile: Boolean,
+        ): DefaultMediaOptimizationSelectorPresenter
+    }
+
+    private val mediaExtractor = mediaExtractorFactory.create(localMedia.uri)
+
+    @Composable
+    override fun present(): MediaOptimizationSelectorState {
+        val displayMediaSelectorViews by produceState<Boolean?>(null) {
+            // When sending as a raw file, never show the optimization selector: images skip
+            // recompression, while videos use the highest available best-fit preset.
+            value = !sendAsFile && featureFlagService.isFeatureEnabled(FeatureFlags.SelectableMediaQuality)
+        }
+
+        var displayVideoPresetSelectorDialog by remember { mutableStateOf(false) }
+
+        val maxUploadSize by produceState(AsyncData.Loading()) {
+            maxUploadSizeProvider.getMaxUploadSize().fold(
+                onSuccess = { value = AsyncData.Success(it) },
+                onFailure = {
+                    Timber.e(it, "Failed to retrieve max upload size for video optimization selector")
+                    value = AsyncData.Success((100 * 1024 * 1024).toLong()) // Default to 100 MB if we can't retrieve the max upload size
+                }
+            )
+        }
+
+        val mediaMimeType = localMedia.info.mimeType
+
+        val videoSizeEstimations by produceState<AsyncData<ImmutableList<VideoUploadEstimation>>>(
+            initialValue = AsyncData.Loading(),
+            key1 = maxUploadSize,
+        ) {
+            if (maxUploadSize !is AsyncData.Success) {
+                return@produceState
+            }
+
+            if (!mediaMimeType.isMimeTypeVideo()) {
+                value = AsyncData.Uninitialized
+                return@produceState
+            }
+
+            val (videoDimensions, duration) = mediaExtractor.use {
+                val size = it.getSize()
+                    .getOrElse { exception ->
+                        value = AsyncData.Failure(exception)
+                        return@produceState
+                    }
+
+                val duration = it.getDuration()
+                    .getOrElse { exception ->
+                        value = AsyncData.Failure(exception)
+                        return@produceState
+                    }
+                size to duration
+            }
+
+            val sizeEstimations = VideoCompressionPreset.entries
+                .map { preset ->
+                    val videoBitRate = preset.compressorHelper().calculateOptimalBitrate(videoDimensions, 30)
+                    // The output always includes an AAC audio track too; ignoring it made the estimate
+                    // systematically lower than the actual compressed file size.
+                    val combinedBitRateAsBytes = (videoBitRate + ASSUMED_AUDIO_BITRATE) / 8f
+                    val durationInSeconds = duration.inWholeSeconds.toFloat()
+                    val calculatedSize = (combinedBitRateAsBytes * durationInSeconds * 1.1f).roundToLong() // Adding 10% overhead for safety
+                    VideoUploadEstimation(
+                        preset = preset,
+                        sizeInBytes = calculatedSize,
+                        canUpload = calculatedSize <= (maxUploadSize as AsyncData.Success).data
+                    )
+                }
+                .toImmutableList()
+                .also { sizes ->
+                    Timber.d(sizes.joinToString("\n") { "Calculated size for ${it.preset}: ${it.sizeInBytes} MB. Max upload size: $maxUploadSize" })
+                }
+
+            value = AsyncData.Success(sizeEstimations)
+        }
+
+        var selectedImageOptimization by remember { mutableStateOf<AsyncData<Boolean>>(AsyncData.Loading()) }
+        var selectedVideoOptimizationPreset by remember { mutableStateOf<AsyncData<VideoCompressionPreset>>(AsyncData.Loading()) }
+
+        LaunchedEffect(videoSizeEstimations.dataOrNull()) {
+            if (sendAsFile) {
+                // Send-as-file path: pin to no image compression, and pick the highest-quality
+                // video preset that still fits the upload limit (we have no true "do not re-encode
+                // video" path in the pre-processor right now).
+                selectedImageOptimization = AsyncData.Success(false)
+                selectedVideoOptimizationPreset = videoCompressionPresetSelector.selectBestVideoPreset(
+                    expectedVideoPreset = VideoCompressionPreset.HIGH,
+                    videoSizeEstimations = videoSizeEstimations,
+                )
+                return@LaunchedEffect
+            }
+            val mediaOptimizationConfig = mediaOptimizationConfigProvider.get()
+            selectedImageOptimization = AsyncData.Success(mediaOptimizationConfig.compressImages)
+            // Find the best video preset based on the default preset and the video size estimations
+            // Since the estimation for the current preset may be way too large to upload, we check the ones that provide lower file sizes
+            selectedVideoOptimizationPreset = videoCompressionPresetSelector.selectBestVideoPreset(
+                expectedVideoPreset = mediaOptimizationConfig.videoCompressionPreset,
+                videoSizeEstimations = videoSizeEstimations,
+            )
+        }
+
+        fun handleEvent(event: MediaOptimizationSelectorEvent) {
+            when (event) {
+                is MediaOptimizationSelectorEvent.SelectImageOptimization -> {
+                    selectedImageOptimization = AsyncData.Success(event.enabled)
+                }
+                is MediaOptimizationSelectorEvent.SelectVideoPreset -> {
+                    val estimations = videoSizeEstimations.dataOrNull()
+                    if (estimations != null) {
+                        val preset = estimations.find { it.preset == event.preset }
+                        if (preset == null) {
+                            Timber.e("Selected video preset ${event.preset} is not available in the estimations")
+                            return
+                        }
+                        if (!preset.canUpload) {
+                            Timber.w("Selected video preset ${event.preset} exceeds max upload size")
+                            return
+                        }
+                    } else {
+                        Timber.e("Video size estimations are not available")
+                        return
+                    }
+                    selectedVideoOptimizationPreset = AsyncData.Success(event.preset)
+                    displayVideoPresetSelectorDialog = false
+                }
+                is MediaOptimizationSelectorEvent.OpenVideoPresetSelectorDialog -> {
+                    displayVideoPresetSelectorDialog = true
+                }
+                is MediaOptimizationSelectorEvent.DismissVideoPresetSelectorDialog -> {
+                    displayVideoPresetSelectorDialog = false
+                }
+            }
+        }
+
+        return MediaOptimizationSelectorState(
+            index = index,
+            maxUploadSize = maxUploadSize,
+            videoSizeEstimations = videoSizeEstimations,
+            isImageOptimizationEnabled = selectedImageOptimization.dataOrNull(),
+            selectedVideoPreset = selectedVideoOptimizationPreset.dataOrNull(),
+            displayMediaSelectorViews = displayMediaSelectorViews,
+            displayVideoPresetSelectorDialog = displayVideoPresetSelectorDialog,
+            eventSink = ::handleEvent,
+        )
+    }
+}/*
+ * Copyright (c) 2025 Element Creations Ltd.
  * Copyright 2023-2025 New Vector Ltd.
  *
  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/VideoCompressor.kt
@@ -1,215 +1,5 @@
 /*
  * Copyright (c) 2025 Element Creations Ltd.
- * Copyright 2025 New Vector Ltd.
- *
- * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
- * Please see LICENSE files in the repository root for full details.
- */
-
-package io.element.android.features.messages.impl.attachments.video
-
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
-import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesBinding
-import io.element.android.libraries.architecture.AsyncData
-import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
-import io.element.android.libraries.di.SessionScope
-import io.element.android.libraries.featureflag.api.FeatureFlagService
-import io.element.android.libraries.featureflag.api.FeatureFlags
-import io.element.android.libraries.mediaupload.api.MaxUploadSizeProvider
-import io.element.android.libraries.mediaupload.api.MediaOptimizationConfigProvider
-import io.element.android.libraries.mediaupload.api.compressorHelper
-import io.element.android.libraries.mediaviewer.api.local.LocalMedia
-import io.element.android.libraries.preferences.api.store.VideoCompressionPreset
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
-import timber.log.Timber
-import kotlin.math.roundToLong
-
-@AssistedInject
-class DefaultMediaOptimizationSelectorPresenter(
-    @Assisted private val index: Int,
-    @Assisted private val localMedia: LocalMedia,
-    @Assisted private val sendAsFile: Boolean,
-    private val maxUploadSizeProvider: MaxUploadSizeProvider,
-    private val featureFlagService: FeatureFlagService,
-    private val mediaOptimizationConfigProvider: MediaOptimizationConfigProvider,
-    private val videoCompressionPresetSelector: VideoCompressionPresetSelector,
-    mediaExtractorFactory: VideoMetadataExtractor.Factory,
-) : MediaOptimizationSelectorPresenter {
-    companion object {
-        /**
-         * Approximate bitrate (in bits per second) used by the AAC audio encoder for compressed videos.
-         * The video pre-processor doesn't override the audio encoder settings, so this should track
-         * whatever the platform default AAC bitrate ends up being. Used to avoid under-estimating the
-         * final file size, since the video bitrate alone doesn't account for the audio track.
-         */
-        private const val ASSUMED_AUDIO_BITRATE = 128_000
-    }
-
-    @ContributesBinding(SessionScope::class)
-    @AssistedFactory
-    interface Factory : MediaOptimizationSelectorPresenter.Factory {
-        override fun create(
-            index: Int,
-            localMedia: LocalMedia,
-            sendAsFile: Boolean,
-        ): DefaultMediaOptimizationSelectorPresenter
-    }
-
-    private val mediaExtractor = mediaExtractorFactory.create(localMedia.uri)
-
-    @Composable
-    override fun present(): MediaOptimizationSelectorState {
-        val displayMediaSelectorViews by produceState<Boolean?>(null) {
-            // When sending as a raw file, never show the optimization selector: images skip
-            // recompression, while videos use the highest available best-fit preset.
-            value = !sendAsFile && featureFlagService.isFeatureEnabled(FeatureFlags.SelectableMediaQuality)
-        }
-
-        var displayVideoPresetSelectorDialog by remember { mutableStateOf(false) }
-
-        val maxUploadSize by produceState(AsyncData.Loading()) {
-            maxUploadSizeProvider.getMaxUploadSize().fold(
-                onSuccess = { value = AsyncData.Success(it) },
-                onFailure = {
-                    Timber.e(it, "Failed to retrieve max upload size for video optimization selector")
-                    value = AsyncData.Success((100 * 1024 * 1024).toLong()) // Default to 100 MB if we can't retrieve the max upload size
-                }
-            )
-        }
-
-        val mediaMimeType = localMedia.info.mimeType
-
-        val videoSizeEstimations by produceState<AsyncData<ImmutableList<VideoUploadEstimation>>>(
-            initialValue = AsyncData.Loading(),
-            key1 = maxUploadSize,
-        ) {
-            if (maxUploadSize !is AsyncData.Success) {
-                return@produceState
-            }
-
-            if (!mediaMimeType.isMimeTypeVideo()) {
-                value = AsyncData.Uninitialized
-                return@produceState
-            }
-
-            val (videoDimensions, duration) = mediaExtractor.use {
-                val size = it.getSize()
-                    .getOrElse { exception ->
-                        value = AsyncData.Failure(exception)
-                        return@produceState
-                    }
-
-                val duration = it.getDuration()
-                    .getOrElse { exception ->
-                        value = AsyncData.Failure(exception)
-                        return@produceState
-                    }
-                size to duration
-            }
-
-            val sizeEstimations = VideoCompressionPreset.entries
-                .map { preset ->
-                    val videoBitRate = preset.compressorHelper().calculateOptimalBitrate(videoDimensions, 30)
-                    // The output always includes an AAC audio track too; ignoring it made the estimate
-                    // systematically lower than the actual compressed file size.
-                    val combinedBitRateAsBytes = (videoBitRate + ASSUMED_AUDIO_BITRATE) / 8f
-                    val durationInSeconds = duration.inWholeSeconds.toFloat()
-                    val calculatedSize = (combinedBitRateAsBytes * durationInSeconds * 1.1f).roundToLong() // Adding 10% overhead for safety
-                    VideoUploadEstimation(
-                        preset = preset,
-                        sizeInBytes = calculatedSize,
-                        canUpload = calculatedSize <= (maxUploadSize as AsyncData.Success).data
-                    )
-                }
-                .toImmutableList()
-                .also { sizes ->
-                    Timber.d(sizes.joinToString("\n") { "Calculated size for ${it.preset}: ${it.sizeInBytes} MB. Max upload size: $maxUploadSize" })
-                }
-
-            value = AsyncData.Success(sizeEstimations)
-        }
-
-        var selectedImageOptimization by remember { mutableStateOf<AsyncData<Boolean>>(AsyncData.Loading()) }
-        var selectedVideoOptimizationPreset by remember { mutableStateOf<AsyncData<VideoCompressionPreset>>(AsyncData.Loading()) }
-
-        LaunchedEffect(videoSizeEstimations.dataOrNull()) {
-            if (sendAsFile) {
-                // Send-as-file path: pin to no image compression, and pick the highest-quality
-                // video preset that still fits the upload limit (we have no true "do not re-encode
-                // video" path in the pre-processor right now).
-                selectedImageOptimization = AsyncData.Success(false)
-                selectedVideoOptimizationPreset = videoCompressionPresetSelector.selectBestVideoPreset(
-                    expectedVideoPreset = VideoCompressionPreset.HIGH,
-                    videoSizeEstimations = videoSizeEstimations,
-                )
-                return@LaunchedEffect
-            }
-            val mediaOptimizationConfig = mediaOptimizationConfigProvider.get()
-            selectedImageOptimization = AsyncData.Success(mediaOptimizationConfig.compressImages)
-            // Find the best video preset based on the default preset and the video size estimations
-            // Since the estimation for the current preset may be way too large to upload, we check the ones that provide lower file sizes
-            selectedVideoOptimizationPreset = videoCompressionPresetSelector.selectBestVideoPreset(
-                expectedVideoPreset = mediaOptimizationConfig.videoCompressionPreset,
-                videoSizeEstimations = videoSizeEstimations,
-            )
-        }
-
-        fun handleEvent(event: MediaOptimizationSelectorEvent) {
-            when (event) {
-                is MediaOptimizationSelectorEvent.SelectImageOptimization -> {
-                    selectedImageOptimization = AsyncData.Success(event.enabled)
-                }
-                is MediaOptimizationSelectorEvent.SelectVideoPreset -> {
-                    val estimations = videoSizeEstimations.dataOrNull()
-                    if (estimations != null) {
-                        val preset = estimations.find { it.preset == event.preset }
-                        if (preset == null) {
-                            Timber.e("Selected video preset ${event.preset} is not available in the estimations")
-                            return
-                        }
-                        if (!preset.canUpload) {
-                            Timber.w("Selected video preset ${event.preset} exceeds max upload size")
-                            return
-                        }
-                    } else {
-                        Timber.e("Video size estimations are not available")
-                        return
-                    }
-                    selectedVideoOptimizationPreset = AsyncData.Success(event.preset)
-                    displayVideoPresetSelectorDialog = false
-                }
-                is MediaOptimizationSelectorEvent.OpenVideoPresetSelectorDialog -> {
-                    displayVideoPresetSelectorDialog = true
-                }
-                is MediaOptimizationSelectorEvent.DismissVideoPresetSelectorDialog -> {
-                    displayVideoPresetSelectorDialog = false
-                }
-            }
-        }
-
-        return MediaOptimizationSelectorState(
-            index = index,
-            maxUploadSize = maxUploadSize,
-            videoSizeEstimations = videoSizeEstimations,
-            isImageOptimizationEnabled = selectedImageOptimization.dataOrNull(),
-            selectedVideoPreset = selectedVideoOptimizationPreset.dataOrNull(),
-            displayMediaSelectorViews = displayMediaSelectorViews,
-            displayVideoPresetSelectorDialog = displayVideoPresetSelectorDialog,
-            eventSink = ::handleEvent,
-        )
-    }
-}/*
- * Copyright (c) 2025 Element Creations Ltd.
  * Copyright 2023-2025 New Vector Ltd.
  *
  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
@@ -312,8 +102,10 @@ class VideoCompressor(
         val encoderFactory = DefaultEncoderFactory.Builder(context)
             .setRequestedVideoEncoderSettings(
                 VideoEncoderSettings.Builder()
-                    // Use VBR which is generally better for quality and compatibility, although slightly worse for file size
-                    .setBitrateMode(MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR)
+                    // Use CBR so the requested bitrate is treated as a hard target rather than an average.
+                    // VBR lets many hardware encoders spend significantly more bits than requested on complex
+                    // footage, which made the resulting file size unpredictable (and much larger than estimated).
+                    .setBitrateMode(MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR)
                     .setBitrate(newBitrate)
                     .build()
             )
@@ -327,6 +119,15 @@ class VideoCompressor(
             .setMuxerFactory(removeMetadataMuxer)
             .addListener(object : Transformer.Listener {
                 override fun onCompleted(composition: Composition, exportResult: ExportResult) {
+                    // Useful for tuning the audio-bitrate assumption used in the upload size estimate
+                    // (DefaultMediaOptimizationSelectorPresenter.ASSUMED_AUDIO_BITRATE), since Media3 doesn't
+                    // expose a public way to pin the audio encoder's bitrate up front.
+                    Timber.d(
+                        "Video transcoding completed. durationMs=${exportResult.durationMs} " +
+                            "fileSizeBytes=${exportResult.fileSizeBytes} " +
+                            "videoEncoderName=${exportResult.videoEncoderName} " +
+                            "averageAudioBitrate=${exportResult.averageAudioBitrate}"
+                    )
                     trySend(VideoTranscodingEvent.Completed(tmpFile))
                     close()
                 }
@@ -341,7 +142,15 @@ class VideoCompressor(
                     composition: Composition,
                     originalTransformationRequest: TransformationRequest,
                     fallbackTransformationRequest: TransformationRequest
-                ) = Unit
+                ) {
+                    // The requested transformation (bitrate/mode/resolution/etc.) could not be honored by the
+                    // device's encoder, and Media3 substituted different settings. Log this so we can tell when
+                    // the actual output diverges from what we planned for (e.g. size estimates becoming inaccurate).
+                    Timber.w(
+                        "Video transcoding fallback applied. Requested: $originalTransformationRequest, " +
+                            "actual: $fallbackTransformationRequest"
+                    )
+                }
             })
             .build()
 


### PR DESCRIPTION
By Claude.

## Fix video compression producing files much larger than the size shown to the user

### Problem

When compressing a video before upload, the size the user is shown in the media-quality picker (e.g. "≈4 MB" for the Low preset) can be wildly optimistic compared to the actual uploaded file size (e.g. 19 MB, from a 74 MB source). This makes the size estimate misleading and can cause uploads to exceed a homeserver's upload limit even when the picker said they'd fit.

This is also visible as general "video quality/size is unpredictable after compression" reports, e.g. [element-hq/element-x-android#5203](https://github.com/element-hq/element-x-android/issues/5203) and [#4191](https://github.com/element-hq/element-x-android/issues/4191).

### Root cause

Two independent issues compound to make the estimate diverge from reality:

1. **`VideoCompressor` requests VBR, which many hardware encoders don't tightly bound.**
   In `VideoCompressor.kt`, the `DefaultEncoderFactory` is configured with `BITRATE_MODE_VBR`:

   ```kotlin
   VideoEncoderSettings.Builder()
       // Use VBR which is generally better for quality and compatibility, although slightly worse for file size
       .setBitrateMode(MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR)
       .setBitrate(newBitrate)
       .build()
   ```

   Under VBR, `setBitrate()` is treated by many device encoders as a rough average/target rather than a ceiling — for busier footage the encoder can spend significantly more bits than requested to preserve quality. This is a known characteristic of `androidx.media3` Transformer specifically (see [androidx/media#1707](https://github.com/androidx/media/issues/1707), where a user configured a lower bitrate/resolution/framerate and still got a *higher* output bitrate than the input). This is the dominant cause of the multi-times-larger-than-estimated output.

2. **The upload size estimate only accounts for the video bitrate, never the audio track.**
   In `DefaultMediaOptimizationSelectorPresenter.kt`, the per-preset size estimate is:

   ```kotlin
   val bitRateAsBytes = preset.compressorHelper().calculateOptimalBitrate(videoDimensions, 30) / 8f
   val durationInSeconds = duration.inWholeSeconds.toFloat()
   val calculatedSize = (bitRateAsBytes * durationInSeconds * 1.1f).roundToLong() // Adding 10% overhead for safety
   ```

   But the compressed output always includes an AAC audio track (`.setAudioMimeType(MimeTypes.AUDIO_AAC)` in `VideoCompressor.kt`), which this formula never accounts for. For longer videos this alone can be a multi-MB gap.

3. **Silent fallback handling made this hard to diagnose.**
   `Transformer.Listener.onFallbackApplied` was a no-op (`= Unit`). If a device's encoder can't honor the requested bitrate/mode and Media3 substitutes different settings, the app had no visibility into it at all.

### Changes

**`libraries/mediaupload/impl/.../VideoCompressor.kt`**
- Switch the video encoder from `BITRATE_MODE_VBR` to `BITRATE_MODE_CBR` so the computed bitrate is enforced as a target rather than treated as a loose average. This is the primary fix for output size unpredictability.
- Log `onFallbackApplied` (previously a no-op) so we can see when a device's encoder can't honor our requested transformation and substitutes something else.
- Log key `ExportResult` fields (`durationMs`, `fileSizeBytes`, `videoEncoderName`, `averageAudioBitrate`) in `onCompleted`, to give us real data for tuning the audio-bitrate assumption below across real devices, since Media3's `DefaultEncoderFactory` doesn't expose a public way to pin the audio bitrate up front.

**`features/messages/impl/.../DefaultMediaOptimizationSelectorPresenter.kt`**
- Add an `ASSUMED_AUDIO_BITRATE` constant (128 kbps, a reasonable default for AAC) and fold it into the per-preset size estimate, so the audio track is no longer silently excluded.


### Testing

- [x] Verified the patch applies cleanly against a fresh checkout of `26.08.0` (`git apply --check`).
- [ ] Manual test: compress the same video at Low/Standard/High before and after this change, on at least one device, and compare estimated vs. actual output size.
- [ ] Manual test: force an encoder fallback (e.g. request CBR on a device/codec combo that doesn't support it) and confirm `Timber.w` fires with the fallback details.
- [ ] Existing unit tests (`VideoCompressorConfigFactoryTest`, `DefaultMediaOptimizationSelectorPresenterTest`) should continue to pass unmodified — neither test hardcodes an expected `sizeInBytes`/bitrate value, only resize/no-resize behavior, which is unaffected by this change.

### Known limitations / follow-ups

- `ASSUMED_AUDIO_BITRATE` (128 kbps) is a reasonable default for Media3's AAC encoder, not a value read back from the actual encoder — `DefaultEncoderFactory`'s public API in media3 1.10.1 doesn't expose a way to pin the audio bitrate the way `VideoEncoderSettings` does for video. The new `onCompleted` logging of `averageAudioBitrate` is meant to let us confirm/tune this constant against real device data; if it's consistently off, a follow-up PR should adjust it (or explore whether a newer media3 version exposes audio encoder settings).
- Even with `BITRATE_MODE_CBR`, not every device/encoder combination is guaranteed to honor it — the new fallback logging will surface cases where a device silently reverts to a different mode, which we should monitor after this ships.
- This does not address the separate, larger design question raised in #5203 — that there is currently no way to fully skip video re-encoding, unlike images (`compressImages` bool). That would be a bigger, separate change and is out of scope here.

### Related issues

- Closes/relates to #5203 (videos degraded and forced-compressed regardless of settings)
- Relates to #4191 (compressed video ending up larger than original for some sources)
