### PR TITLE
Log the SDK git Sha at application startup

### DIFF
--- a/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
+++ b/app/src/main/kotlin/io/element/android/x/ElementXApplication.kt
@@ -13,10 +13,14 @@ import androidx.compose.material3.ComposeMaterial3Flags.isAnchoredDraggableCompo
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.startup.AppInitializer
 import androidx.work.Configuration
+import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.createGraphFactory
+import io.element.android.libraries.architecture.bindings
 import io.element.android.libraries.di.DependencyInjectionGraphOwner
+import io.element.android.libraries.matrix.api.SdkMetadata
 import io.element.android.libraries.workmanager.api.di.MetroWorkerFactory
 import io.element.android.x.di.AppGraph
+import io.element.android.x.di.ApplicationBindings
 import io.element.android.x.info.logApplicationInfo
 import io.element.android.x.initializer.CacheCleanerInitializer
 import io.element.android.x.initializer.CrashInitializer
@@ -29,6 +33,8 @@ class ElementXApplication : Application(), DependencyInjectionGraphOwner, Config
         .setWorkerFactory(MetroWorkerFactory(graph.workerProviders))
         .build()
 
+    @Inject lateinit var sdkMetadata: SdkMetadata
+
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate() {
         super.onCreate()
@@ -38,7 +44,8 @@ class ElementXApplication : Application(), DependencyInjectionGraphOwner, Config
             initializeComponent(CacheCleanerInitializer::class.java)
         }
 
-        logApplicationInfo(this)
+        bindings<ApplicationBindings>().inject(this)
+        logApplicationInfo(this, sdkMetadata.sdkGitSha)
 
         // Disable the strict offset check for anchored draggable components, as it can cause issues with bottom sheets.
         // Remove once https://issuetracker.google.com/issues/477038695 is fixed.

--- a/app/src/main/kotlin/io/element/android/x/di/ApplicationBindings.kt
+++ b/app/src/main/kotlin/io/element/android/x/di/ApplicationBindings.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.x.di
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import io.element.android.x.ElementXApplication
+
+@ContributesTo(AppScope::class)
+interface ApplicationBindings {
+    fun inject(application: ElementXApplication)
+}

--- a/app/src/main/kotlin/io/element/android/x/info/Logs.kt
+++ b/app/src/main/kotlin/io/element/android/x/info/Logs.kt
@@ -10,32 +10,22 @@ package io.element.android.x.info
 
 import android.content.Context
 import io.element.android.libraries.androidutils.system.getVersionCodeFromManifest
+import io.element.android.libraries.core.log.logger.wrapInBox
 import io.element.android.x.BuildConfig
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun logApplicationInfo(context: Context) {
-    val appVersion = buildString {
-        append(BuildConfig.VERSION_NAME)
-        append(" (")
-        append(context.getVersionCodeFromManifest())
-        append(") - ")
-        append(BuildConfig.BUILD_TYPE)
-        append(" / ")
-        append(BuildConfig.FLAVOR)
-    }
-    // TODO Get SDK version somehow
-    val sdkVersion = "SDK VERSION (TODO)"
+fun logApplicationInfo(context: Context, sdkGitSha: String) {
+    val appVersion = "${BuildConfig.VERSION_NAME} (${context.getVersionCodeFromManifest()}) - ${BuildConfig.BUILD_TYPE} / ${BuildConfig.FLAVOR}"
     val date = SimpleDateFormat("MM-dd HH:mm:ss.SSSZ", Locale.US).format(Date())
-
-    Timber.d("----------------------------------------------------------------")
-    Timber.d("----------------------------------------------------------------")
-    Timber.d(" Application version: $appVersion")
-    Timber.d(" Git SHA: ${BuildConfig.GIT_REVISION}")
-    Timber.d(" SDK version: $sdkVersion")
-    Timber.d(" Local time: $date")
-    Timber.d("----------------------------------------------------------------")
-    Timber.d("----------------------------------------------------------------\n\n\n\n")
+    listOf(
+        " Application version: $appVersion",
+        " Element X: https://github.com/element-hq/element-x-android/commit/${BuildConfig.GIT_REVISION}",
+        " SDK      : https://github.com/matrix-org/matrix-rust-sdk/commit/$sdkGitSha",
+        " Local time: $date",
+    )
+        .wrapInBox(minBoxInsideWidth = 80)
+        .forEach { Timber.d(it) }
 }

--- a/libraries/core/src/main/kotlin/io/element/android/libraries/core/log/logger/BoxWrapper.kt
+++ b/libraries/core/src/main/kotlin/io/element/android/libraries/core/log/logger/BoxWrapper.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.libraries.core.log.logger
+
+import kotlin.math.max
+
+/**
+ * Wraps a list of strings in a box with borders.
+ * Allow to print pretty logs.
+ *
+ * @param minBoxInsideWidth The minimum width of the box inside, default is 80.
+ * @return A list of strings representing the boxed lines.
+ */
+fun List<String>.wrapInBox(
+    minBoxInsideWidth: Int = 80,
+): List<String> {
+    val maxLength = maxOfOrNull { it.length } ?: 0
+    val boxWidth = max(maxLength, minBoxInsideWidth) + 4
+    val topBorder = "┌" + "─".repeat(boxWidth - 2) + "┐"
+    val bottomBorder = "└" + "─".repeat(boxWidth - 2) + "┘"
+    val boxedLines = map { line ->
+        val padding = " ".repeat(max(0, boxWidth - line.length - 4))
+        "│ $line$padding │"
+    }
+    return listOf(topBorder) + boxedLines + listOf(bottomBorder)
+}


### PR DESCRIPTION


<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

<!-- Describe shortly what has been changed -->
Log the SDK git Sha at application startup. Also improve the rendering of the log

Example of output:

```
 ┌──────────────────────────────────────────────────────────────────────────────────┐
 │  Application version: 26.08.4 (202608040) - debug / gplay                        │
 │  Element X: https://github.com/element-hq/element-x-android/commit/65878c6a      │
 │  SDK      : https://github.com/matrix-org/matrix-rust-sdk/commit/1d1c0cbbd       │
 │  Local time: 08-28 12:17:37.161+0200                                             │
 └──────────────────────────────────────────────────────────────────────────────────┘
```

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix a TODO
Provide clickable links in the log, to quickly see the commits details

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run the app
- Observe the updated logs in logcat.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
