### PR TITLE
Improve detection of invalid placeholders in localazy strings

### DIFF
--- a/tools/localazy/checkForbiddenTerms.py
+++ b/tools/localazy/checkForbiddenTerms.py
@@ -59,11 +59,34 @@ _PLACEHOLDER_MATCHES = re.compile(r'%%|%[0-9$.A-Za-z]*')
 def find_invalid_placeholders(value):
     """Return the list of malformed placeholder tokens found in `value`."""
     invalid = []
-    for token in _PLACEHOLDER_MATCHES.findall(value):
+    # The % character is special: when using the strings without placeholder replacement, it will be just printed as-is.
+    # However, if the string is used with placeholder replacement, a single '%' will be interpreted as an invalid placeholder,
+    # and will cause a crash at runtime unless it's escaped as '%%'.
+    has_unescaped_percent = False
+    has_escaped_percent = False
+    has_valid_placeholders = False
+    placeholders = _PLACEHOLDER_MATCHES.findall(value)
+    for token in placeholders:
         if token == '%%':
+            has_escaped_percent = True
             continue  # escaped percent is fine
+        if token == '%':
+            has_unescaped_percent = True # We'll check later if having this token alongside valid placeholders is an error
+            continue
         if not _VALID_PLACEHOLDER.fullmatch(token):
             invalid.append(token)
+        else:
+            has_valid_placeholders = True
+
+    # If we found a single unescaped '%' and there are valid placeholders, we assume it'll be interpreted as an invalid placeholder,
+    # so this is an error.
+    if has_unescaped_percent and has_valid_placeholders:
+        invalid.append('%')
+
+    # If we found an escaped percent but no valid placeholders, this is probably a mistake, so we warn about it.
+    if has_escaped_percent and not has_valid_placeholders:
+        print('Warning: string `' + value + '` contains escaped percent (%%) but no valid placeholders. This is probably a mistake.', file=sys.stderr)
+
     return invalid
 
 
@@ -85,9 +108,10 @@ for elem in content.getElementsByTagName('string'):
         matches = re.search(term, value)
         if matches and name not in exceptions:
             errors.append('Forbidden term "' + term + '" in string: "' + name + '": ' + value)
-        invalid_placeholders = find_invalid_placeholders(value)
-        for placeholder in invalid_placeholders:
-            errors.append('Invalid placeholder "' + placeholder + '" in string: "' + name + '": ' + value)
+
+    invalid_placeholders = find_invalid_placeholders(value)
+    for placeholder in invalid_placeholders:
+        errors.append('Invalid placeholder "' + placeholder + '" in string: "' + name + '": ' + value)
 
 ### Plurals
 for elem in content.getElementsByTagName('plurals'):
@@ -106,9 +130,10 @@ for elem in content.getElementsByTagName('plurals'):
             matches = re.search(term, value)
             if matches and name not in exceptions:
                 errors.append('Forbidden term "' + term + '" in plural: "' + name + '": ' + value)
-            invalid_placeholders = find_invalid_placeholders(value)
-            for placeholder in invalid_placeholders:
-                errors.append('Invalid placeholder "' + placeholder + '" in plural: "' + name + '": ' + value)
+
+        invalid_placeholders = find_invalid_placeholders(value)
+        for placeholder in invalid_placeholders:
+            errors.append('Invalid placeholder "' + placeholder + '" in plural: "' + name + '": ' + value)
 
 # If errors is not empty print the report
 if errors:


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Only detect `%` as an invalid placeholder if there are other placeholders present in the string.
- When there are no placeholders present and we find '%%', mention it as a possible mistake in a warning log.
- Only check for invalid placeholders once per string: previously this was incorrectly added inside a loop and ran several times.

## Motivation and context

When we use `Resources.getString(id)` without any params, this will internally just fetch the string and return it as is. In this case, having a `%` symbol is fine, and having `%%` would print both symbols when rendered.

However when `Resources.getString(id, arg1, arg2, ...)` is called, this will use `String.format(result, arg1, arg2, ...)` under the hood and a single `%` symbol will be detected as an invalid placeholder and crash in runtime. In this case we need to check if any valid placeholder exists in the string before checking whether `%` or `%%` is present.

## Tests

I just modified a few strings with several cases: no placeholder and a single %, no placeholder and several % (2-3), and the same with actual placeholders.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
