### PR TITLE
Hide the encryption badge when key storage is set up on the server

### DIFF
--- a/libraries/indicator/impl/src/main/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorService.kt
+++ b/libraries/indicator/impl/src/main/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorService.kt
@@ -9,11 +9,14 @@
 package io.element.android.libraries.indicator.impl
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.indicator.api.IndicatorService
@@ -43,12 +46,17 @@ class DefaultIndicatorService(
     override fun showSettingChatBackupIndicator(): State<Boolean> {
         val backupState by encryptionService.backupStateStateFlow.collectAsState()
         val recoveryState by encryptionService.recoveryStateStateFlow.collectAsState()
+        var doesBackupExistOnServer by remember { mutableStateOf<Boolean?>(null) }
+
+        LaunchedEffect(backupState) {
+            if (backupState == BackupState.UNKNOWN) {
+                doesBackupExistOnServer = encryptionService.doesBackupExistOnServer().getOrNull()
+            }
+        }
 
         return remember {
             derivedStateOf {
-                val showForBackup = backupState in listOf(
-                    BackupState.UNKNOWN,
-                )
+                val showForBackup = backupState == BackupState.UNKNOWN && doesBackupExistOnServer != true
                 val showForRecovery = recoveryState in listOf(
                     RecoveryState.DISABLED,
                     RecoveryState.INCOMPLETE,

--- a/libraries/indicator/impl/src/test/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorServiceTest.kt
+++ b/libraries/indicator/impl/src/test/kotlin/io/element/android/libraries/indicator/impl/DefaultIndicatorServiceTest.kt
@@ -42,8 +42,10 @@ class DefaultIndicatorServiceTest {
     }
 
     @Test
-    fun `test - showSettingChatBackupIndicator is true when BackupState is UNKNOWN`() = runTest {
-        val encryptionService = FakeEncryptionService()
+    fun `test - showSettingChatBackupIndicator is true when BackupState is UNKNOWN and no backup exists on the server`() = runTest {
+        val encryptionService = FakeEncryptionService().apply {
+            givenDoesBackupExistOnServerResult(Result.success(false))
+        }
         val sessionVerificationService = FakeSessionVerificationService()
         val sut = DefaultIndicatorService(
             sessionVerificationService = sessionVerificationService,
@@ -58,6 +60,24 @@ class DefaultIndicatorServiceTest {
             assertThat(awaitItem()).isFalse()
             encryptionService.emitBackupState(BackupState.UNKNOWN)
             assertThat(awaitItem()).isTrue()
+        }
+    }
+
+    @Test
+    fun `test - showSettingChatBackupIndicator is false when BackupState is UNKNOWN but a backup exists on the server`() = runTest {
+        val encryptionService = FakeEncryptionService().apply {
+            givenDoesBackupExistOnServerResult(Result.success(true))
+        }
+        val sessionVerificationService = FakeSessionVerificationService()
+        val sut = DefaultIndicatorService(
+            sessionVerificationService = sessionVerificationService,
+            encryptionService = encryptionService,
+        )
+        moleculeFlow(RecompositionMode.Immediate) {
+            sut.showSettingChatBackupIndicator().value
+        }.test {
+            assertThat(awaitItem()).isTrue()
+            assertThat(awaitItem()).isFalse()
         }
     }
 


### PR DESCRIPTION
## Content

The badge next to Encryption in Settings was shown for every unknown backup state. A session whose key backup exists on the server but has not been reported as enabled by the SDK therefore kept a red dot, while the Encryption screen itself showed key storage as on and offered nothing to do. That is the mismatch reported in the issue.

The indicator now resolves an unknown backup state the way `SecureBackupRootState` already does, by asking whether a backup exists on the server, and only badges the entry when there is none. The recovery half of the indicator is unchanged, and the room list top bar indicator follows because it reuses this one.

## Motivation and context

Part of #6518.

## Tests

- `libraries/indicator/impl/.../DefaultIndicatorServiceTest.kt`: an unknown backup state with a backup on the server no longer shows the indicator, and an unknown backup state without one still does.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
