### PR TITLE
Convert markdown to HTML when a caption is edited

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/timeline/RustTimeline.kt
@@ -75,6 +75,7 @@ import org.matrix.rustcomponents.sdk.PollData
 import org.matrix.rustcomponents.sdk.SendAttachmentJoinHandle
 import org.matrix.rustcomponents.sdk.UploadParameters
 import org.matrix.rustcomponents.sdk.UploadSource
+import org.matrix.rustcomponents.sdk.createCaptionEdit
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import uniffi.matrix_sdk.PaginationStatus
@@ -341,7 +342,7 @@ class RustTimeline(
         formattedCaption: String?,
     ): Result<Unit> = withContext(dispatcher) {
         runCatchingExceptions<Unit> {
-            val editedContent = EditedContent.MediaCaption(
+            val editedContent = createCaptionEdit(
                 caption = caption,
                 formattedCaption = formattedCaption?.let {
                     FormattedBody(body = it, format = MessageFormat.Html)


### PR DESCRIPTION
## Content

Adding or editing a caption on an already sent media message from the plain composer sent the caption as text only, so markdown in it was never rendered. Sending the very same caption with the media does render it.

The plain composer has no HTML to pass, so `formattedCaption` is null, and `RustTimeline.editCaption` built `EditedContent.MediaCaption` by hand with a null formatted body. The send path does not do that: `UploadParameters` is turned into a caption by the SDK, which derives the formatted body from the markdown when there is none.

`editCaption` now builds the edit with the SDK's `createCaptionEdit`, which runs the caption through the same conversion. Removing a caption still passes a null caption and is unaffected.

## Motivation and context

Part of #5978.

## Tests

- Send an image with no caption, add a caption such as `some *emphasis*` from the plain composer, and check that the emphasis is rendered, in this client and in one that displays `formatted_body`.
- Edit that caption and check that the formatted body is updated rather than dropped.
- No unit test: the conversion happens behind the FFI boundary, the same reason `sendMessage` and `editMessage`, which use the SDK's markdown constructors through `MessageEventContent`, have none either.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
