### PR TITLE
Fix outgoing session verification stuck with incomplete recovery setup

### DIFF
--- a/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/outgoing/OutgoingVerificationStateMachine.kt
+++ b/features/verifysession/impl/src/main/kotlin/io/element/android/features/verifysession/impl/outgoing/OutgoingVerificationStateMachine.kt
@@ -15,7 +15,6 @@ import com.freeletics.flowredux.dsl.FlowReduxStateMachine
 import io.element.android.features.verifysession.impl.util.andLogStateChange
 import io.element.android.features.verifysession.impl.util.logReceivedEvents
 import io.element.android.libraries.core.bool.orFalse
-import io.element.android.libraries.core.data.tryOrNull
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
 import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.api.verification.SessionVerificationData
@@ -23,6 +22,7 @@ import io.element.android.libraries.matrix.api.verification.SessionVerificationS
 import io.element.android.libraries.matrix.api.verification.VerificationRequest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.timeout
@@ -95,10 +95,13 @@ class OutgoingVerificationStateMachine(
                     // If a key backup exists, wait until it's restored or a timeout happens
                     val hasBackup = encryptionService.doesBackupExistOnServer().getOrNull().orFalse()
                     if (hasBackup) {
-                        tryOrNull {
-                            encryptionService.recoveryStateStateFlow.filter { it == RecoveryState.ENABLED }
+                        try {
+                            encryptionService.recoveryStateStateFlow
+                                .filter { it == RecoveryState.ENABLED || it == RecoveryState.DISABLED || it == RecoveryState.INCOMPLETE }
                                 .timeout(10.seconds)
                                 .first()
+                        } catch (_: TimeoutCancellationException) {
+                            // The backup was not restored in time, proceed to the Completed state anyway
                         }
                     }
                     state.override { State.Completed.andLogStateChange() }

--- a/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/outgoing/OutgoingVerificationPresenterTest.kt
+++ b/features/verifysession/impl/src/test/kotlin/io/element/android/features/verifysession/impl/outgoing/OutgoingVerificationPresenterTest.kt
@@ -16,6 +16,7 @@ import io.element.android.features.verifysession.impl.outgoing.OutgoingVerificat
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
+import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.api.verification.SessionVerificationData
 import io.element.android.libraries.matrix.api.verification.SessionVerificationService
 import io.element.android.libraries.matrix.api.verification.SessionVerifiedStatus
@@ -213,6 +214,85 @@ class OutgoingVerificationPresenterTest {
             service.emitVerificationFlowState(VerificationFlowState.DidFinish)
             service.emitVerifiedStatus(SessionVerifiedStatus.Verified)
             assertThat(awaitItem().step).isEqualTo(Step.Completed)
+        }
+    }
+
+    @Test
+    fun `present - When verification is approved and a backup exists but recovery is disabled, the flow completes`() = runTest {
+        val service = unverifiedSessionService(
+            requestUserVerificationLambda = { },
+            startSasVerificationLambda = { },
+            approveVerificationLambda = { },
+        )
+        val encryptionService = FakeEncryptionService().apply {
+            givenDoesBackupExistOnServerResult(Result.success(true))
+            recoveryStateStateFlow.value = RecoveryState.DISABLED
+        }
+        val presenter = createOutgoingVerificationPresenter(
+            service = service,
+            verificationRequest = anOutgoingUserVerificationRequest(),
+            encryptionService = encryptionService,
+        )
+        presenter.test {
+            val state = requestVerificationAndAwaitVerifyingState(service)
+            state.eventSink(OutgoingVerificationViewEvents.ConfirmVerification)
+            assertThat(awaitItem().step).isInstanceOf(Step.Verifying::class.java)
+            service.emitVerificationFlowState(VerificationFlowState.DidFinish)
+            assertThat(awaitItem().step).isEqualTo(Step.Completed)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - When verification is approved and a backup exists but recovery is incomplete, the flow completes`() = runTest {
+        val service = unverifiedSessionService(
+            requestUserVerificationLambda = { },
+            startSasVerificationLambda = { },
+            approveVerificationLambda = { },
+        )
+        val encryptionService = FakeEncryptionService().apply {
+            givenDoesBackupExistOnServerResult(Result.success(true))
+            recoveryStateStateFlow.value = RecoveryState.INCOMPLETE
+        }
+        val presenter = createOutgoingVerificationPresenter(
+            service = service,
+            verificationRequest = anOutgoingUserVerificationRequest(),
+            encryptionService = encryptionService,
+        )
+        presenter.test {
+            val state = requestVerificationAndAwaitVerifyingState(service)
+            state.eventSink(OutgoingVerificationViewEvents.ConfirmVerification)
+            assertThat(awaitItem().step).isInstanceOf(Step.Verifying::class.java)
+            service.emitVerificationFlowState(VerificationFlowState.DidFinish)
+            assertThat(awaitItem().step).isEqualTo(Step.Completed)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - When verification is approved but the recovery state is not determined, the flow completes after the timeout`() = runTest {
+        val service = unverifiedSessionService(
+            requestUserVerificationLambda = { },
+            startSasVerificationLambda = { },
+            approveVerificationLambda = { },
+        )
+        val encryptionService = FakeEncryptionService().apply {
+            givenDoesBackupExistOnServerResult(Result.success(true))
+        }
+        val presenter = createOutgoingVerificationPresenter(
+            service = service,
+            verificationRequest = anOutgoingUserVerificationRequest(),
+            encryptionService = encryptionService,
+        )
+        presenter.test {
+            val state = requestVerificationAndAwaitVerifyingState(service)
+            state.eventSink(OutgoingVerificationViewEvents.ConfirmVerification)
+            assertThat(awaitItem().step).isInstanceOf(Step.Verifying::class.java)
+            service.emitVerificationFlowState(VerificationFlowState.DidFinish)
+            // The recovery state never leaves UNKNOWN, so the 10 seconds timeout fires and the flow completes anyway
+            this@runTest.advanceUntilIdle()
+            assertThat(awaitItem().step).isEqualTo(Step.Completed)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 


### PR DESCRIPTION
## Content

- In the outgoing verification state machine, when the `recoveryStateStateFlow` times out waiting for the `ENABLED` state, continue to the `Completed` state instead of aborting the transition.
- Stop waiting as soon as the recovery state is `ENABLED`, `DISABLED` or `INCOMPLETE` rather than only when it becomes `ENABLED`, so sessions for which recovery is not enabled do not wait 10 seconds for no reason.

## Motivation and context

On continuwuity-based home servers, I noticed that Element X got stuck indefinitely on the emoji verification screen, while the other user could see that the verification had completed successfully. This PR fixes this issue.

Server-side issues:
https://github.com/matrix-construct/tuwunel/issues/292
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1476

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

Can provide if required.

## Tests

<!-- Explain how you tested your development -->

Investigation, fix and units tests are AI-generated. However, I manually reproduced the bug on a tuwunel server between one Element-Web user and one Element X  user on a fresh build without the fix (FOSS variant). All 3 unit tests were failing. With the fix, they pass, and the verification flow properly completes. Manually tested with and without a recovery key added to the Element X user account.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): LineageOS 23.2

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
