### PR TITLE
Stop showing a sender's read receipt on their own message

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/factories/event/TimelineItemEventFactory.kt
@@ -191,6 +191,7 @@ class TimelineItemEventFactory(
         }
         return TimelineItemReadReceipts(
             receipts = event.receipts
+                .filterNot { it.userId == event.sender }
                 .map { receipt ->
                     val roomMember = roomMembers.find { it.userId == receipt.userId }
                     ReadReceiptData(

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/TimelinePresenterTest.kt
@@ -62,6 +62,7 @@ import io.element.android.libraries.matrix.test.A_THREAD_ID_2
 import io.element.android.libraries.matrix.test.A_UNIQUE_ID
 import io.element.android.libraries.matrix.test.A_UNIQUE_ID_2
 import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
 import io.element.android.libraries.matrix.test.room.aRoomInfo
@@ -1674,7 +1675,7 @@ class TimelinePresenterTest {
                             sender = A_USER_ID,
                             receipts = persistentListOf(
                                 Receipt(
-                                    userId = A_USER_ID,
+                                    userId = A_USER_ID_2,
                                     timestamp = 0L,
                                 )
                             )
@@ -1703,7 +1704,7 @@ class TimelinePresenterTest {
 
             room.givenRoomMembersState(
                 RoomMembersState.Ready(
-                    persistentListOf(aRoomMember(userId = A_USER_ID, avatarUrl = avatarUrl))
+                    persistentListOf(aRoomMember(userId = A_USER_ID_2, avatarUrl = avatarUrl))
                 )
             )
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/timeline/factories/TimelineItemsFactoryTest.kt
@@ -16,9 +16,13 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.libraries.matrix.api.core.UniqueId
 import io.element.android.libraries.matrix.api.timeline.MatrixTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.event.OtherMessageType
+import io.element.android.libraries.matrix.api.timeline.item.event.Receipt
 import io.element.android.libraries.matrix.test.A_USER_ID
+import io.element.android.libraries.matrix.test.A_USER_ID_2
+import io.element.android.libraries.matrix.test.A_USER_ID_3
 import io.element.android.libraries.matrix.test.timeline.aMessageContent
 import io.element.android.libraries.matrix.test.timeline.anEventTimelineItem
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -124,6 +128,42 @@ class TimelineItemsFactoryTest {
                 .filterIsInstance<TimelineItem.Event>()
                 .map { (it.content as TimelineItemTextContent).body }
             assertThat(bodies).containsExactly("A regular message")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `the sender's own read receipt is not shown on their message`() = runTest {
+        val factory = aTimelineItemsFactory(
+            config = TimelineItemsFactoryConfig(
+                computeReadReceipts = true,
+                computeReactions = false,
+            )
+        )
+        val items = listOf(
+            MatrixTimelineItem.Event(
+                uniqueId = UniqueId("event-0"),
+                event = anEventTimelineItem(
+                    sender = A_USER_ID_2,
+                    content = aMessageContent(body = "A message from Bob"),
+                    receipts = persistentListOf(
+                        Receipt(userId = A_USER_ID_2, timestamp = 0L),
+                        Receipt(userId = A_USER_ID_3, timestamp = 1L),
+                    ),
+                ),
+            ),
+        )
+        factory.timelineItems.test {
+            factory.replaceWith(
+                timelineItems = items,
+                roomMembers = emptyList(),
+                renderReadReceipts = true,
+            )
+            val receipts = awaitItem()
+                .filterIsInstance<TimelineItem.Event>()
+                .flatMap { it.readReceiptState.receipts }
+                .map { it.avatarData.id }
+            assertThat(receipts).containsExactly(A_USER_ID_3.value)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Content

A message shows a read receipt avatar for the person who wrote it. A user's receipt marks the last event they have read, so it lands on their own message the moment they send one, and the row then reports that the author has read what they just wrote.

The receipt is dropped where the receipts are computed, so the avatar row, the grouped-event row and the read receipt bottom sheet all agree. Nothing is lost: a receipt sitting on its own author's message is the only place that author's receipt can be, so hiding it hides no position the reader could otherwise have seen.

`TimelinePresenterTest`'s avatar propagation case used the same user as both the sender and the only receipt holder, so with this change it had nothing left to assert. Its receipt now comes from another member; both of its assertions are unchanged.

## Motivation and context

Relates to #5813.

## Tests

- `TimelineItemsFactoryTest` — an event with a receipt from its own sender and one from another member keeps only the other member's.
- The rest of `:features:messages:impl` still passes, including `TimelinePresenterTest`.

These do not cover the case where the SDK stops reporting a sender's own receipt at all; the filter is then simply a no-op.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 36

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
