### PR TITLE
Destroy the rooms created for one-shot operations

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/utils/ActiveCallManager.kt
@@ -228,7 +228,7 @@ class DefaultActiveCallManager(
             val notificationData = currentActiveCall.callState.notificationData
             matrixClientProvider.getOrRestore(notificationData.sessionId).getOrNull()
                 ?.getRoom(notificationData.roomId)
-                ?.declineCall(notificationData.eventId)
+                ?.use { it.declineCall(notificationData.eventId) }
                 ?.onFailure {
                     Timber.e(it, "Failed to decline incoming call")
                 }

--- a/features/reportroom/impl/src/main/kotlin/io/element/android/features/reportroom/impl/ReportRoom.kt
+++ b/features/reportroom/impl/src/main/kotlin/io/element/android/features/reportroom/impl/ReportRoom.kt
@@ -41,19 +41,21 @@ class DefaultReportRoom(
         val room = client.getRoom(roomId)
             ?: return Result.failure(ReportRoom.Exception.RoomNotFound)
 
-        if (shouldReport) {
-            room
-                .reportRoom(reason.takeIf { it.isNotBlank() })
-                .onFailure {
-                    return Result.failure(ReportRoom.Exception.ReportRoomFailed)
-                }
-        }
-        if (shouldLeave) {
-            room
-                .leave()
-                .onFailure {
-                    return Result.failure(ReportRoom.Exception.LeftRoomFailed)
-                }
+        room.use {
+            if (shouldReport) {
+                room
+                    .reportRoom(reason.takeIf { it.isNotBlank() })
+                    .onFailure {
+                        return Result.failure(ReportRoom.Exception.ReportRoomFailed)
+                    }
+            }
+            if (shouldLeave) {
+                room
+                    .leave()
+                    .onFailure {
+                        return Result.failure(ReportRoom.Exception.LeftRoomFailed)
+                    }
+            }
         }
         return Result.success(Unit)
     }

--- a/features/reportroom/impl/src/test/kotlin/io/element/android/features/reportroom/impl/DefaultReportRoomTest.kt
+++ b/features/reportroom/impl/src/test/kotlin/io/element/android/features/reportroom/impl/DefaultReportRoomTest.kt
@@ -46,6 +46,7 @@ class DefaultReportRoomTest {
         assertThat(result.isSuccess).isTrue()
         assert(successLeaveRoomLambda).isNeverCalled()
         assert(successReportRoomLambda).isNeverCalled()
+        room.assertDestroyed()
     }
 
     @Test
@@ -67,6 +68,7 @@ class DefaultReportRoomTest {
         assert(successReportRoomLambda)
             .isCalledOnce()
             .with(value("Spam"))
+        room.assertDestroyed()
     }
 
     @Test
@@ -86,6 +88,7 @@ class DefaultReportRoomTest {
         assertThat(result.isSuccess).isTrue()
         assert(successLeaveRoomLambda).isCalledOnce()
         assert(successReportRoomLambda).isNeverCalled()
+        room.assertDestroyed()
     }
 
     @Test
@@ -107,6 +110,7 @@ class DefaultReportRoomTest {
         assert(successReportRoomLambda)
             .isCalledOnce()
             .with(value("Spam"))
+        room.assertDestroyed()
     }
 
     @Test
@@ -127,6 +131,7 @@ class DefaultReportRoomTest {
         assertThat(result.exceptionOrNull()).isEqualTo(ReportRoom.Exception.LeftRoomFailed)
         assert(failureLeaveRoomLambda).isCalledOnce()
         assert(successReportRoomLambda).isCalledOnce()
+        room.assertDestroyed()
     }
 
     @Test
@@ -147,5 +152,6 @@ class DefaultReportRoomTest {
         assertThat(result.exceptionOrNull()).isEqualTo(ReportRoom.Exception.ReportRoomFailed)
         assert(successLeaveRoomLambda).isNeverCalled()
         assert(failureReportRoomLambda).isCalledOnce()
+        room.assertDestroyed()
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeBaseRoom.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/room/FakeBaseRoom.kt
@@ -113,6 +113,10 @@ class FakeBaseRoom(
         check(isDestroyed) { "Room should be destroyed" }
     }
 
+    fun assertNotDestroyed() {
+        check(!isDestroyed) { "Room should not be destroyed" }
+    }
+
     override suspend fun userDisplayName(userId: UserId): Result<String?> = simulateLongTask {
         userDisplayNameResult(userId)
     }

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/CallNotificationEventResolver.kt
@@ -70,11 +70,12 @@ class DefaultCallNotificationEventResolver(
                 val client = clientProvider.getOrRestore(
                     sessionId
                 ).getOrNull() ?: throw NotificationResolverException.UnknownError("Session $sessionId not found")
-                val room = client.getRoom(
+                val isActive = client.getRoom(
                     notificationData.roomId
-                ) ?: throw NotificationResolverException.UnknownError("Room ${notificationData.roomId} not found")
-                // Give a few seconds for the room info flow to catch up with the sync, if needed - this is usually instant
-                val isActive = withTimeoutOrNull(3.seconds) { room.roomInfoFlow.firstOrNull { it.hasRoomCall } }?.hasRoomCall ?: false
+                )?.use { room ->
+                    // Give a few seconds for the room info flow to catch up with the sync, if needed - this is usually instant
+                    withTimeoutOrNull(3.seconds) { room.roomInfoFlow.firstOrNull { it.hasRoomCall } }?.hasRoomCall ?: false
+                } ?: throw NotificationResolverException.UnknownError("Room ${notificationData.roomId} not found")
 
                 // We no longer need the sync service to be active because of a call notification.
                 appForegroundStateService.updateHasRingingCall(previousRingingCallStatus)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandler.kt
@@ -99,7 +99,7 @@ class NotificationBroadcastReceiverHandler(
 
     private fun handleRejectRoom(sessionId: SessionId, roomId: RoomId) = appCoroutineScope.launch {
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return@launch
-        client.getRoom(roomId)?.leave()
+        client.getRoom(roomId)?.use { it.leave() }
     }
 
     @Suppress("unused")
@@ -159,17 +159,21 @@ class NotificationBroadcastReceiverHandler(
             return@launch
         }
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return@launch
-        val room = activeRoomsHolder.getActiveRoomMatching(sessionId, roomId) ?: client.getJoinedRoom(roomId)
+        val (room, needsDestroy) = activeRoomsHolder.getActiveRoomMatching(sessionId, roomId)?.let { it to false }
+            ?: client.getJoinedRoom(roomId)?.let { it to true }
+            ?: return@launch
 
-        room?.let {
-            sendMatrixEvent(
-                sessionId = sessionId,
-                roomId = roomId,
-                replyToEventId = replyToEventId,
-                threadId = threadId,
-                room = it,
-                message = message,
-            )
+        sendMatrixEvent(
+            sessionId = sessionId,
+            roomId = roomId,
+            replyToEventId = replyToEventId,
+            threadId = threadId,
+            room = room,
+            message = message,
+        )
+
+        if (needsDestroy) {
+            room.destroy()
         }
     }
 

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultCallNotificationEventResolverTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultCallNotificationEventResolverTest.kt
@@ -73,6 +73,7 @@ class DefaultCallNotificationEventResolverTest {
         )
         val result = resolver.resolveEvent(A_SESSION_ID, notificationData)
         assertThat(result.getOrNull()).isEqualTo(expectedResult)
+        room.baseRoom.assertDestroyed()
     }
 
     @Test
@@ -161,6 +162,7 @@ class DefaultCallNotificationEventResolverTest {
         )
         val result = resolver.resolveEvent(A_SESSION_ID, notificationData)
         assertThat(result.getOrNull()).isEqualTo(expectedResult)
+        room.baseRoom.assertDestroyed()
     }
 
     private fun createDefaultNotifiableEventResolver(

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/NotificationBroadcastReceiverHandlerTest.kt
@@ -325,6 +325,7 @@ class NotificationBroadcastReceiverHandlerTest : RobolectricTest() {
         leaveRoom.assertions()
             .isCalledOnce()
             .with()
+        joinedRoom.baseRoom.assertDestroyed()
     }
 
     @Test
@@ -384,6 +385,41 @@ class NotificationBroadcastReceiverHandlerTest : RobolectricTest() {
             .isCalledOnce()
         replyMessage.assertions()
             .isNeverCalled()
+        joinedRoom.baseRoom.assertDestroyed()
+    }
+
+    @Test
+    fun `Test send reply with an active room does not destroy it`() = runTest {
+        val sendMessage = lambdaRecorder<String, String?, List<IntentionalMention>, MsgType, Boolean, Result<Unit>> { _, _, _, _, _ -> Result.success(Unit) }
+        val liveTimeline = FakeTimeline().apply {
+            sendMessageLambda = sendMessage
+        }
+        val joinedRoom = FakeJoinedRoom(
+            liveTimeline = liveTimeline,
+            baseRoom = FakeBaseRoom(getUpdatedMemberResult = { Result.success(aRoomMember()) }),
+        ).apply {
+            givenRoomInfo(
+                aRoomInfo(
+                    isDirect = true,
+                    activeMembersCount = 2,
+                )
+            )
+        }
+        val sut = createNotificationBroadcastReceiverHandler(
+            joinedRoom = joinedRoom,
+            onNotifiableEventReceived = FakeOnNotifiableEventReceived(onNotifiableEventsReceivedResult = { }),
+            replyMessageExtractor = FakeReplyMessageExtractor(A_MESSAGE),
+            activeRoomsHolder = DefaultActiveRoomsHolder().apply { addRoom(joinedRoom) },
+        )
+        sut.onReceive(
+            createIntent(
+                action = actionIds.smartReply,
+                roomId = A_ROOM_ID,
+            ),
+        )
+        advanceUntilIdle()
+        sendMessage.assertions().isCalledOnce()
+        joinedRoom.baseRoom.assertNotDestroyed()
     }
 
     @Test


### PR DESCRIPTION
## Content

`MatrixClient.getRoom()` and `getJoinedRoom()` create a new room instance on every call and hand
ownership to the caller, which must close it. Five callers that only need the room for a single
operation never did: reporting or leaving a room from the report flow, rejecting an invite from a
notification, replying from a notification, resolving whether a ringing call is still active, and
declining an incoming call. Each of those leaks the underlying Rust room, the room's child coroutine
scope with its room info subscription and, for a joined room, its live timeline.

They now close the room once the operation is done, using the `use {}` form the rest of the code
base already uses, and the notification reply path uses the same `needsDestroy` handling as the
mark-as-read handler next to it, so a room borrowed from `ActiveRoomsHolder` is left alone and only a
room this path created is destroyed.

The duplicated room creation on room entry that the issue's logcat shows is a separate lifecycle
question and is not addressed here. The two `ActiveCallManager` sites whose room deliberately
outlives the call are also untouched.

## Motivation and context

Part of #4566.

## Tests

`features/reportroom/impl/.../DefaultReportRoomTest.kt`: every case now asserts the room was
destroyed, including the report-failure and leave-failure cases where the early return used to skip
it.

`libraries/push/impl/.../NotificationBroadcastReceiverHandlerTest.kt`: rejecting an invite and
replying from a notification destroy the room they created; a new case proves that a reply routed
through an active room from `ActiveRoomsHolder` does not destroy it.

`libraries/push/impl/.../DefaultCallNotificationEventResolverTest.kt`: both ringing-call cases assert
the room fetched to read the room info is destroyed.

Run with `./gradlew :features:reportroom:impl:testDebugUnitTest :libraries:push:impl:testDebugUnitTest`.

`ActiveCallManager`'s decline path has no assertion of its own — its fake room is not reachable from
the existing test, so that one site is covered by review rather than by a test.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
