### PR TITLE
Keep a room's notification setting when it is upgraded

### DIFF
--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoom.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoom.kt
@@ -10,9 +10,11 @@ package io.element.android.libraries.matrix.impl.room.join
 
 import dev.zacsweers.metro.ContributesBinding
 import im.vector.app.features.analytics.plan.JoinedRoom
+import io.element.android.libraries.core.bool.orFalse
 import io.element.android.libraries.core.extensions.mapFailure
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.matrix.api.MatrixClient
+import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
 import io.element.android.libraries.matrix.api.exception.ClientException
 import io.element.android.libraries.matrix.api.exception.ErrorKind
@@ -44,6 +46,7 @@ class DefaultJoinRoom(
         }.onSuccess { roomInfo ->
             if (roomInfo != null) {
                 analyticsService.capture(roomInfo.toAnalyticsJoinedRoom(trigger))
+                inheritNotificationModeFromPredecessor(roomInfo.id)
             }
         }.mapFailure {
             if (it is ClientException.MatrixApi) {
@@ -55,5 +58,19 @@ class DefaultJoinRoom(
                 it
             }
         }.map { }
+    }
+
+    private suspend fun inheritNotificationModeFromPredecessor(roomId: RoomId) {
+        val room = client.getRoom(roomId) ?: return
+        val predecessorId = room.predecessorRoom()?.roomId ?: return
+        val predecessor = client.getRoom(predecessorId) ?: return
+        val predecessorInfo = predecessor.info()
+        val settings = client.notificationSettingsService.getRoomNotificationSettings(
+            roomId = predecessorId,
+            isEncrypted = predecessorInfo.isEncrypted.orFalse(),
+            isOneToOne = predecessorInfo.isDm,
+        ).getOrNull() ?: return
+        if (settings.isDefault) return
+        client.notificationSettingsService.setRoomNotificationMode(roomId, settings.mode)
     }
 }

--- a/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoomTest.kt
+++ b/libraries/matrix/impl/src/test/kotlin/io/element/android/libraries/matrix/impl/room/join/DefaultJoinRoomTest.kt
@@ -14,11 +14,15 @@ import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
 import io.element.android.libraries.matrix.api.core.toRoomIdOrAlias
+import io.element.android.libraries.matrix.api.room.RoomNotificationMode
+import io.element.android.libraries.matrix.api.room.tombstone.PredecessorRoom
 import io.element.android.libraries.matrix.impl.analytics.toAnalyticsJoinedRoom
 import io.element.android.libraries.matrix.test.A_ROOM_ALIAS
 import io.element.android.libraries.matrix.test.A_ROOM_ID
+import io.element.android.libraries.matrix.test.A_ROOM_ID_2
 import io.element.android.libraries.matrix.test.A_SERVER_LIST
 import io.element.android.libraries.matrix.test.FakeMatrixClient
+import io.element.android.libraries.matrix.test.notificationsettings.FakeNotificationSettingsService
 import io.element.android.libraries.matrix.test.room.FakeBaseRoom
 import io.element.android.libraries.matrix.test.room.aRoomInfo
 import io.element.android.services.analytics.test.FakeAnalyticsService
