### PR TITLE
Actually cancel a media upload when the send is cancelled

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -112,6 +112,7 @@ class AttachmentsPreviewPresenter(
         )
 
         val ongoingSendAttachmentJob = remember { mutableStateOf<Job?>(null) }
+        val ongoingUploadJob = remember { mutableStateOf<Job?>(null) }
 
         var currentIndex by remember { mutableIntStateOf(0) }
 
@@ -264,7 +265,7 @@ class AttachmentsPreviewPresenter(
                         editedTempFiles = emptyMap()
 
                         // Send the media using the session coroutine scope so it doesn't matter if this screen or the chat one are closed
-                        sessionCoroutineScope.launch(dispatchers.io) {
+                        ongoingUploadJob.value = sessionCoroutineScope.launch(dispatchers.io) {
                             sendMedia(
                                 mediaUploadInfos = allMediaUploadInfos,
                                 caption = caption,
@@ -298,10 +299,16 @@ class AttachmentsPreviewPresenter(
                     )
                 }
                 AttachmentsPreviewEvent.CancelAndClearSendState -> {
-                    // Cancel media sending
+                    // Cancel media sending. The upload is aborted first: cancelling the coroutine that awaits it
+                    // would only detach from it and leave the upload running.
+                    mediaSender.cancelOngoingUploads()
                     ongoingSendAttachmentJob.value?.let {
                         it.cancel()
                         ongoingSendAttachmentJob.value = null
+                    }
+                    ongoingUploadJob.value?.let {
+                        it.cancel()
+                        ongoingUploadJob.value = null
                     }
 
                     val mediaUploadInfoList = sendActionState.value.mediaUploadInfoList()

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -75,7 +75,9 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -437,16 +439,17 @@ class AttachmentsPreviewPresenterTest : RobolectricTest() {
 
     @Test
     fun `present - dismissing the progress dialog stops media upload`() = runTest {
-        val onDoneListenerResult = lambdaRecorder<Unit> {}
+        val uploadHandler = FakeMediaUploadHandler()
         val presenter = createAttachmentsPreviewPresenter(
             room = FakeJoinedRoom(
                 liveTimeline = FakeTimeline().apply {
                     sendFileLambda = { _, _, _, _, _ ->
-                        Result.success(FakeMediaUploadHandler())
+                        Result.success(uploadHandler)
                     }
                 }
             ),
-            onDoneListener = onDoneListenerResult,
+            // The upload must never complete, so the done listener must never be called
+            onDoneListener = OnDoneListener { lambdaError() },
         )
         presenter.test {
             skipItems(1)
@@ -456,8 +459,14 @@ class AttachmentsPreviewPresenterTest : RobolectricTest() {
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Sending.Processing(displayProgress = false))
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Sending.ReadyToUpload(listOf(mediaUploadInfo)))
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Sending.Uploading(listOf(mediaUploadInfo)))
+            // Let the upload start before cancelling it: FakeTimeline.sendFile only returns the handler after a delay
+            advanceTimeBy(1)
+            runCurrent()
             initialState.eventSink(AttachmentsPreviewEvent.CancelAndClearSendState)
             assertThat(awaitItem().sendActionState).isEqualTo(SendActionState.Sending.ReadyToUpload(listOf(mediaUploadInfo)))
+            // The upload itself is aborted, not only the coroutine awaiting it
+            uploadHandler.assertCancelled()
+            advanceUntilIdle()
             // The sending is cancelled and the state is kept at ReadyToUpload
             ensureAllEventsConsumed()
         }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/media/FakeMediaUploadHandler.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/media/FakeMediaUploadHandler.kt
@@ -17,7 +17,14 @@ class FakeMediaUploadHandler(
 ) : MediaUploadHandler {
     override suspend fun await(): Result<Unit> = simulateLongTask { result }
 
+    private var isCancelled = false
+
     override fun cancel() {
+        isCancelled = true
         result = Result.failure(CancellationException())
+    }
+
+    fun assertCancelled() {
+        check(isCancelled) { "Upload should be cancelled" }
     }
 }

--- a/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
+++ b/libraries/mediaupload/api/src/main/kotlin/io/element/android/libraries/mediaupload/api/MediaSender.kt
@@ -125,6 +125,14 @@ interface MediaSender {
         inReplyToEventId: EventId?,
     ): Result<Unit>
 
+    /**
+     * Aborts the uploads started by this sender that are still in flight.
+     *
+     * Only cancelling the coroutine that awaits an upload leaves it running, so that closing a screen does not abort a send in progress.
+     * This is the explicit counterpart, for when the user asks for the send to stop.
+     */
+    fun cancelOngoingUploads()
+
     /** Deletes the temporary files produced by pre-processing; must be called even when nothing was ultimately sent. */
     fun cleanUp()
 }

--- a/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/DefaultMediaSender.kt
+++ b/libraries/mediaupload/impl/src/main/kotlin/io/element/android/libraries/mediaupload/impl/DefaultMediaSender.kt
@@ -278,6 +278,12 @@ class DefaultMediaSender(
         }
     }
 
+    override fun cancelOngoingUploads() {
+        Timber.d("Cancelling ${ongoingUploadJobs.size} ongoing upload(s)")
+        ongoingUploadJobs.values.forEach { it.cancel() }
+        ongoingUploadJobs.clear()
+    }
+
     /**
      * Clean up any temporary files or resources used during the media processing.
      */

--- a/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaSender.kt
+++ b/libraries/mediaupload/test/src/main/kotlin/io/element/android/libraries/mediaupload/test/FakeMediaSender.kt
@@ -21,6 +21,7 @@ class FakeMediaSender(
     private val sendVoiceMessageResult: () -> Result<Unit> = { lambdaError() },
     private val sendGalleryResult: () -> Result<Unit> = { lambdaError() },
     private val cleanUpResult: () -> Unit = { lambdaError() },
+    private val cancelOngoingUploadsResult: () -> Unit = { lambdaError() },
 ) : MediaSender {
     override suspend fun preProcessMedia(
         uri: Uri,
@@ -66,6 +67,10 @@ class FakeMediaSender(
         inReplyToEventId: EventId?,
     ): Result<Unit> {
         return sendGalleryResult()
+    }
+
+    override fun cancelOngoingUploads() {
+        cancelOngoingUploadsResult()
     }
 
     override fun cleanUp() {


### PR DESCRIPTION
## Content

The attachment preview screen sends media from the session coroutine scope on purpose, so that
leaving the screen does not abort a send that is already running. The Cancel button on the sending
dialog only cancelled the job that waits for the pre-processing to finish, which is not the job doing
the upload, so the upload carried on: it still marked the send as done and closed the screen, and
pressing Send again started a second upload of the same media.

Cancel now stops the upload itself. `MediaSender` gains an explicit `cancelOngoingUploads()` that
aborts the upload handlers it is holding, and the preview presenter calls it before cancelling the
two jobs. Cancelling a coroutine that merely awaits an upload still leaves that upload running, which
is what keeps a send alive when a screen is closed.

## Motivation and context

Part of #4883.

## Tests

`features/messages/impl/.../AttachmentsPreviewPresenterTest.kt`: the existing
`dismissing the progress dialog stops media upload` test asserted nothing about the upload — it never
advanced past the fake upload, so it passed while the upload completed afterwards. It now advances
the scheduler, asserts the upload handler was cancelled, and fails if the send ever reaches Done.

Run with `./gradlew :features:messages:impl:testDebugUnitTest --tests '*AttachmentsPreviewPresenterTest*'`.

The test covers the app side of the cancellation; what the homeserver does with a partially uploaded
file is not covered.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
