### PR TITLE
Show the build date in the screenshot gallery footer

### DIFF
--- a/screenshots/html/data.js
+++ b/screenshots/html/data.js
@@ -1,4 +1,5 @@
 // Generated file, do not edit
+export const buildDate = 1787667600;
 export const screenshots = [
 ["en","en-dark","de",],
 ["features.messages.impl.timeline.components.event_ATimelineItemEventRow_Day_0_en","features.messages.impl.timeline.components.event_ATimelineItemEventRow_Night_0_en",20675,],

--- a/screenshots/html/screenshots.css
+++ b/screenshots/html/screenshots.css
@@ -150,6 +150,11 @@ input {
     height: 40px;
 }
 
+.build-date {
+    margin-right: 20px;
+    font-size: 13px;
+}
+
 a:link {
   color: white;
   font-size: 14px;

--- a/screenshots/html/script.js
+++ b/screenshots/html/script.js
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
  * Please see LICENSE files in the repository root for full details.
  */
-import { screenshots } from './data.js';
+import { buildDate, screenshots } from './data.js';
 
 const URL_PARAM_LANGUAGES = "l";
 const URL_PARAM_IMAGE_WIDTH = "w";
@@ -360,5 +360,13 @@ function addTable() {
   document.getElementById('lines').textContent = `${linesCounter} lines`;
 }
 
+function addBuildDate() {
+  const element = document.createElement('div');
+  element.className = 'build-date';
+  element.textContent = `Built on ${new Date(buildDate * 1000).toLocaleDateString()}`;
+  document.getElementById('footer').appendChild(element);
+}
+
 addForm();
+addBuildDate();
 addTable();

--- a/tools/test/generateAllScreenshots.py
+++ b/tools/test/generateAllScreenshots.py
@@ -167,6 +167,7 @@ def generateJavascriptFile():
 
     with open("screenshots/html/data.js", "w") as f:
         f.write("// Generated file, do not edit\n")
+        f.write("export const buildDate = %d;\n" % int(time.time()))
         f.write("export const screenshots = [\n")
         for line in data:
             f.write("[")


### PR DESCRIPTION
## Content

The gallery gives no indication of how old the screenshots on the page are, so a reader cannot tell
whether they are looking at the current build.

`generateAllScreenshots.py` now writes the time it ran into `data.js` next to the screenshot data,
and `script.js` renders it in the footer beside the existing links. The committed `data.js` carries
the value already so the two files stay in step until the page is next generated.

## Motivation and context

Part of #2515: "add a date of build in the footer". The other unchecked items on that list are
open-ended design work, so the issue stays open.

## Tests

No automated test covers the gallery. Checked by opening `screenshots/index.html` locally and
confirming the footer reads "Built on …" with the date from `data.js`, and that the page still
renders when the value is the one the generator writes.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
