### PR TITLE
Keep a focused timeline focused until the event has been rendered

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenter.kt
@@ -166,9 +166,14 @@ class TimelinePresenter(
         fun handleEvent(event: TimelineEvent) {
             when (event) {
                 is TimelineEvent.LoadMore -> {
-                    if (event.direction == Timeline.PaginationDirection.FORWARDS && timelineMode is Timeline.Mode.Thread) {
-                        // Do not paginate forwards in thread mode, as it's not supported
-                        return
+                    if (event.direction == Timeline.PaginationDirection.FORWARDS) {
+                        if (timelineMode is Timeline.Mode.Thread) {
+                            // Do not paginate forwards in thread mode, as it's not supported
+                            return
+                        }
+                        if (focusRequestState.value.isPending()) {
+                            return
+                        }
                     }
                     localScope.launch {
                         timelineController.paginate(direction = event.direction)
@@ -534,6 +539,16 @@ private fun FocusRequestState.onFocusEventRender(): FocusRequestState {
     return when (this) {
         is FocusRequestState.Success -> copy(rendered = true)
         else -> this
+    }
+}
+
+private fun FocusRequestState.isPending(): Boolean {
+    return when (this) {
+        is FocusRequestState.Requested,
+        is FocusRequestState.Loading -> true
+        is FocusRequestState.Success -> !rendered
+        FocusRequestState.None,
+        is FocusRequestState.Failure -> false
     }
 }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
@@ -1060,6 +1060,69 @@ class TimelinePresenterTest {
     }
 
     @Test
+    fun `present - a forward pagination while the focused event is not rendered yet is ignored`() = runTest {
+        val paginateLambda = lambdaRecorder(ensureNeverCalled = true) { _: Timeline.PaginationDirection ->
+            Result.success(true)
+        }
+        val presenter = createTimelinePresenter(
+            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
+            val focusedState = consumeItemsUntilPredicate { it.focusRequestState == FocusRequestState.Success(AN_EVENT_ID) }.last()
+            assertThat(focusedState.isLive).isFalse()
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda).isNeverCalled()
+            assertThat(expectMostRecentItem().isLive).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - a forward pagination is performed once the focused event has been rendered`() = runTest {
+        val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
+            Result.success(true)
+        }
+        val presenter = createTimelinePresenter(
+            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
+            consumeItemsUntilPredicate { it.focusRequestState == FocusRequestState.Success(AN_EVENT_ID) }
+            initialState.eventSink.invoke(TimelineEvent.OnFocusEventRender)
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda)
+                .isCalledOnce()
+                .with(value(Timeline.PaginationDirection.FORWARDS))
+            assertThat(expectMostRecentItem().isLive).isTrue()
+        }
+    }
+
+    @Test
+    fun `present - a backward pagination while the focused event is not rendered yet is performed`() = runTest {
+        val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
+            Result.success(false)
+        }
+        val presenter = createTimelinePresenter(
+            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
+            consumeItemsUntilPredicate { it.focusRequestState == FocusRequestState.Success(AN_EVENT_ID) }
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.BACKWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda)
+                .isCalledOnce()
+                .with(value(Timeline.PaginationDirection.BACKWARDS))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `present - focus on known event retrieves the event from cache`() = runTest {
         val timelineItemIndexer = TimelineItemIndexer()
         val presenter = createTimelinePresenter(
@@ -1550,6 +1613,31 @@ class TimelinePresenterTest {
 
     private suspend fun <T> ReceiveTurbine<T>.awaitFirstItem(): T {
         return awaitItem()
+    }
+
+    private fun aRoomWithDetachedTimeline(
+        paginateLambda: (Timeline.PaginationDirection) -> Result<Boolean>,
+    ): FakeJoinedRoom {
+        val detachedTimeline = FakeTimeline(
+            timelineItems = flowOf(
+                listOf(
+                    MatrixTimelineItem.Event(
+                        uniqueId = A_UNIQUE_ID,
+                        event = anEventTimelineItem(eventId = AN_EVENT_ID),
+                    )
+                )
+            )
+        ).apply {
+            this.paginateLambda = paginateLambda
+        }
+        return FakeJoinedRoom(
+            liveTimeline = FakeTimeline(timelineItems = flowOf(emptyList())),
+            createTimelineResult = { Result.success(detachedTimeline) },
+            baseRoom = FakeBaseRoom(
+                roomPermissions = roomPermissions(),
+                threadRootIdForEventResult = { _ -> Result.success(null) },
+            ),
+        )
     }
 
     private fun roomPermissions(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
@@ -1064,8 +1064,10 @@ class TimelinePresenterTest {
         val paginateLambda = lambdaRecorder(ensureNeverCalled = true) { _: Timeline.PaginationDirection ->
             Result.success(true)
         }
+        val room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda)
         val presenter = createTimelinePresenter(
-            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+            room = room,
+            timeline = room.liveTimeline,
         )
         presenter.test {
             val initialState = awaitFirstItem()
@@ -1084,8 +1086,10 @@ class TimelinePresenterTest {
         val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
             Result.success(true)
         }
+        val room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda)
         val presenter = createTimelinePresenter(
-            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+            room = room,
+            timeline = room.liveTimeline,
         )
         presenter.test {
             val initialState = awaitFirstItem()
@@ -1106,13 +1110,109 @@ class TimelinePresenterTest {
         val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
             Result.success(false)
         }
+        val room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda)
         val presenter = createTimelinePresenter(
-            room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda),
+            room = room,
+            timeline = room.liveTimeline,
         )
         presenter.test {
             val initialState = awaitFirstItem()
             initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
             consumeItemsUntilPredicate { it.focusRequestState == FocusRequestState.Success(AN_EVENT_ID) }
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.BACKWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda)
+                .isCalledOnce()
+                .with(value(Timeline.PaginationDirection.BACKWARDS))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - a forward pagination while the focus request is debounced is ignored`() = runTest {
+        val paginateLambda = lambdaRecorder(ensureNeverCalled = true) { _: Timeline.PaginationDirection ->
+            Result.success(true)
+        }
+        val room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda)
+        val presenter = createTimelinePresenter(
+            room = room,
+            timeline = room.liveTimeline,
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID, debounce = 1.seconds))
+            // The focus request has started and is now waiting for the debounce to elapse
+            consumeItemsUntilPredicate { it.focusRequestState is FocusRequestState.Requested }
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda).isNeverCalled()
+            assertThat(expectMostRecentItem().isLive).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - a forward pagination while the focused timeline is loading is ignored`() = runTest {
+        val paginateLambda = lambdaRecorder(ensureNeverCalled = true) { _: Timeline.PaginationDirection ->
+            Result.success(true)
+        }
+        val room = aRoomWithDetachedTimeline(paginateLambda = paginateLambda)
+        val presenter = createTimelinePresenter(
+            room = room,
+            timeline = room.liveTimeline,
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
+            // The focused timeline is being created, the focus request has not resolved yet
+            consumeItemsUntilPredicate { it.focusRequestState is FocusRequestState.Loading }
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda).isNeverCalled()
+            assertThat(expectMostRecentItem().isLive).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - a forward pagination after a failed focus request is performed`() = runTest {
+        val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
+            Result.success(false)
+        }
+        val room = aRoomWithDetachedTimeline(
+            paginateLambda = paginateLambda,
+            createTimelineResult = { Result.failure(RuntimeException("An error")) },
+        )
+        val presenter = createTimelinePresenter(
+            room = room,
+            timeline = room.liveTimeline,
+        )
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.FocusOnEvent(AN_EVENT_ID))
+            consumeItemsUntilPredicate { it.focusRequestState is FocusRequestState.Failure }
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda)
+                .isCalledOnce()
+                .with(value(Timeline.PaginationDirection.FORWARDS))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - a forward pagination in a thread timeline is ignored`() = runTest {
+        val paginateLambda = lambdaRecorder { _: Timeline.PaginationDirection ->
+            Result.success(true)
+        }
+        val timeline = FakeTimeline(mode = Timeline.Mode.Thread(A_THREAD_ID)).apply {
+            this.paginateLambda = paginateLambda
+        }
+        val presenter = createTimelinePresenter(timeline = timeline)
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.FORWARDS))
+            advanceUntilIdle()
+            assert(paginateLambda).isNeverCalled()
+            // A backward pagination is still performed in a thread timeline
             initialState.eventSink.invoke(TimelineEvent.LoadMore(Timeline.PaginationDirection.BACKWARDS))
             advanceUntilIdle()
             assert(paginateLambda)
@@ -1617,27 +1717,33 @@ class TimelinePresenterTest {
 
     private fun aRoomWithDetachedTimeline(
         paginateLambda: (Timeline.PaginationDirection) -> Result<Boolean>,
+        createTimelineResult: () -> Result<Timeline> = { Result.success(aDetachedTimeline(paginateLambda)) },
     ): FakeJoinedRoom {
-        val detachedTimeline = FakeTimeline(
-            timelineItems = flowOf(
-                listOf(
-                    MatrixTimelineItem.Event(
-                        uniqueId = A_UNIQUE_ID,
-                        event = anEventTimelineItem(eventId = AN_EVENT_ID),
-                    )
-                )
-            )
-        ).apply {
-            this.paginateLambda = paginateLambda
-        }
         return FakeJoinedRoom(
-            liveTimeline = FakeTimeline(timelineItems = flowOf(emptyList())),
-            createTimelineResult = { Result.success(detachedTimeline) },
+            liveTimeline = FakeTimeline(timelineItems = flowOf(emptyList())).apply {
+                this.paginateLambda = paginateLambda
+            },
+            createTimelineResult = { createTimelineResult() },
             baseRoom = FakeBaseRoom(
                 roomPermissions = roomPermissions(),
                 threadRootIdForEventResult = { _ -> Result.success(null) },
             ),
         )
+    }
+
+    private fun aDetachedTimeline(
+        paginateLambda: (Timeline.PaginationDirection) -> Result<Boolean>,
+    ) = FakeTimeline(
+        timelineItems = flowOf(
+            listOf(
+                MatrixTimelineItem.Event(
+                    uniqueId = A_UNIQUE_ID,
+                    event = anEventTimelineItem(eventId = AN_EVENT_ID),
+                )
+            )
+        )
+    ).apply {
+        this.paginateLambda = paginateLambda
     }
 
     private fun roomPermissions(


### PR DESCRIPTION
## Content

Opening a room from a notification asks the timeline to focus the notified event. When that event is outside the loaded live window, `TimelineController` creates a detached timeline focused on it, and a detached timeline always carries a forward loading indicator as its last chronological item. The items list is reversed for display, so that indicator is the bottom-most row and is composed on first layout, and merely composing it emits a forward pagination request nobody asked for. Because a notified event sits close to the live end, that single page reaches the end, and the controller responds by closing the detached timeline. The live window replaces the item list while it is still anchored at the bottom, so the user lands on the newest message and the focus request is discarded.

Automatic forward pagination is now deferred while a focus request is still pending. Once the focused event has been rendered the viewport has moved off the indicator row, so only a real scroll back to the live end switches to the live timeline, which is what the controller's existing behaviour is for.

Backward pagination and the explicit jump-to-live action are untouched, and `TimelineController` itself is unchanged, so the intended detached-to-live switch still happens when the user actually scrolls to the end. The loading indicator's timestamp is re-stamped on every timeline emission, so the deferred request is not lost — it fires again on the next emission if the row is still on screen.

## Motivation and context

Part of #4460.

## Tests

`features/messages/impl/.../timeline/TimelinePresenterTest.kt`: a forward pagination while the focused event is not rendered yet is ignored and the detached timeline stays open; the same pagination is performed once `OnFocusEventRender` has arrived, and the timeline then switches back to live; a backward pagination is still performed while the focus request is pending.

`TimelineControllerTest` is unchanged and still green, which is what proves the intended switch to live was not broken.

Run with `./gradlew :features:messages:impl:testDebugUnitTest`.

These are unit tests over the presenter, so they pin the pagination gate rather than the on-device scroll position.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
