### PR TITLE
Offer to open or share a link with another app

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/link/LinkActionsView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/link/LinkActionsView.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.features.messages.impl.link
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import io.element.android.compound.tokens.generated.CompoundIcons
+import io.element.android.libraries.androidutils.system.copyToClipboard
+import io.element.android.libraries.androidutils.system.openUrlInExternalApp
+import io.element.android.libraries.androidutils.system.startSharePlainTextIntent
+import io.element.android.libraries.designsystem.components.list.ListItemContent
+import io.element.android.libraries.designsystem.preview.ElementPreview
+import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.theme.components.IconSource
+import io.element.android.libraries.designsystem.theme.components.ListItem
+import io.element.android.libraries.designsystem.theme.components.ModalBottomSheet
+import io.element.android.libraries.designsystem.theme.components.Text
+import io.element.android.libraries.ui.strings.CommonStrings
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LinkActionsView(
+    url: String,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val copiedMessage = stringResource(CommonStrings.common_copied_to_clipboard)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        scrollable = false,
+    ) {
+        LinkActionsViewContent(
+            onOpenWithClick = {
+                onDismiss()
+                context.openUrlInExternalApp(url)
+            },
+            onShareClick = {
+                onDismiss()
+                context.startSharePlainTextIntent(
+                    activityResultLauncher = null,
+                    chooserTitle = null,
+                    text = url,
+                )
+            },
+            onCopyClick = {
+                onDismiss()
+                context.copyToClipboard(text = url, toastMessage = copiedMessage)
+            },
+        )
+    }
+}
+
+@Composable
+internal fun LinkActionsViewContent(
+    onOpenWithClick: () -> Unit,
+    onShareClick: () -> Unit,
+    onCopyClick: () -> Unit,
+) {
+    Column {
+        ListItem(
+            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.PopOut())),
+            onClick = onOpenWithClick,
+            content = { Text(stringResource(CommonStrings.action_open_with)) },
+        )
+        ListItem(
+            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.ShareAndroid())),
+            onClick = onShareClick,
+            content = { Text(stringResource(CommonStrings.action_share_link)) },
+        )
+        ListItem(
+            leadingContent = ListItemContent.Icon(IconSource.Vector(CompoundIcons.Copy())),
+            onClick = onCopyClick,
+            content = { Text(stringResource(CommonStrings.action_copy_link)) },
+        )
+    }
+}
+
+@PreviewsDayNight
+@Composable
+internal fun LinkActionsViewContentPreview() = ElementPreview {
+    LinkActionsViewContent(
+        onOpenWithClick = {},
+        onShareClick = {},
+        onCopyClick = {},
+    )
+}

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/TimelineView.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
@@ -81,6 +80,7 @@ import androidx.compose.ui.window.PopupProperties
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.crypto.sendfailure.resolve.ResolveVerifiedUserSendFailureView
+import io.element.android.features.messages.impl.link.LinkActionsView
 import io.element.android.features.messages.impl.timeline.components.FloatingDateBadgeOverlay
 import io.element.android.features.messages.impl.timeline.components.TimelineItemRow
 import io.element.android.features.messages.impl.timeline.components.toText
@@ -93,7 +93,6 @@ import io.element.android.features.messages.impl.timeline.model.event.TimelineIt
 import io.element.android.features.messages.impl.timeline.model.event.TimelineItemEventContentPreviewParam
 import io.element.android.features.messages.impl.timeline.protection.TimelineProtectionState
 import io.element.android.features.messages.impl.timeline.protection.aTimelineProtectionState
-import io.element.android.libraries.androidutils.system.copyToClipboard
 import io.element.android.libraries.designsystem.atomic.atoms.UnreadIndicatorAtom
 import io.element.android.libraries.designsystem.components.dialogs.AlertDialog
 import io.element.android.libraries.designsystem.preview.ElementPreview
