### PR TITLE
Fix invalid placeholders in translations

### DIFF
--- a/features/poll/api/src/main/res/values-zh/translations.xml
+++ b/features/poll/api/src/main/res/values-zh/translations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="a11y_polls_percent_of_total">
-    <item quantity="other">"占总投票的 %1$d%"</item>
+    <item quantity="other">"占总投票的 %1$d%%"</item>
   </plurals>
   <string name="a11y_polls_will_remove_selection">"将移除之前的选择"</string>
   <string name="a11y_polls_winning_answer">"此为胜出的答案"</string>

--- a/tools/localazy/checkForbiddenTerms.py
+++ b/tools/localazy/checkForbiddenTerms.py
@@ -42,6 +42,31 @@ forbiddenTerms = {
     ]
 }
 
+# A complete, VALID placeholder, anchored to consume the whole token:
+#   %%              -> literal percent (allowed)
+#   %s %d %f ...    -> simple conversion
+#   %1$s %2$d ...   -> positional
+#   %.2f %1$.2f     -> optional precision
+_VALID_PLACEHOLDER = re.compile(
+    r'%(?:\d+\$)?(?:\.\d+)?[a-zA-Z]'
+)
+
+# Grab each candidate token: a '%' plus the run of chars that could belong to a
+# specifier (digits, '$', '.', and letters). This makes '%sd' and '%1d' surface
+# as single tokens instead of being partially swallowed.
+_PLACEHOLDER_MATCHES = re.compile(r'%%|%[0-9$.A-Za-z]*')
+
+def find_invalid_placeholders(value):
+    """Return the list of malformed placeholder tokens found in `value`."""
+    invalid = []
+    for token in _PLACEHOLDER_MATCHES.findall(value):
+        if token == '%%':
+            continue  # escaped percent is fine
+        if not _VALID_PLACEHOLDER.fullmatch(token):
+            invalid.append(token)
+    return invalid
+
+
 content = minidom.parse(file)
 
 errors = []
@@ -60,6 +85,9 @@ for elem in content.getElementsByTagName('string'):
         matches = re.search(term, value)
         if matches and name not in exceptions:
             errors.append('Forbidden term "' + term + '" in string: "' + name + '": ' + value)
+        invalid_placeholders = find_invalid_placeholders(value)
+        for placeholder in invalid_placeholders:
+            errors.append('Invalid placeholder "' + placeholder + '" in string: "' + name + '": ' + value)
 
 ### Plurals
 for elem in content.getElementsByTagName('plurals'):
@@ -78,6 +106,9 @@ for elem in content.getElementsByTagName('plurals'):
             matches = re.search(term, value)
             if matches and name not in exceptions:
                 errors.append('Forbidden term "' + term + '" in plural: "' + name + '": ' + value)
+            invalid_placeholders = find_invalid_placeholders(value)
+            for placeholder in invalid_placeholders:
+                errors.append('Invalid placeholder "' + placeholder + '" in plural: "' + name + '": ' + value)
 
 # If errors is not empty print the report
 if errors:


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Fixes a crash with the simplified Chinese locale when displaying a poll in the timeline.
- Adds some logic to the script to check for invalid terms in strings and translations so we can detect these issues when we sync the strings.

## Motivation and context

Fixes https://github.com/element-hq/element-x-android/issues/7596.

## Tests

<!-- Explain how you tested your development -->

- Without this branch, change the locale of the app to simplified Chinese and open a timeline where there is a poll with results. It should crash. With the change, it should be fine.
- Also, revert the 2nd commit and run `python tools/localazy/checkForbiddenTerms.py features/poll/api/src/main/res/values-zh/translations.xml`, it should fail.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
