### PR TITLE
Add hooks for X.509 verification of user identities

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/MainActivity.kt
+++ b/app/src/main/kotlin/io/element/android/x/MainActivity.kt
@@ -61,6 +61,9 @@ class MainActivity : NodeActivity() {
         setContent {
             MainContent(appBindings)
         }
+
+        val activity = this
+        lifecycleScope.launch { appBindings.x509Provider().onAppStartup(activity) }
     }
 
     @Composable

--- a/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/AppBindings.kt
@@ -21,6 +21,7 @@ import io.element.android.libraries.di.identifiers.SentrySdkDsn
 import io.element.android.libraries.featureflag.api.FeatureFlagService
 import io.element.android.libraries.matrix.api.platform.InitPlatformService
 import io.element.android.libraries.matrix.api.tracing.TracingService
+import io.element.android.libraries.matrix.api.x509.X509Provider
 import io.element.android.libraries.preferences.api.store.AppPreferencesStore
 import io.element.android.services.analytics.api.AnalyticsService
 
@@ -51,4 +52,6 @@ interface AppBindings {
     fun buildMeta(): BuildMeta
 
     fun sentrySdkDsn(): SentrySdkDsn?
+
+    fun x509Provider(): X509Provider
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signer.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signer.kt
@@ -14,7 +14,7 @@ package io.element.android.libraries.matrix.api.x509
  *
  * @see RawX509Verifier
  */
-interface RawX509Signer {
+fun interface RawX509Signer {
     /** Create a signature for the given data, using our private key. */
     fun sign(message: ByteArray): RawX509Signature
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signer.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Signer.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+/**
+ * A type which can add an X.509 signature to a Matrix object.
+ *
+ * An instance of one of these can be returned by [X509Provider.getRawX509Signer].
+ *
+ * @see RawX509Verifier
+ */
+interface RawX509Signer {
+    /** Create a signature for the given data, using our private key. */
+    fun sign(message: ByteArray): RawX509Signature
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Verifier.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Verifier.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+/**
+ * A type which can verify an X.509 signature to a Matrix object.
+ *
+ * An instance of one of these can be returned by [X509Provider.getRawX509Verifier].
+ *
+ * @see RawX509Signer
+ */
+interface RawX509Verifier {
+    /** Check that `sig` is a valid signature of `message`.
+     *
+     * Implementations must check:
+     *  * The certificate chain is issued via a trusted CA.
+     *  * The certificate is valid for today's date.
+     *  * The signature itself is a valid signature of `message`.
+     *
+     * @return `true` if the signature is valid, otherwise `false`.
+     */
+    fun verify(message: ByteArray, sig: RawX509Signature): Boolean
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Verifier.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509Verifier.kt
@@ -14,7 +14,7 @@ package io.element.android.libraries.matrix.api.x509
  *
  * @see RawX509Signer
  */
-interface RawX509Verifier {
+fun interface RawX509Verifier {
     /** Check that `sig` is a valid signature of `message`.
      *
      * Implementations must check:

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509ignature.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/RawX509ignature.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+/**
+ * The object we receive from [RawX509Signer], and pass to
+ * [RawX509Verifier].
+ *
+ * A simplified representation of the data in the signature object.
+ */
+data class RawX509Signature(
+    /**
+     * The PEM-encoded certificate chain, starting with the device's own
+     * certificate, followed by intermediate certificates.
+     */
+    val certificateChain: String,
+    /** The raw bytes of the signature. */
+    val signatureBytes: ByteArray,
+    /** The algorithm that the signer used to construct the signature. */
+    val signatureScheme: X509SignatureScheme,
+)
+
+enum class X509SignatureScheme {
+    /**
+     * SHA-512 message digest, with RSASSA-PSS signature scheme (aka RSA-PSS),
+     * per [RFC 8017 § 8.1](https://www.rfc-editor.org/info/rfc8017/#section-8.1).
+     *
+     * Not to be confused with RSA-PKCS1, which is incompatible.
+     */
+    RSA_PSS_SHA512,
+}

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
@@ -10,14 +10,20 @@ package io.element.android.libraries.matrix.api.x509
 import android.app.Activity
 
 /**
- * Interface for things which can provide a [RawX509Signer] and/or a [RawX509Verifier]. Called during client creation.
+ * Interface for things which can provide a [RawX509Signer] and/or a [RawX509Verifier].
  */
 interface X509Provider {
-    /** Hook which is called during app startup. Allows the implementation to do any necessary initialization. */
-    suspend fun onAppStartup(parentActivity: Activity)
+    /**
+     * Hook which is called during app startup. Allows the implementation to do any necessary initialization.
+     *
+     * Note that the hook is run in the background: it will not block startup of the app.
+     *
+     * @param activity The activity which is active while the app starts (i.e. the `MainActivity`).
+     * */
+    suspend fun onAppStartup(activity: Activity)
 
     /**
-     * Provide a [RawX509Signer].
+     * Provide a [RawX509Signer]. Called during client creation.
      *
      * If a non-null result is returned, the implementation will be called to add a signature to any newly-created
      * digital identity (i.e., master cross-signing key).
@@ -25,7 +31,7 @@ interface X509Provider {
     suspend fun getRawX509Signer(): RawX509Signer?
 
     /**
-     * Provide a [RawX509Verifier].
+     * Provide a [RawX509Verifier]. Called during client creation.
      *
      * If a non-null result is returned, the implementation will be called to verify X.509 signatures on users'
      * digital identities (i.e. master cross-signing keys).

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/x509/X509Provider.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.api.x509
+
+import android.app.Activity
+
+/**
+ * Interface for things which can provide a [RawX509Signer] and/or a [RawX509Verifier]. Called during client creation.
+ */
+interface X509Provider {
+    /** Hook which is called during app startup. Allows the implementation to do any necessary initialization. */
+    suspend fun onAppStartup(parentActivity: Activity)
+
+    /**
+     * Provide a [RawX509Signer].
+     *
+     * If a non-null result is returned, the implementation will be called to add a signature to any newly-created
+     * digital identity (i.e., master cross-signing key).
+     */
+    suspend fun getRawX509Signer(): RawX509Signer?
+
+    /**
+     * Provide a [RawX509Verifier].
+     *
+     * If a non-null result is returned, the implementation will be called to verify X.509 signatures on users'
+     * digital identities (i.e. master cross-signing keys).
+     */
+    suspend fun getRawX509Verifier(): RawX509Verifier?
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactory.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.paths.SessionPaths
 import io.element.android.libraries.matrix.api.scanner.ContentScannerUrlProvider
+import io.element.android.libraries.matrix.api.x509.X509Provider
 import io.element.android.libraries.matrix.impl.analytics.UtdTracker
 import io.element.android.libraries.matrix.impl.paths.getSessionPaths
 import io.element.android.libraries.matrix.impl.proxy.ProxyProvider
@@ -27,6 +28,8 @@ import io.element.android.libraries.matrix.impl.room.TimelineEventFilterFactory
 import io.element.android.libraries.matrix.impl.scanner.RustContentScanner
 import io.element.android.libraries.matrix.impl.storage.SqliteStoreBuilderProvider
 import io.element.android.libraries.matrix.impl.util.anonymizedTokens
+import io.element.android.libraries.matrix.impl.x509.RawX509SignerWrapper
+import io.element.android.libraries.matrix.impl.x509.RawX509VerifierWrapper
 import io.element.android.libraries.network.useragent.UserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionData
 import io.element.android.libraries.sessionstorage.api.SessionStore
@@ -71,6 +74,7 @@ class RustMatrixClientFactory(
     private val sqliteStoreBuilderProvider: SqliteStoreBuilderProvider,
     private val workManagerScheduler: WorkManagerScheduler,
     private val contentScannerUrlProviderFactory: ContentScannerUrlProvider.Factory,
+    private val x509Provider: X509Provider,
 ) {
     private val sessionDelegate = RustClientSessionDelegate(
         sessionStore = sessionStore,
@@ -183,7 +187,7 @@ class RustMatrixClientFactory(
         slidingSyncType: ClientBuilderSlidingSync,
         isMessageSearchAvailable: Boolean,
     ): ClientBuilder {
-        return clientBuilderProvider.provide()
+        var builder = clientBuilderProvider.provide()
             .run {
                 sqliteStoreBuilderProvider.provide(sessionPaths)
                     .secret(clientSecret)
@@ -236,7 +240,18 @@ class RustMatrixClientFactory(
             )
             // Make sure all built clients use the single process cross-process lock config
             .crossProcessLockConfig(CrossProcessLockConfig.SingleProcess)
-            .run {
+
+        val rawX509signer = x509Provider.getRawX509Signer()
+        if (rawX509signer != null) {
+            builder = builder.withRawX509Signer(RawX509SignerWrapper(rawX509signer))
+        }
+
+        val rawX509verifier = x509Provider.getRawX509Verifier()
+        if (rawX509verifier != null) {
+            builder = builder.withRawX509Verifier(RawX509VerifierWrapper(rawX509verifier))
+        }
+
+        return builder.run {
                 // Apply sliding sync version settings
                 when (slidingSyncType) {
                     ClientBuilderSlidingSync.Restored -> this

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
@@ -22,6 +22,7 @@ import io.element.android.libraries.matrix.api.x509.X509Provider
 @ContributesBinding(AppScope::class)
 class DefaultX509Provider : X509Provider {
     override suspend fun onAppStartup(parentActivity: Activity) {
+        // Nothing to do here.
     }
 
     override suspend fun getRawX509Signer(): RawX509Signer? {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import android.app.Activity
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.matrix.api.x509.RawX509Signer
+import io.element.android.libraries.matrix.api.x509.RawX509Verifier
+import io.element.android.libraries.matrix.api.x509.X509Provider
+
+/**
+ * Default implementation of [X509Provider], which does nothing.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultX509Provider : X509Provider {
+    override suspend fun onAppStartup(parentActivity: Activity) {
+    }
+
+    override suspend fun getRawX509Signer(): RawX509Signer? {
+        return null
+    }
+
+    override suspend fun getRawX509Verifier(): RawX509Verifier? {
+        return null
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
@@ -10,7 +10,6 @@ package io.element.android.libraries.matrix.impl.x509
 import android.app.Activity
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.matrix.api.x509.RawX509Signer
 import io.element.android.libraries.matrix.api.x509.RawX509Verifier
 import io.element.android.libraries.matrix.api.x509.X509Provider

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/DefaultX509Provider.kt
@@ -18,10 +18,9 @@ import io.element.android.libraries.matrix.api.x509.X509Provider
 /**
  * Default implementation of [X509Provider], which does nothing.
  */
-@SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class DefaultX509Provider : X509Provider {
-    override suspend fun onAppStartup(parentActivity: Activity) {
+    override suspend fun onAppStartup(activity: Activity) {
         // Nothing to do here.
     }
 

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509SignerWrapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509SignerWrapper.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import io.element.android.libraries.matrix.api.x509.RawX509Signer
+import io.element.android.libraries.matrix.api.x509.X509SignatureScheme
+import uniffi.matrix_sdk_crypto.RawX509Signature
+
+/** A shim which maps from our own [RawX509Signer] interface to the rust-sdk's interface of the same name. */
+class RawX509SignerWrapper(private val rawX509Signer: RawX509Signer) : org.matrix.rustcomponents.sdk.RawX509Signer {
+    override fun sign(message: ByteArray): RawX509Signature {
+        val sig = rawX509Signer.sign(message)
+        val signatureScheme = when (sig.signatureScheme) {
+            X509SignatureScheme.RSA_PSS_SHA512 -> uniffi.matrix_sdk_crypto.X509SignatureScheme.RSA_PSS_SHA512
+        }
+        return RawX509Signature(sig.signatureBytes, sig.certificateChain, signatureScheme)
+    }
+}

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509VerifierWrapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509VerifierWrapper.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import io.element.android.libraries.matrix.api.x509.RawX509Verifier
+import uniffi.matrix_sdk_crypto.RawX509Signature
+import uniffi.matrix_sdk_crypto.X509SignatureScheme
+
+/** A shim which maps from our own [RawX509Verifier] interface to the rust-sdk's interface of the same name. */
+class RawX509VerifierWrapper(private val rawX509Verifier: RawX509Verifier) : org.matrix.rustcomponents.sdk.RawX509Verifier {
+    override fun verify(message: ByteArray, sig: RawX509Signature): Boolean {
+        val signatureScheme = when (sig.signatureScheme) {
+            X509SignatureScheme.RSA_PSS_SHA512 -> io.element.android.libraries.matrix.api.x509.X509SignatureScheme.RSA_PSS_SHA512
+        }
+
+        val sig = io.element.android.libraries.matrix.api.x509.RawX509Signature(
+            sig.certificateChain,
+            sig.signatureBytes,
+            signatureScheme
+        )
+        return rawX509Verifier.verify(message, sig)
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactoryTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClientFactoryTest.kt
@@ -15,6 +15,7 @@ import io.element.android.libraries.matrix.api.scanner.ContentScannerUrlProvider
 import io.element.android.libraries.matrix.impl.auth.FakeProxyProvider
 import io.element.android.libraries.matrix.impl.room.FakeTimelineEventFilterFactory
 import io.element.android.libraries.matrix.impl.storage.FakeSqliteStoreBuilderProvider
+import io.element.android.libraries.matrix.impl.x509.DefaultX509Provider
 import io.element.android.libraries.network.useragent.SimpleUserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
@@ -68,4 +69,5 @@ fun TestScope.createRustMatrixClientFactory(
     sqliteStoreBuilderProvider = FakeSqliteStoreBuilderProvider(),
     workManagerScheduler = workManagerScheduler,
     contentScannerUrlProviderFactory = contentScannerUrlProviderFactory,
+    x509Provider = DefaultX509Provider(),
 )

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientFactoryTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientFactoryTest.kt
@@ -14,6 +14,7 @@ import io.element.android.libraries.matrix.impl.auth.FakeProxyProvider
 import io.element.android.libraries.matrix.impl.paths.SessionPathsFactory
 import io.element.android.libraries.matrix.impl.room.FakeTimelineEventFilterFactory
 import io.element.android.libraries.matrix.impl.storage.FakeSqliteStoreBuilderProvider
+import io.element.android.libraries.matrix.impl.x509.DefaultX509Provider
 import io.element.android.libraries.network.useragent.SimpleUserAgentProvider
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
@@ -80,5 +81,6 @@ class RustTemporaryMatrixClientFactoryTest {
         sqliteStoreBuilderProvider = FakeSqliteStoreBuilderProvider(),
         workManagerScheduler = workManagerScheduler,
         contentScannerUrlProviderFactory = contentScannerUrlProviderFactory,
+        x509Provider = DefaultX509Provider(),
     )
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509SignerWrapperTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509SignerWrapperTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.x509.RawX509Signature
+import io.element.android.libraries.matrix.api.x509.X509SignatureScheme
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import uniffi.matrix_sdk_crypto.RawX509Signature as RustRawX509Signature
+import uniffi.matrix_sdk_crypto.X509SignatureScheme as RustX509SignatureScheme
+
+class RawX509SignerWrapperTest {
+    @Test
+    fun `sign calls the sign method and maps the result`() = runTest {
+        val message = "message".toByteArray()
+        val signatureBytes = "signature".toByteArray()
+        val certificateChain = "certificate chain"
+        val resultSignature = RawX509Signature(
+            certificateChain = certificateChain,
+            signatureBytes = signatureBytes,
+            signatureScheme = X509SignatureScheme.RSA_PSS_SHA512,
+        )
+        val expectedRustSignature = RustRawX509Signature(
+            signatureBytes = signatureBytes,
+            certificateChain = certificateChain,
+            signatureScheme = RustX509SignatureScheme.RSA_PSS_SHA512,
+        )
+
+        val signLambda = lambdaRecorder<ByteArray, RawX509Signature> { _ -> resultSignature }
+        val wrapper = RawX509SignerWrapper(rawX509Signer = { m -> signLambda(m) })
+        val result = wrapper.sign(message)
+
+        assertThat(result).isEqualTo(expectedRustSignature)
+        signLambda.assertions().isCalledOnce().with(value(message))
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509VerifierWrapperTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/x509/RawX509VerifierWrapperTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.x509
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.x509.RawX509Signature
+import io.element.android.libraries.matrix.api.x509.X509SignatureScheme
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import uniffi.matrix_sdk_crypto.RawX509Signature as RustRawX509Signature
+import uniffi.matrix_sdk_crypto.X509SignatureScheme as RustX509SignatureScheme
+
+class RawX509VerifierWrapperTest {
+    @Test
+    fun `verify maps the rust signature and forwards the result to the wrapped verifier`() = runTest {
+        val message = "message".toByteArray()
+        val signatureBytes = "signature".toByteArray()
+        val certificateChain = "certificate chain"
+        val rustSignature = RustRawX509Signature(
+            signatureBytes = signatureBytes,
+            certificateChain = certificateChain,
+            signatureScheme = RustX509SignatureScheme.RSA_PSS_SHA512,
+        )
+        val expectedApiSignature = RawX509Signature(
+            certificateChain = certificateChain,
+            signatureBytes = signatureBytes,
+            signatureScheme = X509SignatureScheme.RSA_PSS_SHA512,
+        )
+
+        val verifyLambda = lambdaRecorder<ByteArray, RawX509Signature, Boolean> { _, _ -> true }
+        val wrapper = RawX509VerifierWrapper(rawX509Verifier = { m, s -> verifyLambda(m, s) })
+        val result = wrapper.verify(message, rustSignature)
+
+        assertThat(result).isTrue()
+        verifyLambda.assertions().isCalledOnce().with(
+            value(message),
+            value(expectedApiSignature),
+        )
+    }
+
+    @Test
+    fun `verify returns false when the wrapped verifier rejects the signature`() = runTest {
+        val rustSignature = RustRawX509Signature(
+            signatureBytes = "signature".toByteArray(),
+            certificateChain = "certificate chain",
+            signatureScheme = RustX509SignatureScheme.RSA_PSS_SHA512,
+        )
+
+        val wrapper = RawX509VerifierWrapper(rawX509Verifier = { _, _ -> false })
+        val result = wrapper.verify("message".toByteArray(), rustSignature)
+
+        assertThat(result).isFalse()
+    }
+}


### PR DESCRIPTION
Add an interface `io.element.android.libraries.matrix.api.x509.X509Provider`, which can be implmenented to perform automatic verification of users using X.509 certificates, based on the functionality added to matrix-rust-sdk in https://github.com/matrix-org/matrix-rust-sdk/pull/6727.

The default implementation does nothing, but the interface will be implemented in Enterprise builds.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [X] No.
- [X] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR