### PR TITLE
Keep typing in the composer instead of the keyboard's fullscreen editor

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/markdown/MarkdownTextInput.kt
@@ -16,6 +16,7 @@ import android.text.Editable
 import android.text.InputType
 import android.text.Selection
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -99,6 +100,7 @@ fun MarkdownTextInput(
                     InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
                     InputType.TYPE_TEXT_FLAG_MULTI_LINE or
                     InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
+                imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 val textRange = 0..text.length
                 setSelection(state.selection.first.coerceIn(textRange), state.selection.last.coerceIn(textRange))
                 setOnFocusChangeListener { _, hasFocus ->

--- a/libraries/textcomposer/impl/src/test/kotlin/io/element/android/libraries/textcomposer/impl/components/markdown/MarkdownTextInputTest.kt
+++ b/libraries/textcomposer/impl/src/test/kotlin/io/element/android/libraries/textcomposer/impl/components/markdown/MarkdownTextInputTest.kt
@@ -12,6 +12,7 @@ package io.element.android.libraries.textcomposer.impl.components.markdown
 
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
+import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.AndroidComposeUiTest
@@ -41,6 +42,13 @@ import io.element.android.tests.testutils.robolectric.RobolectricTest
 import org.junit.Test
 
 class MarkdownTextInputTest : RobolectricTest() {
+    @Test
+    fun `the composer never hands over to the keyboard's fullscreen editor`() = runAndroidComposeUiTest {
+        setMarkdownTextInput(state = aMarkdownTextEditorState(initialText = "Hello", initialFocus = true))
+        val editor = activity!!.findEditor()
+        assertThat(editor.imeOptions and EditorInfo.IME_FLAG_NO_EXTRACT_UI).isNotEqualTo(0)
+    }
+
     @Test
     fun `pressing enter on a physical keyboard sends the message`() = runAndroidComposeUiTest {
         val state = aMarkdownTextEditorState(initialText = "Hello", initialFocus = true)


### PR DESCRIPTION
## Content

When the window is short — landscape, or a large display size — the keyboard replaces the whole
screen with its extract editor. That editor belongs to the IME, not to us: it is a plain text field
with none of the composer's mention pills, none of the message being replied to, and none of the
room behind it. It is also what the report describes as the composer swallowing input.

Setting `IME_FLAG_NO_EXTRACT_UI` on the plain-text composer turns it off, so what the user types goes
to the composer itself whatever the screen height.

The rich text composer is `EditorEditText`, owned by matrix-rich-text-editor, so it needs the same
flag set there; this only covers the plain-text one.

## Motivation and context

Part of #2153. Honest limitation: the report is from 0.4.0, against the composer as it was before the
rewrite, and I could not reproduce the swallowed input on a current build — the "Direct Messages" in
its title looks like a red herring, since nothing in the composer branches on whether the room is a
DM. So treat this as removing the fullscreen editor because it is wrong for this composer, which also
removes the most likely cause of what was reported, rather than as a confirmed fix.

## Tests

- `MarkdownTextInputTest` — asserts the flag is set on the editor the composer creates. An IME flag
  has no behaviour a unit test can drive, so this guards the setting rather than the outcome.
- Negative control: removing the line fails that test.
- `./gradlew :libraries:textcomposer:impl:testDebugUnitTest :libraries:textcomposer:impl:ktlintCheck :libraries:textcomposer:impl:detekt` — green.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): unit tests only; the fullscreen editor itself needs a short window to appear

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