@@ -138,6 +142,76 @@ class DefaultJoinRoomTest {
             .isNeverCalled()
         assertThat(analyticsService.capturedEvents).containsExactly(
             roomResult.toAnalyticsJoinedRoom(aTrigger)
+        )
+    }
+
+    @Test
+    fun `joining the successor of a room with its own notification mode carries that mode over`() = runTest {
+        val notificationSettingsService = FakeNotificationSettingsService(
+            initialRoomMode = RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY,
+            initialRoomModeIsDefault = false,
+        )
+        val sut = aJoinRoom(
+            notificationSettingsService = notificationSettingsService,
+            predecessorRoom = PredecessorRoom(roomId = A_ROOM_ID_2),
+        )
+
+        sut.invoke(A_ROOM_ID.toRoomIdOrAlias(), emptyList(), JoinedRoom.Trigger.MobilePermalink)
+
+        assertThat(notificationSettingsService.setRoomNotificationModeCalls)
+            .containsExactly(A_ROOM_ID to RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY)
+    }
+
+    @Test
+    fun `joining a room without a predecessor leaves its notification mode alone`() = runTest {
+        val notificationSettingsService = FakeNotificationSettingsService(
+            initialRoomMode = RoomNotificationMode.MENTIONS_AND_KEYWORDS_ONLY,
+            initialRoomModeIsDefault = false,
+        )
+        val sut = aJoinRoom(
+            notificationSettingsService = notificationSettingsService,
+            predecessorRoom = null,
+        )
+
+        sut.invoke(A_ROOM_ID.toRoomIdOrAlias(), emptyList(), JoinedRoom.Trigger.MobilePermalink)
+
+        assertThat(notificationSettingsService.setRoomNotificationModeCalls).isEmpty()
+    }
+
+    @Test
+    fun `joining the successor of a room using the default notification mode leaves the default in place`() = runTest {
+        val notificationSettingsService = FakeNotificationSettingsService(
+            initialRoomModeIsDefault = true,
+        )
+        val sut = aJoinRoom(
+            notificationSettingsService = notificationSettingsService,
+            predecessorRoom = PredecessorRoom(roomId = A_ROOM_ID_2),
+        )
+
+        sut.invoke(A_ROOM_ID.toRoomIdOrAlias(), emptyList(), JoinedRoom.Trigger.MobilePermalink)
+
+        assertThat(notificationSettingsService.setRoomNotificationModeCalls).isEmpty()
+    }
+
+    private fun aJoinRoom(
+        notificationSettingsService: FakeNotificationSettingsService,
+        predecessorRoom: PredecessorRoom?,
+    ): DefaultJoinRoom {
+        val roomInfo = aRoomInfo(id = A_ROOM_ID)
+        val client = FakeMatrixClient(notificationSettingsService = notificationSettingsService).also {
+            it.joinRoomLambda = { Result.success(roomInfo) }
+            it.givenGetRoomResult(
+                roomId = A_ROOM_ID,
+                result = FakeBaseRoom(predecessorRoomResult = { predecessorRoom }).apply { givenRoomInfo(roomInfo) },
+            )
+            it.givenGetRoomResult(
+                roomId = A_ROOM_ID_2,
+                result = FakeBaseRoom().apply { givenRoomInfo(aRoomInfo(id = A_ROOM_ID_2)) },
+            )
+        }
+        return DefaultJoinRoom(
+            client = client,
+            analyticsService = FakeAnalyticsService(),
         )
     }
 }

--- a/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notificationsettings/FakeNotificationSettingsService.kt
+++ b/libraries/matrix/test/src/main/kotlin/io/element/android/libraries/matrix/test/notificationsettings/FakeNotificationSettingsService.kt
@@ -42,6 +42,8 @@ class FakeNotificationSettingsService(
     private var setDefaultNotificationModeError: Throwable? = null
     private var setAtRoomError: Throwable? = null
     private var canHomeServerPushEncryptedEventsToDeviceResult = Result.success(true)
+
+    val setRoomNotificationModeCalls = mutableListOf<Pair<RoomId, RoomNotificationMode>>()
     override val notificationSettingsChangeFlow: SharedFlow<Unit>
         get() = notificationSettingsStateFlow
 
@@ -97,6 +99,7 @@ class FakeNotificationSettingsService(
         return if (error != null) {
             Result.failure(error)
         } else {
+            setRoomNotificationModeCalls.add(roomId to mode)
             roomNotificationModeIsDefault = false
             roomNotificationMode = mode
             notificationSettingsStateFlow.emit(Unit)


### PR DESCRIPTION
## Content

A room that has been upgraded is a different room to the server, so the notification rule a user set on the old one does not apply to the new one. Following the upgrade banner into the replacement room therefore silently returned that conversation to the default, and a room someone had deliberately set to mentions only started notifying for everything again.

The setting is now carried over in `JoinRoom`, which every join already goes through, so it applies however the replacement room is reached rather than only from the banner.

Only a rule the user set themselves is copied. A room that was following the default keeps following it, rather than being pinned to whatever the default happened to be at the moment of the upgrade.

## Motivation and context

Relates to #5797.

## Tests

- `DefaultJoinRoomTest` — joining the successor of a room with its own notification mode sets that mode on the new room; joining a room with no predecessor, or whose predecessor was on the default, changes nothing.

These do not cover the case where the predecessor room is no longer in the client's store, in which case nothing is copied and the new room keeps the default.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 36

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
