### PR TITLE
Fix voice recordings that could not be stopped after tapping record twice

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenter.kt
@@ -76,6 +76,7 @@ class DefaultVoiceMessageComposerPresenter(
 
     private val permissionsPresenter = permissionsPresenterFactory.create(Manifest.permission.RECORD_AUDIO)
     private var pendingEvent: VoiceMessageRecorderEvent.Start? = null
+    private var isRecordingRequested = false
     private val mediaSender = mediaSenderFactory.create(timelineMode)
 
     @Composable
@@ -122,6 +123,9 @@ class DefaultVoiceMessageComposerPresenter(
                 VoiceMessageRecorderEvent.Start -> {
                     Timber.v("Voice message record button pressed")
                     when {
+                        isRecordingRequested -> {
+                            Timber.v("Voice message recording already requested, ignoring")
+                        }
                         permissionState.permissionGranted -> {
                             localCoroutineScope.startRecording()
                         }
@@ -255,29 +259,39 @@ class DefaultVoiceMessageComposerPresenter(
         )
     }
 
-    private fun CoroutineScope.startRecording() = launch {
-        try {
-            audioFocus.requestAudioFocus(AudioFocusRequester.RecordVoiceMessage) {
-                // something else grabbed focus (phone call, etc) - finish gracefully
-                // so the user keeps their partial recording
-                sessionCoroutineScope.finishRecording()
+    private fun CoroutineScope.startRecording() {
+        isRecordingRequested = true
+        launch {
+            try {
+                audioFocus.requestAudioFocus(AudioFocusRequester.RecordVoiceMessage) {
+                    // something else grabbed focus (phone call, etc) - finish gracefully
+                    // so the user keeps their partial recording
+                    sessionCoroutineScope.finishRecording()
+                }
+                voiceRecorder.startRecord()
+            } catch (e: SecurityException) {
+                isRecordingRequested = false
+                audioFocus.releaseAudioFocus()
+                Timber.e(e, "Voice message error")
+                analyticsService.trackError(VoiceMessageException.PermissionMissing("Expected permission to record but none", e))
             }
-            voiceRecorder.startRecord()
-        } catch (e: SecurityException) {
-            audioFocus.releaseAudioFocus()
-            Timber.e(e, "Voice message error")
-            analyticsService.trackError(VoiceMessageException.PermissionMissing("Expected permission to record but none", e))
         }
     }
 
-    private fun CoroutineScope.finishRecording() = launch {
-        voiceRecorder.stopRecord()
-        audioFocus.releaseAudioFocus()
+    private fun CoroutineScope.finishRecording() {
+        isRecordingRequested = false
+        launch {
+            voiceRecorder.stopRecord()
+            audioFocus.releaseAudioFocus()
+        }
     }
 
-    private fun CoroutineScope.cancelRecording() = launch {
-        voiceRecorder.stopRecord(cancelled = true)
-        audioFocus.releaseAudioFocus()
+    private fun CoroutineScope.cancelRecording() {
+        isRecordingRequested = false
+        launch {
+            voiceRecorder.stopRecord(cancelled = true)
+            audioFocus.releaseAudioFocus()
+        }
     }
 
     private fun CoroutineScope.deleteRecording() = launch {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
@@ -127,6 +127,40 @@ class DefaultVoiceMessageComposerPresenterTest {
     }
 
     @Test
+    fun `present - tapping record twice before the state leaves Idle only starts one recording`() = runTest {
+        val presenter = createDefaultVoiceMessageComposerPresenter()
+        presenter.test {
+            val initialState = awaitItem()
+            initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+
+            val finalState = awaitItem()
+            assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
+            voiceRecorder.assertCalls(started = 1)
+
+            testPauseAndDestroy(finalState)
+        }
+    }
+
+    @Test
+    fun `present - recording can be started again after being cancelled`() = runTest {
+        val presenter = createDefaultVoiceMessageComposerPresenter()
+        presenter.test {
+            val initialState = awaitItem()
+            initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Cancel))
+            awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
+
+            val finalState = awaitItem()
+            assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
+            voiceRecorder.assertCalls(started = 2, stopped = 1, deleted = 1)
+
+            testPauseAndDestroy(finalState)
+        }
+    }
+
+    @Test
     fun `present - recording state - number of levels is limited`() = runTest {
         val numberOfLevels = 200
         val levels = List(numberOfLevels) { it / numberOfLevels.toFloat() }

--- a/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
+++ b/libraries/voicerecorder/impl/src/main/kotlin/io/element/android/libraries/voicerecorder/impl/DefaultVoiceRecorder.kt
@@ -105,8 +105,8 @@ class DefaultVoiceRecorder(
                         lock.withLock {
                             levels.add(audioLevel)
                             _state.emit(VoiceRecorderState.Recording(elapsedTime, levels.toList()))
+                            encoder.encode(audio.buffer, audio.readSize)
                         }
-                        encoder.encode(audio.buffer, audio.readSize)
                     }
                     is Audio.Error -> {
                         Timber.e("Voice message error: code=${audio.audioRecordErrorCode}")
@@ -124,7 +124,7 @@ class DefaultVoiceRecorder(
      */
     override suspend fun stopRecord(
         cancelled: Boolean
-    ) {
+    ) = lock.withLock {
         recordingJob?.cancel()?.also {
             Timber.i("Voice recorder stopped recording")
         }
@@ -134,33 +134,35 @@ class DefaultVoiceRecorder(
         audioReader = null
         encoder.release()
 
-        lock.withLock {
-            if (cancelled) {
-                deleteRecording()
-                levels.clear()
-            }
-
-            _state.emit(
-                when (val file = outputFile) {
-                    null -> VoiceRecorderState.Idle
-                    else -> {
-                        val duration = (state.value as? VoiceRecorderState.Recording)?.elapsedTime
-                        VoiceRecorderState.Finished(
-                            file = file,
-                            mimeType = fileConfig.mimeType,
-                            waveform = levels.resample(100),
-                            duration = duration ?: 0.milliseconds
-                        )
-                    }
-                }
-            )
+        if (cancelled) {
+            deleteRecordingUnderLock()
+            levels.clear()
         }
+
+        _state.emit(
+            when (val file = outputFile) {
+                null -> VoiceRecorderState.Idle
+                else -> {
+                    val duration = (state.value as? VoiceRecorderState.Recording)?.elapsedTime
+                    VoiceRecorderState.Finished(
+                        file = file,
+                        mimeType = fileConfig.mimeType,
+                        waveform = levels.resample(100),
+                        duration = duration ?: 0.milliseconds
+                    )
+                }
+            }
+        )
     }
 
     /**
      * Stop the current recording and delete the output file.
      */
-    override suspend fun deleteRecording() {
+    override suspend fun deleteRecording() = lock.withLock {
+        deleteRecordingUnderLock()
+    }
+
+    private suspend fun deleteRecordingUnderLock() {
         outputFile?.let(fileManager::deleteFile)?.also {
             Timber.i("Voice recorder deleted recording")
         }


### PR DESCRIPTION
## Content

Tapping the record button twice quickly could leave a recording that neither Stop nor Delete would
end. The microphone stayed open and the composer kept showing Recording until the room was left and
re-entered.

The guard added in #7346 made two concurrent `startRecord` calls exclusive, but it did not make
start and stop exclusive. `startRecord` does all of its work under the mutex, while `stopRecord`
cancelled the job, cleared `recordingJob` and `audioReader` and released the encoder *before* taking
that mutex. A start that was still in flight could therefore observe the cleared `recordingJob`,
pass the guard, and install a fresh reader and job on top of a teardown that had already happened.
Stop then emitted `Finished`, but the replacement job kept emitting `Recording`, and nothing held a
reference that Stop or Delete could act on.

`stopRecord` and `deleteRecording` now run under the same mutex as `startRecord`, so a recording is
only ever created or destroyed as a whole. `encode()` also moves inside the lock so it can no longer
run against an encoder that `stopRecord` has already released, which is the native crash the issue
mentions.

That alone cannot tell a duplicate tap apart from a genuine new one, because coroutine dispatch has
already lost the ordering by the time the recorder sees it. The composer therefore drops the
duplicate where the order is still known: `handleVoiceMessageRecorderEvent` runs on the main thread
in tap order, so a second Start is ignored while a recording is already requested. The flag is set
and cleared in `startRecording`/`finishRecording`/`cancelRecording`, so the lifecycle and audio focus
paths are covered as well as the buttons.

## Motivation and context

A recording that cannot be stopped holds the microphone for the rest of the session, which is worse
than the visible symptom.

Relates to https://github.com/element-hq/element-x-android/issues/5780

## Tests

- `DefaultVoiceMessageComposerPresenterTest` — `tapping record twice before the state leaves Idle
  only starts one recording` sends two `Start` events from the same Idle state and asserts the
  recorder was started once.
- `DefaultVoiceMessageComposerPresenterTest` — `recording can be started again after being cancelled`
  covers the flag being cleared, so a double tap cannot leave recording permanently disabled.
- Both fail without this change and pass with it.
- The recorder-level race is a data race between two coroutines; it reproduces under a real-threaded
  stress harness but not deterministically in a unit test, so it is not covered by one here.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
