### PR TITLE
Do not render in-chat key verification requests in the timeline

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactory.kt
@@ -21,6 +21,9 @@ import io.element.android.libraries.androidutils.diff.MutableListDiffCache
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.EventTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
+import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.Flow
@@ -110,11 +113,20 @@ class TimelineItemsFactory(
     ): TimelineItem? {
         val timelineItem =
             when (val currentTimelineItem = timelineItems[index]) {
-                is MatrixTimelineItem.Event -> eventItemFactory.create(currentTimelineItem, index, timelineItems, roomMembers, renderReadReceipts)
+                is MatrixTimelineItem.Event -> if (currentTimelineItem.event.isKeyVerificationRequest()) {
+                    null
+                } else {
+                    eventItemFactory.create(currentTimelineItem, index, timelineItems, roomMembers, renderReadReceipts)
+                }
                 is MatrixTimelineItem.Virtual -> virtualItemFactory.create(currentTimelineItem)
                 MatrixTimelineItem.Other -> null
             }
         diffCache[index] = timelineItem
         return timelineItem
     }
+}
+
+private fun EventTimelineItem.isKeyVerificationRequest(): Boolean {
+    val messageType = (content as? MessageContent)?.type
+    return messageType is OtherMessageType && messageType.isKeyVerificationRequest
 }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
@@ -12,8 +12,10 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.features.messages.impl.fixtures.aTimelineItemsFactory
 import io.element.android.features.messages.impl.timeline.model.TimelineItem
 import io.element.android.features.messages.impl.timeline.model.TimelineItemGroupPosition
+import io.element.android.features.messages.impl.timeline.model.event.TimelineItemTextContent
 import io.element.android.libraries.matrix.api.core.UniqueId
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
+import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.timeline.aMessageContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
@@ -80,6 +82,50 @@ class TimelineItemsFactoryTest {
             TimelineItemGroupPosition.Middle,
             TimelineItemGroupPosition.Last,
         ).inOrder()
+    }
+
+    @Test
+    fun `a key verification request is not rendered`() = runTest {
+        val factory = aTimelineItemsFactory(
+            config = TimelineItemsFactoryConfig(
+                computeReadReceipts = false,
+                computeReactions = false,
+            )
+        )
+        val items = listOf(
+            MatrixTimelineItem.Event(
+                uniqueId = UniqueId("event-0"),
+                event = anEventTimelineItem(
+                    sender = A_USER_ID,
+                    content = aMessageContent(
+                        body = "Alice is requesting to verify your key, but your client does not support in-chat key verification.",
+                        messageType = OtherMessageType(
+                            msgType = "m.key.verification.request",
+                            body = "Alice is requesting to verify your key, but your client does not support in-chat key verification.",
+                        ),
+                    ),
+                ),
+            ),
+            MatrixTimelineItem.Event(
+                uniqueId = UniqueId("event-1"),
+                event = anEventTimelineItem(
+                    sender = A_USER_ID,
+                    content = aMessageContent(body = "A regular message"),
+                ),
+            ),
+        )
+        factory.timelineItems.test {
+            factory.replaceWith(
+                timelineItems = items,
+                roomMembers = emptyList(),
+                renderReadReceipts = false,
+            )
+            val bodies = awaitItem()
+                .filterIsInstance<TimelineItem.Event>()
+                .map { (it.content as TimelineItemTextContent).body }
+            assertThat(bodies).containsExactly("A regular message")
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     private suspend fun TestScope.groupPositionsOf(timestamps: List<Long>): List<TimelineItemGroupPosition> {

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/MessageType.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/timeline/item/event/MessageType.kt
@@ -128,4 +128,11 @@ sealed interface GalleryItemType {
 data class OtherMessageType(
     val msgType: String,
     val body: String,
-) : MessageType
+) : MessageType {
+    /**
+     * A `m.key.verification.request` carries a body meant for clients that cannot handle in-chat
+     * verification, so it must not be rendered as a message.
+     */
+    val isKeyVerificationRequest: Boolean
+        get() = msgType == "m.key.verification.request"
+}


### PR DESCRIPTION
## Content

A `m.key.verification.request` sent from a client that supports in-chat verification carries a plain text body aimed at clients that do not, along the lines of "… but your client does not support in-chat key verification". Element X has no msgtype of its own for that event, so it falls through to `OtherMessageType` and the timeline prints that body, telling the user their client cannot do something they may have just done through the session verification flow.

The event is now dropped while the timeline items are built, so it is not rendered at all, which is what Element X iOS does for the same msgtype.

The room list preview and the notification for such an event are left as they are; they are separate formatters and were not part of what was reported.

## Motivation and context

Part of #4519.

## Tests

- `features/messages/impl/.../timeline/factories/TimelineItemsFactoryTest.kt`: a timeline holding a key verification request and a normal message renders only the normal message.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
