### PR TITLE
Fix thread notifications not using the room's conversation channel

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/factories/NotificationCreator.kt
@@ -15,6 +15,7 @@ import android.os.Bundle
 import androidx.annotation.ColorInt
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.MessagingStyle
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
 import coil3.ImageLoader
 import dev.zacsweers.metro.AppScope
@@ -179,6 +180,16 @@ class DefaultNotificationCreator(
                 .apply {
                     if (threadId == null) {
                         setShortcutId(createShortcutId(roomInfo.sessionId, roomInfo.roomId))
+                    } else {
+                        // Thread notifications don't set a shortcut ID so the MessagingStyle
+                        // conversationTitle ("Thread in <room>") is displayed. Instead, look
+                        // up the room's conversation-derived channel and post the thread
+                        // notification there, so it inherits any custom sound the user set.
+                        val roomConversationChannel = NotificationManagerCompat.from(context)
+                            .getNotificationChannel(channelId, createShortcutId(roomInfo.sessionId, roomInfo.roomId))
+                        if (roomConversationChannel != null) {
+                            setChannelId(roomConversationChannel.id)
+                        }
                     }
                 }
                 .setGroupSummary(false)

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/factories/DefaultNotificationCreatorTest.kt
@@ -41,6 +41,7 @@ import io.element.android.libraries.push.impl.notifications.fixtures.aFallbackNo
 import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiableMessageEvent
 import io.element.android.libraries.push.impl.notifications.model.InviteNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.model.SimpleNotifiableEvent
+import io.element.android.libraries.push.impl.notifications.shortcut.createShortcutId
 import io.element.android.services.toolbox.test.sdk.FakeBuildVersionSdkIntProvider
 import io.element.android.services.toolbox.test.strings.FakeStringProvider
 import io.element.android.services.toolbox.test.systemclock.A_FAKE_TIMESTAMP
@@ -271,6 +272,7 @@ class DefaultNotificationCreatorTest : RobolectricTest() {
             events = listOf(aNotifiableMessageEvent()),
         )
         result.commonAssertions()
+        assertThat(result.shortcutId).isEqualTo(createShortcutId(A_SESSION_ID, A_ROOM_ID))
     }
 
     @Test
@@ -300,6 +302,7 @@ class DefaultNotificationCreatorTest : RobolectricTest() {
             events = listOf(aNotifiableMessageEvent()),
         )
         result.commonAssertions()
+        assertThat(result.shortcutId).isNull()
     }
 
     private fun Notification.commonAssertions(


### PR DESCRIPTION
Thread notifications now inherit the parent room's conversation-derived notification channel, so custom sounds, priority, and DND settings configured for a room also apply to thread notifications in that room.

Instead of setting `setShortcutId` on thread notifications (which would override the "Thread in \<room\>" title with the shortcut label), this looks up the room's conversation-derived channel via `NotificationManagerCompat.getNotificationChannel()` and sets it explicitly with `setChannelId`. If no conversation channel exists for the room, the thread notification falls back to the default channel.

## Motivation and context

Fixes #7405

The `threadId == null` guard on `setShortcutId` in `NotificationCreator` (introduced in #5595) prevents thread notifications from being routed to the room's conversation channel. Related: #6196, #5990, #2831.

## Tests

- Verified thread notifications play the room's custom conversation sound
- Verified "Thread in \<room\>" title is preserved
- Verified thread/room notification grouping is unaffected
- Unit tests updated: non-thread notifications assert shortcut ID is set, thread notifications assert shortcut ID is null

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 17 (Pixel 8 Pro)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
  - N/A - No UI changes
- [x] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
  - N/A - No UI changes
- [x] You've made a self review of your PR

## Note

This is my first contribution to Element X. I used Claude Code to locate and implement this fix for an issue I was hitting with my own setup. I've tested it on my Pixel 8 Pro and it works for my use case, but I haven't been able to test on older API levels or across a wide range of devices. Happy to address any feedback.