### PR TITLE
Count only the pinned messages the reader can actually see

### DIFF
--- a/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/pinned/PinnedEventsTimelineProvider.kt
+++ b/features/messages/api/src/main/kotlin/io/element/android/features/messages/api/pinned/PinnedEventsTimelineProvider.kt
@@ -9,10 +9,20 @@
 package io.element.android.features.messages.api.pinned
 
 import io.element.android.libraries.matrix.api.timeline.TimelineProvider
+import kotlinx.coroutines.flow.Flow
 
 /**
  * A [TimelineProvider] whose active timeline holds the pinned events of the room, rather than its live events.
  *
  * It exists as its own type so that it can be injected where only the pinned timeline is wanted.
  */
-interface PinnedEventsTimelineProvider : TimelineProvider
+interface PinnedEventsTimelineProvider : TimelineProvider {
+    /**
+     * How many of the room's pinned events the user can actually see, or `null` while that is not known yet.
+     *
+     * A room can pin an event the user has no access to — one sent before they joined, in a room that does not share
+     * its history. Such an event never appears in the pinned timeline, so counting the ids in the room state would
+     * promise more than any screen can show.
+     */
+    fun displayablePinnedEventsCount(): Flow<Int?>
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/DefaultPinnedEventsTimelineProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/pinned/DefaultPinnedEventsTimelineProvider.kt
@@ -18,12 +18,17 @@ import io.element.android.libraries.di.RoomScope
 import io.element.android.libraries.matrix.api.room.CreateTimelineParams
 import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.sync.SyncService
+import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -47,6 +52,18 @@ class DefaultPinnedEventsTimelineProvider(
     }
 
     val timelineStateFlow = _timelineStateFlow
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun displayablePinnedEventsCount(): Flow<Int?> {
+        return _timelineStateFlow.flatMapLatest { asyncTimeline ->
+            when (asyncTimeline) {
+                is AsyncData.Success -> asyncTimeline.data.timelineItems.map { items ->
+                    items.keepDisplayablePinnedEvents().count { it is MatrixTimelineItem.Event }
+                }
+                else -> flowOf(null)
+            }
+        }
+    }
 
     fun launchIn(scope: CoroutineScope) {
         _timelineStateFlow.subscriptionCount

--- a/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/pinned/FakePinnedEventsTimelineProvider.kt
+++ b/features/messages/test/src/main/kotlin/io/element/android/features/messages/test/pinned/FakePinnedEventsTimelineProvider.kt
@@ -10,10 +10,17 @@ package io.element.android.features.messages.test.pinned
 import io.element.android.features.messages.api.pinned.PinnedEventsTimelineProvider
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.matrix.test.timeline.FakeTimelineProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class FakePinnedEventsTimelineProvider(
     private val fakeTimelineProvider: FakeTimelineProvider = FakeTimelineProvider(),
+    displayablePinnedEventsCount: Int? = null,
 ) : PinnedEventsTimelineProvider {
+    val pinnedEventsCount = MutableStateFlow(displayablePinnedEventsCount)
+
     override fun activeTimelineFlow(): StateFlow<Timeline?> = fakeTimelineProvider.activeTimelineFlow()
+
+    override fun displayablePinnedEventsCount(): Flow<Int?> = pinnedEventsCount
 }

--- a/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
+++ b/features/roomdetails/impl/src/main/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenter.kt
@@ -25,6 +25,7 @@ import io.element.android.features.knockrequests.api.KnockRequestPermissions
 import io.element.android.features.knockrequests.api.knockRequestPermissions
 import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomState
+import io.element.android.features.messages.api.pinned.PinnedEventsTimelineProvider
 import io.element.android.features.roomcall.api.RoomCallState
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
 import io.element.android.features.roomdetailsedit.api.RoomDetailsEditPermissions
@@ -77,6 +78,7 @@ class RoomDetailsPresenter(
     private val appPreferencesStore: AppPreferencesStore,
     private val sessionPreferencesStore: SessionPreferencesStore,
     private val notificationCleaner: NotificationCleaner,
+    private val pinnedEventsTimelineProvider: PinnedEventsTimelineProvider,
 ) : Presenter<RoomDetailsState> {
     @AssistedFactory
     interface Factory {
@@ -105,7 +107,12 @@ class RoomDetailsPresenter(
             }
         }
 
-        val pinnedMessagesCount by remember { derivedStateOf { roomInfo.pinnedEventIds.size } }
+        val displayablePinnedMessagesCount by remember {
+            pinnedEventsTimelineProvider.displayablePinnedEventsCount()
+        }.collectAsState(initial = null)
+        val pinnedMessagesCount by remember {
+            derivedStateOf { displayablePinnedMessagesCount ?: roomInfo.pinnedEventIds.size }
+        }
 
         LaunchedEffect(Unit) {
             room.updateRoomNotificationSettings()

--- a/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
+++ b/features/roomdetails/impl/src/test/kotlin/io/element/android/features/roomdetails/impl/RoomDetailsPresenterTest.kt
@@ -13,6 +13,8 @@ import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.Interaction
 import io.element.android.features.leaveroom.api.LeaveRoomEvent
 import io.element.android.features.leaveroom.api.LeaveRoomState
+import io.element.android.features.messages.api.pinned.PinnedEventsTimelineProvider
+import io.element.android.features.messages.test.pinned.FakePinnedEventsTimelineProvider
 import io.element.android.features.roomcall.api.aStandByCallState
 import io.element.android.features.roomdetails.impl.members.aRoomMember
 import io.element.android.features.roomdetails.impl.members.details.RoomMemberDetailsPresenter
@@ -33,6 +35,7 @@ import io.element.android.libraries.matrix.api.room.powerlevels.RoomPermissions
 import io.element.android.libraries.matrix.api.timeline.ReceiptType
 import io.element.android.libraries.matrix.test.AN_AVATAR_URL
 import io.element.android.libraries.matrix.test.AN_EVENT_ID
+import io.element.android.libraries.matrix.test.AN_EVENT_ID_2
 import io.element.android.libraries.matrix.test.A_ROOM_NAME
 import io.element.android.libraries.matrix.test.A_ROOM_TOPIC
 import io.element.android.libraries.matrix.test.A_SESSION_ID
@@ -63,6 +66,7 @@ import io.element.android.tests.testutils.testWithLifecycleOwner
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -90,6 +94,7 @@ class RoomDetailsPresenterTest {
         navigator: RoomDetailsNavigator = FakeRoomDetailsNavigator(),
         notificationCleaner: NotificationCleaner = FakeNotificationCleaner(),
         sessionPreferencesStore: SessionPreferencesStore = InMemorySessionPreferencesStore(),
+        pinnedEventsTimelineProvider: PinnedEventsTimelineProvider = FakePinnedEventsTimelineProvider(),
     ): RoomDetailsPresenter {
         val matrixClient = FakeMatrixClient(notificationSettingsService = notificationSettingsService)
         val roomMemberDetailsPresenterFactory = object : RoomMemberDetailsPresenter.Factory {
@@ -119,6 +124,7 @@ class RoomDetailsPresenterTest {
             appPreferencesStore = appPreferencesStore,
             notificationCleaner = notificationCleaner,
             sessionPreferencesStore = sessionPreferencesStore,
+            pinnedEventsTimelineProvider = pinnedEventsTimelineProvider,
         )
     }
 
@@ -689,6 +695,38 @@ class RoomDetailsPresenterTest {
             }
             onDoneResult.assertions().isCalledOnce()
             assertThat(room.baseRoom.setUnreadFlagCalls).containsExactly(true)
+        }
+    }
+
+    @Test
+    fun `present - the pinned messages count is the number the pinned timeline can show`() = runTest {
+        val room = aJoinedRoom(roomPermissions = roomPermissions()).apply {
+            givenRoomInfo(aRoomInfo(pinnedEventIds = listOf(AN_EVENT_ID, AN_EVENT_ID_2)))
+        }
+        val presenter = createRoomDetailsPresenter(
+            room = room,
+            pinnedEventsTimelineProvider = FakePinnedEventsTimelineProvider(displayablePinnedEventsCount = 1),
+        )
+        presenter.testWithLifecycleOwner(lifecycleOwner = fakeLifecycleOwner) {
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem().pinnedMessagesCount).isEqualTo(1)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - a room pinning only events the user cannot see reports no pinned messages`() = runTest {
+        val room = aJoinedRoom(roomPermissions = roomPermissions()).apply {
+            givenRoomInfo(aRoomInfo(pinnedEventIds = listOf(AN_EVENT_ID)))
+        }
+        val presenter = createRoomDetailsPresenter(
+            room = room,
+            pinnedEventsTimelineProvider = FakePinnedEventsTimelineProvider(displayablePinnedEventsCount = 0),
+        )
+        presenter.testWithLifecycleOwner(lifecycleOwner = fakeLifecycleOwner) {
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem().pinnedMessagesCount).isEqualTo(0)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 


### PR DESCRIPTION
## Content

The pinned messages row in room details counted the event ids in `m.room.pinned_events`. A room can
pin an event a given member has no access to — one sent before they joined, in a room that does not
share its history — and such an event never reaches the pinned timeline. So the row promised a
message that the pinned list could not show, which is exactly what the reporter saw: room details
saying one pinned message, the list showing none.

The count now comes from the pinned timeline, the same source the pinned banner and the pinned list
already use, so the three agree by construction. Until that timeline has loaded, the row falls back
to the ids in the room state, so it still shows a number straight away rather than a spinner.

## Motivation and context

Part of #6959.

Deliberately not fixed here, and worth saying plainly: the other half of that report — the pinned
list sitting on a spinner instead of saying it has nothing to show — is not app-side. The list leaves
its loading state as soon as the pinned timeline emits anything at all, including an empty list; an
event that cannot be fetched means the SDK's pinned timeline never emits, and nothing in this
repository can turn that into an empty state.

## Tests

- `RoomDetailsPresenterTest` — the count is the number the pinned timeline can show, and a room whose
  only pinned event the user cannot see reports none.
- The two existing assertions on `pinnedMessagesCount` are unchanged and still pass, because the
  fallback keeps today's behaviour whenever the pinned timeline has not loaded.
- Negative control: restoring `roomInfo.pinnedEventIds.size` fails both new tests.
- `./gradlew :features:roomdetails:impl:testDebugUnitTest :features:messages:impl:testDebugUnitTest`
  plus ktlint and detekt on the four modules — green. `:tests:konsist:testDebugUnitTest --rerun-tasks`
  — green.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): unit tests only, no UI change

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
