### PR TITLE
Change a member's role from their moderation actions

### DIFF
--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStatePreviewParam.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/members/RoomMemberListStatePreviewParam.kt
@@ -109,11 +109,13 @@ internal fun aRoomMemberListState(
 fun aRoomMemberModerationState(
     canBan: Boolean = false,
     canKick: Boolean = false,
+    canChangeRoles: Boolean = false,
 ): RoomMemberModerationState {
     return object : RoomMemberModerationState {
         override val permissions: RoomMemberModerationPermissions = RoomMemberModerationPermissions(
             canBan = canBan,
             canKick = canKick,
+            canChangeRoles = canChangeRoles,
         )
         override val eventSink: (RoomMemberModerationEvent) -> Unit = {}
     }

--- a/features/roommembermoderation/api/src/main/kotlin/io/element/android/features/roommembermoderation/api/RoomMemberModerationPermissions.kt
+++ b/features/roommembermoderation/api/src/main/kotlin/io/element/android/features/roommembermoderation/api/RoomMemberModerationPermissions.kt
@@ -8,10 +8,12 @@
 package io.element.android.features.roommembermoderation.api
 
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPermissions
+import io.element.android.libraries.matrix.api.room.powerlevels.canEditRolesAndPermissions
 
 data class RoomMemberModerationPermissions(
     val canKick: Boolean,
     val canBan: Boolean,
+    val canChangeRoles: Boolean,
 ) {
     // Unban requires both kick and ban permission instead of a dedicated unban permission
     val canUnban = canBan && canKick
@@ -20,6 +22,7 @@ data class RoomMemberModerationPermissions(
         val DEFAULT = RoomMemberModerationPermissions(
             canKick = false,
             canBan = false,
+            canChangeRoles = false,
         )
     }
 }
@@ -28,5 +31,6 @@ fun RoomPermissions.roomMemberModerationPermissions(): RoomMemberModerationPermi
     return RoomMemberModerationPermissions(
         canKick = canOwnUserKick(),
         canBan = canOwnUserBan(),
+        canChangeRoles = canEditRolesAndPermissions(),
     )
 }

--- a/features/roommembermoderation/api/src/main/kotlin/io/element/android/features/roommembermoderation/api/RoomMemberModerationState.kt
+++ b/features/roommembermoderation/api/src/main/kotlin/io/element/android/features/roommembermoderation/api/RoomMemberModerationState.kt
@@ -9,6 +9,7 @@
 package io.element.android.features.roommembermoderation.api
 
 import androidx.compose.runtime.Immutable
+import io.element.android.libraries.matrix.api.room.RoomMember
 
 /**
  * State of the member moderation flow, which is the action sheet and the confirmation dialogs shown for a room member.
@@ -32,4 +33,7 @@ sealed interface ModerationAction {
     data object KickUser : ModerationAction
     data object BanUser : ModerationAction
     data object UnbanUser : ModerationAction
+
+    /** Give the member [role], which is only offered for a role they do not already hold. */
+    data class ChangeRole(val role: RoomMember.Role) : ModerationAction
 }

--- a/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationEvent.kt
+++ b/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationEvent.kt
@@ -14,5 +14,6 @@ sealed interface InternalRoomMemberModerationEvent : RoomMemberModerationEvent {
     data class DoKickUser(val reason: String) : InternalRoomMemberModerationEvent
     data class DoBanUser(val reason: String) : InternalRoomMemberModerationEvent
     data class DoUnbanUser(val reason: String) : InternalRoomMemberModerationEvent
+    data object DoChangeRole : InternalRoomMemberModerationEvent
     data object Reset : InternalRoomMemberModerationEvent
 }

--- a/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationState.kt
+++ b/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationState.kt
@@ -13,6 +13,7 @@ import io.element.android.features.roommembermoderation.api.RoomMemberModeration
 import io.element.android.features.roommembermoderation.api.RoomMemberModerationPermissions
 import io.element.android.features.roommembermoderation.api.RoomMemberModerationState
 import io.element.android.libraries.architecture.AsyncAction
