### PR TITLE
Close the invite screen once the invite has been declined

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeFlowNode.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/HomeFlowNode.kt
@@ -269,6 +269,11 @@ class HomeFlowNode(
                     parentNode = this,
                     buildContext = buildContext,
                     inviteData = navTarget.inviteData,
+                    callback = object : DeclineInviteAndBlockEntryPoint.Callback {
+                        override fun onDeclineSuccess() {
+                            backstack.pop()
+                        }
+                    },
                 )
             }
             is NavTarget.SelectNewOwnersWhenLeavingRoom -> {

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/DefaultHomeEntryPointTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/DefaultHomeEntryPointTest.kt
@@ -11,6 +11,7 @@ package io.element.android.features.home.impl
 import com.bumble.appyx.core.modality.BuildContext
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.api.HomeEntryPoint
+import io.element.android.features.invite.test.declineandblock.FakeDeclineInviteAndBlockEntryPoint
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.test.FakeMatrixClient
@@ -36,7 +37,7 @@ class DefaultHomeEntryPointTest : RobolectricTest() {
                 acceptDeclineInviteView = { _, _, _, _ -> lambdaError() },
                 directLogoutView = { _ -> lambdaError() },
                 reportRoomEntryPoint = { _, _, _ -> lambdaError() },
-                declineInviteAndBlockUserEntryPoint = { _, _, _ -> lambdaError() },
+                declineInviteAndBlockUserEntryPoint = FakeDeclineInviteAndBlockEntryPoint(),
                 changeRoomMemberRolesEntryPoint = { _, _, _, _ -> lambdaError() },
                 leaveRoomRenderer = { _, _, _ -> lambdaError() },
                 sessionCoroutineScope = backgroundScope,

--- a/features/invite/api/src/main/kotlin/io/element/android/features/invite/api/declineandblock/DeclineInviteAndBlockEntryPoint.kt
+++ b/features/invite/api/src/main/kotlin/io/element/android/features/invite/api/declineandblock/DeclineInviteAndBlockEntryPoint.kt
@@ -10,13 +10,19 @@ package io.element.android.features.invite.api.declineandblock
 
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.plugin.Plugin
 import io.element.android.features.invite.api.InviteData
 import io.element.android.libraries.architecture.FeatureEntryPoint
 
-fun interface DeclineInviteAndBlockEntryPoint : FeatureEntryPoint {
+interface DeclineInviteAndBlockEntryPoint : FeatureEntryPoint {
     fun createNode(
         parentNode: Node,
         buildContext: BuildContext,
         inviteData: InviteData,
+        callback: Callback,
     ): Node
+
+    interface Callback : Plugin {
+        fun onDeclineSuccess()
+    }
 }

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockNode.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockNode.kt
@@ -17,7 +17,9 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.annotations.ContributesNode
 import io.element.android.features.invite.api.InviteData
+import io.element.android.features.invite.api.declineandblock.DeclineInviteAndBlockEntryPoint
 import io.element.android.libraries.architecture.NodeInputs
+import io.element.android.libraries.architecture.callback
 import io.element.android.libraries.architecture.inputs
 import io.element.android.libraries.di.SessionScope
 
@@ -31,6 +33,7 @@ class DeclineAndBlockNode(
     data class Inputs(val inviteData: InviteData) : NodeInputs
 
     private val inviteData = inputs<Inputs>().inviteData
+    private val callback: DeclineInviteAndBlockEntryPoint.Callback = callback()
     private val presenter = presenterFactory.create(inviteData)
 
     @Composable
@@ -39,6 +42,7 @@ class DeclineAndBlockNode(
         DeclineAndBlockView(
             state = state,
             onBackClick = ::navigateUp,
+            onDeclineSuccess = callback::onDeclineSuccess,
             modifier = modifier
         )
     }

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockView.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockView.kt
@@ -46,6 +46,7 @@ import io.element.android.libraries.ui.strings.CommonStrings
 fun DeclineAndBlockView(
     state: DeclineAndBlockState,
     onBackClick: () -> Unit,
+    onDeclineSuccess: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
@@ -53,7 +54,7 @@ fun DeclineAndBlockView(
     val isDeclining = state.declineAction is AsyncAction.Loading
     AsyncActionView(
         async = state.declineAction,
-        onSuccess = { onBackClick() },
+        onSuccess = { onDeclineSuccess() },
         errorMessage = { stringResource(CommonStrings.error_unknown) },
         onRetry = { state.eventSink(DeclineAndBlockEvents.Decline) },
         onErrorDismiss = { state.eventSink(DeclineAndBlockEvents.ClearDeclineAction) }
@@ -149,5 +150,6 @@ internal fun DeclineAndBlockViewPreview(
     DeclineAndBlockView(
         state = state,
         onBackClick = {},
+        onDeclineSuccess = {},
     )
 }

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DefaultDeclineAndBlockEntryPoint.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/declineandblock/DefaultDeclineAndBlockEntryPoint.kt
@@ -22,8 +22,9 @@ class DefaultDeclineAndBlockEntryPoint : DeclineInviteAndBlockEntryPoint {
         parentNode: Node,
         buildContext: BuildContext,
         inviteData: InviteData,
+        callback: DeclineInviteAndBlockEntryPoint.Callback,
     ): Node {
         val inputs = DeclineAndBlockNode.Inputs(inviteData)
-        return parentNode.createNode<DeclineAndBlockNode>(buildContext, plugins = listOf(inputs))
+        return parentNode.createNode<DeclineAndBlockNode>(buildContext, plugins = listOf(inputs, callback))
     }
 }

--- a/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockViewTest.kt
+++ b/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/declineandblock/DeclineAndBlockViewTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import io.element.android.features.invite.impl.R
+import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.tests.testutils.EnsureNeverCalled
 import io.element.android.tests.testutils.EventsRecorder
@@ -38,6 +39,20 @@ class DeclineAndBlockViewTest : RobolectricTest() {
                 onBackClick = it
             )
             pressBack()
+        }
+    }
+
+    @Test
+    fun `a successful decline invokes the expected callback`() = runAndroidComposeUiTest {
+        val eventsRecorder = EventsRecorder<DeclineAndBlockEvents>(expectEvents = false)
+        ensureCalledOnce {
+            setDeclineAndBlockView(
+                aDeclineAndBlockState(
+                    declineAction = AsyncAction.Success(Unit),
+                    eventSink = eventsRecorder,
+                ),
+                onDeclineSuccess = it,
+            )
         }
     }
 
@@ -112,11 +127,13 @@ class DeclineAndBlockViewTest : RobolectricTest() {
 private fun AndroidComposeUiTest<ComponentActivity>.setDeclineAndBlockView(
     state: DeclineAndBlockState,
     onBackClick: () -> Unit = EnsureNeverCalled(),
+    onDeclineSuccess: () -> Unit = EnsureNeverCalled(),
 ) {
     setContent {
         DeclineAndBlockView(
             state = state,
             onBackClick = onBackClick,
+            onDeclineSuccess = onDeclineSuccess,
         )
     }
 }

--- a/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/declineandblock/DefaultDeclineAndBlockEntryPointTest.kt
+++ b/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/declineandblock/DefaultDeclineAndBlockEntryPointTest.kt
@@ -11,7 +11,9 @@ package io.element.android.features.invite.impl.declineandblock
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.bumble.appyx.core.modality.BuildContext
 import com.google.common.truth.Truth.assertThat
+import io.element.android.features.invite.api.declineandblock.DeclineInviteAndBlockEntryPoint
 import io.element.android.features.invite.test.anInviteData
+import io.element.android.tests.testutils.lambda.lambdaError
 import io.element.android.tests.testutils.node.TestParentNode
 import org.junit.Rule
 import org.junit.Test
@@ -31,12 +33,17 @@ class DefaultDeclineAndBlockEntryPointTest {
             )
         }
         val inviteData = anInviteData()
+        val callback = object : DeclineInviteAndBlockEntryPoint.Callback {
+            override fun onDeclineSuccess() = lambdaError()
+        }
         val result = entryPoint.createNode(
             parentNode = parentNode,
             buildContext = BuildContext.root(null),
-            inviteData = inviteData
+            inviteData = inviteData,
+            callback = callback,
         )
         assertThat(result).isInstanceOf(DeclineAndBlockNode::class.java)
         assertThat(result.plugins).contains(DeclineAndBlockNode.Inputs(inviteData))
+        assertThat(result.plugins).contains(callback)
     }
 }

--- a/features/invite/test/src/main/kotlin/io/element/android/features/invite/test/declineandblock/FakeDeclineInviteAndBlockEntryPoint.kt
+++ b/features/invite/test/src/main/kotlin/io/element/android/features/invite/test/declineandblock/FakeDeclineInviteAndBlockEntryPoint.kt
@@ -19,6 +19,7 @@ class FakeDeclineInviteAndBlockEntryPoint : DeclineInviteAndBlockEntryPoint {
         parentNode: Node,
         buildContext: BuildContext,
         inviteData: InviteData,
+        callback: DeclineInviteAndBlockEntryPoint.Callback,
     ): Node {
         lambdaError()
     }

--- a/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomFlowNode.kt
+++ b/features/joinroom/impl/src/main/kotlin/io/element/android/features/joinroom/impl/JoinRoomFlowNode.kt
@@ -69,6 +69,9 @@ class JoinRoomFlowNode(
                 parentNode = this,
                 buildContext = buildContext,
                 inviteData = navTarget.inviteData,
+                callback = object : DeclineInviteAndBlockEntryPoint.Callback {
+                    override fun onDeclineSuccess() = navigateUp()
+                },
             )
             NavTarget.Root -> rootNode(buildContext)
         }
@@ -99,7 +102,7 @@ class JoinRoomFlowNode(
             acceptDeclineInviteView.Render(
                 state = state.acceptDeclineInviteState,
                 onAcceptInviteSuccess = {},
-                onDeclineInviteSuccess = {},
+                onDeclineInviteSuccess = { navigateUp() },
                 modifier = Modifier
             )
         }


### PR DESCRIPTION
## Content

Declining an invite from the full screen invite left the user on that same screen, so the only way back to the room list was to press back afterwards.

Both ways of declining are affected. The plain decline is handled by `AcceptDeclineInviteView`, which `JoinRoomFlowNode` renders with an empty `onDeclineInviteSuccess`. The decline and block screen is pushed onto the join room flow's own backstack and calls `navigateUp` on success, which pops back into the join room screen rather than out of it.

The flow node now navigates up on a successful decline, exactly as it already does after forgetting a room, and `DeclineInviteAndBlockEntryPoint` gets a callback so its screen can report a successful decline separately from a back press.

Part 2 of the issue, removing the other invites of a user that has just been blocked, is not covered here: it depends on what the homeserver does with the ignore list rather than on this navigation.

## Motivation and context

Part of #7066.

## Tests

- `features/invite/impl/.../declineandblock/DeclineAndBlockViewTest.kt`: a successful decline invokes the new callback and not the back callback.
- `features/invite/impl/.../declineandblock/DefaultDeclineAndBlockEntryPointTest.kt`: the callback is passed to the created node as a plugin.
- The wiring in `JoinRoomFlowNode` itself is not covered: the callbacks are passed from the node's `View`, which has no test harness in this module.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
