### PR TITLE
Model the fake voice recorder on a cancellable recording job

### DIFF
--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/voicemessages/composer/DefaultVoiceMessageComposerPresenterTest.kt
@@ -47,6 +47,7 @@ import io.element.android.libraries.voicerecorder.api.VoiceRecorder
 import io.element.android.libraries.voicerecorder.test.FakeVoiceRecorder
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.consumeItemsUntilTimeout
 import io.element.android.tests.testutils.lambda.any
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.lambda.value
@@ -60,6 +61,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.File
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LargeClass")
@@ -67,8 +69,14 @@ class DefaultVoiceMessageComposerPresenterTest {
     @get:Rule
     val warmUpRule = WarmUpRule()
 
+    private val startRecordResult = lambdaRecorder<Unit> { }
+    private val stopRecordResult = lambdaRecorder<Boolean, Unit> { }
+    private val deleteRecordingResult = lambdaRecorder<Unit> { }
     private val voiceRecorder = FakeVoiceRecorder(
-        recordingDuration = RECORDING_DURATION
+        recordingDuration = RECORDING_DURATION,
+        startRecordResult = startRecordResult,
+        stopRecordResult = stopRecordResult,
+        deleteRecordingResult = deleteRecordingResult,
     )
     private val analyticsService = FakeAnalyticsService()
     private val sendVoiceMessageResult =
@@ -97,7 +105,9 @@ class DefaultVoiceMessageComposerPresenterTest {
 
     companion object {
         private val RECORDING_DURATION = 1.seconds
+        private val FIRST_LEVEL_DURATION = 500.milliseconds
         private val RECORDING_STATE = VoiceMessageState.Recording(RECORDING_DURATION, listOf(0.1f, 0.2f).toImmutableList())
+        private val FIRST_RECORDING_STATE = VoiceMessageState.Recording(FIRST_LEVEL_DURATION, listOf(0.1f).toImmutableList())
     }
 
     @Test
@@ -106,7 +116,7 @@ class DefaultVoiceMessageComposerPresenterTest {
         presenter.test {
             val initialState = awaitItem()
             assertThat(initialState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
-            voiceRecorder.assertCalls(started = 0)
+            startRecordResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(initialState)
         }
@@ -118,9 +128,10 @@ class DefaultVoiceMessageComposerPresenterTest {
         presenter.test {
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
 
+            assertThat(awaitItem().voiceMessageState).isEqualTo(FIRST_RECORDING_STATE)
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
-            voiceRecorder.assertCalls(started = 1)
+            startRecordResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -133,14 +144,16 @@ class DefaultVoiceMessageComposerPresenterTest {
         val voiceRecorder = FakeVoiceRecorder(
             levels = levels,
             recordingDuration = RECORDING_DURATION,
+            startRecordResult = { },
+            stopRecordResult = { },
+            deleteRecordingResult = { },
         )
         val presenter = createDefaultVoiceMessageComposerPresenter(
             voiceRecorder = voiceRecorder,
         )
         presenter.test {
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
-            skipItems(numberOfLevels / 2 - 1)
-            val finalState = awaitItem()
+            val finalState = consumeItemsUntilTimeout().last()
             assertThat(finalState.voiceMessageState).isInstanceOf(VoiceMessageState.Recording::class.java)
             val recordingState = finalState.voiceMessageState as VoiceMessageState.Recording
             // The number of levels should be limited to 128 items
@@ -221,7 +234,8 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(aPreviewState())
-            voiceRecorder.assertCalls(started = 1, stopped = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -235,7 +249,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             awaitItem().eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Cancel))
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(true))
+            deleteRecordingResult.assertions().isCalledOnce()
             testPauseAndDestroy(finalState)
         }
     }
@@ -249,7 +265,9 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(aPreviewState())
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(finalState)
         }
@@ -265,8 +283,10 @@ class DefaultVoiceMessageComposerPresenterTest {
             }
 
             // Nothing should happen
-            assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
-            voiceRecorder.assertCalls(started = 1, stopped = 0, deleted = 0)
+            assertThat(finalState.voiceMessageState).isEqualTo(FIRST_RECORDING_STATE)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isNeverCalled()
+            deleteRecordingResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(finalState)
         }
@@ -282,7 +302,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPlayingState())
             }
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(finalState)
         }
