### PR TITLE
Stop waiting for a room alias that the remote server never resolves

### DIFF
--- a/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenter.kt
+++ b/features/roomaliasresolver/impl/src/main/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasResolverPresenter.kt
@@ -24,7 +24,10 @@ import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.TimeoutException
 import kotlin.jvm.optionals.getOrElse
+import kotlin.time.Duration.Companion.seconds
 
 @AssistedInject
 class RoomAliasResolverPresenter(
@@ -61,9 +64,14 @@ class RoomAliasResolverPresenter(
 
     private fun CoroutineScope.resolveAlias(resolveState: MutableState<AsyncData<ResolvedRoomAlias>>) = launch {
         suspend {
-            matrixClient.resolveRoomAlias(roomAlias)
+            val result = withTimeoutOrNull(ALIAS_RESOLVE_TIMEOUT_IN_SECONDS.seconds) {
+                matrixClient.resolveRoomAlias(roomAlias)
+            } ?: throw TimeoutException("Timed out while resolving ${roomAlias.value}")
+            result
                 .getOrThrow()
                 .getOrElse { throw RoomAliasResolverFailures.UnknownAlias }
         }.runCatchingUpdatingState(resolveState)
     }
 }
+
+private const val ALIAS_RESOLVE_TIMEOUT_IN_SECONDS = 10

--- a/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasHelperPresenterTest.kt
+++ b/features/roomaliasresolver/impl/src/test/kotlin/io/element/android/features/roomaliasresolver/impl/RoomAliasHelperPresenterTest.kt
@@ -22,10 +22,12 @@ import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SERVER_LIST
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.tests.testutils.WarmUpRule
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import java.util.Optional
+import java.util.concurrent.TimeoutException
 
 class RoomAliasHelperPresenterTest {
     @get:Rule
@@ -57,6 +59,22 @@ class RoomAliasHelperPresenterTest {
             val resultState = awaitItem()
             assertThat(resultState.roomAlias).isEqualTo(A_ROOM_ALIAS)
             assertThat(resultState.resolveState.dataOrNull()).isEqualTo(result.get())
+        }
+    }
+
+    @Test
+    fun `present - a server that never answers ends up in an error state`() = runTest {
+        val client = FakeMatrixClient(
+            resolveRoomAliasResult = { awaitCancellation() }
+        )
+        val presenter = createPresenter(matrixClient = client)
+        moleculeFlow(RecompositionMode.Immediate) {
+            presenter.present()
+        }.test {
+            assertThat(awaitItem().resolveState.isUninitialized()).isTrue()
+            assertThat(awaitItem().resolveState.isLoading()).isTrue()
+            val resultState = awaitItem()
+            assertThat(resultState.resolveState.errorOrNull()).isInstanceOf(TimeoutException::class.java)
         }
     }
 

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -99,7 +99,7 @@ class FakeMatrixClient(
     override val roomMembershipObserver: RoomMembershipObserver = RoomMembershipObserver(),
     private val homeserverCapabilitiesProvider: FakeHomeserverCapabilitiesProvider = FakeHomeserverCapabilitiesProvider(),
     private val accountManagementUrlResult: (AccountManagementAction?) -> Result<String?> = { lambdaError() },
-    private val resolveRoomAliasResult: (RoomAlias) -> Result<Optional<ResolvedRoomAlias>> = {
+    private val resolveRoomAliasResult: suspend (RoomAlias) -> Result<Optional<ResolvedRoomAlias>> = {
         Result.success(
             Optional.of(ResolvedRoomAlias(A_ROOM_ID, emptyList()))
         )


### PR DESCRIPTION
## Content

Tapping a room alias whose homeserver is unreachable left the resolver screen on a spinner for as long as the screen stayed open. `resolveRoomAlias` was awaited with no bound, so a federation request that never comes back never produced a state the screen could render, and the only way out was to press back.

The resolution is now bounded by the same ten second timeout that resolving an address already uses when joining a room by address, and a timeout surfaces as a failure. The screen then shows its retry dialog rather than spinning.

The alias is still not resolved locally for a room the user has already joined, which is what the reporter suggested; that needs a way to look a room up by alias that the client does not expose today.

## Motivation and context

Part of #5267.

## Tests

- `features/roomaliasresolver/impl/.../RoomAliasHelperPresenterTest.kt`: a client whose resolution never completes ends in a failure state instead of staying loading.
- `FakeMatrixClient`'s resolve lambda becomes suspending so a server that never answers can be simulated; existing callers are unchanged.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
