### PR TITLE
Show media download progress

### DIFF
--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MatrixMediaLoader.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/media/MatrixMediaLoader.kt
@@ -8,6 +8,8 @@
 
 package io.element.android.libraries.matrix.api.media
 
+import io.element.android.libraries.matrix.api.core.ProgressCallback
+
 /**
  * Fetches media content from the homeserver, decrypting it on the way when the room is encrypted.
  */
@@ -38,5 +40,6 @@ interface MatrixMediaLoader {
         mimeType: String?,
         filename: String?,
         useCache: Boolean = true,
+        progressCallback: ProgressCallback? = null,
     ): Result<MediaFile>
 }

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/media/RustMediaLoader.kt
@@ -12,9 +12,11 @@ import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.core.mimetype.MimeTypes.ensureDefaultSubtype
+import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaFile
 import io.element.android.libraries.matrix.api.media.MediaSource
+import io.element.android.libraries.matrix.impl.core.toProgressWatcher
 import io.element.android.libraries.matrix.impl.exception.mapClientException
 import kotlinx.coroutines.withContext
 import org.matrix.rustcomponents.sdk.Client
@@ -64,17 +66,19 @@ class RustMediaLoader(
         mimeType: String?,
         filename: String?,
         useCache: Boolean,
+        progressCallback: ProgressCallback?,
     ): Result<MediaFile> =
         withContext(mediaDispatcher) {
             runCatchingExceptions {
                 source.toRustMediaSource().use { mediaSource ->
-                    val mediaFile = innerClient.getMediaFile(
+                    val mediaFile = innerClient.getMediaFileWithProgress(
                         mediaSource = mediaSource,
                         filename = filename,
                         // Fallback to a default mime type based on the main type, so that the SDK can create a file with the correct extension.
                         mimeType = mimeType.ensureDefaultSubtype(),
                         useCache = useCache,
                         tempDir = cacheDirectory.path,
+                        progressWatcher = progressCallback?.toProgressWatcher(),
                     )
                     RustMediaFile(mediaFile)
                 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/media/FakeMatrixMediaLoader.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/media/FakeMatrixMediaLoader.kt
@@ -8,6 +8,7 @@
 
 package io.element.android.libraries.matrix.test.media
 
+import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaFile
 import io.element.android.libraries.matrix.api.media.MediaSource
@@ -16,6 +17,7 @@ import io.element.android.tests.testutils.simulateLongTask
 class FakeMatrixMediaLoader : MatrixMediaLoader {
     var shouldFail = false
     var path: String = ""
+    var progressValues: List<Pair<Long, Long>> = emptyList()
 
     override suspend fun loadMediaContent(source: MediaSource): Result<ByteArray> = simulateLongTask {
         if (shouldFail) {
@@ -38,7 +40,9 @@ class FakeMatrixMediaLoader : MatrixMediaLoader {
         mimeType: String?,
         filename: String?,
         useCache: Boolean,
+        progressCallback: ProgressCallback?,
     ): Result<MediaFile> = simulateLongTask {
+        progressValues.forEach { progressCallback?.onProgress(it.first, it.second) }
         if (shouldFail) {
             Result.failure(RuntimeException())
         } else {

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerDataSource.kt
@@ -21,6 +21,7 @@ import io.element.android.features.contentscanner.api.ContentScannerService
 import io.element.android.libraries.architecture.AsyncData
 import io.element.android.libraries.core.extensions.mapCatchingExceptions
 import io.element.android.libraries.matrix.api.core.EventId
+import io.element.android.libraries.matrix.api.core.ProgressCallback
 import io.element.android.libraries.matrix.api.media.MatrixMediaLoader
 import io.element.android.libraries.matrix.api.media.MediaFile
 import io.element.android.libraries.matrix.api.media.MediaSource
@@ -44,6 +45,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -76,6 +78,7 @@ class MediaViewerDataSource(
     // Map of sourceUrl to local media state
     private val localMediaStates: MutableMap<String, MutableState<AsyncData<LocalMedia>>> =
         mutableMapOf()
+    private val downloadProgressStates: MutableMap<String, MutableStateFlow<Int?>> = mutableMapOf()
 
     private val mediaValidationState: MutableMap<String, ContentValidationState> =
         mutableMapOf()
@@ -88,6 +91,8 @@ class MediaViewerDataSource(
         Timber.d("Disposing MediaViewerDataSource, closing ${mediaFiles.size} media files")
         mediaFiles.values.forEach { it.close() }
         mediaFiles.clear()
+        downloadProgressStates.values.forEach { it.value = null }
+        downloadProgressStates.clear()
         localMediaStates.clear()
     }
 
@@ -171,6 +176,9 @@ class MediaViewerDataSource(
                     val localMedia = localMediaStates.getOrPut(sourceUrl) {
                         mutableStateOf(AsyncData.Uninitialized)
                     }
+                    val downloadProgress = downloadProgressStates.getOrPut(sourceUrl) {
+                        MutableStateFlow(null)
+                    }
                     val validationState = mediaValidationState.getOrPut(sourceUrl) {
                         mediaItem.eventId()?.let { contentValidationCache[it] } ?: DefaultContentValidationState()
                     }
@@ -181,6 +189,7 @@ class MediaViewerDataSource(
                             mediaSource = mediaItem.mediaSource(),
                             thumbnailSource = mediaItem.thumbnailSource(),
                             downloadedMedia = localMedia,
+                            downloadProgress = downloadProgress,
                             pagerKey = pagerKeysHandler.getKey(mediaItem),
                             validationState = validationState,
                         )
@@ -198,6 +207,7 @@ class MediaViewerDataSource(
     }.toImmutableList()
 
     fun clearLoadingError(data: MediaViewerPageData.MediaViewerData) {
+        downloadProgressStates[data.mediaSource.safeUrl]?.value = null
         localMediaStates[data.mediaSource.safeUrl]?.value = AsyncData.Uninitialized
     }
 
@@ -218,28 +228,45 @@ class MediaViewerDataSource(
         val localMediaState = localMediaStates.getOrPut(data.mediaSource.safeUrl) {
             mutableStateOf(AsyncData.Uninitialized)
         }
+        val downloadProgress = downloadProgressStates.getOrPut(data.mediaSource.safeUrl) {
+            MutableStateFlow(null)
+        }
+        downloadProgress.value = null
         localMediaState.value = AsyncData.Loading()
-        mediaLoader
-            .downloadMediaFile(
-                source = data.mediaSource,
-                mimeType = data.mediaInfo.mimeType,
-                filename = data.mediaInfo.filename
-            )
-            .onSuccess { mediaFile ->
-                mediaFiles[data.mediaSource] = mediaFile
-            }
-            .mapCatchingExceptions { mediaFile ->
-                localMediaFactory.createFromMediaFile(
-                    mediaFile = mediaFile,
-                    mediaInfo = data.mediaInfo
+        try {
+            mediaLoader
+                .downloadMediaFile(
+                    source = data.mediaSource,
+                    mimeType = data.mediaInfo.mimeType,
+                    filename = data.mediaInfo.filename,
+                    progressCallback = object : ProgressCallback {
+                        override fun onProgress(current: Long, total: Long) {
+                            downloadProgress.value = if (total > 0) {
+                                ((current.coerceIn(0, total) * 100.0) / total).toInt().coerceIn(0, 100)
+                            } else {
+                                null
+                            }
+                        }
+                    }
                 )
-            }
-            .onSuccess {
-                localMediaState.value = AsyncData.Success(it)
-            }
-            .onFailure {
-                localMediaState.value = AsyncData.Failure(it)
-            }
+                .onSuccess { mediaFile ->
+                    mediaFiles[data.mediaSource] = mediaFile
+                }
+                .mapCatchingExceptions { mediaFile ->
+                    localMediaFactory.createFromMediaFile(
+                        mediaFile = mediaFile,
+                        mediaInfo = data.mediaInfo
+                    )
+                }
+                .onSuccess {
+                    localMediaState.value = AsyncData.Success(it)
+                }
+                .onFailure {
+                    localMediaState.value = AsyncData.Failure(it)
+                }
+        } finally {
+            downloadProgress.value = null
+        }
     }
 
     fun validateMedia(mediaSource: MediaSource, thumbnailMediaSource: MediaSource?) {
@@ -257,6 +284,7 @@ class MediaViewerDataSource(
         if (localMediaStates[data.mediaSource.safeUrl]?.value?.isLoading() == true) {
             Timber.d("cancelLoadingMedia for ${data.eventId}")
             mediaFiles.remove(data.mediaSource)?.close()
+            downloadProgressStates[data.mediaSource.safeUrl]?.value = null
             localMediaStates[data.mediaSource.safeUrl]?.value = AsyncData.Uninitialized
         }
     }

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerState.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerState.kt
@@ -20,6 +20,7 @@ import io.element.android.libraries.mediaviewer.api.MediaInfo
 import io.element.android.libraries.mediaviewer.api.local.LocalMedia
 import io.element.android.libraries.mediaviewer.impl.details.MediaBottomSheetState
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.StateFlow
 
 data class MediaViewerState(
     val initiallySelectedEventId: EventId?,
@@ -52,6 +53,7 @@ sealed interface MediaViewerPageData {
         val mediaSource: MediaSource,
         val thumbnailSource: MediaSource?,
         val downloadedMedia: State<AsyncData<LocalMedia>>,
+        val downloadProgress: StateFlow<Int?>,
         val validationState: ContentValidationState,
         override val pagerKey: Long,
     ) : MediaViewerPageData

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerStatePreviewParam.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerStatePreviewParam.kt
@@ -32,6 +32,7 @@ import io.element.android.libraries.mediaviewer.impl.details.MediaBottomSheetSta
 import io.element.android.libraries.mediaviewer.impl.details.aMediaBottomSheetStateDeleteConfirmation
 import io.element.android.libraries.mediaviewer.impl.details.aMediaBottomSheetStateDetails
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
 
 private const val LONG_CAPTION = "This is a very long caption that should be scrollable in the media viewer. " +
     "It contains multiple lines of text to demonstrate the scrolling behavior. " +
@@ -322,6 +323,7 @@ fun aMediaViewerPageDataLoading(
 
 fun aMediaViewerPageData(
     downloadedMedia: AsyncData<LocalMedia> = AsyncData.Uninitialized,
+    downloadProgress: Int? = null,
     mediaInfo: MediaInfo = anImageMediaInfo(),
     mediaSource: MediaSource = MediaSource(""),
     validationState: ContentValidationState = NoopContentValidationState(),
@@ -331,6 +333,7 @@ fun aMediaViewerPageData(
     mediaSource = mediaSource,
     thumbnailSource = null,
     downloadedMedia = mutableStateOf(downloadedMedia),
+    downloadProgress = MutableStateFlow(downloadProgress),
     pagerKey = 0L,
     validationState = validationState,
 )

--- a/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
+++ b/libraries/mediaviewer/impl/src/main/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerView.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -71,6 +72,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.core.text.toSpannable
 import coil3.compose.AsyncImage
 import io.element.android.compound.theme.ElementTheme
@@ -389,6 +391,7 @@ private fun MediaViewerPage(
         modifier = modifier,
     ) {
         val downloadedMedia by data.downloadedMedia
+        val downloadProgress by data.downloadProgress.collectAsState()
         val showProgress = rememberShowProgress(downloadedMedia)
         val mediaValidationState by data.validationState.collectMediaState(data.mediaSource.safeUrl)
         val thumbnailValidationState by data.validationState.collectMediaState(data.thumbnailSource?.safeUrl)
@@ -410,12 +413,22 @@ private fun MediaViewerPage(
             }
 
             if (showProgress) {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .padding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top).asPaddingValues())
-                        .fillMaxWidth()
-                        .height(2.dp)
-                )
+                val downloadingDescription = stringResource(CommonStrings.common_downloading)
+                val progressModifier = Modifier
+                    .padding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top).asPaddingValues())
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .zIndex(1f)
+                    .semantics { contentDescription = downloadingDescription }
+                val progress = downloadProgress
+                if (progress == null) {
+                    LinearProgressIndicator(modifier = progressModifier)
+                } else {
+                    LinearProgressIndicator(
+                        progress = { progress / 100f },
+                        modifier = progressModifier,
+                    )
+                }
             }
 
             Box(contentAlignment = Alignment.Center) {
@@ -536,7 +549,6 @@ private fun rememberShowProgress(downloadedMedia: AsyncData<LocalMedia>): Boolea
         showProgress = downloadedMedia.isLoading()
     } else {
         // Trick to avoid showing progress indicator if the media is already on disk.
-        // When sdk will expose download progress we'll be able to remove this.
         LaunchedEffect(downloadedMedia) {
             showProgress = false
             delay(100)

--- a/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
+++ b/libraries/mediaviewer/impl/src/test/kotlin/io/element/android/libraries/mediaviewer/impl/viewer/MediaViewerViewTest.kt
@@ -251,6 +251,20 @@ class MediaViewerViewTest : RobolectricTest() {
     }
 
     @Test
+    fun `loading media shows download progress`() = runAndroidComposeUiTest {
+        val data = aMediaViewerPageData(
+            downloadedMedia = AsyncData.Loading(),
+            downloadProgress = 50,
+        )
+        setMediaViewerView(aMediaViewerState(listData = listOf(data)))
+
+        mainClock.advanceTimeBy(101)
+
+        val description = activity!!.resources.getString(CommonStrings.common_downloading)
+        onNodeWithContentDescription(description).assertExists()
+    }
+
+    @Test
     fun `error case, click on retry emits the expected Event`() = runAndroidComposeUiTest {
         val eventsRecorder = EventsRecorder<MediaViewerEvent>()
         val data = aMediaViewerPageData(


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Add a progress bar for media download.

## Motivation and context

I had gpt-5.6-sol cook up an implementation for #3493.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

Manual testing: I built and installed an APK, and observed the progress.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
