### PR TITLE
Offer to shuffle the digits of the PIN keypad

### DIFF
--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsEvent.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsEvent.kt
@@ -13,4 +13,5 @@ sealed interface LockScreenSettingsEvent {
     data object ConfirmRemovePin : LockScreenSettingsEvent
     data object CancelRemovePin : LockScreenSettingsEvent
     data object ToggleBiometricAllowed : LockScreenSettingsEvent
+    data object TogglePinKeypadShuffled : LockScreenSettingsEvent
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsPresenter.kt
@@ -45,6 +45,9 @@ class LockScreenSettingsPresenter(
         val isBiometricEnabled by remember {
             lockScreenStore.isBiometricUnlockAllowed()
         }.collectAsState(initial = false)
+        val isPinKeypadShuffled by remember {
+            lockScreenStore.isPinKeypadShuffled()
+        }.collectAsState(initial = false)
         var showRemovePinConfirmation by remember {
             mutableStateOf(false)
         }
@@ -76,6 +79,11 @@ class LockScreenSettingsPresenter(
                         }
                     }
                 }
+                LockScreenSettingsEvent.TogglePinKeypadShuffled -> {
+                    coroutineScope.launch {
+                        lockScreenStore.setIsPinKeypadShuffled(!isPinKeypadShuffled)
+                    }
+                }
             }
         }
 
@@ -84,6 +92,7 @@ class LockScreenSettingsPresenter(
             isBiometricEnabled = isBiometricEnabled,
             showRemovePinConfirmation = showRemovePinConfirmation,
             showToggleBiometric = biometricAuthenticatorManager.isDeviceSecured,
+            isPinKeypadShuffled = isPinKeypadShuffled,
             eventSink = ::handleEvent,
         )
     }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsState.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsState.kt
@@ -13,5 +13,6 @@ data class LockScreenSettingsState(
     val isBiometricEnabled: Boolean,
     val showRemovePinConfirmation: Boolean,
     val showToggleBiometric: Boolean,
+    val isPinKeypadShuffled: Boolean,
     val eventSink: (LockScreenSettingsEvent) -> Unit
 )

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsStatePreviewParam.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsStatePreviewParam.kt
@@ -16,6 +16,7 @@ open class LockScreenSettingsStatePreviewParam : PreviewParameterProvider<LockSc
             aLockScreenSettingsState(),
             aLockScreenSettingsState(isLockMandatory = true),
             aLockScreenSettingsState(showRemovePinConfirmation = true),
+            aLockScreenSettingsState(isPinKeypadShuffled = true),
         )
 }
 
@@ -24,10 +25,12 @@ fun aLockScreenSettingsState(
     isBiometricEnabled: Boolean = false,
     showRemovePinConfirmation: Boolean = false,
     showToggleBiometric: Boolean = true,
+    isPinKeypadShuffled: Boolean = false,
 ) = LockScreenSettingsState(
     showRemovePinOption = isLockMandatory,
     isBiometricEnabled = isBiometricEnabled,
     showRemovePinConfirmation = showRemovePinConfirmation,
     showToggleBiometric = showToggleBiometric,
+    isPinKeypadShuffled = isPinKeypadShuffled,
     eventSink = {}
 )

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/settings/LockScreenSettingsView.kt
@@ -65,6 +65,15 @@ fun LockScreenSettingsView(
                     }
                 )
             }
+            PreferenceDivider()
+            PreferenceSwitch(
+                title = stringResource(id = R.string.screen_app_lock_settings_shuffle_pin_keypad),
+                subtitle = stringResource(id = R.string.screen_app_lock_settings_shuffle_pin_keypad_subtitle),
+                isChecked = state.isPinKeypadShuffled,
+                onCheckedChange = {
+                    state.eventSink(LockScreenSettingsEvent.TogglePinKeypadShuffled)
+                }
+            )
         }
     }
     if (state.showRemovePinConfirmation) {

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/LockScreenStore.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/LockScreenStore.kt
@@ -35,4 +35,14 @@ interface LockScreenStore : EncryptedPinCodeStorage {
      * Sets whether the biometric unlock is allowed or not.
      */
     suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean)
+
+    /**
+     * Returns whether the digits of the PIN keypad are shuffled or not.
+     */
+    fun isPinKeypadShuffled(): Flow<Boolean>
+
+    /**
+     * Sets whether the digits of the PIN keypad are shuffled or not.
+     */
+    suspend fun setIsPinKeypadShuffled(isShuffled: Boolean)
 }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/storage/PreferencesLockScreenStore.kt
