### PR TITLE
Rank the mention suggestions by how well they match what was typed

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessor.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessor.kt
@@ -115,13 +115,26 @@ class SuggestionsProcessor(
                 .filterUpTo(MAX_BATCH_ITEMS) { member ->
                     isJoinedMemberAndNotSelf(member) && memberMatchesQuery(member, query)
                 }
+                .sortedBy { member -> matchRank(member, query) }
                 .map(ResolvedSuggestion::Member)
 
-            if ("room".contains(query) && canSendRoomMention) {
+            if ("room".startsWith(query, ignoreCase = true) && canSendRoomMention) {
                 listOf(ResolvedSuggestion.AtRoom) + matchingMembers
             } else {
                 matchingMembers
             }
+        }
+    }
+
+    /**
+     * Members whose display name starts with the query come first, then members whose user id
+     * localpart starts with it, then the remaining matches on any other part of the name or id.
+     */
+    private fun matchRank(member: RoomMember, query: String): Int {
+        return when {
+            member.displayName?.startsWith(query, ignoreCase = true) == true -> 0
+            member.userId.extractedDisplayName.startsWith(query, ignoreCase = true) -> 1
+            else -> 2
         }
     }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessorTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/messagecomposer/suggestions/SuggestionsProcessorTest.kt
@@ -384,6 +384,48 @@ class SuggestionsProcessorTest {
     }
 
     @Test
+    fun `processing Mention suggestion returns the members matching the start of the query first`() = runTest {
+        val matchingOnAnyPart = aRoomMember(userId = UserId("@carol:server.org"), displayName = "Not Alice")
+        val matchingOnUserIdStart = aRoomMember(userId = UserId("@alicia:server.org"), displayName = null)
+        val matchingOnDisplayNameStart = aRoomMember(userId = UserId("@zoe:server.org"), displayName = "Alice")
+        val result = suggestionsProcessor.process(
+            suggestion = aMentionSuggestion("ali"),
+            roomMembersState = RoomMembersState.Ready(
+                persistentListOf(matchingOnAnyPart, matchingOnUserIdStart, matchingOnDisplayNameStart)
+            ),
+            roomAliasSuggestions = emptyList(),
+            currentUserId = A_USER_ID_2,
+            canSendRoomMention = { false },
+            isInThread = false,
+        )
+        assertThat(result).isEqualTo(
+            listOf(
+                ResolvedSuggestion.Member(matchingOnDisplayNameStart),
+                ResolvedSuggestion.Member(matchingOnUserIdStart),
+                ResolvedSuggestion.Member(matchingOnAnyPart),
+            )
+        )
+    }
+
+    @Test
+    fun `processing Mention suggestion returns room ignoring the case of the query`() = runTest {
+        val aRoomMember = aRoomMember(userId = UserId("@alice:server.org"), displayName = "alice")
+        val result = suggestionsProcessor.process(
+            suggestion = aMentionSuggestion("RO"),
+            roomMembersState = RoomMembersState.Ready(persistentListOf(aRoomMember)),
+            roomAliasSuggestions = emptyList(),
+            currentUserId = A_USER_ID_2,
+            canSendRoomMention = { true },
+            isInThread = false,
+        )
+        assertThat(result).isEqualTo(
+            listOf(
+                ResolvedSuggestion.AtRoom,
+            )
+        )
+    }
+
+    @Test
     fun `processing Mention suggestion with return matching display name but not room if not allowed`() = runTest {
         val aRoomMember = aRoomMember(userId = UserId("@alice:server.org"), displayName = "ro")
         val result = suggestionsProcessor.process(


### PR DESCRIPTION
## Content

The member suggestions offered after `@` were emitted in whatever order the room member list
happened to be in, filtered but never ranked, so a member who matches only in the middle of their
name can be offered above one whose name starts with what was typed.

Matches are now ordered by how well they match the query: display name prefix first, then user ID
localpart prefix, then any other match. The sort is stable, so members of equal rank keep the order
the member list gave them, and the batch cap of 100 members is applied before the sort as it was
before, so nothing new runs over the whole member list.

The `@room` suggestion was compared case sensitively, so typing `@Ro` or `@ROOM` dropped it while
`@ro` kept it. It now matches the query the same way the members do.

## Motivation and context

Part of #3434. This covers the second half of that issue, the ordering of the suggestions. The
first half, inserting a mention from the member info screen, is a separate change and one commenter
on the issue disputes the behaviour it asks for, so it is left alone here.

Ordering by relevance is not ordering by recent activity: a `RoomMember` carries no activity
information, so the older of two equally matching accounts can still come first.

## Tests

`features/messages/impl/.../suggestions/SuggestionsProcessorTest.kt` gains two tests: one that the
three kinds of match come back in rank order, one that an uppercase query still offers `@room`.

Both fail on develop — the ordering one returns the members in input order, the `@room` one returns
an empty list.

Run with `./gradlew :features:messages:impl:testDebugUnitTest --tests '*SuggestionsProcessorTest*'`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
