### PR TITLE
Show an error when the room to leave cannot be found

### DIFF
--- a/features/leaveroom/impl/src/main/kotlin/io/element/android/features/leaveroom/impl/LeaveRoomPresenter.kt
+++ b/features/leaveroom/impl/src/main/kotlin/io/element/android/features/leaveroom/impl/LeaveRoomPresenter.kt
@@ -60,7 +60,13 @@ class LeaveRoomPresenter(
         roomId: RoomId,
         leaveAction: MutableState<AsyncAction<Unit>>,
     ) = launch(dispatchers.io) {
-        client.getRoom(roomId)?.use { room ->
+        val room = client.getRoom(roomId)
+        if (room == null) {
+            Timber.e("Unable to find room $roomId to leave it")
+            leaveAction.value = AsyncAction.Failure(RoomNotFoundException(roomId))
+            return@launch
+        }
+        room.use {
             val roomInfo = room.roomInfoFlow.first()
             leaveAction.value = when {
                 roomInfo.isDm -> Confirmation.Dm(roomId)
@@ -78,7 +84,8 @@ class LeaveRoomPresenter(
         leaveAction: MutableState<AsyncAction<Unit>>,
     ) = launch(dispatchers.io) {
         leaveAction.runCatchingUpdatingState {
-            client.getRoom(roomId)!!.use { room ->
+            val room = client.getRoom(roomId) ?: throw RoomNotFoundException(roomId)
+            room.use {
                 room
                     .leave()
                     .onSuccess { notificationConversationService.onLeftRoom(client.sessionId, roomId) }
@@ -100,3 +107,5 @@ class LeaveRoomPresenter(
         }
     }
 }
+
+internal class RoomNotFoundException(roomId: RoomId) : IllegalStateException("Room $roomId not found")

--- a/features/leaveroom/impl/src/test/kotlin/io/element/android/features/leaveroom/impl/LeaveBaseRoomPresenterTest.kt
+++ b/features/leaveroom/impl/src/test/kotlin/io/element/android/features/leaveroom/impl/LeaveBaseRoomPresenterTest.kt
@@ -176,6 +176,32 @@ class LeaveBaseRoomPresenterTest {
     }
 
     @Test
+    fun `present - show error if the room to confirm leaving is not found`() = runTest {
+        val presenter = createLeaveRoomPresenter(client = FakeMatrixClient())
+        presenter.stateFlow().test {
+            val initialState = awaitItem()
+            initialState.eventSink(LeaveRoomEvent.LeaveRoom(A_ROOM_ID, needsConfirmation = true))
+            val errorState = awaitItem()
+            assertThat(errorState.leaveAction).isInstanceOf(AsyncAction.Failure::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - show error if the room to leave is not found`() = runTest {
+        val presenter = createLeaveRoomPresenter(client = FakeMatrixClient())
+        presenter.stateFlow().test {
+            val initialState = awaitItem()
+            initialState.eventSink(LeaveRoomEvent.LeaveRoom(A_ROOM_ID, needsConfirmation = false))
+            val progressState = awaitItem()
+            assertThat(progressState.leaveAction).isEqualTo(AsyncAction.Loading)
+            val errorState = awaitItem()
+            assertThat(errorState.leaveAction).isInstanceOf(AsyncAction.Failure::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `present - reset state after error`() = runTest {
         val presenter = createLeaveRoomPresenter(
             client = FakeMatrixClient().apply {


### PR DESCRIPTION
## Content

`LeaveRoomPresenter.showLeaveRoomAlert` ran its whole body inside
`client.getRoom(roomId)?.use { }`. When `getRoom` returns `null`, the body was skipped without
writing any state: `leaveAction` stayed `Uninitialized`, so `AsyncActionView` rendered nothing.
Long pressing a room and choosing **Leave room** appeared to do nothing at all, with no
confirmation dialog and no error.

The missing room is now handled explicitly and surfaced as a failure, which `AsyncActionView`
already renders with the existing generic error dialog, so no new string is needed. `leaveRoom`
used a `!!` for the same lookup and reported the miss as a `NullPointerException`; it now throws
the same named exception.

## Motivation and context

Fixes #4594 in part: the user gets an error instead of a dead menu entry. Actually leaving a room
the client cannot resolve is not possible from here, since leaving goes through `Room.leave()` and
`MatrixClient` has no room-id-only leave.

## Tests

- `./gradlew :features:leaveroom:impl:testDebugUnitTest`
- Two new tests in `LeaveBaseRoomPresenterTest` cover the confirmation and the direct leave path
  with a client that does not know the room. The confirmation one fails without the change.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
