### PR TITLE
Don't restart the sync service if the client is shutting down

### DIFF
--- a/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixSessionCache.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/MatrixSessionCache.kt
@@ -115,7 +115,7 @@ class MatrixSessionCache(
 
     private fun onNewMatrixClient(matrixClient: MatrixClient) {
         val syncOrchestrator = syncOrchestratorFactory.create(
-            syncService = matrixClient.syncService,
+            matrixClient = matrixClient,
             sessionCoroutineScope = matrixClient.sessionCoroutineScope,
         )
         sessionIdsToMatrixSession[matrixClient.sessionId] = InMemoryMatrixSession(

--- a/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
@@ -101,7 +101,7 @@ class SyncOrchestrator(
         val isAppActiveFlow = combine(isAppActiveFlows) { actives -> actives.any { it } }
         combine(
             // small debounce to avoid spamming startSync when the state is changing quickly in case of error.
-            matrixClient.syncService.syncState.debounce(100.milliseconds),
+            syncService.syncState.debounce(100.milliseconds),
             networkMonitor.connectivity,
             isAppActiveFlow,
         ) { syncState, networkState, isAppActive ->

--- a/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
+++ b/appnav/src/main/kotlin/io/element/android/appnav/di/SyncOrchestrator.kt
@@ -16,7 +16,7 @@ import io.element.android.features.networkmonitor.api.NetworkMonitor
 import io.element.android.features.networkmonitor.api.NetworkStatus
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.coroutine.childScope
-import io.element.android.libraries.matrix.api.sync.SyncService
+import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.sync.SyncState
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.api.recordTransaction
@@ -37,7 +37,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @AssistedInject
 class SyncOrchestrator(
-    @Assisted private val syncService: SyncService,
+    @Assisted private val matrixClient: MatrixClient,
     @Assisted sessionCoroutineScope: CoroutineScope,
     private val appForegroundStateService: AppForegroundStateService,
     private val networkMonitor: NetworkMonitor,
@@ -47,12 +47,14 @@ class SyncOrchestrator(
     @AssistedFactory
     interface Factory {
         fun create(
-            syncService: SyncService,
+            matrixClient: MatrixClient,
             sessionCoroutineScope: CoroutineScope,
         ): SyncOrchestrator
     }
 
     private val tag = "SyncOrchestrator"
+
+    private val syncService = matrixClient.syncService
 
     private val coroutineScope = sessionCoroutineScope.childScope(dispatchers.io, tag)
 
@@ -94,15 +96,20 @@ class SyncOrchestrator(
             appForegroundStateService.isInCall,
             appForegroundStateService.isSyncingNotificationEvent,
             appForegroundStateService.hasRingingCall,
-            appForegroundStateService.isSharingLiveLocation
+            appForegroundStateService.isSharingLiveLocation,
         )
         val isAppActiveFlow = combine(isAppActiveFlows) { actives -> actives.any { it } }
         combine(
             // small debounce to avoid spamming startSync when the state is changing quickly in case of error.
-            syncService.syncState.debounce(100.milliseconds),
+            matrixClient.syncService.syncState.debounce(100.milliseconds),
             networkMonitor.connectivity,
             isAppActiveFlow,
         ) { syncState, networkState, isAppActive ->
+            if (matrixClient.isShuttingDown) {
+                Timber.tag(tag).d("Matrix client is shutting down, no need to start the sync service again")
+                return@combine SyncStateAction.NoOp
+            }
+
             val isNetworkAvailable = networkState == NetworkStatus.Connected
 
             Timber.tag(tag).d("isAppActive=$isAppActive, isNetworkAvailable=$isNetworkAvailable")

--- a/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/SyncOrchestratorTest.kt
@@ -12,6 +12,7 @@ import io.element.android.appnav.di.SyncOrchestrator
 import io.element.android.features.networkmonitor.api.NetworkStatus
 import io.element.android.features.networkmonitor.test.FakeNetworkMonitor
 import io.element.android.libraries.matrix.api.sync.SyncState
+import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.sync.FakeSyncService
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.services.appnavstate.test.FakeAppForegroundStateService
@@ -40,7 +41,7 @@ class SyncOrchestratorTest {
         }
         val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Disconnected)
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
         )
 
@@ -60,7 +61,7 @@ class SyncOrchestratorTest {
         }
         val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
         )
 
@@ -85,7 +86,7 @@ class SyncOrchestratorTest {
         val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
         val appForegroundStateService = FakeAppForegroundStateService(initialForegroundValue = true)
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -117,7 +118,7 @@ class SyncOrchestratorTest {
         val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Connected)
         val appForegroundStateService = FakeAppForegroundStateService(initialForegroundValue = true)
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -165,7 +166,7 @@ class SyncOrchestratorTest {
             initialIsSyncingNotificationEventValue = false,
         )
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -208,7 +209,7 @@ class SyncOrchestratorTest {
             initialIsSyncingNotificationEventValue = false,
         )
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -252,7 +253,7 @@ class SyncOrchestratorTest {
             initialHasRingingCall = false,
         )
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -296,7 +297,7 @@ class SyncOrchestratorTest {
             initialIsInCallValue = true,
         )
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -339,7 +340,7 @@ class SyncOrchestratorTest {
             initialIsInCallValue = false,
         )
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
             appForegroundStateService = appForegroundStateService,
         )
@@ -369,7 +370,7 @@ class SyncOrchestratorTest {
         }
         val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Disconnected)
         val syncOrchestrator = createSyncOrchestrator(
-            syncService = syncService,
+            matrixClient = FakeMatrixClient(syncService = syncService),
             networkMonitor = networkMonitor,
         )
 
@@ -381,12 +382,44 @@ class SyncOrchestratorTest {
         startSyncRecorder.assertions().isNeverCalled()
     }
 
+    @Test
+    fun `when the client is shutting down, the orchestrator does nothing`() = runTest {
+        val networkMonitor = FakeNetworkMonitor(initialStatus = NetworkStatus.Disconnected)
+        val appForegroundStateService = FakeAppForegroundStateService(
+            initialForegroundValue = false,
+            initialIsSyncingNotificationEventValue = false,
+            initialIsInCallValue = false,
+        )
+
+        val startSyncRecorder = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val syncService = FakeSyncService(initialSyncState = SyncState.Idle).apply {
+            startSyncLambda = startSyncRecorder
+        }
+        val syncOrchestrator = createSyncOrchestrator(
+            matrixClient = FakeMatrixClient(syncService = syncService, isShuttingDownResult = { true }),
+            networkMonitor = networkMonitor,
+            appForegroundStateService = appForegroundStateService,
+        )
+
+        // We start observing
+        syncOrchestrator.observeStates()
+
+        // These should still not trigger a sync, sync the client is shutting down
+        networkMonitor.givenNetworkBlocked(false)
+        appForegroundStateService.updateIsInCallState(true)
+        appForegroundStateService.isInForeground.value = true
+
+        advanceTimeBy(10.seconds)
+
+        startSyncRecorder.assertions().isNeverCalled()
+    }
+
     private fun TestScope.createSyncOrchestrator(
-        syncService: FakeSyncService = FakeSyncService(),
+        matrixClient: FakeMatrixClient = FakeMatrixClient(),
         networkMonitor: FakeNetworkMonitor = FakeNetworkMonitor(),
         appForegroundStateService: FakeAppForegroundStateService = FakeAppForegroundStateService(),
     ) = SyncOrchestrator(
-        syncService = syncService,
+        matrixClient = matrixClient,
         sessionCoroutineScope = backgroundScope,
         networkMonitor = networkMonitor,
         appForegroundStateService = appForegroundStateService,

--- a/appnav/src/test/kotlin/io/element/android/appnav/di/MatrixSessionCacheTest.kt
+++ b/appnav/src/test/kotlin/io/element/android/appnav/di/MatrixSessionCacheTest.kt
@@ -11,7 +11,7 @@ package io.element.android.appnav.di
 import com.bumble.appyx.core.state.MutableSavedStateMapImpl
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.networkmonitor.test.FakeNetworkMonitor
-import io.element.android.libraries.matrix.api.sync.SyncService
+import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.auth.FakeMatrixAuthenticationService
@@ -138,11 +138,11 @@ class MatrixSessionCacheTest {
 
         return object : SyncOrchestrator.Factory {
             override fun create(
-                syncService: SyncService,
+                matrixClient: MatrixClient,
                 sessionCoroutineScope: CoroutineScope,
             ): SyncOrchestrator {
                 return SyncOrchestrator(
-                    syncService = syncService,
+                    matrixClient = matrixClient,
                     sessionCoroutineScope = sessionCoroutineScope,
                     appForegroundStateService = FakeAppForegroundStateService(),
                     networkMonitor = FakeNetworkMonitor(),

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/MatrixClient.kt
@@ -136,6 +136,9 @@ interface MatrixClient : UrlContentFetcher {
     /** Scans media content before it is displayed, or `null` when no content scanner is configured for this session. */
     val contentScanner: ContentScanner?
 
+    /** Whether the session is in the process of shutting down, either because it is being logged out or its cache is being cleared. */
+    val isShuttingDown: Boolean
+
     /**
      * Returns the room with the given id if the user has joined it, along with its live [Timeline].
      * A new instance is created on each call and the caller owns it, so it must be closed once no longer needed.

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -135,6 +135,7 @@ import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
 import java.io.File
 import java.util.Optional
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.jvm.optionals.getOrNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -303,6 +304,10 @@ class RustMatrixClient(
     }
         .buffer(Channel.UNLIMITED)
         .stateIn(sessionCoroutineScope, started = SharingStarted.Eagerly, initialValue = persistentListOf())
+
+    private val _isShuttingDown = AtomicBoolean(false)
+    override val isShuttingDown: Boolean
+        get() = _isShuttingDown.get()
 
     init {
         // Make sure the session delegate has a reference to the client to be able to logout on auth error
@@ -666,11 +671,13 @@ class RustMatrixClient(
     }
 
     override suspend fun clearCache() {
+        _isShuttingDown.set(true)
         innerClient.clearCaches(innerSyncService)
         destroy()
     }
 
     override suspend fun logout(userInitiated: Boolean, ignoreSdkError: Boolean) {
+        _isShuttingDown.set(true)
         sessionCoroutineScope.cancel()
         // Remove current delegate so we don't receive an auth error
         clientDelegateTaskHandle?.cancelAndDestroy()
@@ -708,6 +715,8 @@ class RustMatrixClient(
     }
 
     override suspend fun deactivateAccount(password: String, eraseData: Boolean): Result<Unit> = withContext(sessionDispatcher) {
+        _isShuttingDown.set(true)
+
         Timber.w("Deactivating account")
         // Remove current delegate so we don't receive an auth error
         clientDelegateTaskHandle?.cancelAndDestroy()

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
@@ -29,6 +29,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import org.matrix.rustcomponents.sdk.Membership
 import org.matrix.rustcomponents.sdk.RoomHero
+import timber.log.Timber
 import uniffi.matrix_sdk_base.EncryptionState
 import org.matrix.rustcomponents.sdk.Membership as RustMembership
 import org.matrix.rustcomponents.sdk.RoomInfo as RustRoomInfo
@@ -37,6 +38,9 @@ import org.matrix.rustcomponents.sdk.RoomPowerLevels as RustRoomPowerLevels
 
 class RoomInfoMapper {
     fun map(rustRoomInfo: RustRoomInfo): RoomInfo = rustRoomInfo.let {
+        if (it.id == "!Kk3Pee-WrV8kK3vFLJnyYj3xVT4Kvy3bMG3u7TLZxnA") {
+            Timber.d("Found !Kk3Pee-WrV8kK3vFLJnyYj3xVT4Kvy3bMG3u7TLZxnA")
+        }
         return RoomInfo(
             id = RoomId(it.id),
             creators = it.creators.orEmpty().map(::UserId).toImmutableList(),

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/RoomInfoMapper.kt
@@ -29,7 +29,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import org.matrix.rustcomponents.sdk.Membership
 import org.matrix.rustcomponents.sdk.RoomHero
-import timber.log.Timber
 import uniffi.matrix_sdk_base.EncryptionState
 import org.matrix.rustcomponents.sdk.Membership as RustMembership
 import org.matrix.rustcomponents.sdk.RoomInfo as RustRoomInfo
@@ -38,9 +37,6 @@ import org.matrix.rustcomponents.sdk.RoomPowerLevels as RustRoomPowerLevels
 
 class RoomInfoMapper {
     fun map(rustRoomInfo: RustRoomInfo): RoomInfo = rustRoomInfo.let {
-        if (it.id == "!Kk3Pee-WrV8kK3vFLJnyYj3xVT4Kvy3bMG3u7TLZxnA") {
-            Timber.d("Found !Kk3Pee-WrV8kK3vFLJnyYj3xVT4Kvy3bMG3u7TLZxnA")
-        }
         return RoomInfo(
             id = RoomId(it.id),
             creators = it.creators.orEmpty().map(::UserId).toImmutableList(),

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/FakeMatrixClient.kt
@@ -133,6 +133,7 @@ class FakeMatrixClient(
     private val resetWellKnownConfigLambda: () -> Result<Unit> = { lambdaError() },
     private val enableAutomaticCallStatusLambda: (Boolean) -> Unit = { },
     override val contentScanner: ContentScanner? = null,
+    private val isShuttingDownResult: () -> Boolean = { false },
 ) : MatrixClient {
     var setDisplayNameCalled: Boolean = false
         private set
@@ -304,6 +305,9 @@ class FakeMatrixClient(
     override suspend fun knockRoom(roomIdOrAlias: RoomIdOrAlias, message: String, serverNames: List<String>): Result<RoomInfo?> {
         return knockRoomLambda(roomIdOrAlias, message, serverNames)
     }
+
+    override val isShuttingDown: Boolean
+        get() = isShuttingDownResult()
 
     // Mocks
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Add `val MatrixClient.isShuttingDown: Boolean` field to make the `SynchOrchestrator` ignore any changes to start/stop the sync.

## Motivation and context

The current behaviour was causing issues in the room list when clearing the cache, randomly:

1. The client would ask the SDK to clear the caches.
2. The SDK would stop the sync service, set the `pos` value of sliding sync to 0 so the HS returns all the required state the next time the client is used, then clear the caches.
3. However, between the sync service being stopped with the `pos=0` change and the caches being cleared, there was enough time for the `SyncOrchestrator` to decide the sync service was stopped for no good reason since there is network connectivity and the app is on foreground, so it restarted the sync, with `pos=0` (requesting all the state events) and performed a request immediately.
4. The new `pos` value was persisted, and the next time the new client did an 'initial sync' it had a `pos != 0`, which the HS uses to avoid returning some required state it already fetched.
5. The room list now lacks state events for lots of rooms and room names, avatars, members, etc. are now missing.

*Should* fix https://github.com/element-hq/customer-success/issues/820, as this was most likely caused by the user either clearing the cache manually or enabling/disabling the threads feature in labs.

For users affected by this, clearing the cache in a version with this patch should fix it.

## Tests

Clear the cache or toggle the threads feature as many times as you want. The initial sync should always fetch the room list items in the same order and contain the full info.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
