### PR TITLE
Offer conversations in the system share sheet

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,6 +139,12 @@
                 <data android:host="user" />
                 <data android:host="room" />
             </intent-filter>
+            <!--
+              Conversation shortcuts offered in the Direct Share row of the system share sheet.
+            -->
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
             <!-- Incoming share simple -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2026 Element Creations Ltd.
+
+  SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+  Please see LICENSE files in the repository root for full details.
+-->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+      Lets the system offer the conversation shortcuts published by
+      DefaultNotificationConversationService in the Direct Share row of the share sheet.
+      The category must match SHARE_TARGET_CATEGORY in that class.
+    -->
+    <share-target android:targetClass="io.element.android.x.MainActivity">
+        <data android:mimeType="*/*" />
+        <category android:name="io.element.android.category.SHARE_TARGET" />
+    </share-target>
+</shortcuts>

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationService.kt
@@ -42,6 +42,12 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 
+/**
+ * Category shared with the `<share-target>` in `app/src/main/res/xml/shortcuts.xml`. The system only offers a shortcut
+ * in the Direct Share row of the share sheet when the two match, so the literal has to be kept in step with that file.
+ */
+private const val SHARE_TARGET_CATEGORY = "io.element.android.category.SHARE_TARGET"
+
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class DefaultNotificationConversationService(
@@ -86,7 +92,8 @@ class DefaultNotificationConversationService(
         }
 
         val categories = setOfNotNull(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION else null
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION else null,
+            SHARE_TARGET_CATEGORY,
         )
 
         val client = matrixClientProvider.getOrRestore(sessionId).getOrNull() ?: return

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/conversations/DefaultNotificationConversationServiceTest.kt
@@ -10,6 +10,7 @@ package io.element.android.libraries.push.impl.notifications.conversations
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ShortcutInfo
 import android.os.Build
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -50,6 +51,27 @@ class DefaultNotificationConversationServiceTest : RobolectricTest() {
 
         val shortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
         assertThat(shortcuts).isNotEmpty()
+    }
+
+    @Test
+    fun `the shortcut is offered to the share sheet as a conversation`() = runTest {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val service = createService(context)
+
+        service.onSendMessage(
+            sessionId = A_SESSION_ID,
+            roomId = A_ROOM_ID,
+            roomName = "Room title",
+            roomIsDirect = false,
+            roomAvatarUrl = null,
+        )
+
+        val shortcut = ShortcutManagerCompat.getDynamicShortcuts(context).single()
+        assertThat(shortcut.categories).containsAtLeast(
+            ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION,
+            // Matches the <share-target> category in app/src/main/res/xml/shortcuts.xml
+            "io.element.android.category.SHARE_TARGET",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Content

Sharing something from another app listed Element X once, as a single entry, with no way to pick a
conversation. The Direct Share row of the system share sheet never showed any of them.

The app already publishes a long-lived shortcut per room, categorised as a conversation, which is most
of what the sharing shortcuts API asks for. What was missing is the declaration that ties those
shortcuts to the share intent: the launcher activity carried no `android.app.shortcuts` meta-data, so
there was no `<share-target>` for the system to match them against, and the shortcuts were only ever
used for the launcher long-press menu and for notification bubbles.

It now ships one, pointing at the activity that already receives `ACTION_SEND` and `ACTION_SEND_MULTIPLE`,
and the published shortcuts carry the category it names.

The system offers these from Android 10 onwards, where sharing shortcuts are handled natively. Covering
Android 7 to 9 as well would additionally need the `androidx.sharetarget` library; that is a dependency
this PR deliberately does not add.

## Motivation and context

Part of #3835

## Tests

- `DefaultNotificationConversationServiceTest.the shortcut is offered to the share sheet as a conversation`
  — the published shortcut carries both the conversation category and the share-target category.
- The test was run against the unfixed code and fails there.
- It cannot cover the manifest side: that a `<share-target>` matches is a decision the platform makes.
  Verified instead by building the APK and checking `res/xml/shortcuts.xml` is packaged and the
  `android.app.shortcuts` meta-data is present in the merged manifest.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 16 (API 36)

## Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the UI, check that the design is compliant with the design system
- [x] I declare that I have used AI assistance for this contribution
