### PR TITLE
Keep the push foreground service alive while notifications are fetched

### DIFF
--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/FetchPushForegroundServiceManager.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/FetchPushForegroundServiceManager.kt
@@ -9,7 +9,7 @@ package io.element.android.libraries.push.api.push
 
 /**
  * A helper to manage the foreground service used to keep the device awake, and the process out of background execution limits, from the moment
- * a push is received until the work fetching the notification content has finished.
+ * a push is received until the fetched notification content has been handed over for display.
  */
 interface FetchPushForegroundServiceManager {
     /**

--- a/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/FetchPushForegroundServiceManager.kt
+++ b/libraries/push/api/src/main/kotlin/io/element/android/libraries/push/api/push/FetchPushForegroundServiceManager.kt
@@ -8,7 +8,8 @@
 package io.element.android.libraries.push.api.push
 
 /**
- * A helper to manage the foreground service used to keep the device awake while we schedule and wait for the work to fetch the notification content to run.
+ * A helper to manage the foreground service used to keep the device awake, and the process out of background execution limits, from the moment
+ * a push is received until the work fetching the notification content has finished.
  */
 interface FetchPushForegroundServiceManager {
     /**

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
@@ -9,6 +9,7 @@
 package io.element.android.libraries.push.impl.workmanager
 
 import android.content.Context
+import android.os.Build
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import dev.zacsweers.metro.AppScope
@@ -39,6 +40,7 @@ import io.element.android.services.analytics.api.AnalyticsService
 import io.element.android.services.analytics.api.finishLongRunningTransaction
 import io.element.android.services.analytics.api.recordTransaction
 import io.element.android.services.analyticsproviders.api.AnalyticsTransaction
+import io.element.android.services.toolbox.api.sdk.BuildVersionSdkIntProvider
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
@@ -61,19 +63,18 @@ class FetchPendingNotificationsWorker(
     private val analyticsService: AnalyticsService,
     private val systemClock: SystemClock,
     private val fetchPushForegroundServiceManager: FetchPushForegroundServiceManager,
+    private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
 ) : CoroutineWorker(context, params) {
+    private var foregroundServiceReleased = false
+
     override suspend fun doWork(): Result {
         Timber.d("FetchNotificationsWorker started")
         return try {
             doWorkInternal()
         } finally {
-            // Keep the foreground service, and the wakelock it holds, for the whole duration of the work rather than releasing it as soon as
-            // the worker starts. Resolving the events needs several network round trips (sliding sync, room key retrieval, decryption) and, for
-            // ringing calls, waiting for the room state to be synced. While the service is running the process is in the foreground service
-            // state, so the expedited job quota and Doze restrictions don't cut this work short. Ringing calls acquire their own wakelock once
-            // the results have been processed. NonCancellable so that the service is also stopped when the system cancels the worker.
+            // Make sure the foreground service is released on every exit path, including when the system cancels the worker.
             withContext(NonCancellable) {
-                fetchPushForegroundServiceManager.stop()
+                releaseForegroundService()
             }
         }
     }
@@ -83,6 +84,12 @@ class FetchPendingNotificationsWorker(
         val sessionId = runCatchingExceptions {
             inputData.getString(SyncPendingNotificationsRequestBuilder.SESSION_ID)?.let(::SessionId)
         }.getOrNull() ?: return Result.failure()
+
+        if (!buildVersionSdkIntProvider.isAtLeast(Build.VERSION_CODES.S)) {
+            // Before Android 12 the foreground service notification is displayed immediately, so release the service as soon as the work is
+            // running: the wakelock was only there to make sure the scheduled work starts. See [releaseForegroundService] for newer versions.
+            releaseForegroundService()
+        }
 
         // Fetch pending requests in the last 24 hours
         val fetchSince = Instant.fromEpochMilliseconds(systemClock.epochMillis()).minus(1.days)
@@ -146,11 +153,30 @@ class FetchPendingNotificationsWorker(
 
         pushHistoryService.insertOrUpdatePushRequests(updatedRequests)
 
+        // The results have been handed over, so release the foreground service before the opportunistic sync, which deliberately takes a while
+        // in the background. This keeps the service short-lived in the common case, so its notification is normally never displayed.
+        releaseForegroundService()
+
         analyticsService.recordTransaction("Opportunistic sync", "opportunistic_sync") {
             performOpportunisticSyncIfNeeded(mapOf(sessionId to requests))
         }
 
         return if (updatedRequests.any { it.status == PushRequestStatus.PENDING.value }) Result.retry() else Result.success()
+    }
+
+    /**
+     * Release the foreground service, and the wakelock it holds, that was started when the push was received. Only the first call has an effect.
+     *
+     * From Android 12 on, the service is kept while the events are resolved: this needs several network round trips (sliding sync, room key
+     * retrieval, decryption) and, for ringing calls, waiting for the room state to be synced. While the service is running the process is in the
+     * foreground service state, so the expedited job quota and Doze restrictions don't cut this work short. The system defers the notification
+     * of a foreground service by 10 seconds on these versions, so it only becomes visible when the fetch is slow, which is exactly when the
+     * extra time is needed.
+     */
+    private suspend fun releaseForegroundService() {
+        if (foregroundServiceReleased) return
+        foregroundServiceReleased = true
+        fetchPushForegroundServiceManager.stop()
     }
 
     private suspend fun performOpportunisticSyncIfNeeded(

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationsWorker.kt
@@ -40,7 +40,9 @@ import io.element.android.services.analytics.api.finishLongRunningTransaction
 import io.element.android.services.analytics.api.recordTransaction
 import io.element.android.services.analyticsproviders.api.AnalyticsTransaction
 import io.element.android.services.toolbox.api.systemclock.SystemClock
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import kotlin.time.Duration.Companion.days
@@ -62,13 +64,25 @@ class FetchPendingNotificationsWorker(
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
         Timber.d("FetchNotificationsWorker started")
+        return try {
+            doWorkInternal()
+        } finally {
+            // Keep the foreground service, and the wakelock it holds, for the whole duration of the work rather than releasing it as soon as
+            // the worker starts. Resolving the events needs several network round trips (sliding sync, room key retrieval, decryption) and, for
+            // ringing calls, waiting for the room state to be synced. While the service is running the process is in the foreground service
+            // state, so the expedited job quota and Doze restrictions don't cut this work short. Ringing calls acquire their own wakelock once
+            // the results have been processed. NonCancellable so that the service is also stopped when the system cancels the worker.
+            withContext(NonCancellable) {
+                fetchPushForegroundServiceManager.stop()
+            }
+        }
+    }
+
+    private suspend fun doWorkInternal(): Result {
         // RunCatching for test in debug mode
         val sessionId = runCatchingExceptions {
             inputData.getString(SyncPendingNotificationsRequestBuilder.SESSION_ID)?.let(::SessionId)
         }.getOrNull() ?: return Result.failure()
-
-        // We can stop the foreground service and unlock the wakelock, since the work is now running and the device should be kept awake
-        fetchPushForegroundServiceManager.stop()
 
         // Fetch pending requests in the last 24 hours
         val fetchSince = Instant.fromEpochMilliseconds(systemClock.epochMillis()).minus(1.days)

--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/workmanager/SyncPendingNotificationsRequestBuilder.kt
@@ -91,10 +91,11 @@ class DefaultSyncPendingNotificationsRequestBuilder(
         val request = OneTimeWorkRequestBuilder<FetchPendingNotificationsWorker>()
             .setInputData(workDataOf(SESSION_ID to sessionId.value))
             .apply {
-                // Expedited workers aren't needed on Android 12 or lower:
-                // They force displaying a foreground sync notification for no good reason, since they sync almost immediately anyway
+                // Before Android 12 (API 31), WorkManager runs expedited work as a foreground service with a visible notification, which we
+                // don't want and don't support (no `getForegroundInfo` implementation). From API 31 on, expedited work is a native JobScheduler
+                // expedited job: it starts sooner and is less affected by Doze and App Standby, so use it wherever it is available.
                 // See https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work#backwards-compat
-                if (buildVersionSdkIntProvider.isAtLeast(Build.VERSION_CODES.TIRAMISU)) {
+                if (buildVersionSdkIntProvider.isAtLeast(Build.VERSION_CODES.S)) {
                     setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 }
             }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/DefaultSyncPendingNotificationsRequestBuilderTest.kt
@@ -28,10 +28,10 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33])
 class DefaultSyncPendingNotificationsRequestBuilderTest : RobolectricTest() {
     @Test
-    fun `build - success API 33`() = runTest {
+    fun `build - success API 31`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
-            sdkVersion = 33,
+            sdkVersion = 31,
         )
 
         val results = request.build()
@@ -42,7 +42,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest : RobolectricTest() {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
-                // True in API 33+
+                // True in API 31+
                 assertThat(workSpec.expedited).isTrue()
                 assertThat(workSpec.traceTag).isEqualTo(workManagerTag(A_SESSION_ID, WorkManagerRequestType.NOTIFICATION_SYNC))
             }
@@ -50,10 +50,10 @@ class DefaultSyncPendingNotificationsRequestBuilderTest : RobolectricTest() {
     }
 
     @Test
-    fun `build - success API 32 and lower`() = runTest {
+    fun `build - success API 30 and lower`() = runTest {
         val request = createSyncPendingNotificationsRequestBuilder(
             sessionId = A_SESSION_ID,
-            sdkVersion = 32,
+            sdkVersion = 30,
         )
 
         val results = request.build()
@@ -65,7 +65,7 @@ class DefaultSyncPendingNotificationsRequestBuilderTest : RobolectricTest() {
                 assertThat(this).isInstanceOf(OneTimeWorkRequest::class.java)
                 assertThat(workSpec.input.hasKeyWithValueOfType<String>(SyncPendingNotificationsRequestBuilder.SESSION_ID)).isTrue()
                 assertThat(workSpec.hasConstraints()).isTrue()
-                // False before API 33
+                // False before API 31
                 assertThat(workSpec.expedited).isFalse()
                 assertThat(workSpec.traceTag).isEqualTo(workManagerTag(A_SESSION_ID, WorkManagerRequestType.NOTIFICATION_SYNC))
             }

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.push.test.push.FakeFetchPushForegroundServic
 import io.element.android.libraries.workmanager.api.WorkManagerRequestBuilder
 import io.element.android.libraries.workmanager.api.di.MetroWorkerFactory
 import io.element.android.services.analytics.test.FakeAnalyticsService
+import io.element.android.services.toolbox.test.sdk.FakeBuildVersionSdkIntProvider
 import io.element.android.services.toolbox.test.systemclock.FakeSystemClock
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.robolectric.RobolectricTest
@@ -96,9 +97,43 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
         // An opportunistic sync was triggered
         assertThat(synced).isTrue()
 
-        // The foreground service is stopped once, and only after the results were emitted and the opportunistic sync ran
+        // The foreground service is released once, after the results were handed over and before the opportunistic sync
         stopForegroundServiceLambda.assertions().isCalledOnce()
-        assertThat(callOrder).containsExactly("emit", "sync", "stop").inOrder()
+        assertThat(callOrder).containsExactly("emit", "stop", "sync").inOrder()
+    }
+
+    @Test
+    fun `test - before Android 12 the foreground service is released as soon as the work runs`() = runTest {
+        val callOrder = mutableListOf<String>()
+        val syncOnNotifiableEventLambda = SyncOnNotifiableEvent { callOrder += "sync" }
+        val emitResultLambda = lambdaRecorder<Map<PushRequest, Result<ResolvedPushEvent>>, Unit> { callOrder += "emit" }
+        val processor = FakeNotificationResultProcessor(emit = emitResultLambda)
+        val stopForegroundServiceLambda = lambdaRecorder<Boolean> {
+            callOrder += "stop"
+            true
+        }
+        val pushHistoryService = FakePushHistoryService(
+            getPendingPushRequests = { _, _ -> Result.success(listOf(aPushRequest())) },
+            replacePushRequests = { Result.success(Unit) },
+            removeOldPushRequests = { Result.success(Unit) },
+        )
+
+        val worker = createWorker(
+            input = "@alice:matrix.org",
+            pushHistoryService = pushHistoryService,
+            resultProcessor = processor,
+            syncOnNotifiableEvent = syncOnNotifiableEventLambda,
+            pushHandlingWakeLock = FakeFetchPushForegroundServiceManager(unlock = stopForegroundServiceLambda),
+            buildVersionSdkIntProvider = FakeBuildVersionSdkIntProvider(30),
+        )
+
+        val result = worker.doWork()
+
+        assertThat(result).isEqualTo(ListenableWorker.Result.success())
+
+        // The foreground service is released once, before the events are resolved, since its notification would be displayed immediately
+        stopForegroundServiceLambda.assertions().isCalledOnce()
+        assertThat(callOrder).containsExactly("stop", "emit", "sync").inOrder()
     }
 
     @Test
@@ -263,6 +298,7 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
         resultProcessor: FakeNotificationResultProcessor = FakeNotificationResultProcessor(),
         systemClock: FakeSystemClock = FakeSystemClock(),
         pushHandlingWakeLock: FakeFetchPushForegroundServiceManager = FakeFetchPushForegroundServiceManager(),
+        buildVersionSdkIntProvider: FakeBuildVersionSdkIntProvider = FakeBuildVersionSdkIntProvider(33),
     ) = FetchPendingNotificationsWorker(
         params = createWorkerParams(workDataOf("session_id" to input)),
         context = InstrumentationRegistry.getInstrumentation().context,
@@ -274,6 +310,7 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
         resultProcessor = resultProcessor,
         systemClock = systemClock,
         fetchPushForegroundServiceManager = pushHandlingWakeLock,
+        buildVersionSdkIntProvider = buildVersionSdkIntProvider,
     )
 
     private fun TestScope.createWorkerParams(

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/workmanager/FetchPendingNotificationWorkerTest.kt
@@ -50,10 +50,18 @@ import kotlin.time.Instant
 class FetchPendingNotificationWorkerTest : RobolectricTest() {
     @Test
     fun `test - success`() = runTest {
+        val callOrder = mutableListOf<String>()
         var synced = false
-        val syncOnNotifiableEventLambda = SyncOnNotifiableEvent { synced = true }
-        val emitResultLambda = lambdaRecorder<Map<PushRequest, Result<ResolvedPushEvent>>, Unit> {}
+        val syncOnNotifiableEventLambda = SyncOnNotifiableEvent {
+            synced = true
+            callOrder += "sync"
+        }
+        val emitResultLambda = lambdaRecorder<Map<PushRequest, Result<ResolvedPushEvent>>, Unit> { callOrder += "emit" }
         val processor = FakeNotificationResultProcessor(emit = emitResultLambda)
+        val stopForegroundServiceLambda = lambdaRecorder<Boolean> {
+            callOrder += "stop"
+            true
+        }
 
         val getPendingResultsLambda = lambdaRecorder<SessionId, Instant?, Result<List<PushRequest>>> { _, _ -> Result.success(listOf(aPushRequest())) }
         val replacePushRequestsLambda = lambdaRecorder<List<PushRequest>, Result<Unit>> { Result.success(Unit) }
@@ -69,6 +77,7 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
             pushHistoryService = pushHistoryService,
             resultProcessor = processor,
             syncOnNotifiableEvent = syncOnNotifiableEventLambda,
+            pushHandlingWakeLock = FakeFetchPushForegroundServiceManager(unlock = stopForegroundServiceLambda),
         )
 
         val result = worker.doWork()
@@ -86,16 +95,27 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
 
         // An opportunistic sync was triggered
         assertThat(synced).isTrue()
+
+        // The foreground service is stopped once, and only after the results were emitted and the opportunistic sync ran
+        stopForegroundServiceLambda.assertions().isCalledOnce()
+        assertThat(callOrder).containsExactly("emit", "sync", "stop").inOrder()
     }
 
     @Test
     fun `test - invalid input fails the work`() = runTest {
-        val worker = createWorker(input = "!alice:matrix.org")
+        val stopForegroundServiceLambda = lambdaRecorder<Boolean> { true }
+        val worker = createWorker(
+            input = "!alice:matrix.org",
+            pushHandlingWakeLock = FakeFetchPushForegroundServiceManager(unlock = stopForegroundServiceLambda),
+        )
 
         val result = worker.doWork()
 
         // The process failed
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+
+        // The foreground service is still stopped
+        stopForegroundServiceLambda.assertions().isCalledOnce()
     }
 
     @Test
@@ -108,11 +128,13 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
             replacePushRequests = { Result.success(Unit) },
             removeOldPushRequests = { Result.success(Unit) },
         )
+        val stopForegroundServiceLambda = lambdaRecorder<Boolean> { true }
         val worker = createWorker(
             input = "@alice:matrix.org",
             networkMonitor = networkMonitor,
             resultProcessor = processor,
             pushHistoryService = pushHistoryService,
+            pushHandlingWakeLock = FakeFetchPushForegroundServiceManager(unlock = stopForegroundServiceLambda),
         )
 
         val result = worker.doWork()
@@ -121,6 +143,9 @@ class FetchPendingNotificationWorkerTest : RobolectricTest() {
 
         // The process failed due to a timeout in getting the network connectivity, a retry is scheduled
         assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+
+        // The foreground service is still stopped
+        stopForegroundServiceLambda.assertions().isCalledOnce()
     }
 
     @Test


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

`FetchPendingNotificationsWorker` currently stops the foreground service, and releases its wakelock, as soon as it starts, so resolving the pushed events (sliding sync, room key retrieval, decryption and, for ringing calls, waiting for the room state) runs under the WorkManager job budget only. This change keeps the service until the worker has finished, on every exit path, so the process stays in the foreground service state for the whole fetch.

Additionally, this change enables expedited work from Android 12 (API 31) instead of 13. `WorkManager` only falls back to a foreground service with a visible notification _below_ API 31, which is what the previous gate was meant to avoid but didn't achieve.

## Motivation and context

Once the worker starts, the only thing keeping the process alive is the `WorkManager` job. Expedited jobs run on a quota-based budget that Android sizes for work that finishes within a few minutes, and on API 31 and 32 the job is not expedited at all, so it can be deferred by Doze. In practice this has shown up as pushes that time out before the event is fetched, with the SDK tuned to very short timeouts to compensate. For ringing calls it means the call goes to a plain notification or nothing.

Keeping the foreground service running changes the process state for the whole fetch. While a foreground service is active the app is treated as foreground for scheduling purposes, so the expedited quota does not apply, Doze does not defer the work, and the wakelock keeps the CPU on while the sliding sync, key retrieval and decryption complete. The three-minute short-service limit still bounds it. Stopping the service in a `finally` also fixes two smaller issues: the invalid-input and network-retry paths previously left the service running until its own timeout, and a system cancellation of the worker skipped the stop altogether.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

None.

## Tests

<!-- Explain how you tested your development -->

See unit tests.

## Tested devices

None.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [X] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] You've made a self review of your PR
