### PR TITLE
Drop the sender's name from the room list preview of two-person rooms

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactory.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactory.kt
@@ -19,6 +19,7 @@ import io.element.android.libraries.designsystem.components.avatar.AvatarSize
 import io.element.android.libraries.eventformatter.api.RoomLatestEventFormatter
 import io.element.android.libraries.matrix.api.room.CallIntentConsensus
 import io.element.android.libraries.matrix.api.room.CurrentUserMembership
+import io.element.android.libraries.matrix.api.room.RoomInfo
 import io.element.android.libraries.matrix.api.roomlist.LatestEventValue
 import io.element.android.libraries.matrix.api.roomlist.RoomSummary
 import io.element.android.libraries.matrix.ui.model.dmUserStatus
@@ -47,7 +48,7 @@ class RoomListRoomSummaryFactory(
                 mode = DateFormatterMode.TimeOrDate,
                 useRelative = true,
             ),
-            latestEvent = computeLatestEvent(roomSummary.latestEvent, roomInfo.isDm),
+            latestEvent = computeLatestEvent(roomSummary.latestEvent, roomInfo.hasOnlyTwoMembers()),
             avatarData = avatarData,
             userDefinedNotificationMode = roomInfo.userDefinedNotificationMode,
             hasRoomCall = roomInfo.hasRoomCall,
@@ -79,6 +80,10 @@ class RoomListRoomSummaryFactory(
             isSpace = roomInfo.isSpace,
             dmUserStatus = roomInfo.dmUserStatus(),
         )
+    }
+
+    private fun RoomInfo.hasOnlyTwoMembers(): Boolean {
+        return isDm || activeMembersCount <= 2
     }
 
     private fun computeLatestEvent(latestEvent: LatestEventValue, dm: Boolean): LatestEvent {

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactoryTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/datasource/RoomListRoomSummaryFactoryTest.kt
@@ -8,10 +8,36 @@
 
 package io.element.android.features.home.impl.datasource
 
+import com.google.common.truth.Truth.assertThat
 import io.element.android.libraries.dateformatter.api.DateFormatter
 import io.element.android.libraries.dateformatter.test.FakeDateFormatter
 import io.element.android.libraries.eventformatter.api.RoomLatestEventFormatter
 import io.element.android.libraries.eventformatter.test.FakeRoomLatestEventFormatter
+import io.element.android.libraries.matrix.test.room.aRoomInfo
+import io.element.android.libraries.matrix.test.room.aRoomSummary
+import org.junit.Test
+
+class RoomListRoomSummaryFactoryTest {
+    @Test
+    fun `a room with two members does not prefix its preview with the sender`() {
+        val formatter = FakeRoomLatestEventFormatter()
+        val factory = aRoomListRoomSummaryFactory(roomLatestEventFormatter = formatter)
+
+        factory.create(aRoomSummary(info = aRoomInfo(isDm = false, activeMembersCount = 2)))
+
+        assertThat(formatter.lastIsDmRoom).isTrue()
+    }
+
+    @Test
+    fun `a room with more than two members prefixes its preview with the sender`() {
+        val formatter = FakeRoomLatestEventFormatter()
+        val factory = aRoomListRoomSummaryFactory(roomLatestEventFormatter = formatter)
+
+        factory.create(aRoomSummary(info = aRoomInfo(isDm = false, activeMembersCount = 3)))
+
+        assertThat(formatter.lastIsDmRoom).isFalse()
+    }
+}
 
 fun aRoomListRoomSummaryFactory(
     dateFormatter: DateFormatter = FakeDateFormatter { _, _, _ -> "Today" },

--- a/libraries/eventformatter/test/src/main/kotlin/io/element/android/libraries/eventformatter/test/FakeRoomLatestEventFormatter.kt
+++ b/libraries/eventformatter/test/src/main/kotlin/io/element/android/libraries/eventformatter/test/FakeRoomLatestEventFormatter.kt
@@ -14,11 +14,16 @@ import io.element.android.libraries.matrix.api.roomlist.LatestEventValue
 class FakeRoomLatestEventFormatter : RoomLatestEventFormatter {
     private var result: CharSequence? = null
 
+    var lastIsDmRoom: Boolean? = null
+        private set
+
     override fun format(latestEvent: LatestEventValue.Local, isDmRoom: Boolean): CharSequence? {
+        lastIsDmRoom = isDmRoom
         return result
     }
 
     override fun format(latestEvent: LatestEventValue.Remote, isDmRoom: Boolean): CharSequence? {
+        lastIsDmRoom = isDmRoom
         return result
     }
 


### PR DESCRIPTION
## Content

The room list preview prefixes the sender's name unless the room is a direct message. A room created as a group and later converted to a direct message is not marked as one by the server, so its preview kept naming the only other person in it on every message, while iOS showed no name at all.

The prefix now depends on how many people are actually in the room rather than on the direct message flag: no name while only two people can be talking, the name back as soon as a third joins. That is the behaviour asked for in the issue, and it also keeps the name for a two-person room that has a bot in it, since the bot counts.

## Motivation and context

Relates to #1548.

## Tests

- `RoomListRoomSummaryFactoryTest` — a two-member room formats its preview without the sender, a three-member room formats it with the sender.

These do not cover a room whose member count has not synced yet; the preview then follows whatever count is known, and corrects itself when the count arrives.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 36

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
