### PR TITLE
Keep transparency when an image is shared into the app with an imprecise mime type

### DIFF
--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -85,8 +85,9 @@ class AndroidMediaPreProcessor(
             val result = when {
                 mimeType == MimeTypes.Svg -> processSvgImage(uri, mimeType)
                 mimeType.isMimeTypeImage() -> {
-                    val shouldBeCompressed = mediaOptimizationConfig.compressImages && mimeType !in notCompressibleImageTypes
-                    processImage(uri, mimeType, shouldBeCompressed)
+                    val imageMimeType = resolveImageMimeType(uri, mimeType)
+                    val shouldBeCompressed = mediaOptimizationConfig.compressImages && imageMimeType !in notCompressibleImageTypes
+                    processImage(uri, imageMimeType, shouldBeCompressed)
                 }
                 mimeType.isMimeTypeVideo() -> processVideo(uri, mimeType, mediaOptimizationConfig.videoCompressionPreset)
                 mimeType.isMimeTypeAudio() -> processAudio(uri, mimeType)
@@ -153,6 +154,19 @@ class AndroidMediaPreProcessor(
             is MediaUploadInfo.Video -> copy(file = renamedFile)
             is MediaUploadInfo.VoiceMessage -> copy(file = renamedFile)
         }
+    }
+
+    /**
+     * The declared mime type can be broader than the image actually is - a wildcard from a share intent, or a mislabelled file - and the encoder is picked
+     * from it. Re-encoding a transparent image as JPEG flattens its alpha channel to black, so resolve the real format from the image header first.
+     */
+    private fun resolveImageMimeType(uri: Uri, declaredMimeType: String): String {
+        if (declaredMimeType == MimeTypes.Png || declaredMimeType == MimeTypes.Jpeg) return declaredMimeType
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        tryOrNull {
+            contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
+        }
+        return options.outMimeType?.takeIf { it.isMimeTypeImage() } ?: declaredMimeType
     }
 
     private suspend fun processImage(uri: Uri, mimeType: String, shouldBeCompressed: Boolean): MediaUploadInfo {

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessor.kt
@@ -166,7 +166,7 @@ class AndroidMediaPreProcessor(
         tryOrNull {
             contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
         }
-        return options.outMimeType?.takeIf { it.isMimeTypeImage() } ?: declaredMimeType
+        return options.outMimeType ?: declaredMimeType
     }
 
     private suspend fun processImage(uri: Uri, mimeType: String, shouldBeCompressed: Boolean): MediaUploadInfo {

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
@@ -108,6 +108,37 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
     }
 
     @Test
+    fun `a gif shared with a wildcard mime type is recognised and left uncompressed`() = runTest {
+        val mediaUploadInfo = process(
+            asset = assetAnimatedGif,
+            mimeType = MimeTypes.Images,
+            mediaOptimizationConfig = MediaOptimizationConfig(
+                compressImages = true,
+                videoCompressionPreset = VideoCompressionPreset.STANDARD,
+            ),
+            sdkIntVersion = Build.VERSION_CODES.Q,
+        )
+        val info = mediaUploadInfo as MediaUploadInfo.Image
+        assertThat(info.imageInfo.mimetype).isEqualTo(MimeTypes.Gif)
+        assertThat(info.imageInfo.size).isEqualTo(assetAnimatedGif.size)
+    }
+
+    @Test
+    fun `a file that is not an image keeps the wildcard mime type it was shared with`() = runTest {
+        val mediaUploadInfo = process(
+            asset = assetText,
+            mimeType = MimeTypes.Images,
+            mediaOptimizationConfig = MediaOptimizationConfig(
+                compressImages = false,
+                videoCompressionPreset = VideoCompressionPreset.STANDARD,
+            ),
+            sdkIntVersion = Build.VERSION_CODES.Q,
+        )
+        val info = mediaUploadInfo as MediaUploadInfo.Image
+        assertThat(info.imageInfo.mimetype).isEqualTo(MimeTypes.Images)
+    }
+
+    @Test
     @Ignore("Ignore now that min API for enterprise is 33")
     fun `test processing png`() = runTest {
         val mediaUploadInfo = process(

--- a/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
+++ b/libraries/mediaupload/impl/src/test/kotlin/io/element/android/libraries/mediaupload/impl/AndroidMediaPreProcessorTest.kt
@@ -70,6 +70,7 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
         mediaOptimizationConfig: MediaOptimizationConfig,
         sdkIntVersion: Int = Build.VERSION_CODES.P,
         deleteOriginal: Boolean = false,
+        mimeType: String = asset.mimeType,
     ): MediaUploadInfo {
         val context = InstrumentationRegistry.getInstrumentation().context
         val deleteCallback = lambdaRecorder<Uri?, Unit> {}
@@ -81,7 +82,7 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
         val file = getFileFromAssets(context, asset.filename)
         val result = sut.process(
             uri = file.toUri(),
-            mimeType = asset.mimeType,
+            mimeType = mimeType,
             deleteOriginal = deleteOriginal,
             mediaOptimizationConfig = mediaOptimizationConfig,
         )
@@ -89,6 +90,21 @@ class AndroidMediaPreProcessorTest : RobolectricTest() {
         assertThat(data.file.path).endsWith(asset.filename)
         deleteCallback.assertions().isCalledExactly(if (deleteOriginal) 0 else 1)
         return data
+    }
+
+    @Test
+    fun `a png shared with a wildcard mime type is still encoded as a png`() = runTest {
+        val mediaUploadInfo = process(
+            asset = assetImagePng,
+            mimeType = MimeTypes.Images,
+            mediaOptimizationConfig = MediaOptimizationConfig(
+                compressImages = true,
+                videoCompressionPreset = VideoCompressionPreset.STANDARD,
+            ),
+            sdkIntVersion = Build.VERSION_CODES.Q,
+        )
+        val info = mediaUploadInfo as MediaUploadInfo.Image
+        assertThat(info.imageInfo.mimetype).isEqualTo(MimeTypes.Png)
     }
 
     @Test


### PR DESCRIPTION
## Content

The upload pre-processor picks the bitmap encoder from the mime type it is handed: PNG stays PNG, everything else is re-encoded as JPEG. When an image arrives from another app the declared type is frequently broader than the image really is — a share intent that only says the top-level type, or a file whose declared type does not match its bytes. A transparent PNG that arrives that way is re-encoded as JPEG and its alpha channel is flattened to black, which is what the reporter sees when sharing from outside the app but not from inside it.

Resolve the concrete format from the image header before deciding anything, and use it both for the "can this be compressed at all" check (which is what keeps GIF and WebP untouched) and for the encoder choice. A declared PNG or JPEG is trusted as-is, so the common path does not read the header at all.

This deliberately does not widen the PNG branch of `mimeTypeToCompressFormat`: mapping every image to PNG would re-encode ordinary photos as PNG and inflate uploads.

## Motivation and context

Part of #3964.

## Tests

`libraries/mediaupload/impl/.../AndroidMediaPreProcessorTest.kt`: a PNG asset processed with a wildcard image mime type now reports `image/png`, where before it was re-encoded as JPEG. Run with `./gradlew :libraries:mediaupload:impl:testDebugUnitTest`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
