### PR TITLE
Use the text already in the composer as the attachment caption

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesFlowNode.kt
@@ -169,7 +169,12 @@ class MessagesFlowNode(
         ) : NavTarget
 
         @Parcelize
-        data class AttachmentPreview(val timelineMode: Timeline.Mode, val attachments: ImmutableList<Attachment>, val inReplyToEventId: EventId?) : NavTarget
+        data class AttachmentPreview(
+            val timelineMode: Timeline.Mode,
+            val attachments: ImmutableList<Attachment>,
+            val inReplyToEventId: EventId?,
+            val caption: String?,
+        ) : NavTarget
 
         @Parcelize
         data class LocationViewer(val mode: ShowLocationMode) : NavTarget
@@ -281,12 +286,13 @@ class MessagesFlowNode(
                         )
                     }
 
-                    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) {
+                    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?) {
                         backstack.push(
                             NavTarget.AttachmentPreview(
                                 attachments = attachments,
                                 timelineMode = Timeline.Mode.Live,
                                 inReplyToEventId = inReplyToEventId,
+                                caption = caption,
                             )
                         )
                     }
@@ -443,6 +449,7 @@ class MessagesFlowNode(
                     attachments = navTarget.attachments,
                     timelineMode = navTarget.timelineMode,
                     inReplyToEventId = navTarget.inReplyToEventId,
+                    caption = navTarget.caption,
                 )
                 createNode<AttachmentsPreviewNode>(buildContext, listOf(inputs))
             }
@@ -595,12 +602,13 @@ class MessagesFlowNode(
                         )
                     }
 
-                    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) {
+                    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?) {
                         backstack.push(
                             NavTarget.AttachmentPreview(
                                 attachments = attachments,
                                 timelineMode = Timeline.Mode.Thread(navTarget.threadRootId),
                                 inReplyToEventId = inReplyToEventId,
+                                caption = caption,
                             )
                         )
                     }

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNavigator.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNavigator.kt
@@ -21,7 +21,7 @@ interface MessagesNavigator {
     fun forwardEvent(eventId: EventId)
     fun navigateToReportMessage(eventId: EventId, senderId: UserId)
     fun navigateToEditPoll(eventId: EventId)
-    fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?)
+    fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?)
     fun navigateToRoom(roomId: RoomId, eventId: EventId?, serverNames: List<String>)
     fun navigateToMember(userId: UserId)
     fun navigateToThread(threadRootId: ThreadId, focusedEventId: EventId?)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/MessagesNode.kt
@@ -126,7 +126,7 @@ class MessagesNode(
     interface Callback : Plugin {
         fun handleEventClick(timelineMode: Timeline.Mode, event: TimelineItem.Event, canUseOverlay: Boolean): Boolean
         fun handleGalleryItemClick(timelineMode: Timeline.Mode, event: TimelineItem.Event, galleryItemIndex: Int, canUseOverlay: Boolean): Boolean
-        fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?)
+        fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?)
         fun navigateToRoomMemberDetails(userId: UserId)
         fun handlePermalinkClick(data: PermalinkData)
         fun navigateToEventDebugInfo(eventId: EventId?, debugInfo: TimelineItemDebugInfo)
@@ -225,8 +225,8 @@ class MessagesNode(
         callback.navigateToEditPoll(eventId)
     }
 
