### PR TITLE
Remember the room list filters across app launches

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategy.kt
@@ -10,26 +10,43 @@ package io.element.android.features.home.impl.filters.selection
 
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.features.home.impl.filters.RoomListFilter
+import io.element.android.libraries.core.data.tryOrNull
 import io.element.android.libraries.di.SessionScope
+import io.element.android.libraries.di.annotations.SessionCoroutineScope
+import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 @ContributesBinding(SessionScope::class)
-class DefaultFilterSelectionStrategy : FilterSelectionStrategy {
+class DefaultFilterSelectionStrategy(
+    private val sessionPreferencesStore: SessionPreferencesStore,
+    @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
+) : FilterSelectionStrategy {
     private val selectedFilters = LinkedHashSet<RoomListFilter>()
     private val availableFilters
         get() = RoomListFilter.entries.toSet()
 
     override val filterSelectionStates = MutableStateFlow(buildFilters())
 
+    init {
+        sessionCoroutineScope.launch {
+            sessionPreferencesStore.getSelectedRoomListFilters().first()
+                .mapNotNull { name -> tryOrNull { RoomListFilter.valueOf(name) } }
+                .forEach { filter -> select(filter) }
+        }
+    }
+
     override fun select(filter: RoomListFilter) {
         if (selectedFilters.any { it in filter.incompatibleFilters }) return
         selectedFilters.add(filter)
-        filterSelectionStates.value = buildFilters()
+        onSelectionChanged()
     }
 
     override fun deselect(filter: RoomListFilter) {
         selectedFilters.remove(filter)
-        filterSelectionStates.value = buildFilters()
+        onSelectionChanged()
     }
 
     override fun isSelected(filter: RoomListFilter): Boolean {
@@ -38,7 +55,15 @@ class DefaultFilterSelectionStrategy : FilterSelectionStrategy {
 
     override fun clear() {
         selectedFilters.clear()
+        onSelectionChanged()
+    }
+
+    private fun onSelectionChanged() {
         filterSelectionStates.value = buildFilters()
+        val names = selectedFilters.map { it.name }.toSet()
+        sessionCoroutineScope.launch {
+            sessionPreferencesStore.setSelectedRoomListFilters(names)
+        }
     }
 
     private fun buildFilters(): Set<FilterSelectionState> {

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/RoomListFiltersPresenterTest.kt
@@ -11,6 +11,8 @@ package io.element.android.features.home.impl.filters
 import com.google.common.truth.Truth.assertThat
 import io.element.android.features.home.impl.filters.selection.DefaultFilterSelectionStrategy
 import io.element.android.features.home.impl.filters.selection.FilterSelectionState
+import io.element.android.libraries.preferences.api.store.SessionPreferencesStore
+import io.element.android.libraries.preferences.test.InMemorySessionPreferencesStore
 import io.element.android.tests.testutils.awaitLastSequentialItem
 import io.element.android.tests.testutils.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -131,6 +133,35 @@ class RoomListFiltersPresenterTest {
             }
         }
     }
+
+    @Test
+    fun `present - the filters selected last time are restored`() = runTest {
+        val presenter = createRoomListFiltersPresenter(
+            sessionPreferencesStore = InMemorySessionPreferencesStore(
+                selectedRoomListFilters = setOf(RoomListFilter.Favourites.name),
+            ),
+        )
+        presenter.test {
+            skipItems(1)
+            val state = awaitItem()
+            assertThat(state.filterSelectionStates).contains(
+                filterSelectionState(RoomListFilter.Favourites, selected = true)
+            )
+        }
+    }
+
+    @Test
+    fun `present - an unknown stored filter is ignored`() = runTest {
+        val presenter = createRoomListFiltersPresenter(
+            sessionPreferencesStore = InMemorySessionPreferencesStore(
+                selectedRoomListFilters = setOf("NotAFilter"),
+            ),
+        )
+        presenter.test {
+            val state = awaitItem()
+            assertThat(state.hasAnyFilterSelected).isFalse()
+        }
+    }
 }
 
 private fun filterSelectionState(filter: RoomListFilter, selected: Boolean) = FilterSelectionState(
@@ -138,8 +169,13 @@ private fun filterSelectionState(filter: RoomListFilter, selected: Boolean) = Fi
     isSelected = selected,
 )
 
-private fun TestScope.createRoomListFiltersPresenter(): RoomListFiltersPresenter {
+private fun TestScope.createRoomListFiltersPresenter(
+    sessionPreferencesStore: SessionPreferencesStore = InMemorySessionPreferencesStore(),
+): RoomListFiltersPresenter {
     return RoomListFiltersPresenter(
-        filterSelectionStrategy = DefaultFilterSelectionStrategy(),
+        filterSelectionStrategy = DefaultFilterSelectionStrategy(
+            sessionPreferencesStore = sessionPreferencesStore,
+            sessionCoroutineScope = backgroundScope,
+        ),
     )
 }

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategyTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/filters/selection/DefaultFilterSelectionStrategyTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.home.impl.filters.selection
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.features.home.impl.filters.RoomListFilter
+import io.element.android.libraries.preferences.test.InMemorySessionPreferencesStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultFilterSelectionStrategyTest {
+    @Test
+    fun `selecting a filter stores it`() = runTest {
+        val store = InMemorySessionPreferencesStore()
+        val strategy = createStrategy(store)
+        strategy.select(RoomListFilter.Rooms)
+        advanceUntilIdle()
+        assertThat(store.getSelectedRoomListFilters().first()).containsExactly(RoomListFilter.Rooms.name)
+    }
+
+    @Test
+    fun `deselecting a filter removes it from the store`() = runTest {
+        val store = InMemorySessionPreferencesStore(selectedRoomListFilters = setOf(RoomListFilter.Rooms.name))
+        val strategy = createStrategy(store)
+        advanceUntilIdle()
+        strategy.deselect(RoomListFilter.Rooms)
+        advanceUntilIdle()
+        assertThat(store.getSelectedRoomListFilters().first()).isEmpty()
+    }
+
+    @Test
+    fun `the filters selected last time are restored`() = runTest {
+        val store = InMemorySessionPreferencesStore(selectedRoomListFilters = setOf(RoomListFilter.Favourites.name))
+        val strategy = createStrategy(store)
+        advanceUntilIdle()
+        assertThat(strategy.isSelected(RoomListFilter.Favourites)).isTrue()
+    }
+
+    @Test
+    fun `a stored filter which is no longer known is ignored`() = runTest {
+        val store = InMemorySessionPreferencesStore(selectedRoomListFilters = setOf("NotAFilter"))
+        val strategy = createStrategy(store)
+        advanceUntilIdle()
+        assertThat(strategy.filterSelectionStates.value.none { it.isSelected }).isTrue()
+    }
+
+    @Test
+    fun `incompatible stored filters do not both come back`() = runTest {
+        val store = InMemorySessionPreferencesStore(
+            selectedRoomListFilters = setOf(RoomListFilter.Rooms.name, RoomListFilter.People.name),
+        )
+        val strategy = createStrategy(store)
+        advanceUntilIdle()
+        assertThat(strategy.isSelected(RoomListFilter.Rooms) && strategy.isSelected(RoomListFilter.People)).isFalse()
+    }
+
+    private fun TestScope.createStrategy(store: InMemorySessionPreferencesStore) = DefaultFilterSelectionStrategy(
+        sessionPreferencesStore = store,
+        sessionCoroutineScope = this,
+    )
+}

--- a/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/SessionPreferencesStore.kt
+++ b/libraries/preferences/api/src/main/kotlin/io/element/android/libraries/preferences/api/store/SessionPreferencesStore.kt
@@ -81,6 +81,14 @@ interface SessionPreferencesStore {
     /** The video compression preset; defaults to [VideoCompressionPreset.STANDARD], including when the stored value is unreadable. */
     fun getVideoCompressionPreset(): Flow<VideoCompressionPreset>
 
+    /**
+     * @param filters the names of the room list filters the user has selected.
+     */
+    suspend fun setSelectedRoomListFilters(filters: Set<String>)
+
+    /** The names of the room list filters the user has selected; defaults to none. */
+    fun getSelectedRoomListFilters(): Flow<Set<String>>
+
     /** Erases every preference of this session, so they all fall back to their defaults. */
     suspend fun clear()
 }

--- a/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
+++ b/libraries/preferences/impl/src/main/kotlin/io/element/android/libraries/preferences/impl/store/DefaultSessionPreferencesStore.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import io.element.android.libraries.androidutils.file.safeDelete
 import io.element.android.libraries.androidutils.hash.hash
@@ -47,6 +48,7 @@ class DefaultSessionPreferencesStore(
     private val skipSessionVerification = booleanPreferencesKey("skipSessionVerification")
     private val compressImages = booleanPreferencesKey("compressMedia")
     private val compressMediaPreset = stringPreferencesKey("compressMediaPreset")
+    private val selectedRoomListFilters = stringSetPreferencesKey("selectedRoomListFilters")
 
     private val dataStoreFile = storeFile(context, sessionId)
     private val store = PreferenceDataStoreFactory.create(
@@ -93,6 +95,9 @@ class DefaultSessionPreferencesStore(
     override suspend fun setVideoCompressionPreset(preset: VideoCompressionPreset) = update(compressMediaPreset, preset.name)
     override fun getVideoCompressionPreset(): Flow<VideoCompressionPreset> = get(compressMediaPreset) { VideoCompressionPreset.STANDARD.name }
         .map { tryOrNull { VideoCompressionPreset.valueOf(it) } ?: VideoCompressionPreset.STANDARD }
+
+    override suspend fun setSelectedRoomListFilters(filters: Set<String>) = update(selectedRoomListFilters, filters)
+    override fun getSelectedRoomListFilters(): Flow<Set<String>> = get(selectedRoomListFilters) { emptySet() }
 
     override suspend fun clear() {
         dataStoreFile.safeDelete()

--- a/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemorySessionPreferencesStore.kt
+++ b/libraries/preferences/test/src/main/kotlin/io/element/android/libraries/preferences/test/InMemorySessionPreferencesStore.kt
@@ -22,6 +22,7 @@ class InMemorySessionPreferencesStore(
     isSessionVerificationSkipped: Boolean = false,
     doesCompressMedia: Boolean = true,
     videoCompressionPreset: VideoCompressionPreset = VideoCompressionPreset.STANDARD,
+    selectedRoomListFilters: Set<String> = emptySet(),
 ) : SessionPreferencesStore {
     private val isSharePresenceEnabled = MutableStateFlow(isSharePresenceEnabled)
     private val isSendPublicReadReceiptsEnabled = MutableStateFlow(isSendPublicReadReceiptsEnabled)
@@ -31,6 +32,7 @@ class InMemorySessionPreferencesStore(
     private val isSessionVerificationSkipped = MutableStateFlow(isSessionVerificationSkipped)
     private val doesCompressMedia = MutableStateFlow(doesCompressMedia)
     private val videoCompressionPreset = MutableStateFlow(videoCompressionPreset)
+    private val selectedRoomListFilters = MutableStateFlow(selectedRoomListFilters)
     var clearCallCount = 0
         private set
 
@@ -83,6 +85,12 @@ class InMemorySessionPreferencesStore(
     override fun getVideoCompressionPreset(): Flow<VideoCompressionPreset> {
         return videoCompressionPreset
     }
+
+    override suspend fun setSelectedRoomListFilters(filters: Set<String>) {
+        selectedRoomListFilters.tryEmit(filters)
+    }
+
+    override fun getSelectedRoomListFilters(): Flow<Set<String>> = selectedRoomListFilters
 
     override suspend fun clear() {
         clearCallCount++


### PR DESCRIPTION
## Content

The filter chips above the room list were held in memory only, so every cold start came back with
the filters cleared and the user had to select them again.

The selection is now stored in the session preferences and restored when the selection strategy is
created. A stored name the app no longer knows is ignored, and a stored pair which is incompatible —
People and Rooms, say — resolves exactly as selecting them by hand does, so only the first of the
two comes back.

## Motivation and context

Closes #4910, which asks for the filters to be set for each opening of the app.

This is a change of default behaviour: the app can now open with a filtered room list. It is the
user's own last selection, and clearing the filters is remembered just as well, so the filtered
state can only be one they left behind.

## Tests

`features/home/impl/.../filters/selection/DefaultFilterSelectionStrategyTest.kt` is new and covers
storing a selection, storing a deselection, restoring, an unknown stored name, and an incompatible
stored pair. `RoomListFiltersPresenterTest` gains the restore path through the presenter.

They fail on develop, where nothing is written and nothing is restored.

Run with `./gradlew :features:home:impl:testDebugUnitTest`.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
