### PR TITLE
Relax image compression so photos and screenshots keep more detail

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -62,10 +62,10 @@ class AndroidMediaPreProcessor(
         /**
          * Used for calculating `inSampleSize` for bitmaps.
          *
-         * *Note*: Ideally, this should result in images of up to (but not included) 1280x1280 being sent. However, images with very different width and height
+         * *Note*: Ideally, this should result in images of up to (but not included) 2560x2560 being sent. However, images with very different width and height
          * values may surpass this limit. (i.e.: an image of `480x3000px` would have `inSampleSize=1` and be sent as is).
          */
-        private const val IMAGE_SCALE_REF_SIZE = 640
+        private const val IMAGE_SCALE_REF_SIZE = 1280
 
         private val notCompressibleImageTypes = listOf(MimeTypes.Gif, MimeTypes.WebP)
     }

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
@@ -208,10 +208,10 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
         assertThat(info.thumbnailFile).isNotNull()
         assertThat(info.imageInfo).isEqualTo(
             ImageInfo(
-                height = 979,
-                width = 3006,
+                height = 1958,
+                width = 6012,
                 mimetype = MimeTypes.Jpeg,
-                size = 84_845,
+                size = 682_492,
                 ThumbnailInfo(height = 244, width = 751, mimetype = MimeTypes.Jpeg, size = 7_178),
                 thumbnailSource = null,
                 blurhash = "K07gBzX=j_D4xZjoaSe,s:"
@@ -233,10 +233,10 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
         assertThat(info.thumbnailFile).isNull()
         assertThat(info.imageInfo).isEqualTo(
             ImageInfo(
-                height = 979,
-                width = 3_006,
+                height = 1_958,
+                width = 6_012,
                 mimetype = MimeTypes.Jpeg,
-                size = 84_845,
+                size = 682_492,
                 thumbnailInfo = null,
                 thumbnailSource = null,
                 blurhash = null,


### PR DESCRIPTION
## Content

`AndroidMediaPreProcessor` downscales images against a 640px reference. The KDoc next to it says the intent is to send images of up to 1280x1280, but because `inSampleSize` is a power of two the reference behaves as a half-size target: a 12000x3916 photo comes out as 3006x979, and a 1818x1178 screenshot as 909x589. Text in screenshots becomes unreadable and photo detail is lost.

Raise the reference to 1280 and correct the KDoc to describe what the value actually bounds. Since `inSampleSize` only doubles, every image moves exactly one step up rather than to a fixed size, and images already below the threshold are unaffected.

The trade-off is memory during upload: a very large source now decodes at `inSampleSize=4` instead of `8`, so the transient bitmap is roughly four times larger while it is being rotated and compressed. That is the same order of magnitude the in-app camera path already handles.

## Motivation and context

Part of #7059.

## Tests

`libraries/mediaupload/impl/.../AndroidMediaPreProcessorTest.kt`: the existing JPEG expectations move from 3006x979 to 6012x1958, which is the observable effect of the change. Run with `./gradlew :libraries:mediaupload:impl:testDebugUnitTest`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
