### PR TITLE
Find rooms by their alias when searching the room list

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchDataSource.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchDataSource.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.AssistedInject
 import io.element.android.features.home.impl.datasource.RoomListRoomSummaryFactory
 import io.element.android.features.home.impl.model.RoomListRoomSummary
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.roomlist.RoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
@@ -31,7 +32,7 @@ private const val PAGE_SIZE = 30
 @AssistedInject
 class RoomListSearchDataSource(
     @Assisted coroutineScope: CoroutineScope,
-    roomListService: RoomListService,
+    private val roomListService: RoomListService,
     coroutineDispatchers: CoroutineDispatchers,
     private val roomSummaryFactory: RoomListRoomSummaryFactory,
 ) {
@@ -64,8 +65,26 @@ class RoomListSearchDataSource(
         val filter = if (searchQuery.isBlank()) {
             RoomListFilter.None
         } else {
-            RoomListFilter.NormalizedMatchRoomName(searchQuery)
+            val roomIdsMatchingAlias = roomIdsMatchingAlias(searchQuery)
+            if (roomIdsMatchingAlias.isEmpty()) {
+                RoomListFilter.NormalizedMatchRoomName(searchQuery)
+            } else {
+                RoomListFilter.any(
+                    RoomListFilter.NormalizedMatchRoomName(searchQuery),
+                    RoomListFilter.Identifiers(roomIdsMatchingAlias),
+                )
+            }
         }
         roomList.updateFilter(filter)
+    }
+
+    private fun roomIdsMatchingAlias(searchQuery: String): List<RoomId> {
+        return roomListService.allRooms.summaries.replayCache
+            .lastOrNull()
+            .orEmpty()
+            .filter { summary ->
+                summary.info.aliases.any { alias -> alias.value.contains(searchQuery, ignoreCase = true) }
+            }
+            .map { summary -> summary.roomId }
     }
 }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/search/RoomListSearchPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/search/RoomListSearchPresenterTest.kt
@@ -12,6 +12,8 @@ import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.impl.datasource.aRoomListRoomSummaryFactory
 import io.element.android.libraries.dateformatter.test.FakeDateFormatter
 import io.element.android.libraries.eventformatter.test.FakeRoomLatestEventFormatter
+import io.element.android.libraries.matrix.api.core.RoomAlias
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.test.room.aRoomSummary
@@ -22,6 +24,7 @@ import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.test
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -88,6 +91,36 @@ class RoomListSearchPresenterTest {
                     roomList.currentFilter.value
                 ).isEqualTo(
                     RoomListFilter.None
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `present - query matching a room alias also filters on that room id`() = runTest {
+        val roomWithAlias = aRoomSummary(
+            roomId = RoomId("!aliased:domain"),
+            name = "A room",
+            canonicalAlias = RoomAlias("#element-x-android:matrix.org"),
+        )
+        val roomList = FakeDynamicRoomList()
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { roomList },
+            allRooms = FakeDynamicRoomList(summaries = MutableStateFlow(listOf(roomWithAlias))),
+        )
+        val presenter = createRoomListSearchPresenter(roomListService)
+        presenter.test {
+            awaitItem().let { state ->
+                state.query.edit { append("element-x") }
+            }
+            awaitItem().let {
+                assertThat(
+                    roomList.currentFilter.value
+                ).isEqualTo(
+                    RoomListFilter.any(
+                        RoomListFilter.NormalizedMatchRoomName("element-x"),
+                        RoomListFilter.Identifiers(listOf(roomWithAlias.roomId)),
+                    )
                 )
             }
         }


### PR DESCRIPTION
## Content

Searching the room list only ever asked the SDK to match the room display name, so a room could not
be found by the alias it is published under, even though the alias is right there in the room info
the app already holds.

The search filter now also carries the ids of the rooms whose canonical or alternative alias contains
the query, combined with the name filter using the `Any` filter the SDK already supports, so a room
matches on either its name or one of its aliases. Nothing is added to the API and no extra work
happens per keystroke beyond a string scan over the summaries the home screen already keeps.

Only the room list search is changed. The room picker used by share and forward has the same gap and
is left alone here.

## Motivation and context

Part of #3808.

## Tests

`features/home/impl/.../search/RoomListSearchPresenterTest.kt`: a query that matches a room's
canonical alias but not its name produces a filter that also carries that room's id; the existing
name-only case is unchanged.

Run with `./gradlew :features:home:impl:testDebugUnitTest`.

The test pins the filter the presenter builds, not the SDK's own matching of it.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
