### PR TITLE
Keep the focused login field visible above the keyboard

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/loginpassword/LoginPasswordView.kt
@@ -56,6 +56,7 @@ import io.element.android.libraries.designsystem.components.BigIcon
 import io.element.android.libraries.designsystem.components.button.BackButton
 import io.element.android.libraries.designsystem.components.dialogs.ErrorDialog
 import io.element.android.libraries.designsystem.components.form.textFieldState
+import io.element.android.libraries.designsystem.modifiers.bringIntoViewOnImeVisible
 import io.element.android.libraries.designsystem.modifiers.onTabOrEnterKeyFocusNext
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -191,6 +192,7 @@ private fun LoginForm(
             enabled = !isLoading,
             modifier = Modifier
                 .fillMaxWidth()
+                .bringIntoViewOnImeVisible()
                 .onTabOrEnterKeyFocusNext(focusManager)
                 .testTag(TestTags.loginEmailUsername)
                 .semantics {
@@ -243,6 +245,7 @@ private fun LoginForm(
             enabled = !isLoading,
             modifier = Modifier
                 .fillMaxWidth()
+                .bringIntoViewOnImeVisible()
                 .onTabOrEnterKeyFocusNext(focusManager)
                 .testTag(TestTags.loginPassword)
                 .semantics {

--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/searchaccountprovider/SearchAccountProviderView.kt
@@ -52,6 +52,7 @@ import io.element.android.libraries.designsystem.atomic.molecules.IconTitleSubti
 import io.element.android.libraries.designsystem.components.BigIcon
 import io.element.android.libraries.designsystem.components.button.BackButton
 import io.element.android.libraries.designsystem.components.form.textFieldState
+import io.element.android.libraries.designsystem.modifiers.bringIntoViewOnImeVisible
 import io.element.android.libraries.designsystem.modifiers.onTabOrEnterKeyFocusNext
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
@@ -110,6 +111,7 @@ fun SearchAccountProviderView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                            .bringIntoViewOnImeVisible()
                             .onTabOrEnterKeyFocusNext(focusManager)
                             .testTag(TestTags.changeServerServer),
                         onValueChange = {


### PR DESCRIPTION
## Content

On the login and account provider screens the software keyboard can cover the field being typed into. Both screens put their fields in a scrollable container, but nothing scrolls the content back once the keyboard reduces the viewport, so on shorter screens the focused field ends up behind the keyboard. The maintainer named the login password field specifically on the issue.

Apply the existing `Modifier.bringIntoViewOnImeVisible()` to those fields. It is already used by the recovery key screen for the same purpose: it waits for the IME to actually be visible before requesting `bringIntoView`, so the scroll happens against the reduced viewport rather than the full one.

Scope is deliberately limited to the login flow fields the issue is about, rather than a blanket change to every text field in the app.

## Motivation and context

Part of #4582.

## Tests

No new automated test. The behaviour depends on the IME insets actually changing and on the field being taller than the remaining viewport, neither of which the module's Robolectric view tests can produce; `ExpandSheetWhenImeIsVisibleTest` is the closest existing harness and covers the modifier's sibling rather than layout outcomes. The existing `:features:login:impl` tests pass unchanged.

Manual check: focus the password field on a short screen and confirm it scrolls above the keyboard.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
