### PR TITLE
Remember that the set up recovery banner was dismissed

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/roomlist/RoomListPresenter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/roomlist/RoomListPresenter.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import dev.zacsweers.metro.Inject
@@ -54,6 +53,7 @@ import io.element.android.libraries.matrix.api.encryption.RecoveryState
 import io.element.android.libraries.matrix.api.roomlist.RoomList
 import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.ui.safety.rememberHideInvitesAvatar
+import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
 import io.element.android.libraries.push.api.battery.BatteryOptimizationState
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.api.watchers.AnalyticsColdStartWatcher
@@ -64,6 +64,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -88,6 +89,7 @@ class RoomListPresenter(
     private val spaceFiltersPresenter: Presenter<SpaceFiltersState>,
     private val globalSearchPresenter: Presenter<GlobalSearchState>,
     private val featureFlagService: FeatureFlagService,
+    private val sessionPreferencesStore: SessionPreferencesStore,
 ) : Presenter<RoomListState> {
     private val encryptionService = client.encryptionService
 
@@ -105,7 +107,12 @@ class RoomListPresenter(
             roomListDataSource.launchIn(this)
         }
 
-        var securityBannerDismissed by rememberSaveable { mutableStateOf(false) }
+        val securityBannerDismissed by sessionPreferencesStore.isRecoveryBannerDismissed().collectAsState(initial = false)
+        LaunchedEffect(Unit) {
+            encryptionService.recoveryStateStateFlow
+                .filter { it == RecoveryState.ENABLED }
+                .collect { sessionPreferencesStore.setRecoveryBannerDismissed(false) }
+        }
         val showNewNotificationSoundBanner by remember {
             announcementService.announcementsToShowFlow().map { announcements ->
                 announcements.contains(Announcement.NewNotificationSound)
@@ -123,8 +130,10 @@ class RoomListPresenter(
                 is RoomListEvent.UpdateVisibleRange -> coroutineScope.launch {
                     roomListDataSource.updateVisibleRange(event.range)
                 }
-                RoomListEvent.DismissRequestVerificationPrompt -> securityBannerDismissed = true
-                RoomListEvent.DismissBanner -> securityBannerDismissed = true
+                RoomListEvent.DismissRequestVerificationPrompt,
+                RoomListEvent.DismissBanner -> coroutineScope.launch {
+                    sessionPreferencesStore.setRecoveryBannerDismissed(true)
+                }
                 RoomListEvent.DismissNewNotificationSoundBanner -> coroutineScope.launch {
                     announcementService.onAnnouncementDismissed(Announcement.NewNotificationSound)
                 }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/roomlist/RoomListPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/roomlist/RoomListPresenterTest.kt
@@ -210,6 +210,68 @@ class RoomListPresenterTest {
     }
 
     @Test
+    fun `present - the recovery banner stays dismissed when the presenter is recreated`() = runTest {
+        val sessionPreferencesStore = InMemorySessionPreferencesStore()
+        val encryptionService = FakeEncryptionService().apply {
+            recoveryStateStateFlow.emit(RecoveryState.DISABLED)
+        }
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { FakeDynamicRoomList(loadingState = MutableStateFlow(RoomList.LoadingState.Loaded(1))) }
+        )
+        val client = FakeMatrixClient(
+            roomListService = roomListService,
+            encryptionService = encryptionService,
+            syncService = FakeSyncService(initialSyncState = SyncState.Running),
+        )
+        createRoomListPresenter(client = client, sessionPreferencesStore = sessionPreferencesStore).test {
+            val initialState = consumeItemsUntilPredicate {
+                it.contentState is RoomListContentState.Rooms && it.contentAsRooms().securityBannerState == SecurityBannerState.SetUpRecovery
+            }.last()
+            initialState.eventSink(RoomListEvent.DismissBanner)
+            consumeItemsUntilPredicate {
+                it.contentAsRooms().securityBannerState == SecurityBannerState.None
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+        // A new presenter, as after a cold start, must not show the banner again
+        createRoomListPresenter(client = client, sessionPreferencesStore = sessionPreferencesStore).test {
+            val state = consumeItemsUntilPredicate {
+                it.contentState is RoomListContentState.Rooms
+            }.last()
+            assertThat(state.contentAsRooms().securityBannerState).isEqualTo(SecurityBannerState.None)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - setting up recovery makes a dismissed banner relevant again`() = runTest {
+        val sessionPreferencesStore = InMemorySessionPreferencesStore(isRecoveryBannerDismissed = true)
+        val encryptionService = FakeEncryptionService().apply {
+            recoveryStateStateFlow.emit(RecoveryState.DISABLED)
+        }
+        val roomListService = FakeRoomListService(
+            createRoomListLambda = { FakeDynamicRoomList(loadingState = MutableStateFlow(RoomList.LoadingState.Loaded(1))) }
+        )
+        val client = FakeMatrixClient(
+            roomListService = roomListService,
+            encryptionService = encryptionService,
+            syncService = FakeSyncService(initialSyncState = SyncState.Running),
+        )
+        createRoomListPresenter(client = client, sessionPreferencesStore = sessionPreferencesStore).test {
+            val initialState = consumeItemsUntilPredicate {
+                it.contentState is RoomListContentState.Rooms
+            }.last()
+            assertThat(initialState.contentAsRooms().securityBannerState).isEqualTo(SecurityBannerState.None)
+            encryptionService.emitRecoveryState(RecoveryState.ENABLED)
+            encryptionService.emitRecoveryState(RecoveryState.DISABLED)
+            consumeItemsUntilPredicate {
+                it.contentAsRooms().securityBannerState == SecurityBannerState.SetUpRecovery
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `present - show context menu`() = runTest {
         val room = FakeBaseRoom()
         val client = FakeMatrixClient().apply {
@@ -697,5 +759,6 @@ class RoomListPresenterTest {
         announcementService = announcementService,
         coldStartWatcher = FakeAnalyticsColdStartWatcher(),
         featureFlagService = featureFlagService,
+        sessionPreferencesStore = sessionPreferencesStore,
     )
 }

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/SessionPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/SessionPreferencesStore.kt
@@ -66,6 +66,14 @@ interface SessionPreferencesStore {
     fun isSessionVerificationSkipped(): Flow<Boolean>
 
     /**
+     * @param dismissed true to remember that the user dismissed the banner recommending to set up recovery.
+     */
+    suspend fun setRecoveryBannerDismissed(dismissed: Boolean)
+
+    /** Whether the user dismissed the banner recommending to set up recovery; defaults to `false`. */
+    fun isRecoveryBannerDismissed(): Flow<Boolean>
+
+    /**
      * @param compress true to downscale images before uploading them.
      */
     suspend fun setOptimizeImages(compress: Boolean)

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
@@ -45,6 +45,7 @@ class DefaultSessionPreferencesStore(
     private val sendTypingNotificationsKey = booleanPreferencesKey("sendTypingNotifications")
     private val renderTypingNotificationsKey = booleanPreferencesKey("renderTypingNotifications")
     private val skipSessionVerification = booleanPreferencesKey("skipSessionVerification")
+    private val recoveryBannerDismissed = booleanPreferencesKey("recoveryBannerDismissed")
     private val compressImages = booleanPreferencesKey("compressMedia")
     private val compressMediaPreset = stringPreferencesKey("compressMediaPreset")
 
@@ -86,6 +87,9 @@ class DefaultSessionPreferencesStore(
 
     override suspend fun setSkipSessionVerification(skip: Boolean) = update(skipSessionVerification, skip)
     override fun isSessionVerificationSkipped(): Flow<Boolean> = get(skipSessionVerification) { false }
+
+    override suspend fun setRecoveryBannerDismissed(dismissed: Boolean) = update(recoveryBannerDismissed, dismissed)
+    override fun isRecoveryBannerDismissed(): Flow<Boolean> = get(recoveryBannerDismissed) { false }
 
     override suspend fun setOptimizeImages(compress: Boolean) = update(compressImages, compress)
     override fun doesOptimizeImages(): Flow<Boolean> = get(compressImages) { true }

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemorySessionPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemorySessionPreferencesStore.kt
@@ -20,6 +20,7 @@ class InMemorySessionPreferencesStore(
     isSendTypingNotificationsEnabled: Boolean = true,
     isRenderTypingNotificationsEnabled: Boolean = true,
     isSessionVerificationSkipped: Boolean = false,
+    isRecoveryBannerDismissed: Boolean = false,
     doesCompressMedia: Boolean = true,
     videoCompressionPreset: VideoCompressionPreset = VideoCompressionPreset.STANDARD,
 ) : SessionPreferencesStore {
@@ -29,6 +30,7 @@ class InMemorySessionPreferencesStore(
     private val isSendTypingNotificationsEnabled = MutableStateFlow(isSendTypingNotificationsEnabled)
     private val isRenderTypingNotificationsEnabled = MutableStateFlow(isRenderTypingNotificationsEnabled)
     private val isSessionVerificationSkipped = MutableStateFlow(isSessionVerificationSkipped)
+    private val isRecoveryBannerDismissed = MutableStateFlow(isRecoveryBannerDismissed)
     private val doesCompressMedia = MutableStateFlow(doesCompressMedia)
     private val videoCompressionPreset = MutableStateFlow(videoCompressionPreset)
     var clearCallCount = 0
@@ -71,6 +73,12 @@ class InMemorySessionPreferencesStore(
     override fun isSessionVerificationSkipped(): Flow<Boolean> {
         return isSessionVerificationSkipped
     }
+
+    override suspend fun setRecoveryBannerDismissed(dismissed: Boolean) {
+        isRecoveryBannerDismissed.tryEmit(dismissed)
+    }
+
+    override fun isRecoveryBannerDismissed(): Flow<Boolean> = isRecoveryBannerDismissed
 
     override suspend fun setOptimizeImages(compress: Boolean) = doesCompressMedia.emit(compress)
 


### PR DESCRIPTION
## Content

Dismissing the banner that recommends setting up recovery only held for as long as the room list
composition lived, so the banner came back on the next cold start, and there was no way to stop it
coming back short of setting up recovery. Two people on the issue describe closing it on every
launch.

The dismissal is now stored in the session preferences, next to the existing "skip session
verification" flag, so it survives a restart. It is per account, so another account on the same
device still gets the banner. If recovery is later set up, the dismissal is cleared, so a user who
turns recovery back off is told about it again rather than never seeing the banner for the rest of
that session's life.

## Motivation and context

Part of #5823.

## Tests

`features/home/impl/.../roomlist/RoomListPresenterTest.kt`: a banner dismissed by one presenter stays
dismissed for a presenter built afterwards over the same preferences, and recovery being enabled
makes a dismissed banner show again once recovery goes away.

Run with `./gradlew :features:home:impl:testDebugUnitTest --tests '*RoomListPresenterTest*'`.

The tests use the in-memory preferences store, so they pin the presenter's use of it rather than the
DataStore write itself. `:app:compileFdroidDebugKotlin` was run to check the new dependency resolves
in the real graph.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
