### PR TITLE
Make the account provider screen scrollable so its description is not clipped by the keyboard

### DIFF
--- a/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
+++ b/features/login/impl/src/main/kotlin/io/element/android/features/login/impl/screens/confirmaccountprovider/ConfirmAccountProviderView.kt
@@ -115,6 +115,9 @@ fun ConfirmAccountProviderView(
 
     HeaderFooterPage(
         modifier = modifier,
+        // Let the header and content scroll so the supporting text is not clipped by the footer when the
+        // keyboard is visible and vertical space is reduced.
+        isScrollable = true,
         header = {
             IconTitleSubtitleMolecule(
                 modifier = Modifier.padding(top = 60.dp),


### PR DESCRIPTION
## Content

Make the account provider screen (`ConfirmAccountProviderView`) scrollable.

## Motivation and context

Reported feedback: when the keyboard is visible, the last line of the field's supporting text (e.g. the "…companyname.com)" example) is hidden behind the keyboard. Enabling scrolling lets the header and content scroll so the full description remains reachable while the keyboard is up.

**Konsist test is waiting on an enterprise submodule bump unrelated to this pr

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 16

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