+import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import kotlinx.collections.immutable.ImmutableList
 
@@ -23,6 +24,8 @@ data class InternalRoomMemberModerationState(
     val kickUserAsyncAction: AsyncAction<Unit>,
     val banUserAsyncAction: AsyncAction<Unit>,
     val unbanUserAsyncAction: AsyncAction<Unit>,
+    val changeRoleAsyncAction: AsyncAction<Unit>,
+    val roleToApply: RoomMember.Role?,
     override val eventSink: (RoomMemberModerationEvent) -> Unit,
 ) : RoomMemberModerationState {
     val canDisplayActions = actions.isNotEmpty()

--- a/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationStatePreviewParam.kt
+++ b/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/InternalRoomMemberModerationStatePreviewParam.kt
@@ -16,6 +16,7 @@ import io.element.android.features.roommembermoderation.api.RoomMemberModeration
 import io.element.android.libraries.architecture.AsyncAction
 import io.element.android.libraries.designsystem.preview.USER_NAME_ALICE
 import io.element.android.libraries.matrix.api.core.UserId
+import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.user.DisplayedStatus
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import kotlinx.collections.immutable.toImmutableList
@@ -76,6 +77,20 @@ class InternalRoomMemberModerationStatePreviewParam : PreviewParameterProvider<I
                 selectedUser = anAlice(),
                 unbanUserAsyncAction = AsyncAction.Loading,
             ),
+            aRoomMembersModerationState(
+                selectedUser = anAlice(),
+                actions = listOf(
+                    ModerationActionState(action = ModerationAction.DisplayProfile, isEnabled = true),
+                    ModerationActionState(action = ModerationAction.ChangeRole(RoomMember.Role.Admin), isEnabled = true),
+                    ModerationActionState(action = ModerationAction.ChangeRole(RoomMember.Role.Moderator), isEnabled = true),
+                    ModerationActionState(action = ModerationAction.KickUser, isEnabled = true),
+                ),
+            ),
+            aRoomMembersModerationState(
+                selectedUser = anAlice(),
+                changeRoleAsyncAction = AsyncAction.ConfirmingNoParams,
+                roleToApply = RoomMember.Role.Moderator,
+            ),
         )
 }
 
@@ -93,6 +108,8 @@ fun aRoomMembersModerationState(
     kickUserAsyncAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     banUserAsyncAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
     unbanUserAsyncAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
+    changeRoleAsyncAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
+    roleToApply: RoomMember.Role? = null,
     eventSink: (RoomMemberModerationEvent) -> Unit = {},
 ) = InternalRoomMemberModerationState(
     permissions = permissions,
@@ -101,5 +118,7 @@ fun aRoomMembersModerationState(
     kickUserAsyncAction = kickUserAsyncAction,
     banUserAsyncAction = banUserAsyncAction,
     unbanUserAsyncAction = unbanUserAsyncAction,
+    changeRoleAsyncAction = changeRoleAsyncAction,
+    roleToApply = roleToApply,
     eventSink = eventSink,
 )

--- a/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenter.kt
+++ b/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenter.kt
@@ -33,6 +33,7 @@ import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.room.powerlevels.permissionsAsState
 import io.element.android.libraries.matrix.api.room.roomMembers
 import io.element.android.libraries.matrix.api.user.MatrixUser
@@ -72,6 +73,9 @@ class RoomMemberModerationPresenter(
             remember { mutableStateOf(AsyncAction.Uninitialized as AsyncAction<Unit>) }
         val unbanUserAsyncAction =
             remember { mutableStateOf(AsyncAction.Uninitialized as AsyncAction<Unit>) }
+        val changeRoleAsyncAction =
+            remember { mutableStateOf(AsyncAction.Uninitialized as AsyncAction<Unit>) }
+        var roleToApply by remember { mutableStateOf<RoomMember.Role?>(null) }
         var selectedUser by remember {
             mutableStateOf<MatrixUser?>(null)
         }
@@ -94,7 +98,7 @@ class RoomMemberModerationPresenter(
                     // First, hide any list of existing actions that could be displayed
                     moderationActions.value = persistentListOf()
 
-                    when (event.action) {
+                    when (val action = event.action) {
                         is ModerationAction.DisplayProfile -> Unit
                         is ModerationAction.KickUser -> {
                             selectedUser = event.targetUser
@@ -107,6 +111,11 @@ class RoomMemberModerationPresenter(
                         is ModerationAction.UnbanUser -> {
                             selectedUser = event.targetUser
                             unbanUserAsyncAction.value = AsyncAction.ConfirmingNoParams
+                        }
+                        is ModerationAction.ChangeRole -> {
+                            selectedUser = event.targetUser
+                            roleToApply = action.role
+                            changeRoleAsyncAction.value = AsyncAction.ConfirmingNoParams
                         }
                     }
                 }
@@ -128,12 +137,23 @@ class RoomMemberModerationPresenter(
                     }
                     selectedUser = null
                 }
+                is InternalRoomMemberModerationEvent.DoChangeRole -> {
+                    val user = selectedUser
+                    val role = roleToApply
+                    if (user != null && role != null) {
+                        coroutineScope.changeRole(user.userId, role, changeRoleAsyncAction)
+                    }
+                    selectedUser = null
+                    roleToApply = null
+                }
                 is InternalRoomMemberModerationEvent.Reset -> {
                     selectedUser = null
                     moderationActions.value = persistentListOf()
                     kickUserAsyncAction.value = AsyncAction.Uninitialized
                     banUserAsyncAction.value = AsyncAction.Uninitialized
                     unbanUserAsyncAction.value = AsyncAction.Uninitialized
+                    changeRoleAsyncAction.value = AsyncAction.Uninitialized
+                    roleToApply = null
                 }
             }
         }
@@ -145,6 +165,8 @@ class RoomMemberModerationPresenter(
             kickUserAsyncAction = kickUserAsyncAction.value,
             banUserAsyncAction = banUserAsyncAction.value,
             unbanUserAsyncAction = unbanUserAsyncAction.value,
+            changeRoleAsyncAction = changeRoleAsyncAction.value,
+            roleToApply = roleToApply,
             eventSink = ::handleEvent,
         )
     }
@@ -170,6 +192,14 @@ class RoomMemberModerationPresenter(
                 RoomMembershipState.INVITE,
                 RoomMembershipState.JOIN,
                 RoomMembershipState.KNOCK -> {
+                    if (permissions.canChangeRoles && member?.role !is RoomMember.Role.Owner) {
+                        val currentRole = member?.role ?: RoomMember.Role.User
+                        for (role in assignableRoles) {
+                            if (role != currentRole) {
+                                add(ModerationActionState(action = ModerationAction.ChangeRole(role), isEnabled = canModerateThisUser))
+                            }
+                        }
+                    }
                     if (permissions.canKick) {
                         add(ModerationActionState(action = ModerationAction.KickUser, isEnabled = canModerateThisUser))
                     }
@@ -222,6 +252,18 @@ class RoomMemberModerationPresenter(
         )
     }
 
+    private fun CoroutineScope.changeRole(
+        userId: UserId,
+        role: RoomMember.Role,
+        changeRoleAction: MutableState<AsyncAction<Unit>>,
+    ) {
+        launch(dispatchers.io) {
+            changeRoleAction.runUpdatingState {
+                room.updateUsersRoles(listOf(UserRoleChange(userId, role)))
+            }
+        }
+    }
+
     private fun <T> CoroutineScope.runActionAndWaitForMembershipChange(
         action: MutableState<AsyncAction<T>>,
         block: suspend () -> Result<T>
@@ -245,3 +287,5 @@ class RoomMemberModerationPresenter(
         }
     }
 }
+
+private val assignableRoles = listOf(RoomMember.Role.Admin, RoomMember.Role.Moderator, RoomMember.Role.User)

--- a/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationView.kt
+++ b/features/roommembermoderation/impl/src/main/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationView.kt
@@ -44,6 +44,7 @@ import io.element.android.libraries.designsystem.components.async.rememberAsyncI
 import io.element.android.libraries.designsystem.components.avatar.Avatar
 import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.designsystem.components.avatar.AvatarType
+import io.element.android.libraries.designsystem.components.dialogs.ConfirmationDialog
 import io.element.android.libraries.designsystem.components.dialogs.TextFieldDialog
 import io.element.android.libraries.designsystem.components.list.ListItemContent
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -53,6 +54,7 @@ import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.ListItemStyle
 import io.element.android.libraries.designsystem.theme.components.ModalBottomSheet
 import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.ui.model.getAvatarData
 import io.element.android.libraries.matrix.ui.model.getBestName
@@ -209,7 +211,55 @@ private fun RoomMemberAsyncActions(
             is AsyncAction.Loading,
             AsyncAction.Uninitialized -> Unit
         }
+
+        when (val action = state.changeRoleAsyncAction) {
+            is AsyncAction.Confirming -> {
+                val role = state.roleToApply
+                if (role != null) {
+                    ConfirmationDialog(
+                        title = stringResource(R.string.screen_bottom_sheet_manage_room_member_change_role_confirmation_title),
+                        content = stringResource(
+                            R.string.screen_bottom_sheet_manage_room_member_change_role_confirmation_description,
+                            selectedUser?.getBestName().orEmpty(),
+                            stringResource(role.roleNameId()),
+                        ),
+                        submitText = stringResource(CommonStrings.action_confirm),
+                        onSubmitClick = { state.eventSink(InternalRoomMemberModerationEvent.DoChangeRole) },
+                        onDismiss = { state.eventSink(InternalRoomMemberModerationEvent.Reset) },
+                    )
+                }
+            }
+            is AsyncAction.Failure -> {
+                Timber.e(action.error, "Failed to change the role of a room member.")
+                LaunchedEffect(action) {
+                    asyncIndicatorState.enqueue(AsyncIndicator.DURATION_SHORT) {
+                        AsyncIndicator.Failure(
+                            text = stringResource(CommonStrings.common_failed),
+                        )
+                    }
+                }
+            }
+            is AsyncAction.Success -> {
+                LaunchedEffect(action) { asyncIndicatorState.clear() }
+            }
+            is AsyncAction.Loading,
+            AsyncAction.Uninitialized -> Unit
+        }
     }
