### PR TITLE
build-rust-sdk: print the command we run

### DIFF
--- a/tools/sdk/build-rust-sdk
+++ b/tools/sdk/build-rust-sdk
@@ -215,25 +215,26 @@ if [ "$update_components" == "1" ]; then
 
     printf "\n## Resetting ${kotlinComponentsPath} to the latest main...\n\n"
 
-    cd "${kotlinComponentsPath}"
-    git reset --hard
-    git checkout main
-    git pull
-else
-    cd "${kotlinComponentsPath}"
+    (
+        cd "${kotlinComponentsPath}"
+        git reset --hard
+        git checkout main
+        git pull
+    )
 fi
 
 ## Build the SDK
 
 printf "\n## Building the SDK for ${target_arch}...\n\n"
 
-./scripts/build.sh \
+cmd=("${kotlinComponentsPath}/scripts/build.sh" \
     -p "${rustSdkPath}" \
     -m sdk \
     -t "${target_arch}" \
-    -o "${elementPwd}/libraries/rustsdk"
+    -o "${elementPwd}/libraries/rustsdk")
 
-cd "${elementPwd}"
+echo "$ ${cmd[@]}"
+"${cmd[@]}"
 
 mv \
     ./libraries/rustsdk/sdk-android-debug.aar \

--- a/tools/sdk/build-rust-sdk
+++ b/tools/sdk/build-rust-sdk
@@ -233,7 +233,7 @@ cmd=("${kotlinComponentsPath}/scripts/build.sh" \
     -t "${target_arch}" \
     -o "${elementPwd}/libraries/rustsdk")
 
-echo "$ ${cmd[@]}"
+echo "$" "${cmd[@]}"
 "${cmd[@]}"
 
 mv \


### PR DESCRIPTION
It's helpful to know what exactly is being run.

Also some tweaks to reduce the amount of directory changing that needs to happen.