@@ -168,20 +167,24 @@ fun TimelineView(
         state.eventSink(TimelineEvent.FocusOnEvent(eventId))
     }
 
-    val context = LocalContext.current
-    val toastMessage = stringResource(CommonStrings.common_copied_to_clipboard)
     val view = LocalView.current
     fun inReplyToClick(eventId: EventId) {
         state.eventSink(TimelineEvent.FocusOnEvent(eventId))
     }
 
+    var linkActionsUrl by remember { mutableStateOf<String?>(null) }
+
     fun onLinkLongClick(link: Link) {
         view.performHapticFeedback(
             HapticFeedbackConstants.LONG_PRESS
         )
-        context.copyToClipboard(
-            text = link.url,
-            toastMessage = toastMessage,
+        linkActionsUrl = link.url
+    }
+
+    linkActionsUrl?.let { url ->
+        LinkActionsView(
+            url = url,
+            onDismiss = { linkActionsUrl = null },
         )
     }
 

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/link/LinkActionsViewTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/link/LinkActionsViewTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.element.android.features.messages.impl.link
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import io.element.android.libraries.ui.strings.CommonStrings
+import io.element.android.tests.testutils.EnsureNeverCalled
+import io.element.android.tests.testutils.clickOn
+import io.element.android.tests.testutils.ensureCalledOnce
+import io.element.android.tests.testutils.robolectric.RobolectricTest
+import org.junit.Test
+
+class LinkActionsViewTest : RobolectricTest() {
+    @Test
+    fun `clicking on open with invokes the expected callback`() = runAndroidComposeUiTest {
+        ensureCalledOnce { callback ->
+            setContent {
+                LinkActionsViewContent(
+                    onOpenWithClick = callback,
+                    onShareClick = EnsureNeverCalled(),
+                    onCopyClick = EnsureNeverCalled(),
+                )
+            }
+            clickOn(CommonStrings.action_open_with)
+        }
+    }
+
+    @Test
+    fun `clicking on share invokes the expected callback`() = runAndroidComposeUiTest {
+        ensureCalledOnce { callback ->
+            setContent {
+                LinkActionsViewContent(
+                    onOpenWithClick = EnsureNeverCalled(),
+                    onShareClick = callback,
+                    onCopyClick = EnsureNeverCalled(),
+                )
+            }
+            clickOn(CommonStrings.action_share_link)
+        }
+    }
+
+    @Test
+    fun `clicking on copy invokes the expected callback`() = runAndroidComposeUiTest {
+        ensureCalledOnce { callback ->
+            setContent {
+                LinkActionsViewContent(
+                    onOpenWithClick = EnsureNeverCalled(),
+                    onShareClick = EnsureNeverCalled(),
+                    onCopyClick = callback,
+                )
+            }
+            clickOn(CommonStrings.action_copy_link)
+        }
+    }
+}

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.link_LinkActionsViewContent_Day_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.link_LinkActionsViewContent_Day_0_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ec8f499d4f3c22a94490c9f7178a55be87d47163a291290eaf544ecd454639e
+size 11965

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.link_LinkActionsViewContent_Night_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.link_LinkActionsViewContent_Night_0_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d21bf4e08e32384825893f7e403dc49655680ec3914d57766994b66df012cb4
+size 11244


### PR DESCRIPTION
## Content

Long pressing a link in the timeline copied its address and nothing else, so a link could only ever be followed in the in-app browser. Opening a video address in the player that handles it, or sending an article to a read-later app, meant copying the address and leaving Element to paste it.

Long press now opens a sheet with Open with, Share link and Copy link. The first two hand the address to Android, so whatever the user has installed decides what happens to it; the third is what long press already did.

## Motivation and context

Relates to #3514.

## Tests

- `LinkActionsViewTest` — each of the three rows invokes its own action and neither of the others.

These do not cover what the system does with the intent, which depends on the apps installed on the device.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 36

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
