### PR TITLE
Apply the system theme when switching back to it from a forced light or dark theme

### DIFF
--- a/libraries/compound/src/main/kotlin/io/element/android/compound/theme/Theme.kt
+++ b/libraries/compound/src/main/kotlin/io/element/android/compound/theme/Theme.kt
@@ -8,8 +8,11 @@
 
 package io.element.android.compound.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -27,9 +30,25 @@ private fun Theme.coerceBlackTheme(allowBlackTheme: Boolean): Theme {
 @Composable
 fun Theme.isDark(): Boolean {
     return when (this) {
-        Theme.System -> isSystemInDarkTheme()
+        Theme.System -> isSystemThemeDark()
         Theme.Dark, Theme.Black -> true
         Theme.Light -> false
+    }
+}
+
+/**
+ * Whether the system-wide theme is dark.
+ *
+ * This deliberately does not use [androidx.compose.foundation.isSystemInDarkTheme], which reads the activity configuration: `AppCompatDelegate` rewrites
+ * that configuration whenever a non-system theme is selected, so it keeps reporting the previously forced value. The application configuration is left
+ * untouched by AppCompat and is what AppCompat itself reads to expand `MODE_NIGHT_FOLLOW_SYSTEM`.
+ */
+@Composable
+private fun isSystemThemeDark(): Boolean {
+    val applicationContext = LocalContext.current.applicationContext
+    val activityConfiguration = LocalConfiguration.current
+    return remember(activityConfiguration) {
+        applicationContext.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
     }
 }
 

--- a/libraries/compound/src/test/kotlin/io/element/android/compound/theme/ThemeTest.kt
+++ b/libraries/compound/src/test/kotlin/io/element/android/compound/theme/ThemeTest.kt
@@ -11,19 +11,22 @@ package io.element.android.compound.theme
 import android.content.res.Configuration
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import io.element.android.tests.testutils.robolectric.RobolectricTest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.robolectric.RuntimeEnvironment
 
-class ThemeTest {
+class ThemeTest : RobolectricTest() {
     @Test
     fun `isDark for System dark returns true`() {
         `isDark for System`(
-            uiMode = Configuration.UI_MODE_NIGHT_YES,
+            systemUiMode = Configuration.UI_MODE_NIGHT_YES,
             expected = true,
         )
     }
@@ -31,21 +34,38 @@ class ThemeTest {
     @Test
     fun `isDark for System light return false`() {
         `isDark for System`(
-            uiMode = Configuration.UI_MODE_NIGHT_NO,
+            systemUiMode = Configuration.UI_MODE_NIGHT_NO,
             expected = false,
         )
     }
 
-    fun `isDark for System`(
-        uiMode: Int,
+    @Test
+    fun `isDark for System ignores the night mode AppCompat forced on the activity`() {
+        `isDark for System`(
+            systemUiMode = Configuration.UI_MODE_NIGHT_YES,
+            activityUiMode = Configuration.UI_MODE_NIGHT_NO,
+            expected = true,
+        )
+        `isDark for System`(
+            systemUiMode = Configuration.UI_MODE_NIGHT_NO,
+            activityUiMode = Configuration.UI_MODE_NIGHT_YES,
+            expected = false,
+        )
+    }
+
+    private fun `isDark for System`(
+        systemUiMode: Int,
+        activityUiMode: Int = systemUiMode,
         expected: Boolean,
     ) = runTest {
+        val application = RuntimeEnvironment.getApplication()
+        application.resources.configuration.uiMode = systemUiMode
         moleculeFlow(RecompositionMode.Immediate) {
             var result: Boolean? = null
             CompositionLocalProvider(
-                // Let set the system to dark
+                LocalContext provides application,
                 LocalConfiguration provides Configuration().apply {
-                    this.uiMode = uiMode
+                    this.uiMode = activityUiMode
                 },
             ) {
                 result = Theme.System.isDark()


### PR DESCRIPTION
## Content

`Theme.System` is resolved with `isSystemInDarkTheme()`, which reads `LocalConfiguration` — the activity configuration. When the user picks Light or Dark, `ElementThemeApp` calls `AppCompatDelegate.setDefaultNightMode`, and AppCompat rewrites exactly that configuration to the forced night mode. Selecting System afterwards sets `MODE_NIGHT_FOLLOW_SYSTEM`, but the activity configuration still reports the previously forced value, so the app keeps showing the old theme.

Resolve the system night mode from the application configuration instead. AppCompat leaves it untouched, and it is the same configuration AppCompat itself reads to expand `MODE_NIGHT_FOLLOW_SYSTEM`. The activity configuration is still read, as the recomposition key, so a system-wide theme change still repaints.

## Motivation and context

Part of #4639.

## Tests

`libraries/compound/.../ThemeTest.kt`: the existing System cases now drive the application configuration, and a new case pins the fix — with the application configuration in dark and the activity configuration forced to light, `Theme.System.isDark()` returns true, and the mirror case returns false. Run with `./gradlew :libraries:compound:testDebugUnitTest --tests "*ThemeTest*"`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