@@ -31,6 +31,7 @@ class PreferencesLockScreenStore(
     private val pinCodeKey = stringPreferencesKey("encoded_pin_code")
     private val remainingAttemptsKey = intPreferencesKey("remaining_pin_code_attempts")
     private val biometricUnlockKey = booleanPreferencesKey("biometric_unlock_enabled")
+    private val shuffledKeypadKey = booleanPreferencesKey("shuffled_pin_keypad")
 
     override suspend fun getRemainingPinCodeAttemptsNumber(): Int {
         return dataStore.data.map { preferences ->
@@ -79,6 +80,18 @@ class PreferencesLockScreenStore(
     override suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean) {
         dataStore.edit { preferences ->
             preferences[biometricUnlockKey] = isAllowed
+        }
+    }
+
+    override fun isPinKeypadShuffled(): Flow<Boolean> {
+        return dataStore.data.map { preferences ->
+            preferences[shuffledKeypadKey] ?: false
+        }
+    }
+
+    override suspend fun setIsPinKeypadShuffled(isShuffled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[shuffledKeypadKey] = isShuffled
         }
     }
 

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenter.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenter.kt
@@ -11,6 +11,7 @@ package io.element.android.features.lockscreen.impl.unlock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,6 +24,7 @@ import io.element.android.features.lockscreen.impl.biometric.BiometricAuthentica
 import io.element.android.features.lockscreen.impl.biometric.BiometricAuthenticatorManager
 import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.pin.model.PinEntry
+import io.element.android.features.lockscreen.impl.storage.LockScreenStore
 import io.element.android.features.lockscreen.impl.unlock.keypad.PinKeypadModel
 import io.element.android.features.logout.api.LogoutUseCase
 import io.element.android.libraries.architecture.AsyncAction
@@ -43,6 +45,7 @@ class PinUnlockPresenter(
     @AppCoroutineScope
     private val coroutineScope: CoroutineScope,
     private val pinUnlockHelper: PinUnlockHelper,
+    private val lockScreenStore: LockScreenStore,
 ) : Presenter<PinUnlockState> {
     @AssistedFactory
     interface Factory {
@@ -73,6 +76,9 @@ class PinUnlockPresenter(
         val isUnlocked = remember {
             mutableStateOf(false)
         }
+        val isPinKeypadShuffled by remember {
+            lockScreenStore.isPinKeypadShuffled()
+        }.collectAsState(initial = false)
         val biometricUnlock = biometricAuthenticatorManager.rememberUnlockBiometricAuthenticator()
         LaunchedEffect(Unit) {
             suspend {
@@ -145,6 +151,7 @@ class PinUnlockPresenter(
             showBiometricUnlock = biometricUnlock.isActive,
             biometricUnlockResult = biometricUnlockResult,
             isUnlocked = isUnlocked.value,
+            isPinKeypadShuffled = isPinKeypadShuffled,
             eventSink = ::handleEvent,
         )
     }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockState.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockState.kt
@@ -23,6 +23,7 @@ data class PinUnlockState(
     val signOutAction: AsyncAction<Unit>,
     val showBiometricUnlock: Boolean,
     val isUnlocked: Boolean,
+    val isPinKeypadShuffled: Boolean,
     val biometricUnlockResult: BiometricAuthenticator.AuthenticationResult?,
     val eventSink: (PinUnlockEvent) -> Unit
 ) {

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockStatePreviewParam.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockStatePreviewParam.kt
@@ -60,6 +60,7 @@ fun aPinUnlockState(
     biometricUnlockResult: BiometricAuthenticator.AuthenticationResult? = null,
     isUnlocked: Boolean = false,
     signOutAction: AsyncAction<Unit> = AsyncAction.Uninitialized,
+    isPinKeypadShuffled: Boolean = false,
 ) = PinUnlockState(
     canNavigateBack = canNavigateBack,
     pinEntry = pinEntry,
@@ -70,5 +71,6 @@ fun aPinUnlockState(
     signOutAction = signOutAction,
     biometricUnlockResult = biometricUnlockResult,
     isUnlocked = isUnlocked,
+    isPinKeypadShuffled = isPinKeypadShuffled,
     eventSink = {}
 )

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockView.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockView.kt
@@ -162,6 +162,7 @@ private fun PinUnlockPage(
                     },
                     maxWidth = constraints.maxWidth,
                     maxHeight = constraints.maxHeight,
+                    isShuffled = state.isPinKeypadShuffled,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 )
             }

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypad.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypad.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,6 +49,8 @@ import io.element.android.libraries.ui.utils.time.digit
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
+private val orderedDigits = ('1'..'9') + '0'
+
 private val spaceBetweenPinKey = 16.dp
 private val minSizePinKey = 16.dp
 private val maxSizePinKey = 80.dp
@@ -58,9 +61,13 @@ fun PinKeypad(
     maxWidth: Dp,
     maxHeight: Dp,
     modifier: Modifier = Modifier,
+    isShuffled: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
 ) {
+    val digits = remember(isShuffled) {
+        if (isShuffled) orderedDigits.shuffled() else orderedDigits
+    }
     val pinKeyMaxWidth = ((maxWidth - 2 * spaceBetweenPinKey) / 3).coerceIn(minSizePinKey, maxSizePinKey)
     val pinKeyMaxHeight = ((maxHeight - 3 * spaceBetweenPinKey) / 4).coerceIn(minSizePinKey, maxSizePinKey)
     val pinKeySize = if (pinKeyMaxWidth < pinKeyMaxHeight) pinKeyMaxWidth else pinKeyMaxHeight
@@ -91,28 +98,28 @@ fun PinKeypad(
             pinKeySize = pinKeySize,
             verticalAlignment = verticalAlignment,
             horizontalArrangement = horizontalArrangement,
-            models = persistentListOf(PinKeypadModel.Number('1'), PinKeypadModel.Number('2'), PinKeypadModel.Number('3')),
+            models = persistentListOf(PinKeypadModel.Number(digits[0]), PinKeypadModel.Number(digits[1]), PinKeypadModel.Number(digits[2])),
             onClick = onClick,
         )
         PinKeypadRow(
             pinKeySize = pinKeySize,
             verticalAlignment = verticalAlignment,
             horizontalArrangement = horizontalArrangement,
-            models = persistentListOf(PinKeypadModel.Number('4'), PinKeypadModel.Number('5'), PinKeypadModel.Number('6')),
+            models = persistentListOf(PinKeypadModel.Number(digits[3]), PinKeypadModel.Number(digits[4]), PinKeypadModel.Number(digits[5])),
             onClick = onClick,
         )
         PinKeypadRow(
             pinKeySize = pinKeySize,
             verticalAlignment = verticalAlignment,
             horizontalArrangement = horizontalArrangement,
-            models = persistentListOf(PinKeypadModel.Number('7'), PinKeypadModel.Number('8'), PinKeypadModel.Number('9')),
+            models = persistentListOf(PinKeypadModel.Number(digits[6]), PinKeypadModel.Number(digits[7]), PinKeypadModel.Number(digits[8])),
             onClick = onClick,
         )
         PinKeypadRow(
             pinKeySize = pinKeySize,
             verticalAlignment = verticalAlignment,
             horizontalArrangement = horizontalArrangement,
-            models = persistentListOf(PinKeypadModel.Empty, PinKeypadModel.Number('0'), PinKeypadModel.Back),
+            models = persistentListOf(PinKeypadModel.Empty, PinKeypadModel.Number(digits[9]), PinKeypadModel.Back),
             onClick = onClick,
         )
     }

--- a/features/lockscreen/impl/src/main/res/values/temporary.xml
+++ b/features/lockscreen/impl/src/main/res/values/temporary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,UnusedResources">
+  <string name="screen_app_lock_settings_shuffle_pin_keypad">Shuffle the keypad</string>
+  <string name="screen_app_lock_settings_shuffle_pin_keypad_subtitle">Show the digits in a random order so nobody can read your PIN from the movement of your finger.</string>
+</resources>

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/pin/storage/InMemoryLockScreenStore.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/pin/storage/InMemoryLockScreenStore.kt
@@ -18,6 +18,7 @@ class InMemoryLockScreenStore : LockScreenStore {
     private var pinCode: String? = null
     private var remainingAttempts: Int = DEFAULT_REMAINING_ATTEMPTS
     private var isBiometricUnlockAllowed = MutableStateFlow(false)
+    private var isPinKeypadShuffled = MutableStateFlow(false)
 
     override suspend fun getRemainingPinCodeAttemptsNumber(): Int {
         return remainingAttempts
@@ -49,5 +50,13 @@ class InMemoryLockScreenStore : LockScreenStore {
 
     override suspend fun setIsBiometricUnlockAllowed(isAllowed: Boolean) {
         isBiometricUnlockAllowed.value = isAllowed
+    }
+
+    override fun isPinKeypadShuffled(): Flow<Boolean> {
+        return isPinKeypadShuffled
+    }
+
+    override suspend fun setIsPinKeypadShuffled(isShuffled: Boolean) {
+        isPinKeypadShuffled.value = isShuffled
     }
 }

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenterTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/PinUnlockPresenterTest.kt
@@ -194,6 +194,7 @@ class PinUnlockPresenterTest {
             logoutUseCase = logoutUseCase,
             coroutineScope = this,
             pinUnlockHelper = PinUnlockHelper(biometricAuthenticatorManager, pinCodeManager),
+            lockScreenStore = InMemoryLockScreenStore(),
         )
     }
 }

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypadTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/unlock/keypad/PinKeypadTest.kt
@@ -15,6 +15,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isRoot
@@ -113,14 +114,32 @@ class PinKeypadTest : RobolectricTest() {
         )
     }
 
+    @Test
+    fun `a shuffled keypad still offers every digit exactly once`() = runAndroidComposeUiTest {
+        setPinKeyPad(isShuffled = true)
+        for (digit in '0'..'9') {
+            onAllNodes(hasText(digit.toString())).assertCountEquals(1)
+        }
+    }
+
+    @Test
+    fun `a shuffled keypad still emits the digit that was clicked`() = runAndroidComposeUiTest {
+        val eventsRecorder = EventsRecorder<PinKeypadModel>()
+        setPinKeyPad(onClick = eventsRecorder, isShuffled = true)
+        onNode(hasText("7")).performClick()
+        eventsRecorder.assertSingle(PinKeypadModel.Number('7'))
+    }
+
     private fun AndroidComposeUiTest<ComponentActivity>.setPinKeyPad(
         onClick: (PinKeypadModel) -> Unit = EnsureNeverCalledWithParam(),
+        isShuffled: Boolean = false,
     ) {
         setContent {
             PinKeypad(
                 onClick = onClick,
                 maxWidth = 1000.dp,
                 maxHeight = 1000.dp,
+                isShuffled = isShuffled,
             )
         }
     }

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4615061f43638296af16cf7e515b4a99652fa864e8660774572191bf5ba14745
-size 16573
+oid sha256:180bc54d5d7bf6bafb6b3cb6960f0565e7eb969eaff32438cc2d549ca22587f7
+size 34650

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c6ac7dd26d008a0aff402f8c19a099aa632c94db957ed64db39209e5b9aeaae
-size 18865
+oid sha256:53324476bc14cc323969b483e1d81da06271944b9891741448cf62f8ebfef9bf
+size 37260

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3e38957ec880adb0826805b16ce17ca02c4d4b4144beecf5fefe38e2474844b
-size 28597
+oid sha256:df01cb7cd89f70474a92ef4f0e9cab65493ccea98e41d0b7cff740b2cd9774b3
+size 38095

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Day_3_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eced82e078f3615b064487bf80427ca9f749d4373328be96d87991aab9b23186
+size 34398

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:987d10d47bb3b3ccfd089cbec88ea893c394753cfab98cd20fa5960cede5610f
-size 16025
+oid sha256:b0c08b986a3ae78b4d949a8f3d39ecae68bbc935310c25d8be8631ec17622fb0
+size 33427

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad2296982cfe78d9dda44ebfa67069db317ff09db1aade04c6ff1115ff0c2372
-size 18118
+oid sha256:5fb99befb383b745ea2dbbfd10c4aaafc8f902997da0ee3d369dfd18a8874c27
+size 35835

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e86e29e9af95e444c8e78f4ff5289eca8c00817ee723b32c0a01e295b3e467e
-size 27117
+oid sha256:d72f0ef921c5e23991fc1d11972a30a058b13af9e0d4fa7f0406e57d21f571ed
+size 36036

--- a/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.lockscreen.impl.settings_LockScreenSettingsView_Night_3_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:950207d9b115ea7203b5c5842b6fc8fda0f345f198f3a9f89651ddbca9e3ee74
+size 33070


### PR DESCRIPTION
## Content

The PIN keypad always draws 1 to 0 in the same nine positions, so anyone standing close enough to watch the movement of a finger can read the PIN back without seeing the screen at all. A new switch under Screen lock draws the digits in a random order instead, keeping the same grid so the pad still looks and behaves the way it did.

The order is drawn once per unlock screen rather than after every key, so a PIN can still be entered without hunting for each digit twice. The setting is off by default and lives next to the biometric unlock switch, in the same store.

## Motivation and context

Relates to #6031.

## Tests

- `PinKeypadTest` — a shuffled keypad still offers every digit exactly once, and clicking a digit still emits that digit rather than the one that used to sit in that position.
- The existing keypad and unlock tests are unchanged and still pass with shuffling off.

These do not assert that a shuffled pad differs from an unshuffled one, which is not deterministic; they assert that shuffling never loses, duplicates or mislabels a key.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 36

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
