### PR TITLE
Do not open the editor when finishing the release

### DIFF
--- a/tools/release/releaseV2.sh
+++ b/tools/release/releaseV2.sh
@@ -188,7 +188,10 @@ git commit -a -m "Adding fastlane file for version ${version}"
 
 printf "\n================================================================================\n"
 printf "OK, finishing the release...\n"
-git flow release finish "${version}"
+# GIT_MERGE_AUTOEDIT avoids opening the editor for the 2 merge commits, whose default message is
+# always used, and -m provides the message of the annotated tag. git flow appends the tag name to
+# it, so the tag message ends up being "Release v${version}".
+GIT_MERGE_AUTOEDIT=no git flow release finish -m "Release" "${version}"
 
 printf "\n================================================================================\n"
 read -r -p "Done, push the branch 'main' and the new tag (yes/no) default to yes? " doPush


### PR DESCRIPTION
## Content

`git flow release finish` opened the editor 3 times in `releaseV2.sh`, and the content was never edited: twice for the merge commits, where the message generated by git is always kept, and once for the tag message, where a placeholder was typed by hand (the last tags carry the message `tag`).

`GIT_MERGE_AUTOEDIT=no` keeps the merge messages git already generates, and `-m` provides the tag message. Note that git flow appends the tag name to it, so the tag will read `Release v26.09.0`.

`release.sh` is left untouched.

## Tests

Ran the command in throwaway git flow repositories with `EDITOR=false`, so that any editor prompt fails: it completes without prompting, the tag message is `Release v26.09.0` and the merge messages are unchanged. Without the change, the same run fails with `Fatal: Tagging failed`.

## Checklist

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] You've made a self review of your PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
