### PR TITLE
Dismiss the room screen whichever leave signal arrives last

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/RoomFlowNode.kt
@@ -36,7 +36,6 @@ import io.element.android.libraries.architecture.BaseFlowNode
 import io.element.android.libraries.architecture.NodeInputs
 import io.element.android.libraries.architecture.createNode
 import io.element.android.libraries.architecture.inputs
-import io.element.android.libraries.core.coroutine.withPreviousValue
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.EventId
@@ -44,7 +43,6 @@ import io.element.android.libraries.matrix.api.core.RoomAlias
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
 import io.element.android.libraries.matrix.api.core.ThreadId
-import io.element.android.libraries.matrix.api.room.CurrentUserMembership
 import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
 import io.element.android.libraries.matrix.api.room.alias.ResolvedRoomAlias
 import io.element.android.libraries.matrix.ui.room.LoadingRoomState
@@ -52,13 +50,9 @@ import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.NotificationToMessage
 import io.element.android.services.analytics.api.AnalyticsLongRunningTransaction.OpenRoom
 import io.element.android.services.analytics.api.AnalyticsService
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -152,43 +146,30 @@ class RoomFlowNode(
         val roomInfoFlow = joinedRoom?.roomInfoFlow?.map { Optional.of(it) }
             ?: client.getRoomInfoFlow(roomId)
 
-        // This observes the local membership changes for the room
-        val membershipUpdateFlow = membershipObserver.updates
-            .filter { it.roomId == roomId }
-            .distinctUntilChanged()
-            // We add a replay so we can check the last local membership update
-            .shareIn(lifecycleScope, started = SharingStarted.Eagerly, replay = 1)
-
-        val currentMembershipFlow = roomInfoFlow
-            .map { it.getOrNull()?.currentUserMembership }
-            .distinctUntilChanged()
-            .withPreviousValue()
-        currentMembershipFlow.onEach { (previousMembership, membership) ->
-            Timber.d("Room membership: $membership")
-            if (membership == CurrentUserMembership.JOINED) {
-                val currentNavTarget = backstack.active?.key?.navTarget
-                if (currentNavTarget is NavTarget.JoinedRoom && currentNavTarget.roomId == roomId) {
-                    Timber.d("Already in JoinedRoom $roomId, do nothing")
-                    return@onEach
+        roomMembershipNavigation(
+            roomId = roomId,
+            roomInfoFlow = roomInfoFlow,
+            membershipUpdates = membershipObserver.updates,
+            scope = lifecycleScope,
+        ).onEach { navigation ->
+            Timber.d("Room membership navigation: $navigation")
+            when (navigation) {
+                RoomMembershipNavigation.EnterRoom -> {
+                    val currentNavTarget = backstack.active?.key?.navTarget
+                    if (currentNavTarget is NavTarget.JoinedRoom && currentNavTarget.roomId == roomId) {
+                        Timber.d("Already in JoinedRoom $roomId, do nothing")
+                        return@onEach
+                    }
+                    backstack.newRoot(NavTarget.JoinedRoom(roomId))
                 }
-                backstack.newRoot(NavTarget.JoinedRoom(roomId))
-            } else {
-                val leavingFromCurrentDevice =
-                    membership == CurrentUserMembership.LEFT &&
-                        previousMembership == CurrentUserMembership.JOINED &&
-                        membershipUpdateFlow.replayCache.lastOrNull()?.isUserInRoom == false
-
-                if (leavingFromCurrentDevice) {
-                    navigateUp()
-                } else {
-                    backstack.newRoot(
-                        NavTarget.JoinRoom(
-                            roomId = roomId,
-                            serverNames = serverNames,
-                            trigger = inputs.trigger.getOrNull() ?: JoinedRoomAnalyticsEvent.Trigger.Invite,
-                        )
+                RoomMembershipNavigation.Dismiss -> navigateUp()
+                RoomMembershipNavigation.ShowJoinRoom -> backstack.newRoot(
+                    NavTarget.JoinRoom(
+                        roomId = roomId,
+                        serverNames = serverNames,
+                        trigger = inputs.trigger.getOrNull() ?: JoinedRoomAnalyticsEvent.Trigger.Invite,
                     )
-                }
+                )
             }
         }.launchIn(lifecycleScope)
     }

--- a/appnav/src/main/kotlin/io/element/android/appnav/room/RoomMembershipNavigation.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/room/RoomMembershipNavigation.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.appnav.room
+
+import io.element.android.libraries.core.coroutine.withPreviousValue
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.RoomInfo
+import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import java.util.Optional
+import kotlin.jvm.optionals.getOrNull
+
+internal sealed interface RoomMembershipNavigation {
+    data object EnterRoom : RoomMembershipNavigation
+    data object Dismiss : RoomMembershipNavigation
+    data object ShowJoinRoom : RoomMembershipNavigation
+}
+
+/**
+ * Decide where the room flow must navigate, from the room membership reported by sync and the
+ * local leave notification for that room.
+ *
+ * The two signals are concurrent and the local one may never arrive, so they are combined rather
+ * than sampled: whichever arrives second re-evaluates the decision.
+ */
+internal fun roomMembershipNavigation(
+    roomId: RoomId,
+    roomInfoFlow: Flow<Optional<RoomInfo>>,
+    membershipUpdates: Flow<RoomMembershipObserver.RoomMembershipUpdate>,
+    scope: CoroutineScope,
+): Flow<RoomMembershipNavigation> {
+    val leftFromCurrentDeviceFlow = membershipUpdates
+        .filter { it.roomId == roomId && !it.isUserInRoom }
+        .map { true }
+        .stateIn(scope, started = SharingStarted.Eagerly, initialValue = false)
+
+    val currentMembershipFlow = roomInfoFlow
+        .map { it.getOrNull()?.currentUserMembership }
+        .distinctUntilChanged()
+        .withPreviousValue()
+
+    return combine(currentMembershipFlow, leftFromCurrentDeviceFlow) { (previousMembership, membership), leftFromCurrentDevice ->
+        when {
+            membership == CurrentUserMembership.JOINED -> RoomMembershipNavigation.EnterRoom
+            membership == CurrentUserMembership.LEFT &&
+                previousMembership == CurrentUserMembership.JOINED &&
+                leftFromCurrentDevice -> RoomMembershipNavigation.Dismiss
+            else -> RoomMembershipNavigation.ShowJoinRoom
+        }
+    }
+}

--- a/appnav/src/test/kotlin/io/element/android/appnav/room/RoomMembershipNavigationTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/room/RoomMembershipNavigationTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.appnav.room
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.RoomInfo
+import io.element.android.libraries.matrix.api.room.RoomMembershipObserver
+import io.element.android.libraries.matrix.api.timeline.item.event.MembershipChange
+import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_ROOM_ID_2
+import io.element.android.libraries.matrix.test.room.aRoomInfo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.Optional
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoomMembershipNavigationTest {
+    @Test
+    fun `a joined room enters the room`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.JOINED))
+        navigationFlow(roomInfo).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.EnterRoom)
+        }
+    }
+
+    @Test
+    fun `an invited room shows the join room screen`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.INVITED))
+        navigationFlow(roomInfo).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.ShowJoinRoom)
+        }
+    }
+
+    @Test
+    fun `leaving from this device dismisses the flow when the local leave arrives first`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.JOINED))
+        val membershipUpdates = MutableSharedFlow<RoomMembershipObserver.RoomMembershipUpdate>(extraBufferCapacity = 10)
+        navigationFlow(roomInfo, membershipUpdates).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.EnterRoom)
+            runCurrent()
+            membershipUpdates.emit(aLeftUpdate())
+            runCurrent()
+            roomInfo.value = anOptionalRoomInfo(CurrentUserMembership.LEFT)
+            runCurrent()
+            assertThat(expectMostRecentItem()).isEqualTo(RoomMembershipNavigation.Dismiss)
+        }
+    }
+
+    @Test
+    fun `leaving from this device dismisses the flow when the room info arrives first`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.JOINED))
+        val membershipUpdates = MutableSharedFlow<RoomMembershipObserver.RoomMembershipUpdate>(extraBufferCapacity = 10)
+        navigationFlow(roomInfo, membershipUpdates).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.EnterRoom)
+            runCurrent()
+            roomInfo.value = anOptionalRoomInfo(CurrentUserMembership.LEFT)
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.ShowJoinRoom)
+            membershipUpdates.emit(aLeftUpdate())
+            runCurrent()
+            assertThat(expectMostRecentItem()).isEqualTo(RoomMembershipNavigation.Dismiss)
+        }
+    }
+
+    @Test
+    fun `leaving from another device shows the join room screen`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.JOINED))
+        navigationFlow(roomInfo).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.EnterRoom)
+            roomInfo.value = anOptionalRoomInfo(CurrentUserMembership.LEFT)
+            runCurrent()
+            assertThat(expectMostRecentItem()).isEqualTo(RoomMembershipNavigation.ShowJoinRoom)
+        }
+    }
+
+    @Test
+    fun `a local leave for another room is ignored`() = runTest {
+        val roomInfo = MutableStateFlow(anOptionalRoomInfo(CurrentUserMembership.JOINED))
+        val membershipUpdates = MutableSharedFlow<RoomMembershipObserver.RoomMembershipUpdate>(extraBufferCapacity = 10)
+        navigationFlow(roomInfo, membershipUpdates).test {
+            assertThat(awaitItem()).isEqualTo(RoomMembershipNavigation.EnterRoom)
+            runCurrent()
+            membershipUpdates.emit(aLeftUpdate(roomId = A_ROOM_ID_2))
+            runCurrent()
+            roomInfo.value = anOptionalRoomInfo(CurrentUserMembership.LEFT)
+            runCurrent()
+            assertThat(expectMostRecentItem()).isEqualTo(RoomMembershipNavigation.ShowJoinRoom)
+        }
+    }
+
+    private fun TestScope.navigationFlow(
+        roomInfo: MutableStateFlow<Optional<RoomInfo>>,
+        membershipUpdates: MutableSharedFlow<RoomMembershipObserver.RoomMembershipUpdate> = MutableSharedFlow(extraBufferCapacity = 10),
+    ) = roomMembershipNavigation(
+        roomId = A_ROOM_ID,
+        roomInfoFlow = roomInfo,
+        membershipUpdates = membershipUpdates,
+        scope = backgroundScope,
+    )
+
+    private fun anOptionalRoomInfo(membership: CurrentUserMembership) = Optional.of(aRoomInfo(currentUserMembership = membership))
+
+    private fun aLeftUpdate(roomId: RoomId = A_ROOM_ID) = RoomMembershipObserver.RoomMembershipUpdate(
+        roomId = roomId,
+        isSpace = false,
+        isUserInRoom = false,
+        change = MembershipChange.LEFT,
+    )
+}


