### PR TITLE
Do not open the room again when the app is resumed from the recents list

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/intent/IntentResolver.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/intent/IntentResolver.kt
@@ -76,6 +76,7 @@ class IntentResolver(
 }
 
 private fun Intent.canBeIgnored(): Boolean {
+    if (flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) return true
     return action == Intent.ACTION_MAIN &&
         categories?.contains(Intent.CATEGORY_LAUNCHER) == true
 }

--- a/appnav/src/test/kotlin/io/element/android/appnav/intent/IntentResolverTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/intent/IntentResolverTest.kt
@@ -46,6 +46,24 @@ class IntentResolverTest : RobolectricTest() {
     }
 
     @Test
+    fun `resolve intent replayed from the history should return null`() {
+        val sut = createIntentResolver(
+            deeplinkParserResult = DeeplinkData.Room(
+                sessionId = A_SESSION_ID,
+                roomId = A_ROOM_ID,
+                threadId = null,
+                eventId = null,
+            )
+        )
+        val intent = Intent(RuntimeEnvironment.getApplication(), Activity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            addFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+        }
+        val result = sut.resolve(intent)
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `test resolve navigation intent root`() {
         val sut = createIntentResolver(
             deeplinkParserResult = DeeplinkData.Root(A_SESSION_ID)


### PR DESCRIPTION
## Content

`MainActivity` is a `singleTask` activity that declares the `elementx://open` deep link, so when a
notification tap creates the task, that deep link becomes the task's base intent. Bringing the app
back from the recents list replays that base intent with `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY`,
`IntentResolver` turns it into a navigation again, and the user is pushed back into the room.

Ignore any intent the system replayed from the history, next to the launcher intent that is already
ignored. `RootFlowNode.handleIntent` already treats a `null` resolution as a no-op, so the app
simply stays where Appyx restored it.

## Motivation and context

Fixes #7205.

## Tests

- `./gradlew :appnav:testDebugUnitTest`
- New `IntentResolverTest.resolve intent replayed from the history should return null` builds an
  `ACTION_VIEW` intent with the history flag and a deeplink parser that would otherwise resolve a
  room. It fails without the change.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
