### PR TITLE
Let an invite that is no longer valid be declined

### DIFF
--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DeclineInvite.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/DeclineInvite.kt
@@ -13,6 +13,8 @@ import io.element.android.features.invite.api.SeenInvitesStore
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
+import io.element.android.libraries.matrix.api.exception.ClientException
+import io.element.android.libraries.matrix.api.exception.ErrorKind
 import io.element.android.libraries.push.api.notifications.NotificationCleaner
 
 interface DeclineInvite {
@@ -26,6 +28,7 @@ interface DeclineInvite {
     sealed class Exception : kotlin.Exception() {
         data object RoomNotFound : Exception()
         data object DeclineInviteFailed : Exception()
+        data object InvalidInvite : Exception()
         data object ReportRoomFailed : Exception()
         data object BlockUserFailed : Exception()
     }
@@ -46,7 +49,16 @@ class DefaultDeclineInvite(
         val room = client.getRoom(roomId) ?: return Result.failure(DeclineInvite.Exception.RoomNotFound)
         room.use {
             room.leave()
-                .onFailure { return Result.failure(DeclineInvite.Exception.DeclineInviteFailed) }
+                .recoverCatching { error ->
+                    if (error.isInvalidInvite()) {
+                        room.forget().getOrElse { throw DeclineInvite.Exception.InvalidInvite }
+                    } else {
+                        throw error
+                    }
+                }
+                .onFailure { error ->
+                    return Result.failure(error as? DeclineInvite.Exception ?: DeclineInvite.Exception.DeclineInviteFailed)
+                }
                 .onSuccess {
                     notificationCleaner.clearMembershipNotificationForRoom(
                         sessionId = client.sessionId,
@@ -71,4 +83,8 @@ class DefaultDeclineInvite(
         }
         return Result.success(roomId)
     }
+}
+
+private fun Throwable.isInvalidInvite(): Boolean {
+    return this is ClientException.MatrixApi && kind == ErrorKind.Unknown
 }

--- a/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/acceptdecline/AcceptDeclineInviteView.kt
+++ b/features/invite/impl/src/main/kotlin/io/element/android/features/invite/impl/acceptdecline/AcceptDeclineInviteView.kt
@@ -18,6 +18,7 @@ import io.element.android.features.invite.api.acceptdecline.AcceptDeclineInviteE
 import io.element.android.features.invite.api.acceptdecline.AcceptDeclineInviteState
 import io.element.android.features.invite.api.acceptdecline.ConfirmingDeclineInvite
 import io.element.android.features.invite.impl.AcceptInvite
+import io.element.android.features.invite.impl.DeclineInvite
 import io.element.android.features.invite.impl.R
 import io.element.android.libraries.designsystem.components.async.AsyncActionView
 import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
@@ -66,8 +67,12 @@ fun AcceptDeclineInviteView(
             errorTitle = {
                 stringResource(CommonStrings.common_something_went_wrong)
             },
-            errorMessage = {
-                stringResource(CommonStrings.error_network_or_server_issue)
+            errorMessage = { error ->
+                if (error is DeclineInvite.Exception.InvalidInvite) {
+                    stringResource(CommonStrings.error_invalid_invite)
+                } else {
+                    stringResource(CommonStrings.error_network_or_server_issue)
+                }
             },
             confirmationDialog = { confirming ->
                 // Note: confirming will always be of type ConfirmingDeclineInvite.

--- a/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/DefaultDeclineInviteTest.kt
+++ b/features/invite/impl/src/test/kotlin/io/element/android/features/invite/impl/DefaultDeclineInviteTest.kt
@@ -13,6 +13,8 @@ import io.element.android.features.invite.test.InMemorySeenInvitesStore
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.exception.ClientException
+import io.element.android.libraries.matrix.api.exception.ErrorKind
 import io.element.android.libraries.matrix.test.A_ROOM_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
@@ -41,12 +43,66 @@ class DefaultDeclineInviteTest {
     private val successReportRoomLambda =
         lambdaRecorder<String?, Result<Unit>> { _ -> Result.success(Unit) }
 
+    private val invalidInviteLeaveRoomLambda = lambdaRecorder<Result<Unit>> {
+        Result.failure(ClientException.MatrixApi(ErrorKind.Unknown, "M_UNKNOWN", "Unknown", null))
+    }
+
     private val failureLeaveRoomLambda =
         lambdaRecorder<Result<Unit>> { Result.failure(Exception("Leave room error")) }
     private val failureIgnoreUserLambda =
         lambdaRecorder<UserId, Result<Unit>> { _ -> Result.failure(Exception("Ignore user error")) }
     private val failureReportRoomLambda =
         lambdaRecorder<String?, Result<Unit>> { _ -> Result.failure(Exception("Report room error")) }
+
+    @Test
+    fun `decline invite, the invite is no longer valid, the room is forgotten`() = runTest {
+        val forgetRoomLambda = lambdaRecorder<Result<Unit>> { Result.success(Unit) }
+        val room = FakeBaseRoom(
+            roomId = roomId,
+            leaveRoomLambda = invalidInviteLeaveRoomLambda,
+            forgetResult = forgetRoomLambda,
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(roomId, room)
+        }
+
+        val declineInvite = DefaultDeclineInvite(
+            client = client,
+            notificationCleaner = notificationCleaner,
+            seenInvitesStore = seenInvitesStore
+        )
+
+        val result = declineInvite(roomId, blockUser = false, reportRoom = false, reportReason = null)
+
+        assertThat(result.isSuccess).isTrue()
+        assert(forgetRoomLambda).isCalledOnce()
+        assert(clearMembershipNotificationForRoomLambda)
+            .isCalledOnce()
+            .with(value(client.sessionId), value(roomId))
+        assertThat(seenInvitesStore.seenRoomIds().first()).isEmpty()
+    }
+
+    @Test
+    fun `decline invite, the invite is no longer valid and cannot be forgotten`() = runTest {
+        val room = FakeBaseRoom(
+            roomId = roomId,
+            leaveRoomLambda = invalidInviteLeaveRoomLambda,
+            forgetResult = { Result.failure(Exception("Forget room error")) },
+        )
+        val client = FakeMatrixClient().apply {
+            givenGetRoomResult(roomId, room)
+        }
+
+        val declineInvite = DefaultDeclineInvite(
+            client = client,
+            notificationCleaner = notificationCleaner,
+            seenInvitesStore = seenInvitesStore
+        )
+
+        val result = declineInvite(roomId, blockUser = false, reportRoom = false, reportReason = null)
+
+        assertThat(result.exceptionOrNull()).isEqualTo(DeclineInvite.Exception.InvalidInvite)
+    }
 
     @Test
     fun `decline invite, block=false, report=false, all success`() = runTest {


### PR DESCRIPTION
## Content

An invite that the server no longer considers valid cannot be left, and declining it collapsed every
`leave()` failure into the same generic "network or server issue" error. The invite therefore stayed
in the list with no way to get rid of it: accepting already reports it as an invalid invite, but
declining kept failing.

Declining now recognises the same error the accept path already maps to an invalid invite, and
forgets the room instead, which is what removes it. The rest of the decline flow is unchanged, so
the notification is cleared and the invite is unmarked as seen exactly as for a normal decline. If
forgetting fails too, the user is told the invite is no longer valid rather than that the network is
at fault.

## Motivation and context

Part of #3654.

## Tests

`features/invite/impl/.../DefaultDeclineInviteTest.kt`: declining an invite the server rejects as
unknown forgets the room and completes the usual cleanup; when forgetting also fails the caller gets
the invalid invite error. The existing decline cases are unchanged.

Run with `./gradlew :features:invite:impl:testDebugUnitTest`.

The error kind used as the gate is the one the accept path already treats as an invalid invite; the
tests pin the mapping, not the server behaviour that produces it.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