-    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) {
-        callback.navigateToPreviewAttachments(attachments, inReplyToEventId)
+    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?) {
+        callback.navigateToPreviewAttachments(attachments, inReplyToEventId, caption)
     }
 
     override fun navigateToRoom(roomId: RoomId, eventId: EventId?, serverNames: List<String>) {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/AttachmentCaptionHandOver.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/AttachmentCaptionHandOver.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.attachments
+
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import io.element.android.libraries.di.RoomScope
+import io.element.android.libraries.matrix.api.timeline.Timeline
+
+@SingleIn(RoomScope::class)
+@Inject
+class AttachmentCaptionHandOver {
+    private var sentFor: Timeline.Mode? = null
+
+    fun onSent(timelineMode: Timeline.Mode) {
+        sentFor = timelineMode
+    }
+
+    fun consumeSent(timelineMode: Timeline.Mode): Boolean {
+        if (sentFor != timelineMode) return false
+        sentFor = null
+        return true
+    }
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewNode.kt
@@ -46,6 +46,7 @@ class AttachmentsPreviewNode(
         val attachments: ImmutableList<Attachment>,
         val timelineMode: Timeline.Mode,
         val inReplyToEventId: EventId?,
+        val caption: String?,
     ) : NodeInputs
 
     private val inputs: Inputs = inputs()
@@ -59,6 +60,7 @@ class AttachmentsPreviewNode(
         timelineMode = inputs.timelineMode,
         onDoneListener = onDoneListener,
         inReplyToEventId = inputs.inReplyToEventId,
+        caption = inputs.caption,
     )
 
     @Composable

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -24,6 +24,7 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import io.element.android.features.messages.impl.attachments.Attachment
+import io.element.android.features.messages.impl.attachments.AttachmentCaptionHandOver
 import io.element.android.features.messages.impl.attachments.preview.imageeditor.AttachmentImageEditor
 import io.element.android.features.messages.impl.attachments.preview.imageeditor.AttachmentImageEditorState
 import io.element.android.features.messages.impl.attachments.preview.imageeditor.AttachmentImageEdits
@@ -66,10 +67,12 @@ class AttachmentsPreviewPresenter(
     @Assisted private val onDoneListener: OnDoneListener,
     @Assisted private val timelineMode: Timeline.Mode,
     @Assisted private val inReplyToEventId: EventId?,
+    @Assisted private val caption: String?,
     mediaSenderFactory: MediaSenderFactory,
     private val permalinkBuilder: PermalinkBuilder,
     private val temporaryUriDeleter: TemporaryUriDeleter,
     private val attachmentImageEditor: AttachmentImageEditor,
+    private val attachmentCaptionHandOver: AttachmentCaptionHandOver,
     private val mediaOptimizationSelectorPresenterFactory: MediaOptimizationSelectorPresenter.Factory,
     private val videoCompressionPresetSelector: VideoCompressionPresetSelector,
     @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
@@ -83,6 +86,7 @@ class AttachmentsPreviewPresenter(
             timelineMode: Timeline.Mode,
             onDoneListener: OnDoneListener,
             inReplyToEventId: EventId?,
+            caption: String?,
         ): AttachmentsPreviewPresenter
     }
 
@@ -106,7 +110,7 @@ class AttachmentsPreviewPresenter(
         var displayImageEditError by remember { mutableStateOf(false) }
         var editedTempFiles by remember { mutableStateOf<Map<Int, File>>(emptyMap()) }
 
-        val markdownTextEditorState = rememberMarkdownTextEditorState(initialText = null, initialFocus = false)
+        val markdownTextEditorState = rememberMarkdownTextEditorState(initialText = caption, initialFocus = false)
         val textEditorState by rememberUpdatedState(
             TextEditorState.Markdown(markdownTextEditorState, isRoomEncrypted = null)
         )
@@ -548,6 +552,9 @@ class AttachmentsPreviewPresenter(
     }.fold(
         onSuccess = {
             mediaUploadInfos.forEach { cleanUp(it) }
+            if (this.caption != null) {
+                attachmentCaptionHandOver.onSent(timelineMode)
+            }
             sendActionState.value = SendActionState.Done
             onDoneListener()
         },

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -35,6 +35,7 @@ import io.element.android.features.contentscanner.api.ContentScannerService
 import io.element.android.features.location.api.LocationService
 import io.element.android.features.messages.impl.MessagesNavigator
 import io.element.android.features.messages.impl.attachments.Attachment
+import io.element.android.features.messages.impl.attachments.AttachmentCaptionHandOver
 import io.element.android.features.messages.impl.attachments.preview.error.sendAttachmentError
 import io.element.android.features.messages.impl.draft.ComposerDraftService
 import io.element.android.features.messages.impl.messagecomposer.suggestions.RoomAliasSuggestionsDataSource
@@ -127,6 +128,7 @@ class MessageComposerPresenter(
     private val analyticsService: AnalyticsService,
     private val locationService: LocationService,
     private val messageComposerContext: DefaultMessageComposerContext,
+    private val attachmentCaptionHandOver: AttachmentCaptionHandOver,
     private val richTextEditorStateFactory: RichTextEditorStateFactory,
     private val roomAliasSuggestionsDataSource: RoomAliasSuggestionsDataSource,
     private val permalinkParser: PermalinkParser,
@@ -190,22 +192,27 @@ class MessageComposerPresenter(
             .collectAsState(initial = false)
 
         val galleryMediaPicker = mediaPickerProvider.registerGalleryPicker { uri, mimeType ->
-            handlePickedMedia(uri, mimeType)
+            handlePickedMedia(uri, mimeType, caption = captionToHandOver(markdownTextEditorState, richTextEditorState))
         }
         val galleryMultiMediaPicker = mediaPickerProvider.registerGalleryMultiPicker { uris ->
-            handlePickedMediaList(uris)
+            handlePickedMediaList(uris, caption = captionToHandOver(markdownTextEditorState, richTextEditorState))
         }
         val filesPicker = mediaPickerProvider.registerFileMultiPicker(AnyMimeTypes) { uris ->
-            handlePickedMediaList(uris, sendAsFile = true)
+            handlePickedMediaList(uris, sendAsFile = true, caption = captionToHandOver(markdownTextEditorState, richTextEditorState))
         }
         val fileSinglePicker = mediaPickerProvider.registerFilePicker(AnyMimeTypes) { uri, mimeType ->
-            handlePickedMedia(uri, mimeType ?: MimeTypes.OctetStream, sendAsFile = true)
+            handlePickedMedia(
+                uri = uri,
+                mimeType = mimeType ?: MimeTypes.OctetStream,
+                sendAsFile = true,
+                caption = captionToHandOver(markdownTextEditorState, richTextEditorState),
+            )
         }
         val cameraPhotoPicker = mediaPickerProvider.registerCameraPhotoPicker { uri ->
-            handlePickedMedia(uri, MimeTypes.Jpeg)
+            handlePickedMedia(uri, MimeTypes.Jpeg, caption = captionToHandOver(markdownTextEditorState, richTextEditorState))
         }
         val cameraVideoPicker = mediaPickerProvider.registerCameraVideoPicker { uri ->
-            handlePickedMedia(uri, MimeTypes.Mp4)
+            handlePickedMedia(uri, MimeTypes.Mp4, caption = captionToHandOver(markdownTextEditorState, richTextEditorState))
         }
         val isFullScreen = rememberSaveable {
             mutableStateOf(false)
@@ -252,6 +259,11 @@ class MessageComposerPresenter(
         val slashCommandAction = remember { mutableStateOf<AsyncAction<Unit>>(AsyncAction.Uninitialized) }
 
         LaunchedEffect(Unit) {
+            if (attachmentCaptionHandOver.consumeSent(timelineController.mainTimelineMode())) {
+                setText("", markdownTextEditorState, richTextEditorState)
+                updateDraft(draft = null, isVolatile = false)
+                return@LaunchedEffect
+            }
             val draft = draftService.loadDraft(
                 roomId = room.roomId,
                 threadRoot = threadRoot,
@@ -633,6 +645,7 @@ class MessageComposerPresenter(
         uri: Uri?,
         mimeType: String? = null,
         sendAsFile: Boolean = false,
+        caption: String? = null,
     ) {
         uri ?: return
         val localMedia = localMediaFactory.createFromUri(
@@ -643,7 +656,7 @@ class MessageComposerPresenter(
         )
         val mediaAttachment = Attachment.Media(localMedia, sendAsFile = sendAsFile)
         val inReplyToEventId = (messageComposerContext.composerMode as? MessageComposerMode.Reply)?.eventId
-        navigator.navigateToPreviewAttachments(persistentListOf(mediaAttachment), inReplyToEventId)
+        navigator.navigateToPreviewAttachments(persistentListOf(mediaAttachment), inReplyToEventId, caption)
 
         resetComposerModeAfterAttaching()
     }
@@ -651,10 +664,11 @@ class MessageComposerPresenter(
     private fun handlePickedMediaList(
         uris: List<Uri>,
         sendAsFile: Boolean = false,
+        caption: String? = null,
     ) {
         if (uris.isEmpty()) return
         if (uris.size == 1) {
-            handlePickedMedia(uris.first(), sendAsFile = sendAsFile)
+            handlePickedMedia(uris.first(), sendAsFile = sendAsFile, caption = caption)
             return
         }
         val attachments = uris.map { uri ->
@@ -667,9 +681,19 @@ class MessageComposerPresenter(
             Attachment.Media(localMedia, sendAsFile = sendAsFile)
         }.toImmutableList()
         val inReplyToEventId = (messageComposerContext.composerMode as? MessageComposerMode.Reply)?.eventId
-        navigator.navigateToPreviewAttachments(attachments, inReplyToEventId)
+        navigator.navigateToPreviewAttachments(attachments, inReplyToEventId, caption)
 
         resetComposerModeAfterAttaching()
+    }
+
+    private fun captionToHandOver(
+        markdownTextEditorState: MarkdownTextEditorState,
+        richTextEditorState: RichTextEditorState,
+    ): String? {
+        if (messageComposerContext.composerMode.isEditing) return null
+        return currentComposerMessage(markdownTextEditorState, richTextEditorState, withMentions = false)
+            .markdown
+            .takeIf { it.isNotBlank() }
     }
 
     private fun resetComposerModeAfterAttaching() {

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/threads/ThreadedMessagesNode.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/threads/ThreadedMessagesNode.kt
@@ -131,7 +131,7 @@ class ThreadedMessagesNode(
     interface Callback : Plugin {
         fun handleEventClick(timelineMode: Timeline.Mode, event: TimelineItem.Event, canUseOverlay: Boolean): Boolean
         fun handleGalleryItemClick(timelineMode: Timeline.Mode, event: TimelineItem.Event, galleryItemIndex: Int, canUseOverlay: Boolean): Boolean
-        fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?)
+        fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?)
         fun navigateToRoomMemberDetails(userId: UserId)
         fun handlePermalinkClick(data: PermalinkData)
         fun navigateToEventDebugInfo(eventId: EventId?, debugInfo: TimelineItemDebugInfo)
@@ -231,8 +231,8 @@ class ThreadedMessagesNode(
         callback.navigateToEditPoll(eventId)
     }
 
-    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) {
-        callback.navigateToPreviewAttachments(attachments, inReplyToEventId)
+    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?) {
+        callback.navigateToPreviewAttachments(attachments, inReplyToEventId, caption)
     }
 
     override fun navigateToRoom(roomId: RoomId, eventId: EventId?, serverNames: List<String>) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/FakeMessagesNavigator.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/FakeMessagesNavigator.kt
@@ -22,7 +22,11 @@ class FakeMessagesNavigator(
     private val onForwardEventClickLambda: (eventId: EventId) -> Unit = { _ -> lambdaError() },
     private val onReportContentClickLambda: (eventId: EventId, senderId: UserId) -> Unit = { _, _ -> lambdaError() },
     private val onEditPollClickLambda: (eventId: EventId) -> Unit = { _ -> lambdaError() },
-    private val onPreviewAttachmentLambda: (attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) -> Unit = { _, _ -> lambdaError() },
+    private val onPreviewAttachmentLambda: (
+        attachments: ImmutableList<Attachment>,
+        inReplyToEventId: EventId?,
+        caption: String?,
+    ) -> Unit = { _, _, _ -> lambdaError() },
     private val onNavigateToRoomLambda: (roomId: RoomId, threadId: EventId?, serverNames: List<String>) -> Unit = { _, _, _ -> lambdaError() },
     private val navigateToMemberLambda: (userId: UserId) -> Unit = { lambdaError() },
     private val navigateToDeveloperSettingsLambda: () -> Unit = { lambdaError() },
@@ -46,8 +50,8 @@ class FakeMessagesNavigator(
         onEditPollClickLambda(eventId)
     }
 
-    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?) {
-        onPreviewAttachmentLambda(attachments, inReplyToEventId)
+    override fun navigateToPreviewAttachments(attachments: ImmutableList<Attachment>, inReplyToEventId: EventId?, caption: String?) {
+        onPreviewAttachmentLambda(attachments, inReplyToEventId, caption)
     }
 
     override fun navigateToRoom(roomId: RoomId, eventId: EventId?, serverNames: List<String>) {

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -40,6 +40,7 @@ import io.element.android.libraries.matrix.api.permalink.PermalinkBuilder
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.matrix.test.A_CAPTION
+import io.element.android.libraries.matrix.test.A_THREAD_ID
 import io.element.android.libraries.matrix.test.media.FakeMediaUploadHandler
 import io.element.android.libraries.matrix.test.permalink.FakePermalinkBuilder
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
@@ -933,6 +934,108 @@ class AttachmentsPreviewPresenterTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `present - a handed over caption pre-fills the caption editor`() = runTest {
+        val presenter = createAttachmentsPreviewPresenter(caption = A_CAPTION)
+        presenter.test {
+            skipItems(1)
+            val initialState = awaitItem()
+            assertThat(initialState.textEditorState.messageMarkdown(FakePermalinkBuilder())).isEqualTo(A_CAPTION)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - without a handed over caption the caption editor is empty`() = runTest {
+        val presenter = createAttachmentsPreviewPresenter(caption = null)
+        presenter.test {
+            skipItems(1)
+            val initialState = awaitItem()
+            assertThat(initialState.textEditorState.messageMarkdown(FakePermalinkBuilder())).isEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - sending an attachment reports the handed over caption as sent`() = runTest {
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver()
+        val presenter = createAttachmentsPreviewPresenter(
+            room = aRoomAcceptingFiles(),
+            caption = A_CAPTION,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+            onDoneListener = { },
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().eventSink(AttachmentsPreviewEvent.SendAttachment)
+            consumeItemsUntilPredicate { it.sendActionState == SendActionState.Done }
+            assertThat(attachmentCaptionHandOver.consumeSent(Timeline.Mode.Live)).isTrue()
+        }
+    }
+
+    @Test
+    fun `present - sending an attachment without a handed over caption reports nothing`() = runTest {
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver()
+        val presenter = createAttachmentsPreviewPresenter(
+            room = aRoomAcceptingFiles(),
+            caption = null,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+            onDoneListener = { },
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().eventSink(AttachmentsPreviewEvent.SendAttachment)
+            consumeItemsUntilPredicate { it.sendActionState == SendActionState.Done }
+            assertThat(attachmentCaptionHandOver.consumeSent(Timeline.Mode.Live)).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - cancelling a preview does not report the handed over caption as sent`() = runTest {
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver()
+        val presenter = createAttachmentsPreviewPresenter(
+            caption = A_CAPTION,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+            temporaryUriDeleter = FakeTemporaryUriDeleter { },
+            onDoneListener = { },
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().eventSink(AttachmentsPreviewEvent.CancelAndDismiss)
+            consumeItemsUntilPredicate { it.sendActionState == SendActionState.Done }
+            assertThat(attachmentCaptionHandOver.consumeSent(Timeline.Mode.Live)).isFalse()
+        }
+    }
+
+    @Test
+    fun `present - sending an attachment in a thread reports the caption for that thread only`() = runTest {
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver()
+        val presenter = createAttachmentsPreviewPresenter(
+            room = aRoomAcceptingFiles(),
+            timelineMode = Timeline.Mode.Thread(A_THREAD_ID),
+            caption = A_CAPTION,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+            onDoneListener = { },
+        )
+        presenter.test {
+            skipItems(1)
+            awaitItem().eventSink(AttachmentsPreviewEvent.SendAttachment)
+            consumeItemsUntilPredicate { it.sendActionState == SendActionState.Done }
+            assertThat(attachmentCaptionHandOver.consumeSent(Timeline.Mode.Live)).isFalse()
+            assertThat(attachmentCaptionHandOver.consumeSent(Timeline.Mode.Thread(A_THREAD_ID))).isTrue()
+        }
+    }
+
+    private fun aRoomAcceptingFiles(): FakeJoinedRoom {
+        val timeline = FakeTimeline().apply {
+            sendFileLambda = { _, _, _, _, _ -> Result.success(FakeMediaUploadHandler()) }
+        }
+        return FakeJoinedRoom(
+            liveTimeline = timeline,
+            createTimelineResult = { Result.success(timeline) },
+        )
+    }
+
     private fun TestScope.createAttachmentsPreviewPresenter(
         attachments: List<Attachment> = listOf(
             aMediaAttachment(
@@ -977,6 +1080,8 @@ class AttachmentsPreviewPresenterTest : RobolectricTest() {
             }
         },
         videoCompressionPresetSelector: VideoCompressionPresetSelector = VideoCompressionPresetSelector(),
+        caption: String? = null,
+        attachmentCaptionHandOver: AttachmentCaptionHandOver = AttachmentCaptionHandOver(),
     ): AttachmentsPreviewPresenter {
         return AttachmentsPreviewPresenter(
             attachments = attachments.toImmutableList(),
@@ -1000,6 +1105,8 @@ class AttachmentsPreviewPresenterTest : RobolectricTest() {
             videoCompressionPresetSelector = videoCompressionPresetSelector,
             timelineMode = timelineMode,
             inReplyToEventId = null,
+            caption = caption,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
             mediaOptimizationConfigProvider = mediaOptimizationConfigProvider,
         )
     }

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterSlashCommandTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterSlashCommandTest.kt
@@ -16,6 +16,7 @@ import io.element.android.features.location.api.LocationService
 import io.element.android.features.location.test.FakeLocationService
 import io.element.android.features.messages.impl.FakeMessagesNavigator
 import io.element.android.features.messages.impl.MessagesNavigator
+import io.element.android.features.messages.impl.attachments.AttachmentCaptionHandOver
 import io.element.android.features.messages.impl.draft.ComposerDraftService
 import io.element.android.features.messages.impl.draft.FakeComposerDraftService
 import io.element.android.features.messages.impl.messagecomposer.suggestions.SuggestionsProcessor
@@ -302,6 +303,7 @@ class MessageComposerPresenterSlashCommandTest {
         analyticsService = analyticsService,
         locationService = locationService,
         messageComposerContext = DefaultMessageComposerContext(),
+        attachmentCaptionHandOver = AttachmentCaptionHandOver(),
         richTextEditorStateFactory = TestRichTextEditorStateFactory(),
         roomAliasSuggestionsDataSource = FakeRoomAliasSuggestionsDataSource(),
         permissionsPresenterFactory = FakePermissionsPresenterFactory(permissionPresenter),

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenterTest.kt
@@ -24,6 +24,7 @@ import io.element.android.features.location.test.FakeLocationService
 import io.element.android.features.messages.impl.FakeMessagesNavigator
 import io.element.android.features.messages.impl.MessagesNavigator
 import io.element.android.features.messages.impl.attachments.Attachment
+import io.element.android.features.messages.impl.attachments.AttachmentCaptionHandOver
 import io.element.android.features.messages.impl.draft.ComposerDraftService
 import io.element.android.features.messages.impl.draft.FakeComposerDraftService
 import io.element.android.features.messages.impl.messagecomposer.suggestions.SuggestionsProcessor
@@ -107,6 +108,7 @@ import io.element.android.libraries.textcomposer.model.SuggestionType
 import io.element.android.libraries.textcomposer.model.TextEditorState
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.consumeItemsUntilTimeout
 import io.element.android.tests.testutils.lambda.any
 import io.element.android.tests.testutils.lambda.assert
 import io.element.android.tests.testutils.lambda.lambdaRecorder
@@ -702,7 +704,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
         val room = FakeJoinedRoom(
             typingNoticeResult = { Result.success(Unit) }
         )
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -736,11 +738,99 @@ class MessageComposerPresenterTest : RobolectricTest() {
     }
 
     @Test
+    fun `present - Pick image from gallery hands the composer text over as the caption`() = runTest {
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
+        val presenter = createPresenter(
+            navigator = FakeMessagesNavigator(onPreviewAttachmentLambda = onPreviewAttachmentLambda),
+        )
+        pickerProvider.givenMimeType(MimeTypes.Images)
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.textEditorState.setHtml(A_MESSAGE)
+            initialState.eventSink(MessageComposerEvent.PickAttachmentSource.FromGallery)
+            onPreviewAttachmentLambda.assertions()
+                .isCalledOnce()
+                .with(any(), any(), value(A_MESSAGE))
+        }
+    }
+
+    @Test
+    fun `present - Pick image from gallery with an empty composer hands over no caption`() = runTest {
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
+        val presenter = createPresenter(
+            navigator = FakeMessagesNavigator(onPreviewAttachmentLambda = onPreviewAttachmentLambda),
+        )
+        pickerProvider.givenMimeType(MimeTypes.Images)
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink(MessageComposerEvent.PickAttachmentSource.FromGallery)
+            onPreviewAttachmentLambda.assertions()
+                .isCalledOnce()
+                .with(any(), any(), value(null))
+        }
+    }
+
+    @Test
+    fun `present - Pick image from gallery while editing hands over no caption`() = runTest {
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
+        val presenter = createPresenter(
+            navigator = FakeMessagesNavigator(onPreviewAttachmentLambda = onPreviewAttachmentLambda),
+        )
+        pickerProvider.givenMimeType(MimeTypes.Images)
+        presenter.test {
+            val initialState = awaitFirstItem()
+            initialState.eventSink(MessageComposerEvent.SetMode(anEditMode(message = ANOTHER_MESSAGE)))
+            val editingState = awaitItem()
+            editingState.eventSink(MessageComposerEvent.PickAttachmentSource.FromGallery)
+            onPreviewAttachmentLambda.assertions()
+                .isCalledOnce()
+                .with(any(), any(), value(null))
+        }
+    }
+
+    @Test
+    fun `present - the composer is cleared and its draft deleted when the handed over caption has been sent`() = runTest {
+        val updateDraftLambda = lambdaRecorder { _: RoomId, _: ThreadId?, _: ComposerDraft?, _: Boolean -> }
+        val draftService = FakeComposerDraftService().apply {
+            this.loadDraftLambda = { _, _, _ -> ComposerDraft(A_MESSAGE, A_MESSAGE, ComposerDraftType.NewMessage) }
+            this.saveDraftLambda = updateDraftLambda
+        }
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver().apply { onSent(Timeline.Mode.Live) }
+        val presenter = createPresenter(
+            draftService = draftService,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+        )
+        presenter.test {
+            val state = consumeItemsUntilTimeout().last()
+            assertThat(state.textEditorState.messageHtml()).isEmpty()
+            assert(updateDraftLambda)
+                .isCalledOnce()
+                .with(value(A_ROOM_ID), value(null), value(null), value(false))
+        }
+    }
+
+    @Test
+    fun `present - a handed over caption sent in a thread does not clear the live composer`() = runTest {
+        val draftService = FakeComposerDraftService().apply {
+            this.loadDraftLambda = { _, _, _ -> ComposerDraft(A_MESSAGE, A_MESSAGE, ComposerDraftType.NewMessage) }
+        }
+        val attachmentCaptionHandOver = AttachmentCaptionHandOver().apply { onSent(Timeline.Mode.Thread(A_THREAD_ID)) }
+        val presenter = createPresenter(
+            draftService = draftService,
+            attachmentCaptionHandOver = attachmentCaptionHandOver,
+        )
+        presenter.test {
+            val state = consumeItemsUntilTimeout().last()
+            assertThat(state.textEditorState.messageHtml()).isEqualTo(A_MESSAGE)
+        }
+    }
+
+    @Test
     fun `present - Pick video from gallery`() = runTest {
         val room = FakeJoinedRoom(
             typingNoticeResult = { Result.success(Unit) }
         )
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -776,7 +866,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
 
     @Test
     fun `present - Pick media from gallery while editing keeps the edit pending`() = runTest {
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -799,7 +889,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
 
     @Test
     fun `present - Pick media from gallery while replying clears the reply mode`() = runTest {
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -820,7 +910,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
 
     @Test
     fun `present - Pick multiple media from gallery while editing keeps the edit pending`() = runTest {
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -866,7 +956,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
         val room = FakeJoinedRoom(
             typingNoticeResult = { Result.success(Unit) }
         )
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -921,7 +1011,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
             typingNoticeResult = { Result.success(Unit) }
         )
         val permissionPresenter = FakePermissionsPresenter().apply { setPermissionGranted() }
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -943,7 +1033,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
             typingNoticeResult = { Result.success(Unit) }
         )
         val permissionPresenter = FakePermissionsPresenter()
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -967,7 +1057,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
             typingNoticeResult = { Result.success(Unit) }
         )
         val permissionPresenter = FakePermissionsPresenter().apply { setPermissionGranted() }
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -989,7 +1079,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
             typingNoticeResult = { Result.success(Unit) }
         )
         val permissionPresenter = FakePermissionsPresenter()
-        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId? -> }
+        val onPreviewAttachmentLambda = lambdaRecorder { _: ImmutableList<Attachment>, _: EventId?, _: String? -> }
         val navigator = FakeMessagesNavigator(
             onPreviewAttachmentLambda = onPreviewAttachmentLambda
         )
@@ -1625,6 +1715,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
         threadRoot: ThreadId? = null,
         slashCommandService: SlashCommandService = FakeSlashCommandService(),
         featureFlagService: FakeFeatureFlagService = FakeFeatureFlagService(),
+        attachmentCaptionHandOver: AttachmentCaptionHandOver = AttachmentCaptionHandOver(),
     ) = MessageComposerPresenter(
         navigator = navigator,
         sessionCoroutineScope = this,
@@ -1650,6 +1741,7 @@ class MessageComposerPresenterTest : RobolectricTest() {
         analyticsService = analyticsService,
         locationService = locationService,
         messageComposerContext = DefaultMessageComposerContext(),
+        attachmentCaptionHandOver = attachmentCaptionHandOver,
         richTextEditorStateFactory = TestRichTextEditorStateFactory(),
         roomAliasSuggestionsDataSource = FakeRoomAliasSuggestionsDataSource(),
         permissionsPresenterFactory = FakePermissionsPresenterFactory(permissionPresenter),


### PR DESCRIPTION
## Content

Typing a message and then picking an image opened the attachment preview with an empty caption editor, so the text had to be retyped, and the original was still sitting in the composer after the image was sent.

The composer's text now travels forwards to the preview as the initial caption, carried on the existing parcelable navigation target. A single room-scoped bit travels back to say that a handed-over caption was actually sent, keyed by `Timeline.Mode`, and the composer clears itself and deletes its saved draft on its next composition.

Clearing on send rather than on hand-over is deliberate. Cancelling the preview reports nothing, so the typed text is still there, restored by the composer's own saveable state and by the draft that Appyx's pause of the off-screen composer persists. If the back-channel bit is ever lost, for example to process death while the preview is open, the user keeps a duplicate copy of their text, which is a better failure than losing it.

Two cases are deliberately left alone. A pending edit hands over nothing and is not cleared, so the text being edited still edits the original on the next send. And `MessageComposerEvent.SendUri`, the share-into-app and keyboard-image path, bypasses the preview entirely and is unchanged.

Keying the hand-over on the timeline mode is what keeps a live composer and a thread composer from clearing each other; they share one room-scoped composer context, so a plain flag would not have been safe.

## Motivation and context

Part of #5224.

## Tests

`features/messages/impl/.../attachments/AttachmentsPreviewPresenterTest.kt`: a handed-over caption pre-fills the caption editor and no caption leaves it empty; sending reports the caption as sent, sending without one reports nothing, and cancelling reports nothing; sending in a thread reports the caption for that thread only.

`features/messages/impl/.../messagecomposer/MessageComposerPresenterTest.kt`: picking an image hands the composer text over, hands over nothing when the composer is empty, and hands over nothing while editing; the composer is cleared and its draft deleted once a handed-over caption has been sent; a caption sent in a thread does not clear the live composer.

Run with `./gradlew :features:messages:impl:testDebugUnitTest`.

Rich-text formatting is flattened to markdown by the hand-over, which is what a caption can carry today; converting a caption to HTML is separate scope.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
