### PR TITLE
Keep the inline formatting in the room list preview

### DIFF
--- a/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
+++ b/libraries/eventformatter/impl/src/main/kotlin/io/element/android/libraries/eventformatter/impl/DefaultRoomLatestEventFormatter.kt
@@ -45,6 +45,7 @@ import io.element.android.libraries.matrix.api.timeline.item.event.UnknownConten
 import io.element.android.libraries.matrix.api.timeline.item.event.VideoMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.VoiceMessageType
 import io.element.android.libraries.matrix.api.timeline.item.event.getDisambiguatedDisplayName
+import io.element.android.libraries.matrix.ui.messages.toAnnotatedText
 import io.element.android.libraries.matrix.ui.messages.toPlainText
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.services.toolbox.api.strings.StringProvider
@@ -138,7 +139,7 @@ class DefaultRoomLatestEventFormatter(
                 return "* ${senderDisambiguatedDisplayName.bidiIsolate()} ${messageType.body}"
             }
             is TextMessageType -> {
-                messageType.toPlainText(permalinkParser)
+                messageType.toAnnotatedText(permalinkParser)
             }
             is VideoMessageType -> {
                 messageType.toPlainText(permalinkParser).prefixWith(sp.getString(CommonStrings.common_video))

--- a/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
+++ b/libraries/matrixui/src/main/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainText.kt
@@ -8,6 +8,12 @@
 
 package io.element.android.libraries.matrix.ui.messages
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.timeline.item.event.FormattedBody
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
@@ -57,28 +63,51 @@ fun FormattedBody.toPlainText(
 }
 
 /**
+ * Converts the HTML string in [TextMessageType.formatted] to a text representation keeping the inline formatting, such as bold or strikethrough.
+ * If the message is not formatted or the format is not [MessageFormat.HTML], the [TextMessageType.body] is returned instead.
+ */
+fun TextMessageType.toAnnotatedText(
+    permalinkParser: PermalinkParser,
+): CharSequence = formatted?.toHtmlDocument(permalinkParser = permalinkParser)?.toAnnotatedText() ?: body
+
+/**
  * Converts the HTML [Document] to a plain text representation by parsing it and removing all formatting.
  */
-fun Document.toPlainText(): String {
-    val visitor = PlainTextNodeVisitor()
+fun Document.toPlainText(): String = toAnnotatedText().text
+
+/**
+ * Converts the HTML [Document] to a text representation which keeps the inline formatting as spans.
+ */
+fun Document.toAnnotatedText(): AnnotatedString {
+    val visitor = AnnotatedTextNodeVisitor()
     traverse(visitor)
     return visitor.build()
 }
 
 private const val FALLBACK_REPLY_NODE_TAG = "mx-reply"
 
-private class PlainTextNodeVisitor : NodeVisitor {
-    private val builder = StringBuilder()
+private fun Element.spanStyle(): SpanStyle? = when (tagName().lowercase()) {
+    "del", "s", "strike" -> SpanStyle(textDecoration = TextDecoration.LineThrough)
+    "u" -> SpanStyle(textDecoration = TextDecoration.Underline)
+    "b", "strong" -> SpanStyle(fontWeight = FontWeight.Bold)
+    "i", "em" -> SpanStyle(fontStyle = FontStyle.Italic)
+    "code" -> SpanStyle(fontFamily = FontFamily.Monospace)
+    else -> null
+}
+
+private class AnnotatedTextNodeVisitor : NodeVisitor {
+    private val builder = AnnotatedString.Builder()
+    private var lastChar: Char? = null
 
     override fun head(node: Node, depth: Int) {
         if (node is TextNode) {
             // If the text node is blank, only add a single whitespace char if there wasn't already one
             if (node.text().isBlank()) {
-                if (builder.lastOrNull()?.isWhitespace() == false) {
-                    builder.append(" ")
+                if (lastChar?.isWhitespace() == false) {
+                    append(" ")
                 }
             } else {
-                builder.append(node.text())
+                append(node.text())
             }
         } else if (node is Element && node.tagName() == "li") {
             val index = node.elementSiblingIndex() + 1
@@ -90,27 +119,41 @@ private class PlainTextNodeVisitor : NodeVisitor {
                 } else {
                     index
                 }
-                builder.append("$actualIndex. ")
+                append("$actualIndex. ")
             } else {
-                builder.append("• ")
+                append("• ")
             }
         } else if (node is Element && node.tagName() == FALLBACK_REPLY_NODE_TAG) {
             // Remove the fallback reply node and its contents so they aren't added to the plain text message
             node.remove()
-        } else if (node is Element && node.isBlock && builder.lastOrNull() != '\n') {
-            builder.append("\n")
+        } else if (node is Element && node.isBlock && lastChar != '\n') {
+            append("\n")
         }
+        (node as? Element)?.spanStyle()?.let { builder.pushStyle(it) }
     }
 
     override fun tail(node: Node, depth: Int) {
         fun nodeIsBlockButNotLastOne(node: Node) = node is Element && node.isBlock && node.lastElementSibling() !== node
         fun nodeIsLineBreak(node: Node) = node.nodeName().lowercase() == "br"
+        if ((node as? Element)?.spanStyle() != null) {
+            builder.pop()
+        }
         if (nodeIsBlockButNotLastOne(node) || nodeIsLineBreak(node)) {
-            builder.append("\n")
+            append("\n")
         }
     }
 
-    fun build(): String {
-        return builder.toString().trim()
+    private fun append(text: String) {
+        if (text.isEmpty()) return
+        builder.append(text)
+        lastChar = text.last()
+    }
+
+    fun build(): AnnotatedString {
+        val annotatedString = builder.toAnnotatedString()
+        val start = annotatedString.text.indexOfFirst { !it.isWhitespace() }
+        if (start == -1) return AnnotatedString("")
+        val end = annotatedString.text.indexOfLast { !it.isWhitespace() } + 1
+        return annotatedString.subSequence(start, end)
     }
 }

--- a/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
+++ b/libraries/matrixui/src/test/kotlin/io/element/android/libraries/matrix/ui/messages/ToPlainTextTest.kt
@@ -8,6 +8,9 @@
 
 package io.element.android.libraries.matrix.ui.messages
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.matrix.api.timeline.item.event.FormattedBody
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageFormat
@@ -148,5 +151,35 @@ class ToPlainTextTest : RobolectricTest() {
             )
         )
         assertThat(messageType.toPlainText(permalinkParser = FakePermalinkParser())).isEqualTo("This is the message content.")
+    }
+
+    @Test
+    fun `TextMessageType toAnnotatedText - keeps the inline formatting`() {
+        val messageType = TextMessageType(
+            body = "Hello striked bold world",
+            formatted = FormattedBody(
+                format = MessageFormat.HTML,
+                body = "Hello <del>striked</del> <strong>bold</strong> world",
+            )
+        )
+
+        val result = messageType.toAnnotatedText(permalinkParser = FakePermalinkParser()) as AnnotatedString
+
+        // The text itself is the same as the plain text version
+        assertThat(result.text).isEqualTo(messageType.toPlainText(permalinkParser = FakePermalinkParser()))
+        val struckThrough = result.spanStyles.single { it.item.textDecoration == TextDecoration.LineThrough }
+        assertThat(result.text.substring(struckThrough.start, struckThrough.end)).isEqualTo("striked")
+        val bold = result.spanStyles.single { it.item.fontWeight == FontWeight.Bold }
+        assertThat(result.text.substring(bold.start, bold.end)).isEqualTo("bold")
+    }
+
+    @Test
+    fun `TextMessageType toAnnotatedText - returns the body when there is no formatted body`() {
+        val messageType = TextMessageType(
+            body = "Hello world",
+            formatted = null,
+        )
+
+        assertThat(messageType.toAnnotatedText(permalinkParser = FakePermalinkParser())).isEqualTo("Hello world")
     }
 }


### PR DESCRIPTION
## Content

The room list preview is built by stripping the formatted body down to plain text, so a message that
was sent struck through, bold or italic is previewed without any of it — the reporter's screenshots
show a struck-through message previewed as ordinary text. The room list row already renders an
`AnnotatedString` when the formatter provides one, it just never got one.

The visitor that walks the sanitised HTML now builds an `AnnotatedString` and carries the inline tags
the sanitiser keeps — `del`, `u`, `b`/`strong`, `i`/`em` and `code` — as spans, and the room list
formatter uses it for text messages. `toPlainText()` is now that same text without the spans, so the
text itself, including its line breaks, is byte for byte what it was; nothing but the styling
changes, and every other consumer (notifications, the pinned messages banner, captions) is untouched.

This is the second half of what jmartinesp suggested on the issue: strip the HTML first, then allow
simple formatting tags.

## Motivation and context

Part of #1171.

## Tests

`libraries/matrixui/.../ToPlainTextTest.kt`: a message mixing struck-through and bold text produces
spans covering exactly those words, and the same text as the plain text version; a message with no
formatted body is returned unchanged.

`libraries/eventformatter/impl` and `features/home/impl` suites still pass unchanged, which is what
proves the preview text itself did not move.

Run with `./gradlew :libraries:matrixui:testDebugUnitTest :libraries:eventformatter:impl:testDebugUnitTest`.

The tests pin the spans the formatter produces, not how the room list row draws them.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
