### PR TITLE
Remove the reference to the decommissioned OIDC playground

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -6,8 +6,6 @@ Rust sdk branch: https://github.com/matrix-org/matrix-rust-sdk/tree/oidc-ffi
 
 Figma https://www.figma.com/file/o9p34zmiuEpZRyvZXJZAYL/FTUE?node-id=133-5426&t=yQXKeANatk6keoZF-0
 
-Server list: https://github.com/element-hq/oidc-playground
-
 Metadata iOS: (from https://github.com/element-hq/element-x-ios/blob/5f9d07377cebc4f21d9668b1a25f6e3bb22f64a1/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift#L28)
 
 clientName: InfoPlistReader.main.bundleDisplayName,


### PR DESCRIPTION
## Content

Drop reference to https://github.com/element-hq/oidc-playground in `docs/oauth.md`.

## Motivation and context

The OIDC playground is being decommissioned, so that link no longer points at anything usable. Arguably that documentation could be reworked quite a bit, but at this point I'm mostly looking into scraping any references to the OIDC playground, and redirect people to just use matrix.org for example.

See https://github.com/element-hq/oidc-playground/pull/6

Reason for Claude co-authoring the commit is because I've asked it to sweep for references and it prepared a bunch of patches for me, including this one.