### PR TITLE
Use the right base URL for the ESS config/well known endpoints

### DIFF
--- a/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/EnterpriseService.kt
+++ b/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/EnterpriseService.kt
@@ -10,7 +10,7 @@ package io.element.android.features.enterprise.api
 
 import androidx.compose.ui.graphics.Color
 import io.element.android.compound.colors.SemanticColorsLightDark
-import io.element.android.libraries.matrix.api.UrlContentFetcher
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.core.SessionId
 import kotlinx.coroutines.flow.Flow
 
@@ -31,10 +31,9 @@ interface EnterpriseService {
      * Rewrites the authentication server URL when the deployment requires a different one from the one advertised.
      *
      * @param url the URL to rewrite.
-     * @param homeserver the homeserver the URL belongs to.
      * @param urlContentFetcher used to read the deployment configuration; a client that is not authenticated yet also works.
      */
-    suspend fun tweakMasUrl(url: String, homeserver: String, urlContentFetcher: UrlContentFetcher): String
+    suspend fun tweakMasUrl(url: String, urlContentFetcher: ClientUrlContentFetcher): String
 
     /**
      * Returns the list of homeservers the user is allowed to sign in to.
@@ -53,9 +52,9 @@ interface EnterpriseService {
     /**
      * Whether the given homeserver enforces the use of Element Pro or a derived app.
      *
-     * @param homeserverUrl the homeserver to check.
+     * @param serverName the homeserver to check.
      */
-    suspend fun isElementProEnforced(homeserverUrl: String): Boolean
+    suspend fun isElementProEnforced(serverName: String): Boolean
 
     /**
      * Override the brand color.
@@ -98,14 +97,6 @@ interface EnterpriseService {
      * @param sessionId the session whose channel is requested.
      */
     fun getNoisyNotificationChannelId(sessionId: SessionId): String?
-
-    /**
-     * Gets the Element Server Suite (ESS) config endpoint URL for the given domain.
-     * Returns `null` when this build does not read its configuration from an ESS deployment.
-     *
-     * @param domain the server whose configuration endpoint is requested.
-     */
-    fun essConfigEndpointUrl(domain: String): String?
 
     companion object {
         const val ANY_ACCOUNT_PROVIDER = "*"

--- a/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/remoteconfig/RemoteEnterpriseConfigResult.kt
+++ b/features/enterprise/api/src/main/kotlin/io/element/android/features/enterprise/api/remoteconfig/RemoteEnterpriseConfigResult.kt
@@ -19,9 +19,11 @@ sealed interface RemoteEnterpriseConfigResult<out T> {
     data class Outdated<out T>(val data: T) : RemoteEnterpriseConfigResult<T>
 
     /**
-     * Well-known data is not found (file does not exist server side, we got a 404).
+     * Well-known data is not found (file does not exist server side, we got a 404). `needsRefresh` indicates whether a refresh must be done
+     * to replace this value: if it's `true`, the caller must trigger a refresh to try to fetch the data again;
+     * if it's `false`, the caller can assume that the data is not available and no refresh is needed before returning the data.
      */
-    data object NotFound : RemoteEnterpriseConfigResult<Nothing>
+    data class NotFound(val needsRefresh: Boolean) : RemoteEnterpriseConfigResult<Nothing>
 
     /**
      * Any other error.
@@ -32,13 +34,13 @@ sealed interface RemoteEnterpriseConfigResult<out T> {
         is Success<T> -> data
         is Outdated<T> -> data
         is Error -> null
-        NotFound -> null
+        is NotFound -> null
     }
 
     fun upToDateDataOrNull(): T? = when (this) {
         is Success<T> -> data
         is Outdated<T> -> null
         is Error -> null
-        NotFound -> null
+        is NotFound -> null
     }
 }

--- a/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/DefaultEnterpriseService.kt
+++ b/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/DefaultEnterpriseService.kt
@@ -14,7 +14,7 @@ import dev.zacsweers.metro.ContributesBinding
 import io.element.android.compound.colors.SemanticColorsLightDark
 import io.element.android.features.enterprise.api.BugReportUrl
 import io.element.android.features.enterprise.api.EnterpriseService
-import io.element.android.libraries.matrix.api.UrlContentFetcher
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.core.SessionId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -22,10 +22,10 @@ import kotlinx.coroutines.flow.flowOf
 @ContributesBinding(AppScope::class)
 class DefaultEnterpriseService : EnterpriseService {
     override suspend fun isEnterpriseUser(sessionId: SessionId) = false
-    override suspend fun tweakMasUrl(url: String, homeserver: String, urlContentFetcher: UrlContentFetcher) = url
+    override suspend fun tweakMasUrl(url: String, urlContentFetcher: ClientUrlContentFetcher) = url
     override fun homeserverAllowList(): List<String> = emptyList()
     override suspend fun isAllowedToConnectToHomeserver(homeserverUrl: String) = true
-    override suspend fun isElementProEnforced(homeserverUrl: String): Boolean = false
+    override suspend fun isElementProEnforced(serverName: String): Boolean = false
 
     override suspend fun overrideBrandColor(sessionId: SessionId?, brandColor: String?) = Unit
 
@@ -45,6 +45,4 @@ class DefaultEnterpriseService : EnterpriseService {
     }
 
     override fun getNoisyNotificationChannelId(sessionId: SessionId): String? = null
-
-    override fun essConfigEndpointUrl(domain: String): String? = null
 }

--- a/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/scanner/DefaultContentScannerUrlProvider.kt
+++ b/features/enterprise/impl-foss/src/main/kotlin/io/element/android/features/enterprise/impl/scanner/DefaultContentScannerUrlProvider.kt
@@ -9,7 +9,7 @@ package io.element.android.features.enterprise.impl.scanner
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import io.element.android.libraries.matrix.api.UrlContentFetcher
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.scanner.ContentScannerUrlProvider
 
@@ -22,7 +22,7 @@ class DefaultContentScannerUrlProvider : ContentScannerUrlProvider {
 
     @ContributesBinding(AppScope::class)
     class Factory : ContentScannerUrlProvider.Factory {
-        override fun create(urlContentFetcher: UrlContentFetcher): ContentScannerUrlProvider {
+        override fun create(urlContentFetcher: ClientUrlContentFetcher): ContentScannerUrlProvider {
             return DefaultContentScannerUrlProvider()
         }
     }

--- a/features/enterprise/test/src/main/kotlin/io/element/android/features/enterprise/test/FakeEnterpriseService.kt
+++ b/features/enterprise/test/src/main/kotlin/io/element/android/features/enterprise/test/FakeEnterpriseService.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 import io.element.android.compound.colors.SemanticColorsLightDark
 import io.element.android.features.enterprise.api.BugReportUrl
 import io.element.android.features.enterprise.api.EnterpriseService
-import io.element.android.libraries.matrix.api.UrlContentFetcher
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.tests.testutils.lambda.lambdaError
 import io.element.android.tests.testutils.simulateLongTask
@@ -30,8 +30,7 @@ class FakeEnterpriseService(
     private val firebasePushGatewayResult: () -> String? = { lambdaError() },
     private val unifiedPushDefaultPushGatewayResult: () -> String? = { lambdaError() },
     private val getNoisyNotificationChannelIdResult: (SessionId?) -> String? = { lambdaError() },
-    private val tweakMasUrlResult: (String, String, UrlContentFetcher) -> String = { _, _, _ -> lambdaError() },
-    private val essConfigEndpointUrlResult: (String) -> String = { lambdaError() },
+    private val tweakMasUrlResult: (String, ClientUrlContentFetcher) -> String = { _, _ -> lambdaError() },
     private val isElementProEnforcedResult: (String) -> Boolean = { lambdaError() },
 ) : EnterpriseService {
     private val brandColorState = MutableStateFlow(initialBrandColor)
@@ -41,8 +40,8 @@ class FakeEnterpriseService(
         isEnterpriseUserResult(sessionId)
     }
 
-    override suspend fun tweakMasUrl(url: String, homeserver: String, urlContentFetcher: UrlContentFetcher): String = simulateLongTask {
-        tweakMasUrlResult(url, homeserver, urlContentFetcher)
+    override suspend fun tweakMasUrl(url: String, urlContentFetcher: ClientUrlContentFetcher): String = simulateLongTask {
+        tweakMasUrlResult(url, urlContentFetcher)
     }
 
     override fun homeserverAllowList(): List<String> {
@@ -53,8 +52,8 @@ class FakeEnterpriseService(
         isAllowedToConnectToHomeserverResult(homeserverUrl)
     }
 
-    override suspend fun isElementProEnforced(homeserverUrl: String): Boolean = simulateLongTask {
-        isElementProEnforcedResult(homeserverUrl)
+    override suspend fun isElementProEnforced(serverName: String): Boolean = simulateLongTask {
+        isElementProEnforcedResult(serverName)
     }
 
     override suspend fun overrideBrandColor(sessionId: SessionId?, brandColor: String?) = simulateLongTask {
@@ -84,9 +83,5 @@ class FakeEnterpriseService(
 
     override fun getNoisyNotificationChannelId(sessionId: SessionId): String? {
         return getNoisyNotificationChannelIdResult(sessionId)
-    }
-
-    override fun essConfigEndpointUrl(domain: String): String {
-        return essConfigEndpointUrlResult(domain)
     }
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/ClientUrlContentFetcher.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/ClientUrlContentFetcher.kt
@@ -8,9 +8,19 @@
 package io.element.android.libraries.matrix.api
 
 /**
- * An interface to fetch content from a URL using a simple GET request.
+ * An interface to fetch content from a URL using a simple GET request launched from a Matrix client.
  */
-fun interface UrlContentFetcher {
+interface ClientUrlContentFetcher {
+    /**
+     * The domain of the public server for this homeserver.
+     */
+    val server: String?
+
+    /**
+     * The URL of the actual Matrix homeserver.
+     */
+    val homeserverUrl: String
+
     /**
      * Execute generic GET requests through the SDKs internal HTTP client.
      */

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -60,15 +60,12 @@ import java.util.Optional
  * One instance exists per session, created on login or session restore and torn down by [logout], [clearCache] or account deactivation.
  * Suspending members here report failures through a [Result] instead of throwing, and run their work off the main thread.
  */
-interface MatrixClient : UrlContentFetcher {
+interface MatrixClient : ClientUrlContentFetcher {
     /** Identifier of the logged in user; a [SessionId] and a [UserId] are the same value. */
     val sessionId: SessionId
 
     /** Identifier of this device, as assigned by the homeserver when the session was created. */
     val deviceId: DeviceId
-
-    /** Base URL of the homeserver this client is connected to. */
-    val homeserverUrl: String
 
     /** Directories holding this session's databases, caches and downloaded media. */
     val sessionPaths: SessionPaths

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/TemporaryMatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/TemporaryMatrixClient.kt
@@ -15,4 +15,4 @@ import java.lang.AutoCloseable
  * Note: this client implements an [AutoCloseable] interface, so using [AutoCloseable.close] or [AutoCloseable.use] will clean up any resources associated
  * with it, such as temporary files.
  */
-interface TemporaryMatrixClient : UrlContentFetcher, AutoCloseable
+interface TemporaryMatrixClient : ClientUrlContentFetcher, AutoCloseable

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/TemporaryMatrixClientFactory.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/TemporaryMatrixClientFactory.kt
@@ -12,10 +12,10 @@ package io.element.android.libraries.matrix.api
  */
 interface TemporaryMatrixClientFactory {
     /**
-     * Builds an unauthenticated client pointing at [homeServerUrl], backed by a fresh set of temporary session directories.
+     * Builds an unauthenticated client pointing at [serverName], backed by a fresh set of temporary session directories.
      * The caller owns the returned client and must close it to delete those directories.
      *
-     * @param homeServerUrl the URL of the homeserver the client will talk to.
+     * @param serverName the domain of the public-facing server for the actual homeserver
      */
-    suspend fun create(homeServerUrl: String): Result<TemporaryMatrixClient>
+    suspend fun create(serverName: String): Result<TemporaryMatrixClient>
 }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/scanner/ContentScannerUrlProvider.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/scanner/ContentScannerUrlProvider.kt
@@ -7,7 +7,7 @@
 
 package io.element.android.libraries.matrix.api.scanner
 
-import io.element.android.libraries.matrix.api.UrlContentFetcher
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.core.SessionId
 
 /**
@@ -26,6 +26,6 @@ fun interface ContentScannerUrlProvider {
         /**
          * @param urlContentFetcher used to read the configuration advertised by the homeserver; a client that is not authenticated yet also works.
          */
-        fun create(urlContentFetcher: UrlContentFetcher): ContentScannerUrlProvider
+        fun create(urlContentFetcher: ClientUrlContentFetcher): ContentScannerUrlProvider
     }
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -162,6 +162,7 @@ class RustMatrixClient(
 ) : MatrixClient {
     override val sessionId: UserId = UserId(innerClient.userId())
     override val deviceId: DeviceId = DeviceId(innerClient.deviceId())
+    override val server: String? = innerClient.server()
     override val homeserverUrl: String = innerClient.homeserver()
     override val sessionCoroutineScope = appCoroutineScope.childScope(dispatchers.main, "Session-$sessionId")
     private val sessionDispatcher = dispatchers.io.limitedParallelism(64)

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClient.kt
@@ -22,6 +22,9 @@ class RustTemporaryMatrixClient(
         client.getUrl(url)
     }.mapFailure { it.mapClientException() }
 
+    override val server: String? = client.server()
+    override val homeserverUrl: String = client.homeserver()
+
     override fun close() {
         client.close()
         paths?.let {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientFactory.kt
@@ -19,7 +19,7 @@ class RustTemporaryMatrixClientFactory(
     private val sessionPathsFactory: SessionPathsFactory,
     private val rustMatrixClientFactory: RustMatrixClientFactory,
 ) : TemporaryMatrixClientFactory {
-    override suspend fun create(homeServerUrl: String): Result<TemporaryMatrixClient> {
+    override suspend fun create(serverName: String): Result<TemporaryMatrixClient> {
         return runCatchingExceptions {
             val sessionPaths = sessionPathsFactory.create()
             val client = rustMatrixClientFactory.getBaseClientBuilder(
@@ -28,7 +28,7 @@ class RustTemporaryMatrixClientFactory(
                 slidingSyncType = ClientBuilderSlidingSync.Native,
                 isMessageSearchAvailable = false,
             )
-                .homeserverUrl(homeServerUrl)
+                .serverName(serverName)
                 .build()
             RustTemporaryMatrixClient(client, sessionPaths)
         }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/auth/RustMatrixAuthenticationService.kt
@@ -278,7 +278,6 @@ class RustMatrixAuthenticationService(
                     .let {
                         enterpriseService.tweakMasUrl(
                             url = it,
-                            homeserver = client.server() ?: client.homeserver(),
                             urlContentFetcher = getUrlResolver,
                         )
                     }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/di/SessionMatrixModule.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/di/SessionMatrixModule.kt
@@ -13,9 +13,9 @@ import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.libraries.matrix.api.HomeserverCapabilitiesProvider
 import io.element.android.libraries.matrix.api.MatrixClient
-import io.element.android.libraries.matrix.api.UrlContentFetcher
 import io.element.android.libraries.matrix.api.core.DeviceId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.encryption.EncryptionService
@@ -111,7 +111,7 @@ object SessionMatrixModule {
     }
 
     @Provides
-    fun providesGetUrlResolverClient(matrixClient: MatrixClient): UrlContentFetcher {
+    fun providesGetUrlResolverClient(matrixClient: MatrixClient): ClientUrlContentFetcher {
         return matrixClient
     }
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/RustTemporaryMatrixClientTest.kt
@@ -16,7 +16,6 @@ import io.element.android.tests.testutils.lambda.value
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.matrix.rustcomponents.sdk.Client
-import org.matrix.rustcomponents.sdk.NoHandle
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import org.matrix.rustcomponents.sdk.ClientException as RustClientException
@@ -84,7 +83,7 @@ class RustTemporaryMatrixClientTest {
     }
 
     private fun createRustTemporaryMatrixClient(
-        client: Client = Client(NoHandle),
+        client: Client = FakeFfiClient(),
         paths: SessionPaths,
     ): RustTemporaryMatrixClient {
         return RustTemporaryMatrixClient(client, paths)

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiClient.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/fixtures/fakes/FakeFfiClient.kt
@@ -12,6 +12,7 @@ import io.element.android.libraries.matrix.impl.fixtures.factories.aRustSession
 import io.element.android.libraries.matrix.impl.fixtures.factories.aRustUserProfile
 import io.element.android.libraries.matrix.test.A_DEVICE_ID
 import io.element.android.libraries.matrix.test.A_HOMESERVER_URL
+import io.element.android.libraries.matrix.test.A_SERVER_NAME
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.tests.testutils.lambda.lambdaError
 import io.element.android.tests.testutils.simulateLongTask
@@ -45,6 +46,7 @@ class FakeFfiClient(
     private val userId: String = A_USER_ID.value,
     private val deviceId: String = A_DEVICE_ID.value,
     private val homeserver: String = A_HOMESERVER_URL,
+    private val server: String? = A_SERVER_NAME,
     private val notificationClient: NotificationClient = FakeFfiNotificationClient(),
     private val notificationSettings: NotificationSettings = FakeFfiNotificationSettings(),
     private val encryption: Encryption = FakeFfiEncryption(),
@@ -66,6 +68,7 @@ class FakeFfiClient(
     override fun userId(): String = userId
     override fun deviceId(): String = deviceId
     override fun homeserver(): String = homeserver
+    override fun server(): String? = server
     override suspend fun notificationClient(processSetup: NotificationProcessSetup) = notificationClient
     override suspend fun getNotificationSettings(): NotificationSettings = notificationSettings
     override fun encryption(): Encryption = encryption

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeClientUrlContentFetcher.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeClientUrlContentFetcher.kt
@@ -7,15 +7,15 @@
 
 package io.element.android.libraries.matrix.test
 
-import io.element.android.libraries.matrix.api.TemporaryMatrixClient
+import io.element.android.libraries.matrix.api.ClientUrlContentFetcher
 import io.element.android.tests.testutils.lambda.lambdaError
 
-class FakeTemporaryMatrixClient(
+class FakeClientUrlContentFetcher(
     override val server: String = A_SERVER_NAME,
     override val homeserverUrl: String = A_HOMESERVER_URL,
     private val getUrlResult: (String) -> Result<ByteArray> = { lambdaError() },
-    private val closeLambda: () -> Unit = {},
-) : TemporaryMatrixClient {
-    override suspend fun getUrl(url: String): Result<ByteArray> = getUrlResult(url)
-    override fun close() = closeLambda()
+) : ClientUrlContentFetcher {
+    override suspend fun getUrl(url: String): Result<ByteArray> {
+        return getUrlResult(url)
+    }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -79,6 +79,7 @@ class FakeMatrixClient(
     override val sessionId: SessionId = A_SESSION_ID,
     override val sessionPaths: SessionPaths = SessionPaths(fileDirectory = File("files"), cacheDirectory = File("cache")),
     override val deviceId: DeviceId = A_DEVICE_ID,
+    override val server: String = A_SERVER_NAME,
     override val homeserverUrl: String = A_HOMESERVER_URL,
     override val sessionCoroutineScope: CoroutineScope = TestScope(),
     private val userDisplayName: String? = A_USER_NAME,

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeTemporaryMatrixClientFactory.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeTemporaryMatrixClientFactory.kt
@@ -13,5 +13,5 @@ import io.element.android.libraries.matrix.api.TemporaryMatrixClientFactory
 class FakeTemporaryMatrixClientFactory(
     private val createResult: (String) -> Result<TemporaryMatrixClient> = { Result.success(FakeTemporaryMatrixClient()) },
 ) : TemporaryMatrixClientFactory {
-    override suspend fun create(homeServerUrl: String): Result<TemporaryMatrixClient> = createResult(homeServerUrl)
+    override suspend fun create(serverName: String): Result<TemporaryMatrixClient> = createResult(serverName)
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/TestData.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/TestData.kt
@@ -72,6 +72,7 @@ const val A_SPACE_NAME = "A space name"
 
 const val A_REDACTION_REASON = "A redaction reason"
 
+const val A_SERVER_NAME = "matrix.org"
 const val A_HOMESERVER_URL = "matrix.org"
 const val A_HOMESERVER_URL_2 = "matrix-client.org"
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Rename `UrlContentFetcher` to `ClientUrlContentFetcher` and add a couple `server` and `homeserverUrl` properties to it, so anything using the fetcher can use any of those as base URLs. This is needed for a Pro feature.
- When we try to load a remote config from an endpoint and we don't find a valid value, store it as `NotFound(needsRefresh = false)` so we know we've already checked and there was nothing there. This should still trigger a request to fetch the value, but on background, not blocking. This was causing the session restoration to be slower than needed, since `ContentScannerUrlProvider` was trying to fetch the remote config.

FOSS part of https://github.com/element-hq/element-android-enterprise/pull/45

## Motivation and context

- Fix an issue where the incorrect ESS config URL was being created.
- Fix the delay when restoring a client.

## Tests

With Element Pro, check the right ESS config endpoint and alternatively the right well-known endpoints are checked.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
