### PR TITLE
Move strings to the login module

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
+import io.element.android.features.login.impl.R
 import io.element.android.features.login.impl.changeserver.ChangeServerView
 import io.element.android.features.login.impl.login.LoginModeEvent
 import io.element.android.features.login.impl.login.LoginModeView
@@ -120,9 +121,9 @@ fun ConfirmAccountProviderView(
                 iconStyle = BigIcon.Style.Default(CompoundIcons.UserProfileSolid()),
                 title = stringResource(
                     id = if (state.isAccountCreation) {
-                        CommonStrings.screen_change_server_title_register
+                        R.string.screen_change_server_title_register
                     } else {
-                        CommonStrings.screen_change_server_title_login
+                        R.string.screen_change_server_title_login
                     }
                 ),
                 subTitle = null,
@@ -157,13 +158,13 @@ fun ConfirmAccountProviderView(
                 .padding(top = 40.dp)
                 .focusRequester(focusRequester)
                 .testTag(TestTags.changeServerServer),
-            label = stringResource(id = CommonStrings.screen_change_server_textfield_header),
-            placeholder = stringResource(id = CommonStrings.screen_change_server_textfield_placeholder),
+            label = stringResource(id = R.string.screen_change_server_textfield_header),
+            placeholder = stringResource(id = R.string.screen_change_server_textfield_placeholder),
             supportingText = stringResource(
                 id = if (state.isAccountCreation) {
-                    CommonStrings.screen_change_server_textfield_footer_register
+                    R.string.screen_change_server_textfield_footer_register
                 } else {
-                    CommonStrings.screen_change_server_textfield_footer_login
+                    R.string.screen_change_server_textfield_footer_login
                 }
             ),
             visualTransformation = ghostTransformation,

--- a/features/login/impl/src/main/res/values-es/translations.xml
+++ b/features/login/impl/src/main/res/values-es/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"No se permite el proveedor de cuentas %1$s."</string>
   <string name="screen_change_server_form_header">"URL del servidor base"</string>
   <string name="screen_change_server_form_notice">"Introduce una dirección de dominio."</string>
+  <string name="screen_change_server_navigation_title_login">"Iniciar sesión"</string>
+  <string name="screen_change_server_navigation_title_register">"Crear cuenta"</string>
   <string name="screen_change_server_subtitle">"¿Cuál es la dirección de tu servidor?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Si tu cuenta te la proporciona tu empresa o una comunidad, cambia el proveedor de la cuenta (ejemplo: nombredeempresa.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Crea una cuenta gratuita en matrix.org. Si deseas crear una cuenta con otro proveedor, modifícala según corresponda (por ejemplo: communityname.org)."</string>
+  <string name="screen_change_server_textfield_header">"Proveedor de cuentas"</string>
+  <string name="screen_change_server_textfield_placeholder">"ejemplo.com"</string>
   <string name="screen_change_server_title">"Selecciona tu servidor"</string>
+  <string name="screen_change_server_title_login">"Introduce tu proveedor de cuenta"</string>
+  <string name="screen_change_server_title_register">"Elegir proveedor de cuentas"</string>
   <string name="screen_create_account_title">"Crear cuenta"</string>
   <string name="screen_login_error_deactivated_account">"Esta cuenta ha sido eliminada."</string>
   <string name="screen_login_error_invalid_credentials">"Usuario y/o contraseña incorrectos"</string>

--- a/features/login/impl/src/main/res/values-et/translations.xml
+++ b/features/login/impl/src/main/res/values-et/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"%1$s teenusepakkuja pole lubatud."</string>
   <string name="screen_change_server_form_header">"Koduserveri url"</string>
   <string name="screen_change_server_form_notice">"Sisesta domeeni aadress."</string>
+  <string name="screen_change_server_navigation_title_login">"Logi sisse"</string>
+  <string name="screen_change_server_navigation_title_register">"Loo kasutajakonto"</string>
   <string name="screen_change_server_subtitle">"Mis on sinu koduserveri aadress?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Kui sinu kasutajakonto paikneb äriühingu või kogukonna serveris, siis muuda kontoteenuse pakkujat (näiteks: minufirmanimi.ee)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Loo tasuta kasutajakonto matrix.org serverisse. Kui soovid luua kasutajakonto mõne teise teenusepakkuja juures, siis muuda seda vastavalt (näiteks: minukogukond.ee)."</string>
+  <string name="screen_change_server_textfield_header">"Teenusepakkuja"</string>
+  <string name="screen_change_server_textfield_placeholder">"domeeninäidis.ee"</string>
   <string name="screen_change_server_title">"Vali oma server"</string>
+  <string name="screen_change_server_title_login">"Sisesta oma kasutajakonto teenusepakkuja"</string>
+  <string name="screen_change_server_title_register">"Vali kasutajakonto teenusepakkuja"</string>
   <string name="screen_create_account_title">"Loo kasutajakonto"</string>
   <string name="screen_login_error_deactivated_account">"See kasutajakonto on kustutatud."</string>
   <string name="screen_login_error_invalid_credentials">"Vigane kasutajanimi ja/või salasõna"</string>

--- a/features/login/impl/src/main/res/values-fi/translations.xml
+++ b/features/login/impl/src/main/res/values-fi/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Palveluntarjoaja %1$s ei ole sallittu."</string>
   <string name="screen_change_server_form_header">"Kotipalvelimen osoite"</string>
   <string name="screen_change_server_form_notice">"Anna verkkotunnuksen osoite."</string>
+  <string name="screen_change_server_navigation_title_login">"Kirjaudu sisään"</string>
+  <string name="screen_change_server_navigation_title_register">"Luo tili"</string>
   <string name="screen_change_server_subtitle">"Mikä on palvelimesi osoite?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Jos tilisi on yrityksesi tai yhteisön tarjoama, vaihda palveluntarjoaja (esimerkki: companyname.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Luo tili matrix.org -palvelimelle ilmaiseksi. Jos haluat luoda tilin eri palveluntarjoajan kautta, muuta sitä vastaavasti (esimerkiksi: communityname.org)."</string>
+  <string name="screen_change_server_textfield_header">"Palveluntarjoaja"</string>
+  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
   <string name="screen_change_server_title">"Valitse palvelimesi"</string>
+  <string name="screen_change_server_title_login">"Anna palveluntarjoajasi"</string>
+  <string name="screen_change_server_title_register">"Valitse palveluntarjoaja"</string>
   <string name="screen_create_account_title">"Luo tili"</string>
   <string name="screen_login_error_deactivated_account">"Tämä tili on poistettu."</string>
   <string name="screen_login_error_invalid_credentials">"Väärä käyttäjänimi ja/tai salasana"</string>

--- a/features/login/impl/src/main/res/values-fr/translations.xml
+++ b/features/login/impl/src/main/res/values-fr/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Le fournisseur de compte %1$s n’est pas autorisé."</string>
   <string name="screen_change_server_form_header">"URL du serveur d’accueil"</string>
   <string name="screen_change_server_form_notice">"Saisissez une adresse de domaine."</string>
+  <string name="screen_change_server_navigation_title_login">"Se connecter"</string>
+  <string name="screen_change_server_navigation_title_register">"Créer un compte"</string>
   <string name="screen_change_server_subtitle">"Quelle est l’adresse de votre serveur ?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Si votre fournisseur de compte est fourni par votre entreprise ou une communauté, veuillez le saisir ici (exemple : monentreprise.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Créez un compte sur matrix.org gratuitement. Si vous souhaitez créer un compte auprès d’un autre fournisseur, veuillez modifier l’adresse ici (exemple : monassociation.org)."</string>
+  <string name="screen_change_server_textfield_header">"Fournisseur de compte"</string>
+  <string name="screen_change_server_textfield_placeholder">"exemple.com"</string>
   <string name="screen_change_server_title">"Choisissez votre serveur"</string>
+  <string name="screen_change_server_title_login">"Saisissez votre fournisseur de compte"</string>
+  <string name="screen_change_server_title_register">"Choisissez un fournisseur de compte"</string>
   <string name="screen_create_account_title">"Créer un compte"</string>
   <string name="screen_login_error_deactivated_account">"Ce compte a été supprimé."</string>
   <string name="screen_login_error_invalid_credentials">"Nom d’utilisateur et/ou mot de passe incorrects"</string>

--- a/features/login/impl/src/main/res/values-in/translations.xml
+++ b/features/login/impl/src/main/res/values-in/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Penyedia akun %1$s tidak diizinkan."</string>
   <string name="screen_change_server_form_header">"URL Homeserver"</string>
   <string name="screen_change_server_form_notice">"Masukkan alamat domain."</string>
+  <string name="screen_change_server_navigation_title_login">"Login"</string>
+  <string name="screen_change_server_navigation_title_register">"Buat akun"</string>
   <string name="screen_change_server_subtitle">"Apa alamat server Anda?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Jika akun Anda disediakan oleh perusahaan atau komunitas Anda, maka ubah penyedia akun (contoh: companyname.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Buat akun di matrix.org secara gratis. Jika anda ingin membuat akun dengan penyedia lain, ubah sesuai kebutuhan (contoh: communityname.org)."</string>
+  <string name="screen_change_server_textfield_header">"Penyedia akun"</string>
+  <string name="screen_change_server_textfield_placeholder">"contoh.com"</string>
   <string name="screen_change_server_title">"Pilih server Anda"</string>
+  <string name="screen_change_server_title_login">"Masukkan penyedia akun Anda"</string>
+  <string name="screen_change_server_title_register">"Pilih penyedia akun"</string>
   <string name="screen_create_account_title">"Buat akun"</string>
   <string name="screen_login_error_deactivated_account">"Akun ini telah dinonaktifkan."</string>
   <string name="screen_login_error_invalid_credentials">"Nama pengguna dan/atau kata sandi salah"</string>

--- a/features/login/impl/src/main/res/values-ja/translations.xml
+++ b/features/login/impl/src/main/res/values-ja/translations.xml
@@ -24,8 +24,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"アカウント提供元 %1$s は許可されていません。"</string>
   <string name="screen_change_server_form_header">"ホームサーバーURL"</string>
   <string name="screen_change_server_form_notice">"ドメイン名を入力してください"</string>
+  <string name="screen_change_server_navigation_title_login">"サインイン"</string>
+  <string name="screen_change_server_navigation_title_register">"アカウントを作成"</string>
   <string name="screen_change_server_subtitle">"サーバーのアドレスは何ですか？"</string>
+  <string name="screen_change_server_textfield_footer_login">"アカウントが会社やコミュニティから発行されている場合は、アカウント提供元を変更してください (例: kaisha-mei.com)。"</string>
+  <string name="screen_change_server_textfield_footer_register">"matrix.org 上に無料でアカウントを作成できます。異なるアカウント提供元上にアカウントを作成したい場合は、それにならって変更してください (例: dantai-mei.org)。"</string>
+  <string name="screen_change_server_textfield_header">"アカウント提供元"</string>
+  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
   <string name="screen_change_server_title">"サーバーを選択"</string>
+  <string name="screen_change_server_title_login">"アカウント提供元を入力"</string>
+  <string name="screen_change_server_title_register">"アカウント提供元を選択"</string>
   <string name="screen_create_account_title">"アカウントを作成"</string>
   <string name="screen_login_error_deactivated_account">"アカウントは削除されました。"</string>
   <string name="screen_login_error_invalid_credentials">"ユーザー名またはパスワードが違います"</string>

--- a/features/login/impl/src/main/res/values-pl/translations.xml
+++ b/features/login/impl/src/main/res/values-pl/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Dostawca konta %1$s jest niedozwolony."</string>
   <string name="screen_change_server_form_header">"URL serwera domowego"</string>
   <string name="screen_change_server_form_notice">"Wprowadź adres domeny."</string>
+  <string name="screen_change_server_navigation_title_login">"Zaloguj"</string>
+  <string name="screen_change_server_navigation_title_register">"Utwórz konto"</string>
   <string name="screen_change_server_subtitle">"Jaki jest adres Twojego serwera?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Jeśli uzyskałeś konto od firmy lub społeczności, wprowadź dostawcę konta (na przykład: nazwafirmy.com)"</string>
+  <string name="screen_change_server_textfield_footer_register">"Załóż darmowe konto na matrix.org. Jeśli chcesz założyć konto u innego dostawcy wprowadź własny adres (na przykład: nazwaspołeczności.org)."</string>
+  <string name="screen_change_server_textfield_header">"Dostawca konta"</string>
+  <string name="screen_change_server_textfield_placeholder">"przykład.com"</string>
   <string name="screen_change_server_title">"Wybierz swój serwer"</string>
+  <string name="screen_change_server_title_login">"Wprowadź dostawcę swojego konta"</string>
+  <string name="screen_change_server_title_register">"Wybierz dostawcę konta"</string>
   <string name="screen_create_account_title">"Utwórz konto"</string>
   <string name="screen_login_error_deactivated_account">"To konto zostało usunięte."</string>
   <string name="screen_login_error_invalid_credentials">"Nieprawidłowa nazwa użytkownika i/lub hasło"</string>

--- a/features/login/impl/src/main/res/values-ro/translations.xml
+++ b/features/login/impl/src/main/res/values-ro/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Furnizorul de cont %1$s nu este permis."</string>
   <string name="screen_change_server_form_header">"Adresa URL a homeserver-ului"</string>
   <string name="screen_change_server_form_notice">"Introduceți o adresă de domeniu."</string>
+  <string name="screen_change_server_navigation_title_login">"Autentificare"</string>
+  <string name="screen_change_server_navigation_title_register">"Creați un cont"</string>
   <string name="screen_change_server_subtitle">"Care este adresa serverului dumneavoastră?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Dacă contul este furnizat de compania dumneavoastră sau de o comunitate, schimbați furnizorul contului (exemplu: numecompanie.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Creați un cont gratuit pe matrix.org. Dacă doriți să creați un cont la un alt furnizor, schimbați-l în consecință (exemplu: numecomunitate.org)."</string>
+  <string name="screen_change_server_textfield_header">"Furnizor de cont"</string>
+  <string name="screen_change_server_textfield_placeholder">"exemplu.ro"</string>
   <string name="screen_change_server_title">"Selectați serverul dumneavoastra"</string>
+  <string name="screen_change_server_title_login">"Introduceți furnizorul contului dumneavoastră"</string>
+  <string name="screen_change_server_title_register">"Alegeți un furnizor de cont"</string>
   <string name="screen_create_account_title">"Creați un cont"</string>
   <string name="screen_login_error_deactivated_account">"Acest cont a fost șters."</string>
   <string name="screen_login_error_invalid_credentials">"Utilizator și/sau parolă incorecte"</string>

--- a/features/login/impl/src/main/res/values-uk/translations.xml
+++ b/features/login/impl/src/main/res/values-uk/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Постачальник облікового запису %1$s не дозволений."</string>
   <string name="screen_change_server_form_header">"URL-адреса домашнього сервера"</string>
   <string name="screen_change_server_form_notice">"Введіть адресу домену."</string>
+  <string name="screen_change_server_navigation_title_login">"Увійти"</string>
+  <string name="screen_change_server_navigation_title_register">"Створити обліковий запис"</string>
   <string name="screen_change_server_subtitle">"Яка адреса вашого сервера?"</string>
+  <string name="screen_change_server_textfield_footer_login">"Якщо ваш обліковий запис надано вашою компанією або спільнотою, змініть постачальника облікового запису (наприклад: companyname.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Створіть обліковий запис на matrix.org безплатно. Якщо ви хочете створити обліковий запис у іншого постачальника, змініть його відповідно (наприклад: communityname.org)."</string>
+  <string name="screen_change_server_textfield_header">"Постачальник облікового запису"</string>
+  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
   <string name="screen_change_server_title">"Виберіть свій сервер"</string>
+  <string name="screen_change_server_title_login">"Вкажіть постачальника вашого облікового запису"</string>
+  <string name="screen_change_server_title_register">"Оберіть постачальника облікового запису"</string>
   <string name="screen_create_account_title">"Створити обліковий запис"</string>
   <string name="screen_login_error_deactivated_account">"Цей обліковий запис було видалено."</string>
   <string name="screen_login_error_invalid_credentials">"Неправильне ім\'я користувача та/або пароль"</string>

--- a/features/login/impl/src/main/res/values-zh/translations.xml
+++ b/features/login/impl/src/main/res/values-zh/translations.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"账户提供者 %1$s 不被允许。"</string>
   <string name="screen_change_server_form_header">"主服务器 URL"</string>
   <string name="screen_change_server_form_notice">"输入域名地址。"</string>
+  <string name="screen_change_server_navigation_title_login">"登录"</string>
+  <string name="screen_change_server_navigation_title_register">"创建账户"</string>
   <string name="screen_change_server_subtitle">"你的服务器地址是什么？"</string>
+  <string name="screen_change_server_textfield_footer_login">"如果你的账户由你的公司或社区提供，则应更改账户提供者（例如：companyname.com）。"</string>
+  <string name="screen_change_server_textfield_footer_register">"在 matrix.org 创建免费账户。如果你想使用其它服务提供者创建账户，请相应地更改域名（例如：communityname.org）。"</string>
+  <string name="screen_change_server_textfield_header">"账户提供者"</string>
+  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
   <string name="screen_change_server_title">"选择服务器"</string>
+  <string name="screen_change_server_title_login">"输入你的账户提供者"</string>
+  <string name="screen_change_server_title_register">"选择账户提供者"</string>
   <string name="screen_create_account_title">"创建账户"</string>
   <string name="screen_login_error_deactivated_account">"此账户已被删除。"</string>
   <string name="screen_login_error_invalid_credentials">"用户名与（或）密码不正确"</string>

--- a/features/login/impl/src/main/res/values/localazy.xml
+++ b/features/login/impl/src/main/res/values/localazy.xml
@@ -25,8 +25,16 @@
   <string name="screen_change_server_error_unauthorized_homeserver_title">"Account provider %1$s not allowed."</string>
   <string name="screen_change_server_form_header">"Homeserver URL"</string>
   <string name="screen_change_server_form_notice">"Enter a domain address."</string>
+  <string name="screen_change_server_navigation_title_login">"Sign in"</string>
+  <string name="screen_change_server_navigation_title_register">"Create account"</string>
   <string name="screen_change_server_subtitle">"What is the address of your server?"</string>
+  <string name="screen_change_server_textfield_footer_login">"If your account is provided by your company or a community, then change the account provider (example: companyname.com)."</string>
+  <string name="screen_change_server_textfield_footer_register">"Create an account on matrix.org for free. If you want to create an account with a different provider, then change it accordingly (example: communityname.org)."</string>
+  <string name="screen_change_server_textfield_header">"Account provider"</string>
+  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
   <string name="screen_change_server_title">"Select your server"</string>
+  <string name="screen_change_server_title_login">"Enter your account provider"</string>
+  <string name="screen_change_server_title_register">"Choose an account provider"</string>
   <string name="screen_create_account_title">"Create account"</string>
   <string name="screen_login_error_deactivated_account">"This account has been deleted."</string>
   <string name="screen_login_error_invalid_credentials">"Incorrect username and/or password"</string>

--- a/libraries/ui-strings/src/main/res/values-es/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-es/translations.xml
@@ -516,14 +516,6 @@ Motivo: %1$s."</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Agitar con fuerza para informar de un error"</string>
   <string name="screen_bug_report_a11y_screenshot">"Captura de pantalla"</string>
-  <string name="screen_change_server_navigation_title_login">"Iniciar sesión"</string>
-  <string name="screen_change_server_navigation_title_register">"Crear cuenta"</string>
-  <string name="screen_change_server_textfield_footer_login">"Si tu cuenta te la proporciona tu empresa o una comunidad, cambia el proveedor de la cuenta (ejemplo: nombredeempresa.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Crea una cuenta gratuita en matrix.org. Si deseas crear una cuenta con otro proveedor, modifícala según corresponda (por ejemplo: communityname.org)."</string>
-  <string name="screen_change_server_textfield_header">"Proveedor de cuentas"</string>
-  <string name="screen_change_server_textfield_placeholder">"ejemplo.com"</string>
-  <string name="screen_change_server_title_login">"Introduce tu proveedor de cuenta"</string>
-  <string name="screen_change_server_title_register">"Elegir proveedor de cuentas"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Opciones"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Eliminar %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-et/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-et/translations.xml
@@ -507,14 +507,6 @@ Kas sa oled kindel, et soovid jätkata?"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Veast teatamiseks raputa nutiseadet ägedalt"</string>
   <string name="screen_bug_report_a11y_screenshot">"Ekraanitõmmis"</string>
-  <string name="screen_change_server_navigation_title_login">"Logi sisse"</string>
-  <string name="screen_change_server_navigation_title_register">"Loo kasutajakonto"</string>
-  <string name="screen_change_server_textfield_footer_login">"Kui sinu kasutajakonto paikneb äriühingu või kogukonna serveris, siis muuda kontoteenuse pakkujat (näiteks: minufirmanimi.ee)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Loo tasuta kasutajakonto matrix.org serverisse. Kui soovid luua kasutajakonto mõne teise teenusepakkuja juures, siis muuda seda vastavalt (näiteks: minukogukond.ee)."</string>
-  <string name="screen_change_server_textfield_header">"Teenusepakkuja"</string>
-  <string name="screen_change_server_textfield_placeholder">"domeeninäidis.ee"</string>
-  <string name="screen_change_server_title_login">"Sisesta oma kasutajakonto teenusepakkuja"</string>
-  <string name="screen_change_server_title_register">"Vali kasutajakonto teenusepakkuja"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Valikud"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Kustuta: %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-fi/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-fi/translations.xml
@@ -516,14 +516,6 @@ Haluatko varmasti jatkaa?"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Raivostunut ravistaminen ilmoittaa virheestä"</string>
   <string name="screen_bug_report_a11y_screenshot">"Näyttökuva"</string>
-  <string name="screen_change_server_navigation_title_login">"Kirjaudu sisään"</string>
-  <string name="screen_change_server_navigation_title_register">"Luo tili"</string>
-  <string name="screen_change_server_textfield_footer_login">"Jos tilisi on yrityksesi tai yhteisön tarjoama, vaihda palveluntarjoaja (esimerkki: companyname.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Luo tili matrix.org -palvelimelle ilmaiseksi. Jos haluat luoda tilin eri palveluntarjoajan kautta, muuta sitä vastaavasti (esimerkiksi: communityname.org)."</string>
-  <string name="screen_change_server_textfield_header">"Palveluntarjoaja"</string>
-  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
-  <string name="screen_change_server_title_login">"Anna palveluntarjoajasi"</string>
-  <string name="screen_change_server_title_register">"Valitse palveluntarjoaja"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Vaihtoehdot"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Poista %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-fr/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-fr/translations.xml
@@ -516,14 +516,6 @@ Raison : %1$s."</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Rageshake pour signaler un problème"</string>
   <string name="screen_bug_report_a11y_screenshot">"Capture d’écran"</string>
-  <string name="screen_change_server_navigation_title_login">"Se connecter"</string>
-  <string name="screen_change_server_navigation_title_register">"Créer un compte"</string>
-  <string name="screen_change_server_textfield_footer_login">"Si votre fournisseur de compte est fourni par votre entreprise ou une communauté, veuillez le saisir ici (exemple : monentreprise.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Créez un compte sur matrix.org gratuitement. Si vous souhaitez créer un compte auprès d’un autre fournisseur, veuillez modifier l’adresse ici (exemple : monassociation.org)."</string>
-  <string name="screen_change_server_textfield_header">"Fournisseur de compte"</string>
-  <string name="screen_change_server_textfield_placeholder">"exemple.com"</string>
-  <string name="screen_change_server_title_login">"Saisissez votre fournisseur de compte"</string>
-  <string name="screen_change_server_title_register">"Choisissez un fournisseur de compte"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Options"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Supprimer %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-pl/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-pl/translations.xml
@@ -528,14 +528,6 @@ Czy na pewno chcesz kontynuować?"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Wstrząśnij gniewnie, aby zgłosić błąd"</string>
   <string name="screen_bug_report_a11y_screenshot">"Zrzut ekranu"</string>
-  <string name="screen_change_server_navigation_title_login">"Zaloguj"</string>
-  <string name="screen_change_server_navigation_title_register">"Utwórz konto"</string>
-  <string name="screen_change_server_textfield_footer_login">"Jeśli uzyskałeś konto od firmy lub społeczności, wprowadź dostawcę konta (na przykład: nazwafirmy.com)"</string>
-  <string name="screen_change_server_textfield_footer_register">"Załóż darmowe konto na matrix.org. Jeśli chcesz założyć konto u innego dostawcy wprowadź własny adres (na przykład: nazwaspołeczności.org)."</string>
-  <string name="screen_change_server_textfield_header">"Dostawca konta"</string>
-  <string name="screen_change_server_textfield_placeholder">"przykład.com"</string>
-  <string name="screen_change_server_title_login">"Wprowadź dostawcę swojego konta"</string>
-  <string name="screen_change_server_title_register">"Wybierz dostawcę konta"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Opcje"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Usuń %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-ro/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-ro/translations.xml
@@ -528,14 +528,6 @@ Sunteți sigur că doriți să continuați?"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Rageshake pentru a raporta erori"</string>
   <string name="screen_bug_report_a11y_screenshot">"Captură de ecran"</string>
-  <string name="screen_change_server_navigation_title_login">"Autentificare"</string>
-  <string name="screen_change_server_navigation_title_register">"Creați un cont"</string>
-  <string name="screen_change_server_textfield_footer_login">"Dacă contul este furnizat de compania dumneavoastră sau de o comunitate, schimbați furnizorul contului (exemplu: numecompanie.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Creați un cont gratuit pe matrix.org. Dacă doriți să creați un cont la un alt furnizor, schimbați-l în consecință (exemplu: numecomunitate.org)."</string>
-  <string name="screen_change_server_textfield_header">"Furnizor de cont"</string>
-  <string name="screen_change_server_textfield_placeholder">"exemplu.ro"</string>
-  <string name="screen_change_server_title_login">"Introduceți furnizorul contului dumneavoastră"</string>
-  <string name="screen_change_server_title_register">"Alegeți un furnizor de cont"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Opțiuni"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Ștergeți %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-uk/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-uk/translations.xml
@@ -528,14 +528,6 @@
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Повідомляти про помилку потрусивши телефон"</string>
   <string name="screen_bug_report_a11y_screenshot">"Знімок екрана"</string>
-  <string name="screen_change_server_navigation_title_login">"Увійти"</string>
-  <string name="screen_change_server_navigation_title_register">"Створити обліковий запис"</string>
-  <string name="screen_change_server_textfield_footer_login">"Якщо ваш обліковий запис надано вашою компанією або спільнотою, змініть постачальника облікового запису (наприклад: companyname.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Створіть обліковий запис на matrix.org безплатно. Якщо ви хочете створити обліковий запис у іншого постачальника, змініть його відповідно (наприклад: communityname.org)."</string>
-  <string name="screen_change_server_textfield_header">"Постачальник облікового запису"</string>
-  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
-  <string name="screen_change_server_title_login">"Вкажіть постачальника вашого облікового запису"</string>
-  <string name="screen_change_server_title_register">"Оберіть постачальника облікового запису"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Варіанти"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Вилучити %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values-zh/translations.xml
+++ b/libraries/ui-strings/src/main/res/values-zh/translations.xml
@@ -504,14 +504,6 @@
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"摇一摇以报告 bug"</string>
   <string name="screen_bug_report_a11y_screenshot">"屏幕截图"</string>
-  <string name="screen_change_server_navigation_title_login">"登录"</string>
-  <string name="screen_change_server_navigation_title_register">"创建账户"</string>
-  <string name="screen_change_server_textfield_footer_login">"如果你的账户由你的公司或社区提供，则应更改账户提供者（例如：companyname.com）。"</string>
-  <string name="screen_change_server_textfield_footer_register">"在 matrix.org 创建免费账户。如果你想使用其它服务提供者创建账户，请相应地更改域名（例如：communityname.org）。"</string>
-  <string name="screen_change_server_textfield_header">"账户提供者"</string>
-  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
-  <string name="screen_change_server_title_login">"输入你的账户提供者"</string>
-  <string name="screen_change_server_title_register">"选择账户提供者"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s：%2$s"</string>
   <string name="screen_create_poll_options_section_title">"选项"</string>
   <string name="screen_create_poll_remove_accessibility_label">"移除 %1$s"</string>

--- a/libraries/ui-strings/src/main/res/values/localazy.xml
+++ b/libraries/ui-strings/src/main/res/values/localazy.xml
@@ -516,14 +516,6 @@ Are you sure you want to continue?"</string>
   <string name="login_initial_device_name_android">"%1$s Android"</string>
   <string name="preference_rageshake">"Rageshake to report bug"</string>
   <string name="screen_bug_report_a11y_screenshot">"Screenshot"</string>
-  <string name="screen_change_server_navigation_title_login">"Sign in"</string>
-  <string name="screen_change_server_navigation_title_register">"Create account"</string>
-  <string name="screen_change_server_textfield_footer_login">"If your account is provided by your company or a community, then change the account provider (example: companyname.com)."</string>
-  <string name="screen_change_server_textfield_footer_register">"Create an account on matrix.org for free. If you want to create an account with a different provider, then change it accordingly (example: communityname.org)."</string>
-  <string name="screen_change_server_textfield_header">"Account provider"</string>
-  <string name="screen_change_server_textfield_placeholder">"example.com"</string>
-  <string name="screen_change_server_title_login">"Enter your account provider"</string>
-  <string name="screen_change_server_title_register">"Choose an account provider"</string>
   <string name="screen_create_poll_option_accessibility_label">"%1$s: %2$s"</string>
   <string name="screen_create_poll_options_section_title">"Options"</string>
   <string name="screen_create_poll_remove_accessibility_label">"Remove %1$s"</string>

--- a/tools/localazy/config.json
+++ b/tools/localazy/config.json
@@ -173,6 +173,7 @@
       "includeRegex" : [
         "screen_onboarding_.*",
         "screen\\.onboarding\\..*",
+        "screen\\.change_server\\..*",
         "screen\\.missing_key_backup\\..*",
         "screen_login_.*",
         "screen_server_confirmation_.*",


### PR DESCRIPTION
Just a change in the Localazy config.json, so that the string of the new server selection screen are routed to the correct module.
Then import that Localazy strings and their already existing translation.