### PR TITLE
Run the database migrations again when a database is upgraded

### DIFF
--- a/libraries/encrypted-db/build.gradle.kts
+++ b/libraries/encrypted-db/build.gradle.kts
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
  * Please see LICENSE files in the repository root for full details.
  */
+import extension.testCommonDependencies
+
 plugins {
     id("io.element.android-library")
 }
@@ -27,4 +29,6 @@ dependencies {
     implementation(libs.google.tink)
 
     implementation(projects.libraries.androidutils)
+
+    testCommonDependencies(libs)
 }

--- a/libraries/encrypted-db/src/main/kotlin/io/element/encrypteddb/SqlCipherDriverFactory.kt
+++ b/libraries/encrypted-db/src/main/kotlin/io/element/encrypteddb/SqlCipherDriverFactory.kt
@@ -51,12 +51,28 @@ class SqlCipherDriverFactory(
             is ClientSecret.Passphrase -> secret.formattedAsString().hexToByteArray()
         }
         val factory = SupportOpenHelperFactory(key)
-        return AndroidSqliteDriver(schema = schema, context = context, name = name, factory = factory, callback = object : AndroidSqliteDriver.Callback(
-                schema
-            ) {
-            override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-                onUpgradeCallback?.invoke(db, oldVersion, newVersion)
-            }
-        })
+        return AndroidSqliteDriver(
+            schema = schema,
+            context = context,
+            name = name,
+            factory = factory,
+            callback = MigrationCallback(schema, onUpgradeCallback),
+        )
+    }
+}
+
+/**
+ * Runs [onUpgradeCallback] and then the schema migrations themselves.
+ *
+ * @param schema The SQLite DB schema, whose migrations are applied by [AndroidSqliteDriver.Callback.onUpgrade].
+ * @param onUpgradeCallback Called before the migrations run, so that the database key can be replaced first.
+ */
+internal class MigrationCallback(
+    schema: SqlSchema<QueryResult.Value<Unit>>,
+    private val onUpgradeCallback: ((driver: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) -> Unit)?,
+) : AndroidSqliteDriver.Callback(schema) {
+    override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        onUpgradeCallback?.invoke(db, oldVersion, newVersion)
+        super.onUpgrade(db, oldVersion, newVersion)
     }
 }

--- a/libraries/encrypted-db/src/test/kotlin/io/element/encrypteddb/MigrationCallbackTest.kt
+++ b/libraries/encrypted-db/src/test/kotlin/io/element/encrypteddb/MigrationCallbackTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.encrypteddb
+
+import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.Test
+
+class MigrationCallbackTest {
+    @Test
+    fun `onUpgrade migrates the schema`() {
+        val schema = RecordingSchema()
+        MigrationCallback(schema, onUpgradeCallback = null).onUpgrade(mockk(relaxed = true), 9, 11)
+        assertThat(schema.migrations).containsExactly(9L to 11L)
+    }
+
+    @Test
+    fun `onUpgrade replaces the database key before migrating the schema`() {
+        val order = mutableListOf<String>()
+        val schema = RecordingSchema(onMigrate = { order.add("migrate") })
+        MigrationCallback(schema, onUpgradeCallback = { _, _, _ -> order.add("rekey") })
+            .onUpgrade(mockk(relaxed = true), 9, 11)
+        assertThat(order).containsExactly("rekey", "migrate").inOrder()
+    }
+}
+
+private class RecordingSchema(
+    private val onMigrate: () -> Unit = {},
+) : SqlSchema<QueryResult.Value<Unit>> {
+    val migrations = mutableListOf<Pair<Long, Long>>()
+
+    override val version = 11L
+
+    override fun create(driver: SqlDriver) = QueryResult.Unit
+
+    override fun migrate(
+        driver: SqlDriver,
+        oldVersion: Long,
+        newVersion: Long,
+        vararg callbacks: AfterVersion,
+    ): QueryResult.Value<Unit> {
+        migrations.add(oldVersion to newVersion)
+        onMigrate()
+        return QueryResult.Unit
+    }
+}


### PR DESCRIPTION
## Content

Upgrading over an older install crashed the app before the login screen with
`SQLiteException: no such column: SessionData.position`. The session, cache and push databases were
opened at their new schema version but their tables were never migrated, so the first query against
a column added by migrations 9–11 failed.

`SqlCipherDriverFactory` overrides `AndroidSqliteDriver.Callback.onUpgrade` so that the database key
can be replaced, but it never called through to the base implementation — and that base
implementation is the only thing that runs `schema.migrate(...)`. Every SQLDelight migration in the
app was therefore skipped. The override now calls `super.onUpgrade` after the re-key, and it moved
out of an anonymous object into a named `MigrationCallback` so the behaviour can be tested.

The re-key still runs first, so a database that crosses the re-key version is re-encrypted before
its tables are migrated, exactly as before.

## Motivation and context

Part of #7509

## Tests

- `libraries/encrypted-db/src/test/kotlin/io/element/encrypteddb/MigrationCallbackTest.kt` — asserts
  the schema migrations run on upgrade, and that the key replacement happens before them.
- Both tests were run against the unfixed code and both fail there.
- They do not prove that a real 25.05.4 SQLCipher database upgrades end to end; that still needs a
  device.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 16 (API 36)

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the UI, check that the design is compliant with the design system
- [x] I declare that I have used AI assistance for this contribution
