### PR TITLE
Exclude carriage returns from the login and password fields

### DIFF
--- a/features/deactivation/impl/src/main/kotlin/io/element/android/features/logout/impl/AccountDeactivationView.kt
+++ b/features/deactivation/impl/src/main/kotlin/io/element/android/features/logout/impl/AccountDeactivationView.kt
@@ -299,10 +299,10 @@ private fun Content(
 }
 
 /**
- * Ensure that the string does not contain any new line characters, which can happen when pasting values.
+ * Ensure that the string does not contain any line separator, which can happen when pasting values.
  */
 private fun String.sanitize(): String {
-    return replace("\n", "")
+    return filterNot { it == '\n' || it == '\r' }
 }
 
 @PreviewsDayNight

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -274,10 +274,10 @@ private fun LoginForm(
 }
 
 /**
- * Ensure that the string does not contain any new line characters, which can happen when pasting values.
+ * Ensure that the string does not contain any line separator, which can happen when pasting values.
  */
 private fun String.sanitize(): String {
-    return replace("\n", "")
+    return filterNot { it == '\n' || it == '\r' }
 }
 
 @Composable

--- a/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordViewTest.kt
+++ b/features/login/impl/src/test/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordViewTest.kt
@@ -82,6 +82,21 @@ class LoginPasswordViewTest : RobolectricTest() {
     }
 
     @Test
+    fun `changing login removes carriage returns the expected event`() = runAndroidComposeUiTest {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        setLoginPasswordView(
+            aLoginPasswordState(
+                eventSink = eventsRecorder,
+            ),
+        )
+        val userNameHint = activity!!.getString(CommonStrings.common_username)
+        onNodeWithText(userNameHint).performTextInput("a\r\nb")
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetLogin("ab")
+        )
+    }
+
+    @Test
     fun `clearing login invokes the expected event`() = runAndroidComposeUiTest {
         val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
         setLoginPasswordView(
@@ -109,6 +124,21 @@ class LoginPasswordViewTest : RobolectricTest() {
         onNodeWithText(userNameHint).performTextInput(A_PASSWORD)
         eventsRecorder.assertSingle(
             LoginPasswordEvents.SetPassword(A_PASSWORD)
+        )
+    }
+
+    @Test
+    fun `changing password removes carriage returns the expected event`() = runAndroidComposeUiTest {
+        val eventsRecorder = EventsRecorder<LoginPasswordEvents>()
+        setLoginPasswordView(
+            aLoginPasswordState(
+                eventSink = eventsRecorder,
+            ),
+        )
+        val passwordHint = activity!!.getString(CommonStrings.common_password)
+        onNodeWithText(passwordHint).performTextInput("a\r\nb")
+        eventsRecorder.assertSingle(
+            LoginPasswordEvents.SetPassword("ab")
         )
     }
 


### PR DESCRIPTION
## Content

The `sanitize()` helper applied to the login and password fields, and to the account deactivation
password field, promises in its own KDoc to remove "any new line characters" but only removes LF. A
value pasted from a source with CRLF line endings keeps its CR, which is invisible in the field and
is sent to the homeserver as part of the credential, so the login is rejected while typing the same
characters by hand works.

Both copies of the helper now drop every line separator. Whitespace that can legitimately be part
of a password, such as spaces and tabs, is deliberately left untouched.

## Motivation and context

Related to #5153. This closes a real CRLF paste hole, but the reporter's follow-up is not
conclusive that a carriage return was their case, so it may not be the full story of that issue.

The LF half of this helper was added in 732ec3f263 for #2263; CR was simply missed at the time.

## Tests

- `./gradlew :features:login:impl:testDebugUnitTest`
- `./gradlew :features:deactivation:impl:testDebugUnitTest`
- Two new tests in `LoginPasswordViewTest`, next to the existing LF ones, paste `a\r\nb` into the
  login and the password fields and assert the event carries `ab`. Both fail without the change.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
