### PR TITLE
Add missing tests for `RustTemporaryMatrixClient`

### DIFF
--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.exception.ClientException
+import io.element.android.libraries.matrix.api.paths.SessionPaths
+import io.element.android.libraries.matrix.impl.fixtures.fakes.FakeFfiClient
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.matrix.rustcomponents.sdk.Client
+import org.matrix.rustcomponents.sdk.NoHandle
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import org.matrix.rustcomponents.sdk.ClientException as RustClientException
+
+class RustTemporaryMatrixClientTest {
+    @Test
+    fun `getUrl method uses client getUrl`() = runTest {
+        val paths = SessionPaths(
+            fileDirectory = File("files"),
+            cacheDirectory = File("cache"),
+        )
+
+        val getUrlRecorder = lambdaRecorder<String, ByteArray> { ByteArray(0) }
+        val client = createRustTemporaryMatrixClient(
+            client = FakeFfiClient(
+                getUrlResult = getUrlRecorder,
+            ),
+            paths = paths,
+        )
+        val url = "https://example.com"
+
+        client.getUrl(url)
+
+        getUrlRecorder.assertions().isCalledOnce().with(value(url))
+    }
+
+    @Test
+    fun `getUrl method can fail gracefully and map errors to public ones`() = runTest {
+        val paths = SessionPaths(
+            fileDirectory = File("files"),
+            cacheDirectory = File("cache"),
+        )
+
+        val getUrlRecorder = lambdaRecorder<String, ByteArray> { throw RustClientException.Generic("Error", null) }
+        val client = createRustTemporaryMatrixClient(
+            client = FakeFfiClient(
+                getUrlResult = getUrlRecorder,
+            ),
+            paths = paths,
+        )
+        val url = "https://example.com"
+
+        val result = client.getUrl(url)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(ClientException.Generic::class.java)
+    }
+
+    @Test
+    fun `close deletes the directories if they exist`() = runTest {
+        val paths = SessionPaths(
+            fileDirectory = createTempDirectory().toFile(),
+            cacheDirectory = createTempDirectory().toFile(),
+        )
+
+        val client = createRustTemporaryMatrixClient(paths = paths)
+
+        assertThat(paths.fileDirectory.exists()).isTrue()
+        assertThat(paths.cacheDirectory.exists()).isTrue()
+
+        client.close()
+
+        assertThat(paths.fileDirectory.exists()).isFalse()
+        assertThat(paths.cacheDirectory.exists()).isFalse()
+    }
+
+    private fun createRustTemporaryMatrixClient(
+        client: Client = Client(NoHandle),
+        paths: SessionPaths,
+    ): RustTemporaryMatrixClient {
+        return RustTemporaryMatrixClient(client, paths)
+    }
+}

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiClient.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiClient.kt
@@ -60,6 +60,7 @@ class FakeFfiClient(
     private val setAccountDataResult: (String, String) -> Unit = { _, _ -> lambdaError() },
     private val isUserStatusSupportedResult: () -> Boolean = { false },
     private val subscribeToOwnProfileResult: (ProfileListener) -> Unit = {},
+    private val getUrlResult: (String) -> ByteArray = { lambdaError() },
     private val closeResult: () -> Unit = {},
 ) : Client(NoHandle) {
     override fun userId(): String = userId
@@ -132,6 +133,10 @@ class FakeFfiClient(
 
     override suspend fun setAccountData(eventType: String, content: String) = simulateLongTask {
         setAccountDataResult(eventType, content)
+    }
+
+    override suspend fun getUrl(url: String): ByteArray = simulateLongTask {
+        getUrlResult(url)
     }
 
     override fun close() = closeResult()


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says.

## Motivation and context

Coverage! And also, i felt a bit guilty about not adding these when I was meant to.

## Tests

That's what's in here.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
