### PR TITLE
Allow retrying finding the release assets in release script

### DIFF
--- a/tools/release/releaseV2.sh
+++ b/tools/release/releaseV2.sh
@@ -452,19 +452,22 @@ releaseAssets=(
   "${fdroidTargetPath}/app-fdroid-x86_64-release-signed.apk"
 )
 
-missingAsset=0
+# Set this variable to something other than 0 to enter the loop, and reset it to 0 when all files are found.
+missingAsset=-1
 
-for releaseAsset in "${releaseAssets[@]}"; do
-  if [[ ! -f "${releaseAsset}" ]]; then
-    printf "Error: the file %s does not exist.\n" "${releaseAsset}"
-    missingAsset=1
+while [[ ${missingAsset} -ne 0 ]]; do
+  missingAsset=0
+  for releaseAsset in "${releaseAssets[@]}"; do
+    if [[ ! -f "${releaseAsset}" ]]; then
+      printf "Error: the file %s does not exist.\n" "${releaseAsset}"
+      missingAsset=1
+    fi
+  done
+
+  if [[ ${missingAsset} -ne 0 ]]; then
+    read -r -p "Some files are missing, please fix the issue and press enter to retry. Press Ctrl+C to exit. "
   fi
 done
-
-if [[ ${missingAsset} -ne 0 ]]; then
-  printf "Fatal: some files are missing, cannot create the GitHub release.\n"
-  exit 1
-fi
 
 printf "Creating the pre-release v%s and uploading the %d files, this can take a while...\n" "${version}" "${#releaseAssets[@]}"
 gh release create "v${version}" \


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Makes the check for the release assets run in a loop so it can be retried later if all files are not found at first.

## Motivation and context

I failed to fully read the new instructions, which ended up with the release script failing because it couldn't find a file I should have downloaded and having to start the flow again 😅 .

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