+}
+
+private fun RoomMember.Role.roleNameId(): Int = when (this) {
+    is RoomMember.Role.Owner -> R.string.screen_bottom_sheet_manage_room_member_role_owner
+    RoomMember.Role.Admin -> R.string.screen_bottom_sheet_manage_room_member_role_admin
+    RoomMember.Role.Moderator -> R.string.screen_bottom_sheet_manage_room_member_role_moderator
+    RoomMember.Role.User -> R.string.screen_bottom_sheet_manage_room_member_role_member
+}
+
+private fun RoomMember.Role.actionLabelId(): Int = when (this) {
+    is RoomMember.Role.Owner,
+    RoomMember.Role.Admin -> R.string.screen_bottom_sheet_manage_room_member_make_admin
+    RoomMember.Role.Moderator -> R.string.screen_bottom_sheet_manage_room_member_make_moderator
+    RoomMember.Role.User -> R.string.screen_bottom_sheet_manage_room_member_make_member
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -331,6 +381,19 @@ private fun RoomMemberActionsBottomSheet(
                             content = { Text(stringResource(R.string.screen_bottom_sheet_manage_room_member_ban)) },
                             leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Block())),
                             style = ListItemStyle.Destructive,
+                            onClick = {
+                                coroutineScope.launch {
+                                    bottomSheetState.hide()
+                                    onSelectAction(action, user)
+                                }
+                            },
+                            enabled = actionState.isEnabled
+                        )
+                    }
+                    is ModerationAction.ChangeRole -> {
+                        ListItem(
+                            content = { Text(stringResource(action.role.actionLabelId())) },
+                            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Admin())),
                             onClick = {
                                 coroutineScope.launch {
                                     bottomSheetState.hide()

--- a/features/roommembermoderation/impl/src/main/res/values/temporary.xml
+++ b/features/roommembermoderation/impl/src/main/res/values/temporary.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 Element Creations Ltd.
+  ~
+  ~ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  ~ Please see LICENSE files in the repository root for full details.
+  -->
+
+<resources>
+    <string name="screen_bottom_sheet_manage_room_member_make_admin">Make admin</string>
+    <string name="screen_bottom_sheet_manage_room_member_make_moderator">Make moderator</string>
+    <string name="screen_bottom_sheet_manage_room_member_make_member">Make member</string>
+    <string name="screen_bottom_sheet_manage_room_member_role_owner">Owner</string>
+    <string name="screen_bottom_sheet_manage_room_member_role_admin">Admin</string>
+    <string name="screen_bottom_sheet_manage_room_member_role_moderator">Moderator</string>
+    <string name="screen_bottom_sheet_manage_room_member_role_member">Member</string>
+    <string name="screen_bottom_sheet_manage_room_member_change_role_confirmation_title">Change role?</string>
+    <string name="screen_bottom_sheet_manage_room_member_change_role_confirmation_description">%1$s will be given the “%2$s” role in this room.</string>
+</resources>

--- a/features/roommembermoderation/impl/src/test/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenterTest.kt
+++ b/features/roommembermoderation/impl/src/test/kotlin/io/element/android/features/roommembermoderation/impl/RoomMemberModerationPresenterTest.kt
@@ -21,7 +21,9 @@ import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.RoomMember
 import io.element.android.libraries.matrix.api.room.RoomMembersState
 import io.element.android.libraries.matrix.api.room.RoomMembershipState
+import io.element.android.libraries.matrix.api.room.StateEventType
 import io.element.android.libraries.matrix.api.room.powerlevels.RoomPowerLevels
+import io.element.android.libraries.matrix.api.room.powerlevels.UserRoleChange
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.matrix.test.A_USER_ID
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
@@ -33,12 +35,15 @@ import io.element.android.libraries.matrix.test.room.powerlevels.FakeRoomPermiss
 import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.test.FakeAnalyticsService
 import io.element.android.tests.testutils.WarmUpRule
+import io.element.android.tests.testutils.lambda.lambdaRecorder
+import io.element.android.tests.testutils.lambda.value
 import io.element.android.tests.testutils.test
 import io.element.android.tests.testutils.testCoroutineDispatchers
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -355,19 +360,23 @@ class RoomMemberModerationPresenterTest {
         canKick: Boolean = false,
         canBan: Boolean = false,
         myUserRole: RoomMember.Role = RoomMember.Role.User,
+        canChangeRoles: Boolean = false,
+        updateUsersRolesResult: (List<UserRoleChange>) -> Result<Unit> = { Result.success(Unit) },
         kickUserResult: Result<Unit> = Result.success(Unit),
         banUserResult: Result<Unit> = Result.success(Unit),
         unBanUserResult: Result<Unit> = Result.success(Unit),
         targetRoomMember: RoomMember? = null,
     ): FakeJoinedRoom {
         return FakeJoinedRoom(
+            updateUserRoleResult = updateUsersRolesResult,
             kickUserResult = { _, _ -> kickUserResult },
             banUserResult = { _, _ -> banUserResult },
             unBanUserResult = { _, _ -> unBanUserResult },
             baseRoom = FakeBaseRoom(
                 roomPermissions = FakeRoomPermissions(
                     canBan = canBan,
-                    canKick = canKick
+                    canKick = canKick,
+                    canSendState = { it == StateEventType.RoomPowerLevels && canChangeRoles },
                 ),
                 userRoleResult = { Result.success(myUserRole) },
                 updateMembersResult = { Result.success(Unit) },
@@ -381,6 +390,98 @@ class RoomMemberModerationPresenterTest {
         ).apply {
             val roomMembers = listOfNotNull(targetRoomMember).toImmutableList()
             givenRoomMembersState(state = RoomMembersState.Ready(roomMembers))
+        }
+    }
+
+    @Test
+    fun `present - changing a role is offered only for the roles the member does not already hold`() = runTest {
+        val room = aJoinedRoom(
+            canBan = false,
+            canKick = false,
+            canChangeRoles = true,
+            myUserRole = RoomMember.Role.Admin,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.Moderator.powerLevel, role = RoomMember.Role.Moderator),
+        )
+        createRoomMemberModerationPresenter(room = room).test {
+            val initialState = awaitState()
+            initialState.eventSink(RoomMemberModerationEvent.ShowActionsForUser(targetUser))
+            skipItems(2)
+            val updatedState = awaitState()
+            assertThat(updatedState.actions).containsExactly(
+                ModerationActionState(action = ModerationAction.DisplayProfile, isEnabled = true),
+                ModerationActionState(action = ModerationAction.ChangeRole(RoomMember.Role.Admin), isEnabled = true),
+                ModerationActionState(action = ModerationAction.ChangeRole(RoomMember.Role.User), isEnabled = true),
+            )
+        }
+    }
+
+    @Test
+    fun `present - changing a role is not offered without the power levels permission`() = runTest {
+        val room = aJoinedRoom(
+            canBan = false,
+            canKick = false,
+            canChangeRoles = false,
+            myUserRole = RoomMember.Role.Admin,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.User.powerLevel),
+        )
+        createRoomMemberModerationPresenter(room = room).test {
+            val initialState = awaitState()
+            initialState.eventSink(RoomMemberModerationEvent.ShowActionsForUser(targetUser))
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem().let { it as InternalRoomMemberModerationState }.actions).containsExactly(
+                ModerationActionState(action = ModerationAction.DisplayProfile, isEnabled = true),
+            )
+        }
+    }
+
+    @Test
+    fun `present - changing a role is not offered for an owner`() = runTest {
+        val room = aJoinedRoom(
+            canChangeRoles = true,
+            myUserRole = RoomMember.Role.Owner(isCreator = true),
+            targetRoomMember = aRoomMember(
+                userId = A_USER_ID,
+                powerLevel = RoomMember.Role.Owner(isCreator = false).powerLevel,
+                role = RoomMember.Role.Owner(isCreator = false),
+            ),
+        )
+        createRoomMemberModerationPresenter(room = room).test {
+            val initialState = awaitState()
+            initialState.eventSink(RoomMemberModerationEvent.ShowActionsForUser(targetUser))
+            skipItems(2)
+            val updatedState = awaitState()
+            assertThat(updatedState.actions).containsExactly(
+                ModerationActionState(action = ModerationAction.DisplayProfile, isEnabled = true),
+            )
+        }
+    }
+
+    @Test
+    fun `present - confirming a role change applies it once`() = runTest {
+        val updateUsersRolesLambda = lambdaRecorder<List<UserRoleChange>, Result<Unit>> { Result.success(Unit) }
+        val room = aJoinedRoom(
+            canChangeRoles = true,
+            myUserRole = RoomMember.Role.Admin,
+            updateUsersRolesResult = updateUsersRolesLambda,
+            targetRoomMember = aRoomMember(userId = A_USER_ID, powerLevel = RoomMember.Role.User.powerLevel),
+        )
+        createRoomMemberModerationPresenter(room = room).test {
+            val initialState = awaitState()
+            initialState.eventSink(
+                RoomMemberModerationEvent.ProcessAction(ModerationAction.ChangeRole(RoomMember.Role.Moderator), targetUser)
+            )
+            advanceUntilIdle()
+            val confirmingState = expectMostRecentItem() as InternalRoomMemberModerationState
+            assertThat(confirmingState.changeRoleAsyncAction).isEqualTo(AsyncAction.ConfirmingNoParams)
+            assertThat(confirmingState.roleToApply).isEqualTo(RoomMember.Role.Moderator)
+            updateUsersRolesLambda.assertions().isNeverCalled()
+
+            initialState.eventSink(InternalRoomMemberModerationEvent.DoChangeRole)
+            advanceUntilIdle()
+            updateUsersRolesLambda.assertions().isCalledOnce().with(
+                value(listOf(UserRoleChange(A_USER_ID, RoomMember.Role.Moderator)))
+            )
+            cancelAndIgnoreRemainingEvents()
         }
     }
 

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Day_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Day_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66b0552139c7c6f57b265baba81151275a0f0cfbd44c4680a4bb2256d97abbe8
+size 29725

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Day_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Day_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fecdff2e3c74484d7d19337698d22965e45bd76d36e63bd74616d5aa1c0ec5d0
+size 20904

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b10e0637957134e5d530fe59243e76847d888b6e1d62d5c4e359cb9869a876c
+size 28881

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_11_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_11_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3189b498ec9ffd65d0c7e650f020bf2f115e42d8dc48a30fda9bb40d1f69c78d
+size 19199

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:410a8596d4c70b9a3856d959d6d71ade8e831e8581ff410c9900957a93b3eb50
-size 8114
+oid sha256:520cae2544153ba45f8fe4b021286c2d22da06aa1b60be7f1b13879723ff994c
+size 3664

--- a/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_7_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.roommembermoderation.impl_RoomMemberModerationView_Night_7_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:520cae2544153ba45f8fe4b021286c2d22da06aa1b60be7f1b13879723ff994c
-size 3664
+oid sha256:0f3a0cb5d9bae6725a1c527f3d9575aabf85d3edf63a28d9faa23f4f0b65e2d0
+size 7624


### PR DESCRIPTION
## Content

Promoting or demoting somebody meant leaving the member you were looking at, going to Roles and
permissions, and editing a list. The actions sheet for a member now offers the roles they do not
already hold — Make admin, Make moderator, Make member — and applies the choice with
`updateUsersRoles` after a confirmation.

It reuses the sheet the moderation actions already live in rather than adding a screen. The offer is
gated on the current user being able to send `m.room.power_levels`, enabled only for a target they
already outrank (the same rule kick and ban use), and never shown for an owner, whose role this
screen cannot safely change.

## Motivation and context

Part of #5727, which points at a meta issue I cannot read, so the placement and wording here are my
own — happy to move them if the design says otherwise. The strings are in `temporary.xml` for the
Localazy import.

## Tests

- `RoomMemberModerationPresenterTest` — the roles offered exclude the one the member already holds;
  nothing is offered without the power levels permission; nothing is offered for an owner; confirming
  calls `updateUsersRoles` exactly once with the expected `UserRoleChange`, and not before.
- Negative control: removing the permission gate and the `updateUsersRoles` call fails two of the four.
- `./gradlew :features:roommembermoderation:impl:testDebugUnitTest :features:roomdetails:impl:testDebugUnitTest`
  plus ktlint and detekt — green. `RoomMemberModerationPermissions` gains a field, so
  `RoomMemberListStatePreviewParam` in `features/roomdetails` is updated to match.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): unit tests and Composable previews

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