### PR DESCRIPTION
## Content

Leaving a room from the room screen produces two independent signals: sync reports the membership as `LEFT`, and `RoomMembershipObserver` reports the local leave. `RoomFlowNode` decided what to do by sampling the second one at the moment the first arrived, peeking at a shared flow's replay cache. When sync won that race the peek came back empty, so a room the user had just left looked like a room left elsewhere, and the join room screen was shown instead of returning to the room list. Nothing re-evaluated the decision when the local signal did arrive, so the user was left on a screen for a room they had already left.

The two signals are now combined rather than one being sampled, so whichever arrives second re-evaluates the decision and the dismissal is not lost. Waiting for the local signal is not an option: it never arrives for a leave from another device, which is why commit e52f2e2274 replaced a suspending read with the peek in the first place. Combining keeps that fix — the latch simply stays false for a remote leave — while making the outcome independent of arrival order.

The decision itself moved into its own function, so both orderings can be tested without standing up the navigation graph. The node keeps only the navigation.

This addresses the navigation half of the issue. The other half in the title, a left room lingering in the room list, is room-list filtering in the SDK and is not touched here.

## Motivation and context

Part of #3790.

## Tests

`appnav/src/test/kotlin/io/element/android/appnav/room/RoomMembershipNavigationTest.kt`: a joined room enters the room and an invited room shows the join room screen; leaving from this device dismisses the flow in both arrival orders; leaving from another device shows the join room screen; a local leave for a different room is ignored.

The room-info-first ordering is the regression guard — it fails with the previous replay-cache peek and passes with the combined flow.

Run with `./gradlew :appnav:testDebugUnitTest`.

These are flow-level tests, so they pin the decision rather than the resulting Appyx transition.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
