### PR TITLE
Point the proxy debugging doc at the method that builds the clients

### DIFF
--- a/docs/debug_proxying.md
+++ b/docs/debug_proxying.md
@@ -9,13 +9,18 @@
     1) Set `127.0.0.1` as "Host name" and `8080` as "Port number".
     1) Click "Apply" and verify that "Proxy status" is "Success" and close the settings window.
        <img width="932" alt="Screenshot 2023-10-04 at 14 48 47" src="https://github.com/element-hq/element-x-android/assets/1273124/bf99a053-20b0-42a4-91d3-9602f709f684">
+    1) Alternatively, set the proxy on the device itself, which the app honours through `DefaultProxyProvider`, and which also works on a physical device:
+       ```
+       adb shell settings put global http_proxy 10.0.2.2:8080
+       ```
+       Use `adb shell settings delete global http_proxy` to remove it afterwards. On a physical device, replace `10.0.2.2` with the address of the machine running mitmproxy.
 1) Install the mitmproxy CA cert (this is needed to see traffic from java/kotlin code, it's not needed for traffic coming from native code e.g. the matrix-rust-sdk).
     1) Open the emulator Chrome browser app
     1) Go to the url `mitm.it`
     1) Follow the instructions to install the CA cert on Android devices.
        <img width="606" alt="Screenshot 2023-10-04 at 14 51 27" src="https://github.com/element-hq/element-x-android/assets/1273124/5f2b6f27-6958-4ea7-97fe-c7f06d105da5">
 1) Slightly modify the Element X app source code.
-    1) Go to the `RustMatrixClientFactory.create()` method.
+    1) Go to the `RustMatrixClientFactory.getBaseClientBuilder()` method, which builds every client the app creates, whether it is logging in or restoring a session.
     1) Add `.disableSslVerification()` in the `ClientBuilder` method chain.
 1) Build and run the Element X app. 
 1) Enjoy, you will see all the traffic in mitmproxy's web interface.


### PR DESCRIPTION
## Content

`docs/debug_proxying.md` told the reader to add `.disableSslVerification()` to
`RustMatrixClientFactory.create()`. That method has not built the client for a long time — the
`ClientBuilder` chain lives in `getBaseClientBuilder()`, which is what both the login client and the
restored session client are built from — so the instruction cannot be followed as written.

The emulator proxy step also gains the alternative the app already supports: the device's global
proxy, which `DefaultProxyProvider` reads and passes to the SDK. That is the only way to do this on
a physical device.

## Motivation and context

Closes #2812. The reporter could not find the method the doc names. @jmartinesp answered the
reverse-engineering half of the question on the issue; this fixes the part of it that is a genuine
mistake in this repo.

## Tests

Documentation only, no code change. `./gradlew checkDocs` passes; the file has no TOC markers, so it
is skipped by that check as before.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
