### PR TITLE
Only hide membership changes in rooms that are actually publicly joinable

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/TimelineEventFilterFactory.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/TimelineEventFilterFactory.kt
@@ -37,7 +37,7 @@ class RustTimelineEventFilterFactory : TimelineEventFilterFactory {
         }
         // If the room is publicly joinable and not encrypted, we also want to exclude membership changes and profile changes,
         // as they will pollute the timelines since they're quite common and not add much value.
-        val excludedMembershipChanges = if (joinRule !is JoinRule.Invite && isEncrypted == false) {
+        val excludedMembershipChanges = if (hidesMembershipAndProfileChanges(joinRule, isEncrypted)) {
             listOf(
                 FilterTimelineEventCondition.MembershipChange(MembershipChangeFilter.JOIN),
                 FilterTimelineEventCondition.MembershipChange(MembershipChangeFilter.LEAVE),
@@ -52,4 +52,8 @@ class RustTimelineEventFilterFactory : TimelineEventFilterFactory {
             null
         }
     }
+}
+
+internal fun hidesMembershipAndProfileChanges(joinRule: JoinRule?, isEncrypted: Boolean?): Boolean {
+    return joinRule is JoinRule.Public && isEncrypted == false
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/TimelineEventFilterFactoryTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/TimelineEventFilterFactoryTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.matrix.impl.room
+
+import com.google.common.truth.Truth.assertThat
+import io.element.android.libraries.matrix.api.room.join.JoinRule
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Test
+
+class TimelineEventFilterFactoryTest {
+    @Test
+    fun `membership and profile changes are hidden in unencrypted public rooms`() {
+        assertThat(hidesMembershipAndProfileChanges(JoinRule.Public, isEncrypted = false)).isTrue()
+    }
+
+    @Test
+    fun `membership and profile changes are shown in rooms that are not publicly joinable`() {
+        val joinRules = listOf(
+            JoinRule.Invite,
+            JoinRule.Knock,
+            JoinRule.Restricted(persistentListOf()),
+            JoinRule.KnockRestricted(persistentListOf()),
+            JoinRule.Custom("org.example.rule"),
+        )
+        for (joinRule in joinRules) {
+            assertThat(hidesMembershipAndProfileChanges(joinRule, isEncrypted = false)).isFalse()
+        }
+    }
+
+    @Test
+    fun `membership and profile changes are shown when the room is encrypted or its encryption is unknown`() {
+        assertThat(hidesMembershipAndProfileChanges(JoinRule.Public, isEncrypted = true)).isFalse()
+        assertThat(hidesMembershipAndProfileChanges(JoinRule.Public, isEncrypted = null)).isFalse()
+    }
+
+    @Test
+    fun `membership and profile changes are shown when the join rule is unknown`() {
+        assertThat(hidesMembershipAndProfileChanges(joinRule = null, isEncrypted = false)).isFalse()
+    }
+}


### PR DESCRIPTION
## Content

`RustTimelineEventFilterFactory` hides membership changes and profile changes from the timeline, and
the comment above the guard says it does so when "the room is publicly joinable and not encrypted".
The guard itself was `joinRule !is JoinRule.Invite`, which is much broader — it also matched knock
rooms, restricted rooms, `KnockRestricted`, custom join rules, and rooms whose join rule the app had
not learnt yet (`joinRule == null`). None of those are publicly joinable, so joins, leaves and
display-name changes were being hidden in rooms where they carry real information.

This narrows the guard to `JoinRule.Public`, which is what the comment already describes, and moves
the decision into `hidesMembershipAndProfileChanges` so it can be unit tested — `TimelineEventFilter`
itself is a uniffi object and needs the native library, whereas the guard is plain Kotlin.

Genuinely public rooms are unchanged: they still hide the events, deliberately, as #7025 intended.

## Motivation and context

Relates to #7310. The issue asks for membership changes to come back in public rooms and ideally to
be configurable; this only recovers the rooms the filter was never meant to cover, so the public-room
half of the request stays open — that one is a product decision rather than a defect.

## Tests

- `libraries/matrix/impl/src/test/kotlin/.../room/TimelineEventFilterFactoryTest.kt` — four cases:
  public + unencrypted hides the events; invite / knock / restricted / knock-restricted / custom show
  them; encrypted or unknown-encryption public rooms show them; unknown join rule shows them.
- Negative control: with the old `joinRule !is JoinRule.Invite` guard restored, two of the four fail
  (`...are shown in rooms that are not publicly joinable` and `...when the join rule is unknown`),
  so the tests are guarding the change rather than restating it.
- `./gradlew :libraries:matrix:impl:testDebugUnitTest :libraries:matrix:impl:ktlintCheck :libraries:matrix:impl:detekt` — green.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): unit tests only, no UI change

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
