### PR TITLE
Refresh the room members when a mention is started

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -86,6 +86,7 @@ import io.element.android.libraries.textcomposer.model.MarkdownTextEditorState
 import io.element.android.libraries.textcomposer.model.Message
 import io.element.android.libraries.textcomposer.model.MessageComposerMode
 import io.element.android.libraries.textcomposer.model.Suggestion
+import io.element.android.libraries.textcomposer.model.SuggestionType
 import io.element.android.libraries.textcomposer.model.TextEditorState
 import io.element.android.libraries.textcomposer.model.rememberMarkdownTextEditorState
 import io.element.android.services.analytics.api.AnalyticsService
@@ -103,7 +104,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -458,6 +461,15 @@ class MessageComposerPresenter(
             val mentionCompletionTrigger = suggestionSearchTrigger.debounce(0.3.seconds).filter { !it?.text.isNullOrEmpty() }
 
             val mentionTriggerFlow = merge(mentionStartTrigger, mentionCompletionTrigger)
+
+            // Refresh the room members, which are only loaded on demand, when a mention starts
+            launch {
+                suggestionSearchTrigger
+                    .map { it?.type == SuggestionType.Mention }
+                    .distinctUntilChanged()
+                    .filter { it }
+                    .collect { room.updateMembers() }
+            }
 
             val roomAliasSuggestionsFlow = roomAliasSuggestionsDataSource
                 .getAllRoomAliasSuggestions()

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -104,7 +104,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -465,9 +465,8 @@ class MessageComposerPresenter(
             // Refresh the room members, which are only loaded on demand, when a mention starts
             launch {
                 suggestionSearchTrigger
-                    .map { it?.type == SuggestionType.Mention }
-                    .distinctUntilChanged()
-                    .filter { it }
+                    .distinctUntilChangedBy { it?.type }
+                    .filter { it?.type == SuggestionType.Mention }
                     .collect { room.updateMembers() }
             }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
@@ -1056,7 +1056,8 @@ class MessageComposerPresenterTest : RobolectricTest() {
             baseRoom = FakeBaseRoom(
                 roomPermissions = FakeRoomPermissions(
                     canTriggerRoomNotification = true,
-                )
+                ),
+                updateMembersResult = {},
             ),
             typingNoticeResult = { Result.success(Unit) }
         ).apply {
@@ -1104,6 +1105,42 @@ class MessageComposerPresenterTest : RobolectricTest() {
     }
 
     @Test
+    fun `present - mention suggestions refresh the room members`() = runTest {
+        val currentUser = aRoomMember(userId = A_USER_ID, membership = RoomMembershipState.JOIN)
+        val bob = aRoomMember(userId = A_USER_ID_2, membership = RoomMembershipState.JOIN)
+        val updateMembersResult = lambdaRecorder<Unit> { }
+        val room = FakeJoinedRoom(
+            baseRoom = FakeBaseRoom(
+                roomPermissions = FakeRoomPermissions(
+                    canTriggerRoomNotification = true,
+                ),
+                updateMembersResult = updateMembersResult,
+            ),
+            typingNoticeResult = { Result.success(Unit) }
+        ).apply {
+            givenRoomMembersState(
+                RoomMembersState.Ready(
+                    persistentListOf(currentUser, bob),
+                )
+            )
+            givenRoomInfo(aRoomInfo(isDirect = false))
+        }
+        val presenter = createPresenter(
+            room = room,
+            slashCommandService = FakeSlashCommandService(
+                getSuggestionsResult = { _, _ -> emptyList() },
+            ),
+        )
+        presenter.test {
+            val initialState = awaitItem()
+            initialState.eventSink(MessageComposerEvent.SuggestionReceived(Suggestion(0, 0, SuggestionType.Mention, "")))
+            skipItems(1)
+            assertThat(awaitItem().suggestions).containsExactly(ResolvedSuggestion.AtRoom, ResolvedSuggestion.Member(bob))
+            updateMembersResult.assertions().isCalledOnce()
+        }
+    }
+
+    @Test
     fun `present - room mention suggestions no permission`() = runTest {
         val currentUser = aRoomMember(userId = A_USER_ID, membership = RoomMembershipState.JOIN)
         val invitedUser = aRoomMember(userId = A_USER_ID_3, membership = RoomMembershipState.INVITE)
@@ -1113,7 +1150,8 @@ class MessageComposerPresenterTest : RobolectricTest() {
             baseRoom = FakeBaseRoom(
                 roomPermissions = FakeRoomPermissions(
                     canTriggerRoomNotification = false,
-                )
+                ),
+                updateMembersResult = {},
             ),
             typingNoticeResult = { Result.success(Unit) }
         ).apply {
@@ -1144,6 +1182,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
         val room = FakeJoinedRoom(
             baseRoom = FakeBaseRoom(
                 roomPermissions = FakeRoomPermissions(canTriggerRoomNotification = true),
+                updateMembersResult = {},
             ),
             typingNoticeResult = { Result.success(Unit) }
         ).apply {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
@@ -1137,6 +1137,19 @@ class MessageComposerPresenterTest : RobolectricTest() {
             skipItems(1)
             assertThat(awaitItem().suggestions).containsExactly(ResolvedSuggestion.AtRoom, ResolvedSuggestion.Member(bob))
             updateMembersResult.assertions().isCalledOnce()
+
+            // Typing after the `@` must not refresh the members again
+            initialState.eventSink(MessageComposerEvent.SuggestionReceived(Suggestion(0, 1, SuggestionType.Mention, "b")))
+            initialState.eventSink(MessageComposerEvent.SuggestionReceived(Suggestion(0, 2, SuggestionType.Mention, "bo")))
+            advanceUntilIdle()
+            updateMembersResult.assertions().isCalledOnce()
+
+            // Starting a new mention refreshes them again
+            initialState.eventSink(MessageComposerEvent.SuggestionReceived(null))
+            initialState.eventSink(MessageComposerEvent.SuggestionReceived(Suggestion(0, 0, SuggestionType.Mention, "")))
+            advanceUntilIdle()
+            updateMembersResult.assertions().isCalledExactly(2)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 


### PR DESCRIPTION
## Content

The mention suggestions in the composer read `room.membersStateFlow`, which is a cache filled only
by an explicit `updateMembers()` call — the contract on `BaseRoom` says so. Nothing calls it while
a room is open, so a member who joins after the room was opened never shows up in the suggestion
list until the room is left and entered again.

`updateMembers()` is now called when a mention search starts. The trigger is
`distinctUntilChanged` on "the current suggestion is a mention", so it fires once per mention
rather than on every keystroke, and `RoomMemberListFetcher.fetchRoomMembers` already no-ops while a
fetch is in flight.

## Motivation and context

Fixes #4236.

The joined member count from `roomInfoFlow` was deliberately not used as the trigger: it comes from
sliding sync and is not reliably refreshed, which is the point jmartinesp makes on the related
#4238, so keying off it would miss exactly the joins this issue is about.

## Tests

- `./gradlew :features:messages:impl:testDebugUnitTest --tests "*MessageComposerPresenterTest*"`
- New `present - mention suggestions refresh the room members` asserts `updateMembers()` is called
  once when an `@` mention starts. It fails without the change. The three existing mention
  suggestion tests are unchanged apart from being given an `updateMembers` result on their fake.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
