### PR TITLE
Fix crash at startup after upgrading from an older version (run database migrations on upgrade)

### DIFF
--- a/libraries/encrypted-db/src/main/kotlin/io/element/encrypteddb/SqlCipherDriverFactory.kt
+++ b/libraries/encrypted-db/src/main/kotlin/io/element/encrypteddb/SqlCipherDriverFactory.kt
@@ -55,6 +55,9 @@ class SqlCipherDriverFactory(
                 schema
             ) {
             override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
+                // The base implementation runs the SQLDelight migrations (schema.migrate); without it
+                // the database keeps its old schema after an upgrade and the next query crashes.
+                super.onUpgrade(db, oldVersion, newVersion)
                 onUpgradeCallback?.invoke(db, oldVersion, newVersion)
             }
         })


### PR DESCRIPTION
## Content

`SqlCipherDriverFactory`'s `AndroidSqliteDriver.Callback.onUpgrade` override now calls `super.onUpgrade(db, oldVersion, newVersion)` before the re-key callback, so the SQLDelight `.sqm` migrations actually run on upgrade (the base implementation is what executes `schema.migrate()`).

## Motivation and context

Fixes #7509: upgrading from a build whose session database predates migrations 9–11 (e.g. 25.05.4) crashed at startup with `SQLiteException: no such column: SessionData.position` (in `AppMigration02`), because no migration was executed while `user_version` was still bumped. One-line fix; no user-facing change other than the crash disappearing.

Note for maintainers: databases already opened by an affected build have `user_version` stamped at the current schema with the old columns, so this fix alone does not repair them; a self-heal that inspects `PRAGMA table_info(SessionData)` and applies the missing migrations is what we ship in our fork — happy to contribute it as a follow-up if wanted.

## Screenshots / GIFs

No UI change.

## Tests

- Installed the official 25.05.4 release APK, launched it once (creates the v9 session database).
- Installed a release build with this patch over it: app starts, migrations applied, relaunch healthy.
- Same steps without the patch: crash 100 % (stack trace in #7509).
- `./gradlew :libraries:session-storage:impl:verifySqlDelightMigration` passes.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 17 (Pixel 8 Pro)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24 (tested on API 37)
- [ ] UI change has been tested on both light and dark themes (no UI change)
- [ ] Accessibility has been taken into account (no UI change)
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes (none)
- [x] You've made a self review of your PR

Suggested label: `PR-Bugfix` (I cannot add labels on this repository).