### PR TITLE
Publish the conversation shortcut for rooms you have only received messages in

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -595,7 +595,7 @@ class MessageComposerPresenter(
         val roomInfo = room.info()
         val roomMembers = room.membersStateFlow.value
 
-        notificationConversationService.onSendMessage(
+        notificationConversationService.onMessageInRoom(
             sessionId = room.sessionId,
             roomId = roomInfo.id,
             roomName = roomInfo.name,

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/notifications/conversations/NotificationConversationService.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/notifications/conversations/NotificationConversationService.kt
@@ -16,16 +16,16 @@ import io.element.android.libraries.matrix.api.core.SessionId
  */
 interface NotificationConversationService {
     /**
-     * Called when a new message is received in a room.
+     * Called when a message is sent to, or received in, a room.
      * It should create a new conversation shortcut for this room.
      *
      * @param sessionId the session the message belongs to.
-     * @param roomId the room the message was received in.
+     * @param roomId the room the message belongs to.
      * @param roomName the name to show on the shortcut, or `null` when the room has none.
      * @param roomIsDirect whether the room is a direct message, which changes how the shortcut is presented.
      * @param roomAvatarUrl the avatar to show on the shortcut, or `null` when the room has none.
      */
-    suspend fun onSendMessage(
+    suspend fun onMessageInRoom(
         sessionId: SessionId,
         roomId: RoomId,
         roomName: String?,

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRenderer.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRenderer.kt
@@ -16,6 +16,7 @@ import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.libraries.core.log.logger.LoggerTag
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.push.api.notifications.NotificationIdProvider
+import io.element.android.libraries.push.api.notifications.conversations.NotificationConversationService
 import io.element.android.libraries.push.impl.notifications.factories.NotificationAccountParams
 import io.element.android.libraries.push.impl.notifications.factories.NotificationCreator
 import io.element.android.libraries.push.impl.notifications.model.FallbackNotifiableEvent
@@ -40,6 +41,7 @@ class NotificationRenderer(
     private val enterpriseService: EnterpriseService,
     private val sessionStore: SessionStore,
     private val analyticsService: AnalyticsService,
+    private val notificationConversationService: NotificationConversationService,
 ) {
     suspend fun render(
         currentUser: MatrixUser,
@@ -73,6 +75,18 @@ class NotificationRenderer(
             notificationDisplayer.cancelNotification(
                 tag = null,
                 id = NotificationIdProvider.getSummaryNotificationId(currentUser.userId)
+            )
+        }
+
+        // The notifications point at a conversation shortcut, which only exists for rooms the user has already sent a message to. Publish it here too, so
+        // that rooms the user has only ever received messages in also get the system's conversation treatment.
+        groupedEvents.roomEvents.distinctBy { it.roomId }.forEach { event ->
+            notificationConversationService.onMessageInRoom(
+                sessionId = event.sessionId,
+                roomId = event.roomId,
+                roomName = event.roomName,
+                roomIsDirect = event.roomIsDm,
+                roomAvatarUrl = event.roomAvatarPath,
             )
         }
 

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
@@ -73,7 +73,7 @@ class DefaultNotificationConversationService(
             .launchIn(coroutineScope)
     }
 
-    override suspend fun onSendMessage(
+    override suspend fun onMessageInRoom(
         sessionId: SessionId,
         roomId: RoomId,
         roomName: String?,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationDrawerManagerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationDrawerManagerTest.kt
@@ -38,6 +38,7 @@ import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiable
 import io.element.android.libraries.push.impl.notifications.fixtures.aSimpleNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.fixtures.anInviteNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
+import io.element.android.libraries.push.test.notifications.conversations.FakeNotificationConversationService
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
 import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
@@ -527,6 +528,7 @@ fun TestScope.createDefaultNotificationDrawerManager(
             enterpriseService = enterpriseService,
             sessionStore = sessionStore,
             analyticsService = analyticsService,
+            notificationConversationService = FakeNotificationConversationService(),
         ),
         appNavigationStateService = appNavigationStateService,
         coroutineScope = backgroundScope,

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRendererTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationRendererTest.kt
@@ -8,14 +8,17 @@
 
 package io.element.android.libraries.push.impl.notifications
 
+import com.google.common.truth.Truth.assertThat
 import io.element.android.features.enterprise.api.EnterpriseService
 import io.element.android.features.enterprise.test.FakeEnterpriseService
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.ui.media.test.FakeImageLoader
 import io.element.android.libraries.push.api.notifications.NotificationIdProvider
+import io.element.android.libraries.push.api.notifications.conversations.NotificationConversationService
 import io.element.android.libraries.push.impl.notifications.fake.FakeActiveNotificationsProvider
 import io.element.android.libraries.push.impl.notifications.fake.FakeNotificationCreator
 import io.element.android.libraries.push.impl.notifications.fake.FakeNotificationDataFactory
@@ -27,6 +30,7 @@ import io.element.android.libraries.push.impl.notifications.fixtures.aNotifiable
 import io.element.android.libraries.push.impl.notifications.fixtures.aSimpleNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.fixtures.anInviteNotifiableEvent
 import io.element.android.libraries.push.impl.notifications.model.NotifiableEvent
+import io.element.android.libraries.push.test.notifications.conversations.FakeNotificationConversationService
 import io.element.android.libraries.sessionstorage.api.SessionStore
 import io.element.android.libraries.sessionstorage.test.InMemorySessionStore
 import io.element.android.services.analytics.test.FakeAnalyticsService
@@ -58,10 +62,32 @@ class NotificationRendererTest : RobolectricTest() {
     )
     private val notificationIdProvider = NotificationIdProvider
 
+    private val publishedShortcutRooms = mutableListOf<RoomId>()
+    private val notificationConversationService = FakeNotificationConversationService(
+        onMessageInRoomLambda = { _, roomId, _, _, _ -> publishedShortcutRooms.add(roomId) },
+    )
+
     private val notificationRenderer = createNotificationRenderer(
         notificationDisplayer = notificationDisplayer,
         notificationDataFactory = notificationDataFactory,
+        notificationConversationService = notificationConversationService,
     )
+
+    @Test
+    fun `given a room message notification when rendering then the conversation shortcut is published`() = runTest {
+        roomGroupMessageCreator.createRoomMessageResult = lambdaRecorder { _, _, _, _, _, _ -> A_NOTIFICATION }
+
+        renderEventsAsNotifications(listOf(aNotifiableMessageEvent(), aNotifiableMessageEvent()))
+
+        assertThat(publishedShortcutRooms).containsExactly(A_ROOM_ID)
+    }
+
+    @Test
+    fun `given no room message notification when rendering then no conversation shortcut is published`() = runTest {
+        renderEventsAsNotifications(listOf(anInviteNotifiableEvent()))
+
+        assertThat(publishedShortcutRooms).isEmpty()
+    }
 
     @Test
     fun `given no notifications when rendering then cancels summary notification`() = runTest {
@@ -122,10 +148,12 @@ fun createNotificationRenderer(
     enterpriseService: EnterpriseService = FakeEnterpriseService(),
     sessionStore: SessionStore = InMemorySessionStore(),
     analyticsService: FakeAnalyticsService = FakeAnalyticsService(),
+    notificationConversationService: NotificationConversationService = FakeNotificationConversationService(),
 ) = NotificationRenderer(
     notificationDisplayer = notificationDisplayer,
     notificationDataFactory = notificationDataFactory,
     enterpriseService = enterpriseService,
     sessionStore = sessionStore,
     analyticsService = analyticsService,
+    notificationConversationService = notificationConversationService,
 )

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
@@ -36,11 +36,11 @@ import org.robolectric.annotation.Config
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 class DefaultNotificationConversationServiceTest : RobolectricTest() {
     @Test
-    fun `onSendMessage adds a shortcut`() = runTest {
+    fun `onMessageInRoom adds a shortcut`() = runTest {
         val context = InstrumentationRegistry.getInstrumentation().context
         val service = createService(context)
 
-        service.onSendMessage(
+        service.onMessageInRoom(
             sessionId = A_SESSION_ID,
             roomId = A_ROOM_ID,
             roomName = "Room title",

--- a/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/conversations/FakeNotificationConversationService.kt
+++ b/libraries/push/test/src/main/kotlin/io/element/android/libraries/push/test/notifications/conversations/FakeNotificationConversationService.kt
@@ -12,14 +12,16 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.push.api.notifications.conversations.NotificationConversationService
 
-class FakeNotificationConversationService : NotificationConversationService {
-    override suspend fun onSendMessage(
+class FakeNotificationConversationService(
+    private val onMessageInRoomLambda: (SessionId, RoomId, String?, Boolean, String?) -> Unit = { _, _, _, _, _ -> },
+) : NotificationConversationService {
+    override suspend fun onMessageInRoom(
         sessionId: SessionId,
         roomId: RoomId,
         roomName: String?,
         roomIsDirect: Boolean,
         roomAvatarUrl: String?,
-    ) = Unit
+    ) = onMessageInRoomLambda(sessionId, roomId, roomName, roomIsDirect, roomAvatarUrl)
 
     override suspend fun onLeftRoom(sessionId: SessionId, roomId: RoomId) = Unit
 


### PR DESCRIPTION
## Content

`NotificationCreator` sets a shortcut id on every message notification so the system gives it the conversation treatment — its own section in the shade, bubbles, conversation-specific settings. The shortcut that id points at is only ever published from `MessageComposerPresenter`, when the user sends a message. For any room the user has only ever received messages in, the notification therefore references a shortcut that was never created, and the conversation treatment is silently not applied.

Publish the shortcut from the notification path as well, once per room and before the notification is shown, so the id always resolves. `DefaultNotificationConversationService` already skips publishing when a PIN code is set, so the privacy behaviour is unchanged, and republishing an existing shortcut is an update rather than a duplicate.

The service method is renamed from `onSendMessage` to `onMessageInRoom`, since it is no longer only about sending.

This closes the notification half of the issue. Publishing the whole room list as shortcuts, in room-list order, plus Direct Share targets, is a separate and much larger piece of work.

## Motivation and context

Part of #1586.

## Tests

`libraries/push/impl/.../NotificationRendererTest.kt`: rendering room message notifications publishes one conversation shortcut per room, and rendering a notification that is not a room message publishes none.

`FakeNotificationConversationService` gains an optional lambda so tests can observe what was published.

Run with `./gradlew :libraries:push:impl:testDebugUnitTest`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
