### PR TITLE
Document how the Element Call base URL developer option is used

### DIFF
--- a/docs/element_call.md
+++ b/docs/element_call.md
@@ -1,0 +1,53 @@
+# Element Call
+
+<!--- TOC -->
+
+* [Overview](#overview)
+* [Setting a custom base URL](#setting-a-custom-base-url)
+* [Why the application does not add the room path itself](#why-the-application-does-not-add-the-room-path-itself)
+* [Where the value is read](#where-the-value-is-read)
+
+<!--- END -->
+
+## Overview
+
+Element X embeds a copy of [Element Call](https://github.com/element-hq/element-call) in the
+application assets and loads it from
+`https://appassets.androidplatform.net/element-call/index.html`. Calls therefore work out of the box
+with no extra deployment, and the embedded copy is the one every user gets.
+
+Developers can point the application at another Element Call deployment instead — a local
+development server, a staging deployment, or a self-hosted one — with the **Element Call base URL**
+developer option.
+
+## Setting a custom base URL
+
+The option lives in *Settings* → *Developer options* → *Element Call*, under "Element Call base
+URL". On a release build the *Developer options* entry is hidden until the version number at the
+bottom of *Settings* is tapped seven times. Leaving the field empty restores the embedded copy.
+
+The value is used verbatim as the widget base URL, so it must be the URL of the page that joins a
+room, not the URL of the deployment root. For the public deployments that means:
+
+| Deployment | Value to enter |
+|---|---|
+| `call.element.io` | `https://call.element.io/room` |
+| `call.element.dev` | `https://call.element.dev/room` |
+
+Entering `https://call.element.io` without the `/room` suffix loads the Element Call lobby rather
+than the room, so the call is never joined.
+
+## Why the application does not add the room path itself
+
+The path that joins a room is a property of the deployment, not of Element Call. Unpacking the
+Element Call release tarball behind a reverse proxy can put it at any path — `https://call.foo.tld`,
+`https://call.foo.tld/some/path/somewhere` — and a proxy that already maps a subdomain onto
+`https://1.2.3.4/room` would end up with the suffix twice. The application passes the value through
+unchanged so that every one of those deployments can be reached.
+
+## Where the value is read
+
+`AppDeveloperSettingsView` renders the field and sends
+`AppDeveloperSettingsEvent.SetCustomElementCallBaseUrl`, which `DefaultAppPreferencesStore` persists.
+`DefaultCallWidgetProvider.getWidget` reads it back and falls back to the embedded copy when it is
+unset.


### PR DESCRIPTION

## Content

Adds `docs/element_call.md`. It covers where the Element Call base URL developer option lives, that
the value is used verbatim as the widget base URL and therefore has to be the URL of the page that
joins a room (`https://call.element.io/room`, not `https://call.element.io`), why the application
cannot append the room path itself, and where the value is read in the code.

The placeholder itself is unchanged: as explained in the issue thread, the path is a property of the
deployment, so there is no suffix the application could safely add.

## Motivation and context

Relates to #4475. The issue asks to remove the placeholder from the field, but the thread settled on
a different resolution — hughns: *"Rather than attempting to make this developer option fully self
explanatory inline within the app (which might take a lot of text), what I would suggest is adding
something to the docs in the EX repositories that explains how this developer option can be used."*
This is the Android half of that. element-x-ios still needs its own page.

## Tests

- `python3 tools/docs/generate_toc.py --verify ./*.md docs/*.md` (the `checkDocs` gate) reports `OK`
  for the new file with its generated table of contents.
- Documentation only — nothing here is covered by a unit test.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s): n/a — documentation only

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
