### PR TITLE
Announce the clear filters control as a button

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersView.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersView.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -148,7 +149,10 @@ private fun RoomListClearFiltersButton(
         modifier = modifier
             .clip(CircleShape)
             .background(ElementTheme.colors.bgActionPrimaryRest)
-            .clickable(onClick = onClick)
+            .clickable(
+                onClick = onClick,
+                role = Role.Button,
+            )
             .padding(4.dp)
     ) {
         Icon(

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersViewTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersViewTest.kt
@@ -11,7 +11,12 @@
 package io.element.android.features.home.impl.filters
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import io.element.android.features.home.impl.R
 import io.element.android.features.home.impl.filters.selection.FilterSelectionState
@@ -56,5 +61,20 @@ class RoomListFiltersViewTest : RobolectricTest() {
                 RoomListFiltersEvent.ClearSelectedFilters,
             )
         )
+    }
+
+    @Test
+    fun `clear filters is exposed as a button`() = runAndroidComposeUiTest<ComponentActivity> {
+        val eventsRecorder = EventsRecorder<RoomListFiltersEvent>(expectEvents = false)
+        setContent {
+            RoomListFiltersView(
+                state = aRoomListFiltersState(
+                    filterSelectionStates = RoomListFilter.entries.map { FilterSelectionState(it, isSelected = true) },
+                    eventSink = eventsRecorder
+                ),
+            )
+        }
+        onNodeWithTag(TestTags.homeScreenClearFilters.value)
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
     }
 }


### PR DESCRIPTION
## Content

The control that clears the selected room list filters is a clickable `Box`, so it carries no role in
its semantics: TalkBack announces it as plain text rather than as a button, and switch access and
voice control have nothing telling them it is actionable. The filter chips next to it are Material
`FilterChip`s and already carry their own semantics, which is why only this one control is affected.

It now declares `Role.Button` on its click handler, the same way the login, composer and read receipt
controls were fixed before. Nothing else changes: the layout and the goldens are untouched, because
enlarging the touch target here grows the whole filter row and pushes a chip off screen.

## Motivation and context

Relates to #6402. That issue also asks for a way to reach off-screen chips, which is a design
question the maintainers have not settled; this only closes the missing-role part of the same row.

## Tests

`features/home/impl/.../filters/RoomListFiltersViewTest.kt`: the clear filters node exposes
`Role.Button`.

Run with `./gradlew :features:home:impl:testDebugUnitTest --tests '*RoomListFiltersViewTest*'`.

The test asserts the semantics; it does not exercise a real screen reader.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
