### PR TITLE
Open the user profile of a user id that contains a slash

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/permalink/DefaultPermalinkParser.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/permalink/DefaultPermalinkParser.kt
@@ -8,11 +8,13 @@
 
 package io.element.android.libraries.matrix.impl.permalink
 
+import android.net.Uri
 import androidx.core.net.toUri
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.core.MatrixPatterns
 import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.UserId
@@ -51,6 +53,10 @@ class DefaultPermalinkParser(
             matrixToConverter.convert(uri) ?: return PermalinkData.FallbackLink(uri)
         }
 
+        matrixToUri.userIdWithSlash()?.let { userId ->
+            return PermalinkData.UserLink(userId = userId)
+        }
+
         val result = runCatchingExceptions {
             parseMatrixEntityFrom(matrixToUri.toString())
         }.getOrNull()
@@ -83,4 +89,18 @@ class DefaultPermalinkParser(
             }
         }
     }
+}
+
+/**
+ * A slash is allowed in the local part of a user id, but it also separates an identifier from an
+ * event id in a permalink, so [parseMatrixEntityFrom] cannot tell the two apart. Only a user id can
+ * start with an `@`, so recover it here rather than letting the ambiguity reach the SDK.
+ */
+private fun Uri.userIdWithSlash(): UserId? {
+    val identifier = fragment
+        ?.removePrefix("/")
+        ?.substringBefore('?')
+        ?: return null
+    if (!identifier.startsWith("@") || !identifier.contains('/')) return null
+    return identifier.takeIf { MatrixPatterns.isUserId(it) }?.let(::UserId)
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/permalink/DefaultPermalinkParserTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/permalink/DefaultPermalinkParserTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.permalink
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.permalink.PermalinkData
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+
+class DefaultPermalinkParserTest : RobolectricTest() {
+    @Test
+    fun `a matrix-to link to a user id with a slash is parsed as a user link`() {
+        val result = createParser().parse("https://matrix.to/#/@it/sme:matrix.org")
+        assertThat(result).isEqualTo(PermalinkData.UserLink(UserId("@it/sme:matrix.org")))
+    }
+
+    @Test
+    fun `an escaped slash in a user id is parsed as a user link`() {
+        val result = createParser().parse("https://matrix.to/#/@it%2Fsme:matrix.org")
+        assertThat(result).isEqualTo(PermalinkData.UserLink(UserId("@it/sme:matrix.org")))
+    }
+
+    @Test
+    fun `an element web link to a user id with a slash is parsed as a user link`() {
+        val result = createParser().parse("https://app.element.io/#/user/@it/sme:matrix.org")
+        assertThat(result).isEqualTo(PermalinkData.UserLink(UserId("@it/sme:matrix.org")))
+    }
+
+    @Test
+    fun `a user id with a slash that is not a valid user id is not a user link`() {
+        val result = createParser().parse("https://example.org/foo/@it/sme")
+        assertThat(result).isInstanceOf(PermalinkData.FallbackLink::class.java)
+    }
+
+    private fun createParser() = DefaultPermalinkParser(
+        matrixToConverter = DefaultMatrixToConverter(),
+    )
+}


### PR DESCRIPTION
## Content

A slash is valid in the local part of a user id, but in a permalink it also separates the identifier from an event id. `parseMatrixEntityFrom` cannot tell the two apart, so a mention of a user such as `@it/sme:matrix.org` failed to parse and the link was treated as an ordinary URL: tapping it opened matrix.to in a browser instead of the user profile.

Only a user id can start with an `@`, so the identifier is now recovered before the URI is handed to the SDK. The recovery is applied only when the identifier really contains a slash and is a valid user id, so every other permalink still takes exactly the same path as before.

## Motivation and context

Part of #2617.

## Tests

- `libraries/matrix/impl/.../permalink/DefaultPermalinkParserTest.kt`: a matrix.to link, a matrix.to link with the slash escaped, and an Element Web link all resolve to a user link, while a URL that is not a permalink stays a fallback link.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
