### PR TITLE
Show the summary of a details element on its own line

### DIFF
--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocument.kt
@@ -67,8 +67,19 @@ private fun fixMentions(
 private object CustomHtmlToDomParser {
     fun document(html: String): Document {
         val outputSettings = OutputSettings().prettyPrint(false).indentAmount(0)
-        val cleanHtml = Jsoup.clean(html, "", safeList, outputSettings)
+        val cleanHtml = Jsoup.clean(html.withSummariesAsParagraphs(), "", safeList, outputSettings)
         return Jsoup.parse(cleanHtml)
+    }
+
+    /**
+     * `summary` is not in [safeList], so its content would be merged into the text of the
+     * surrounding `details`. Turn it into a paragraph, which is the closest supported tag.
+     */
+    private fun String.withSummariesAsParagraphs(): String {
+        if (!contains("<summary", ignoreCase = true)) return this
+        val body = Jsoup.parseBodyFragment(this).body()
+        body.getElementsByTag("summary").forEach { it.tagName("p") }
+        return body.html()
     }
 
     private val safeList = Safelist()

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToHtmlDocumentTest.kt
@@ -60,6 +60,32 @@ class ToHtmlDocumentTest : RobolectricTest() {
     }
 
     @Test
+    fun `toHtmlDocument - the summary of a details element becomes its own paragraph`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<details><summary>Summary example</summary>Text inside details</details>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+
+        assertThat(document?.getElementsByTag("summary")).isEmpty()
+        assertThat(document?.getElementsByTag("p")?.map { it.text() }).containsExactly("Summary example")
+        assertThat(document?.text()).isEqualTo("Summary example Text inside details")
+    }
+
+    @Test
+    fun `toHtmlDocument - a document without a summary keeps its paragraphs`() {
+        val body = FormattedBody(
+            format = MessageFormat.HTML,
+            body = "<p>Hello</p><p>world</p>"
+        )
+
+        val document = body.toHtmlDocument(permalinkParser = FakePermalinkParser())
+
+        assertThat(document?.getElementsByTag("p")?.map { it.text() }).containsExactly("Hello", "world").inOrder()
+    }
+
+    @Test
     fun `toHtmlDocument - if a mention is found without an '@' prefix, it will be added`() {
         val body = FormattedBody(
             format = MessageFormat.HTML,


### PR DESCRIPTION
## Content

The HTML safelist used to render formatted messages does not contain `summary`, so jsoup dropped the tag and kept its text. The summary of a `details` element and the text inside it were then run together on a single line, which is how the reported message rendered.

Before cleaning, a `summary` is now rewritten as a paragraph, the closest tag the safelist supports, so the two parts are separated the way they are on Element Web. Messages that contain no `summary` take the same path as before.

This is the line break half of the issue only. Rendering `details` as a collapsed section with a disclosure triangle needs real support for the element in the renderer and is not attempted here.

## Motivation and context

Part of #5966.

## Tests

- `libraries/matrixui/.../messages/ToHtmlDocumentTest.kt`: a `details` element ends up with its summary in a paragraph of its own and the body text after it, and a document with no summary keeps its paragraphs untouched.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
