### PR TITLE
Add hooks to allow providing additional feature flags in EX pro

### DIFF
--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeaturesProvider.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeaturesProvider.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.featureflag.api
+
+/**
+ * Provides a list of available [Feature]s that the application supports.
+ * Used by [FeatureFlagService.getAvailableFeatures] to obtain a list of features
+ * that can be presented to the user.
+ *
+ * Multiple instances can exist within the application, and all instances are polled
+ * to provide features for the list. This means that additional features can be provided
+ * by compile-time extensions.
+ */
+fun interface FeaturesProvider {
+    fun provide(): List<Feature>
+}

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagService.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagService.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.SingleIn
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.featureflag.api.Feature
 import io.element.android.libraries.featureflag.api.FeatureFlagService
+import io.element.android.libraries.featureflag.api.FeaturesProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.flowOf
 class DefaultFeatureFlagService(
     private val providers: Set<@JvmSuppressWildcards FeatureFlagProvider>,
     private val buildMeta: BuildMeta,
-    private val featuresProvider: FeaturesProvider,
+    private val featuresProviders: Set<FeaturesProvider>,
 ) : FeatureFlagService {
     override fun isFeatureEnabledFlow(feature: Feature): Flow<Boolean> {
         return if (feature.isFinished) {
@@ -47,7 +48,7 @@ class DefaultFeatureFlagService(
         includeFinishedFeatures: Boolean,
         isInLabs: Boolean,
     ): List<Feature> {
-        return featuresProvider.provide().filter { flag ->
+        return featuresProviders.flatMap { provider -> provider.provide() }.filter { flag ->
             (includeFinishedFeatures || !flag.isFinished) &&
                 flag.isInLabs == isInLabs
         }

--- a/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeaturesProvider.kt
+++ b/libraries/featureflag/impl/src/main/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeaturesProvider.kt
@@ -9,15 +9,12 @@
 package io.element.android.libraries.featureflag.impl
 
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.ContributesIntoSet
 import io.element.android.libraries.featureflag.api.Feature
 import io.element.android.libraries.featureflag.api.FeatureFlags
+import io.element.android.libraries.featureflag.api.FeaturesProvider
 
-fun interface FeaturesProvider {
-    fun provide(): List<Feature>
-}
-
-@ContributesBinding(AppScope::class)
+@ContributesIntoSet(AppScope::class)
 class DefaultFeaturesProvider : FeaturesProvider {
     override fun provide(): List<Feature> = FeatureFlags.entries
 }

--- a/libraries/featureflag/impl/src/test/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagServiceTest.kt
+++ b/libraries/featureflag/impl/src/test/kotlin/io/element/android/libraries/featureflag/impl/DefaultFeatureFlagServiceTest.kt
@@ -12,6 +12,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.core.meta.BuildMeta
 import io.element.android.libraries.featureflag.api.Feature
+import io.element.android.libraries.featureflag.api.FeaturesProvider
 import io.element.android.libraries.featureflag.test.FakeFeature
 import io.element.android.libraries.matrix.test.core.aBuildMeta
 import kotlinx.coroutines.test.runTest
@@ -166,5 +167,5 @@ private fun createDefaultFeatureFlagService(
 ) = DefaultFeatureFlagService(
     providers = providers,
     buildMeta = buildMeta,
-    featuresProvider = { features }
+    featuresProviders = setOf(FeaturesProvider { features })
 )


### PR DESCRIPTION
We modify the existing `FeaturesProvider` interface so that there can be more than one of them, and the Features provided by *all* of the instances are shown. We can then make another instance in element-android-enterprise, which exposes enterprise-only features.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR