### PR TITLE
[LinkNewDevice] Ensure the notice screen is also protected by the timeout.

### DIFF
--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDesktopHandler.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDesktopHandler.kt
@@ -53,13 +53,18 @@ class LinkNewDesktopHandler(
         timerJob = null
     }
 
-    fun createNewHandler() {
-        resetJobs()
-        handler = matrixClient.createLinkDesktopHandler().getOrNull()
+    fun startTimer() {
+        timerJob?.cancel()
         timerJob = sessionScope.launch {
             delay(2.minutes)
             linkDesktopStepFlow.emit(LinkDesktopStep.Error(ErrorType.Expired("Scanning QrCode took too long.")))
         }
+    }
+
+    fun createNewHandler() {
+        currentJob?.cancel()
+        currentJob = null
+        handler = matrixClient.createLinkDesktopHandler().getOrNull()
     }
 
     fun reset() {

--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDesktopHandler.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDesktopHandler.kt
@@ -39,6 +39,10 @@ class LinkNewDesktopHandler(
         LinkDesktopStep.Uninitialized
     )
 
+    /**
+     * A [StateFlow] that emits the current step of the link desktop process.
+     * It starts with [LinkDesktopStep.Uninitialized] and will emit other steps as they occur.
+     */
     val stepFlow: StateFlow<LinkDesktopStep>
         get() = linkDesktopStepFlow.asStateFlow()
 
@@ -53,6 +57,9 @@ class LinkNewDesktopHandler(
         timerJob = null
     }
 
+    /**
+     * Starts (or restarts) a timer that will emit an error in [stepFlow] after 2 minutes.
+     */
     fun startTimer() {
         timerJob?.cancel()
         timerJob = sessionScope.launch {
@@ -61,12 +68,20 @@ class LinkNewDesktopHandler(
         }
     }
 
+    /**
+     * Creates a new [LinkDesktopHandler] and cancels any existing job.
+     * This should be called when the user wants to retry scanning a QR code.
+     */
     fun createNewHandler() {
         currentJob?.cancel()
         currentJob = null
         handler = matrixClient.createLinkDesktopHandler().getOrNull()
     }
 
+    /**
+     * Resets the state of the handler and cancels any existing job.
+     * This should be called when the user wants to start over.
+     */
     fun reset() {
         resetJobs()
         sessionScope.launch {
@@ -74,6 +89,12 @@ class LinkNewDesktopHandler(
         }
     }
 
+    /**
+     * Handles the scanned QR code data.
+     * This should be called when the user scans a QR code.
+     *
+     * @param data The scanned QR code data as a byte array.
+     */
     fun onScannedCode(data: ByteArray) {
         resetJobs()
         val currentHandler = handler

--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDeviceFlowNode.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDeviceFlowNode.kt
@@ -280,13 +280,13 @@ class LinkNewDeviceFlowNode(
             NavTarget.DesktopNotice -> {
                 val callback = object : DesktopNoticeNode.Callback {
                     override fun navigateBack() {
-                        // reset the timer when the user leaves the screen (user will have to authenticate again)
+                        // Stop the timer when the user leaves the screen (user will have to authenticate again)
                         linkNewDesktopHandler.reset()
                         backstack.pop()
                     }
 
                     override fun navigateToQrCodeScanner() {
-                        // reset the timer when the user enters the next screen (they clicked on "Ready to scan")
+                        // Start again the timer when the user enters the next screen (they clicked on "Ready to scan")
                         linkNewDesktopHandler.startTimer()
                         backstack.push(NavTarget.DesktopScanQrCode)
                     }
@@ -296,7 +296,7 @@ class LinkNewDeviceFlowNode(
             NavTarget.DesktopScanQrCode -> {
                 val callback = object : ScanQrCodeNode.Callback {
                     override fun cancel() {
-                        // reset the timer when the user goes back to the DesktopNoticeNode
+                        // start again the timer when the user goes back to the DesktopNoticeNode
                         linkNewDesktopHandler.startTimer()
                         backstack.pop()
                     }

--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDeviceFlowNode.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewDeviceFlowNode.kt
@@ -263,6 +263,8 @@ class LinkNewDeviceFlowNode(
                                 }
                                 LinkDeviceType.Desktop -> {
                                     linkNewDesktopHandler.reset()
+                                    // Ensure unlock state does not last longer than the timeout for scanning the QR code, so start the timer after unlock
+                                    linkNewDesktopHandler.startTimer()
                                     backstack.push(NavTarget.DesktopNotice)
                                 }
                             }
@@ -278,10 +280,14 @@ class LinkNewDeviceFlowNode(
             NavTarget.DesktopNotice -> {
                 val callback = object : DesktopNoticeNode.Callback {
                     override fun navigateBack() {
+                        // reset the timer when the user leaves the screen (user will have to authenticate again)
+                        linkNewDesktopHandler.reset()
                         backstack.pop()
                     }
 
                     override fun navigateToQrCodeScanner() {
+                        // reset the timer when the user enters the next screen (they clicked on "Ready to scan")
+                        linkNewDesktopHandler.startTimer()
                         backstack.push(NavTarget.DesktopScanQrCode)
                     }
                 }
@@ -290,6 +296,8 @@ class LinkNewDeviceFlowNode(
             NavTarget.DesktopScanQrCode -> {
                 val callback = object : ScanQrCodeNode.Callback {
                     override fun cancel() {
+                        // reset the timer when the user goes back to the DesktopNoticeNode
+                        linkNewDesktopHandler.startTimer()
                         backstack.pop()
                     }
                 }

--- a/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewMobileHandler.kt
+++ b/features/linknewdevice/impl/src/main/kotlin/io/element/android/features/linknewdevice/impl/LinkNewMobileHandler.kt
@@ -40,9 +40,19 @@ class LinkNewMobileHandler(
         LinkMobileStep.Uninitialized
     )
 
+    /**
+     * A [StateFlow] that emits the current step of the link mobile process.
+     * It starts with [LinkMobileStep.Uninitialized] and will emit other steps as they occur.
+     */
     val stepFlow: StateFlow<LinkMobileStep>
         get() = linkMobileStepFlow.asStateFlow()
 
+    /**
+     * Creates a new [LinkMobileHandler] and starts the linking process.
+     * If [forRotating] is true, it indicates that this is a rotation of the QR code.
+     *
+     * @param forRotating Whether this is a rotation of the QR code. Defaults to false.
+     */
     fun createAndStartNewHandler(forRotating: Boolean = false) {
         Timber.tag(loggerTag.value).d("createAndStartNewHandler()")
         currentJob?.cancel()
@@ -62,6 +72,10 @@ class LinkNewMobileHandler(
         }
     }
 
+    /**
+     * Resets the handler and cancels any ongoing job.
+     * This will also emit [LinkMobileStep.Uninitialized] to the [stepFlow].
+     */
     fun reset() {
         currentJob?.cancel()
         currentJob = null
@@ -70,10 +84,18 @@ class LinkNewMobileHandler(
         }
     }
 
+    /**
+     * Rotates the QR code by creating a new handler and starting the linking process.
+     * This is typically called when a timeout occurs for the current QR code.
+     */
     fun rotateQrCode() {
         createAndStartNewHandler(forRotating = true)
     }
 
+    /**
+     * Handles the case where there are too many QR code rotations.
+     * This will reset the handler and emit an error to the [stepFlow].
+     */
     fun onTooManyRotation() {
         reset()
         sessionScope.launch {


### PR DESCRIPTION


<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
Move the timeout management when linking a new desktop device to the LinkNewDeviceFlowNode so that it can also be used for the DesktopNotice screen.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
All screens for which access is protected by user credential should not stay forever displayed when the device is idle.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Link a new device
- Choose "Desktop computer"
- Wait 2 minutes
- A timeout screen should be displayed
- User has to authenticated again to start over

Each time the Desktop Notice screen is displayed or the QrCode scanner screen is displayed, the timeout of 2 minutes should be reset.


## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