@@ -299,7 +321,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem().also {
                 assertThat(it.voiceMessageState).isEqualTo(aPausedState())
             }
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(finalState)
         }
@@ -340,7 +364,9 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -360,7 +386,9 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -377,7 +405,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isCalledOnce()
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -455,7 +485,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isCalledOnce()
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -476,7 +508,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isCalledOnce()
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -499,7 +533,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             assertThat(finalState.voiceMessageState).isEqualTo(aPreviewState(isSending = true))
             sendVoiceMessageResult.assertions().isNeverCalled()
             assertThat(analyticsService.trackedErrors).isEmpty()
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 0)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(finalState)
         }
@@ -527,7 +563,9 @@ class DefaultVoiceMessageComposerPresenterTest {
             val finalState = awaitItem()
             assertThat(finalState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isCalledOnce()
-            voiceRecorder.assertCalls(started = 1, stopped = 1, deleted = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
+            deleteRecordingResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -577,7 +615,7 @@ class DefaultVoiceMessageComposerPresenterTest {
             assertThat(initialState.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
             sendVoiceMessageResult.assertions().isNeverCalled()
             assertThat(analyticsService.trackedErrors).hasSize(1)
-            voiceRecorder.assertCalls(started = 0)
+            startRecordResult.assertions().isNeverCalled()
 
             testPauseAndDestroy(initialState)
         }
@@ -586,8 +624,14 @@ class DefaultVoiceMessageComposerPresenterTest {
     @Test
     fun `present - record error - security exceptions are tracked`() = runTest {
         val exception = SecurityException("")
-        voiceRecorder.givenThrowsSecurityException(exception)
-        val presenter = createDefaultVoiceMessageComposerPresenter()
+        val startRecordResult = lambdaRecorder<Unit> { throw exception }
+        val voiceRecorder = FakeVoiceRecorder(
+            recordingDuration = RECORDING_DURATION,
+            startRecordResult = startRecordResult,
+        )
+        val presenter = createDefaultVoiceMessageComposerPresenter(
+            voiceRecorder = voiceRecorder,
+        )
         presenter.test {
             val initialState = awaitItem()
             initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Start))
@@ -596,7 +640,7 @@ class DefaultVoiceMessageComposerPresenterTest {
             assertThat(analyticsService.trackedErrors).containsExactly(
                 VoiceMessageException.PermissionMissing(message = "Expected permission to record but none", cause = exception)
             )
-            voiceRecorder.assertCalls(started = 1)
+            startRecordResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(initialState)
         }
@@ -616,7 +660,8 @@ class DefaultVoiceMessageComposerPresenterTest {
             assertThat(awaitItem().voiceMessageState).isEqualTo(VoiceMessageState.Idle)
 
             initialState.eventSink(VoiceMessageComposerEvent.RecorderEvent(VoiceMessageRecorderEvent.Stop))
-            voiceRecorder.assertCalls(stopped = 1)
+            startRecordResult.assertions().isNeverCalled()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
 
             permissionsPresenter.setPermissionGranted()
 
@@ -625,7 +670,8 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = expectMostRecentItem()
             assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
-            voiceRecorder.assertCalls(stopped = 1, started = 1)
+            startRecordResult.assertions().isCalledOnce()
+            stopRecordResult.assertions().isCalledOnce().with(value(false))
 
             testPauseAndDestroy(finalState)
         }
@@ -659,7 +705,7 @@ class DefaultVoiceMessageComposerPresenterTest {
 
             val finalState = expectMostRecentItem()
             assertThat(finalState.voiceMessageState).isEqualTo(RECORDING_STATE)
-            voiceRecorder.assertCalls(started = 1)
+            startRecordResult.assertions().isCalledOnce()
 
             testPauseAndDestroy(finalState)
         }
@@ -696,7 +742,7 @@ class DefaultVoiceMessageComposerPresenterTest {
                 assertThat(it.voiceMessageState).isEqualTo(VoiceMessageState.Idle)
                 assertThat(it.showPermissionRationaleDialog).isTrue()
             }
-            voiceRecorder.assertCalls(started = 0)
+            startRecordResult.assertions().isNeverCalled()
 
             cancelAndIgnoreRemainingEvents()
             testPauseAndDestroy(finalState)

--- a/libraries/voicerecorder/test/build.gradle.kts
+++ b/libraries/voicerecorder/test/build.gradle.kts
@@ -19,6 +19,5 @@ dependencies {
     implementation(projects.tests.testutils)
 
     implementation(libs.coroutines.test)
-    implementation(libs.test.truth)
     implementation(projects.libraries.core)
 }

--- a/libraries/voicerecorder/test/src/main/kotlin/io/element/android/libraries/voicerecorder/test/FakeVoiceRecorder.kt
+++ b/libraries/voicerecorder/test/src/main/kotlin/io/element/android/libraries/voicerecorder/test/FakeVoiceRecorder.kt
@@ -8,13 +8,13 @@
 
 package io.element.android.libraries.voicerecorder.test
 
-import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.core.mimetype.MimeTypes
 import io.element.android.libraries.voicerecorder.api.VoiceRecorder
 import io.element.android.libraries.voicerecorder.api.VoiceRecorderState
+import io.element.android.tests.testutils.lambda.lambdaError
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.yield
 import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -23,51 +23,45 @@ import kotlin.time.TestTimeSource
 class FakeVoiceRecorder(
     private val timeSource: TestTimeSource = TestTimeSource(),
     private val recordingDuration: Duration = 0.seconds,
-    private val levels: List<Float> = listOf(0.1f, 0.2f)
+    private val levels: List<Float> = listOf(0.1f, 0.2f),
+    val waveform: List<Float> = A_WAVEFORM,
+    private val startRecordResult: () -> Unit = { lambdaError() },
+    private val stopRecordResult: (Boolean) -> Unit = { lambdaError() },
+    private val deleteRecordingResult: () -> Unit = { lambdaError() },
 ) : VoiceRecorder {
     private val _state = MutableStateFlow<VoiceRecorderState>(VoiceRecorderState.Idle)
     override val state: StateFlow<VoiceRecorderState> = _state
 
-    private var curRecording: File? = null
+    private val levelInterval = if (levels.isEmpty()) Duration.ZERO else recordingDuration / levels.size
 
-    private var securityException: SecurityException? = null
+    private var currentRecording: File? = null
+    private var isRecording = false
 
-    private var startedCount = 0
-    private var stoppedCount = 0
-    private var deletedCount = 0
-
-    var waveform: List<Float> = listOf(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 8f, 7f, 6f, 5f, 4f, 3f, 2f, 1f, 0f)
     override suspend fun startRecord() {
-        startedCount += 1
+        startRecordResult()
+        if (isRecording) return
+        isRecording = true
+        currentRecording = File("file.ogg")
         val startedAt = timeSource.markNow()
-        securityException?.let { throw it }
-
-        if (curRecording != null) {
-            error("Previous recording was not cleared")
-        }
-        curRecording = File("file.ogg")
-
-        timeSource += recordingDuration
         for (i in 1..levels.size) {
+            delay(levelInterval)
+            timeSource += levelInterval
+            if (!isRecording) return
             _state.emit(VoiceRecorderState.Recording(startedAt.elapsedNow(), levels.take(i)))
-            yield()
         }
     }
 
-    override suspend fun stopRecord(
-        cancelled: Boolean
-    ) {
-        stoppedCount++
-
+    override suspend fun stopRecord(cancelled: Boolean) {
+        stopRecordResult(cancelled)
+        isRecording = false
         if (cancelled) {
             deleteRecording()
         }
-
         _state.emit(
-            when (curRecording) {
+            when (val file = currentRecording) {
                 null -> VoiceRecorderState.Idle
                 else -> VoiceRecorderState.Finished(
-                    file = curRecording!!,
+                    file = file,
                     mimeType = MimeTypes.Ogg,
                     duration = recordingDuration,
                     waveform = waveform,
@@ -77,25 +71,11 @@ class FakeVoiceRecorder(
     }
 
     override suspend fun deleteRecording() {
-        deletedCount++
-        curRecording = null
-
-        _state.emit(
-            VoiceRecorderState.Idle
-        )
-    }
-
-    fun assertCalls(
-        started: Int = 0,
-        stopped: Int = 0,
-        deleted: Int = 0,
-    ) {
-        assertThat(startedCount).isEqualTo(started)
-        assertThat(stoppedCount).isEqualTo(stopped)
-        assertThat(deletedCount).isEqualTo(deleted)
-    }
-
-    fun givenThrowsSecurityException(exception: SecurityException) {
-        this.securityException = exception
+        deleteRecordingResult()
+        isRecording = false
+        currentRecording = null
+        _state.emit(VoiceRecorderState.Idle)
     }
 }
+
+private val A_WAVEFORM = listOf(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 8f, 7f, 6f, 5f, 4f, 3f, 2f, 1f, 0f)

--- a/libraries/voicerecorder/test/src/main/kotlin/io/element/android/libraries/voicerecorder/test/FakeVoiceRecorder.kt
+++ b/libraries/voicerecorder/test/src/main/kotlin/io/element/android/libraries/voicerecorder/test/FakeVoiceRecorder.kt
@@ -35,25 +35,27 @@ class FakeVoiceRecorder(
     private val levelInterval = if (levels.isEmpty()) Duration.ZERO else recordingDuration / levels.size
 
     private var currentRecording: File? = null
-    private var isRecording = false
+    private var lastRecordingId = 0
+    private var activeRecordingId = 0
 
     override suspend fun startRecord() {
         startRecordResult()
-        if (isRecording) return
-        isRecording = true
+        if (activeRecordingId != 0) return
+        val recordingId = ++lastRecordingId
+        activeRecordingId = recordingId
         currentRecording = File("file.ogg")
         val startedAt = timeSource.markNow()
         for (i in 1..levels.size) {
             delay(levelInterval)
+            if (activeRecordingId != recordingId) return
             timeSource += levelInterval
-            if (!isRecording) return
             _state.emit(VoiceRecorderState.Recording(startedAt.elapsedNow(), levels.take(i)))
         }
     }
 
     override suspend fun stopRecord(cancelled: Boolean) {
         stopRecordResult(cancelled)
-        isRecording = false
+        activeRecordingId = 0
         if (cancelled) {
             deleteRecording()
         }
@@ -72,7 +74,7 @@ class FakeVoiceRecorder(
 
     override suspend fun deleteRecording() {
         deleteRecordingResult()
-        isRecording = false
+        activeRecordingId = 0
         currentRecording = null
         _state.emit(VoiceRecorderState.Idle)
     }


### PR DESCRIPTION
## Content

`FakeVoiceRecorder` pushed a whole recording synchronously from a single suspending call, which made it both weaker and stricter than `DefaultVoiceRecorder`. It now models a cancellable recording job, the way the real recorder does.

Every level emission carried the same elapsed time and the emissions were coalesced by Molecule, so no intermediate recording state was observable. `present - recording state - number of levels is limited` had to compensate with `skipItems(numberOfLevels / 2 - 1)`, a magic number that only worked because of the two-to-one coalescing ratio. Each level now advances the test time source and suspends for its share of the recording duration, so the states arrive one at a time, `present - recording state` asserts both of them, and that magic number is gone.

Call verification moved to the constructor lambdas used elsewhere in the repo, replacing the hand-rolled `startedCount`/`stoppedCount`/`deletedCount` and `assertCalls`. The counters discarded the argument, so nothing pinned that cancelling a recording stops it with `cancelled = true`; `present - abort recording` now asserts exactly that. `givenThrowsSecurityException` is replaced by a throwing `startRecordResult`, and Truth is no longer a dependency of the fixture module.

Finally, a second `startRecord()` no longer raises `error("Previous recording was not cleared")`, where `DefaultVoiceRecorder` only warns and returns, and stopping or deleting now terminates an in-flight emission loop the way cancelling the real recording job does — so a stale `Recording` state can no longer arrive after `Finished`, which is what made adding a delay to the fake break tests before.

No production code changes.

## Motivation and context

Part of #4770.

## Tests

Test-only change. `DefaultVoiceMessageComposerPresenterTest` is 28 tests green with the reworked fake.

Behavioural gains, rather than a rename: `present - recording state` now asserts the intermediate `Recording(500ms, [0.1f])` as well as the final state; `present - recording state - number of levels is limited` no longer depends on the coalescing ratio; `present - abort recording` asserts `stopRecord(cancelled = true)`, which the old counters could not see.

Run with `./gradlew :features:messages:impl:testDebugUnitTest`.

Checked that the new `lambdaError()` defaults do not fire through `FakeDefaultVoiceMessageComposerPresenterFactory` by running `MessagesPresenterTest` unchanged, and that `:libraries:voicerecorder:test` and `:features:messages:test` still compile.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
