### PR TITLE
Make NotificationResultProcessor.emit wait until the batch is processed

### DIFF
--- a/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationResultProcessor.kt
+++ b/libraries/push/impl/src/main/kotlin/io/element/android/libraries/push/impl/notifications/NotificationResultProcessor.kt
@@ -12,6 +12,7 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import io.element.android.features.call.api.CallData
 import io.element.android.features.call.api.ElementCallEntryPoint
+import io.element.android.libraries.core.extensions.runCatchingExceptions
 import io.element.android.libraries.di.annotations.AppCoroutineScope
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.core.RoomId
@@ -31,18 +32,25 @@ import io.element.android.libraries.push.impl.push.MutableBatteryOptimizationSto
 import io.element.android.libraries.push.impl.push.OnNotifiableEventReceived
 import io.element.android.libraries.push.impl.push.OnRedactedEventReceived
 import io.element.android.libraries.pushstore.api.UserPushStoreFactory
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import timber.log.Timber
 
 private const val TAG = "NotifResultProcessor"
 
 interface NotificationResultProcessor {
+    /**
+     * Queue a batch of resolved push events for processing and suspend until it has been processed, so that the caller can keep the process
+     * alive (e.g. through a foreground service) until any resulting notification or ringing call has been set up.
+     */
     suspend fun emit(results: Map<PushRequest, Result<ResolvedPushEvent>>)
     fun start()
     fun stop()
@@ -61,23 +69,50 @@ class DefaultNotificationResultProcessor(
     private val notificationChannels: NotificationChannels,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
 ) : NotificationResultProcessor {
-    private val resultFlow = MutableSharedFlow<Map<PushRequest, Result<ResolvedPushEvent>>>(extraBufferCapacity = Int.MAX_VALUE)
+    private data class PendingResults(
+        val results: Map<PushRequest, Result<ResolvedPushEvent>>,
+        val processed: CompletableDeferred<Unit> = CompletableDeferred(),
+    )
+
+    // A channel rather than a shared flow: it keeps the results until the collector takes them, so nothing is dropped if the collector isn't
+    // running yet (e.g. the worker runs in a process where no push has been received, after a WorkManager retry) or hasn't subscribed yet.
+    private val pendingResults = Channel<PendingResults>(Channel.UNLIMITED)
     private var processJob: Job? = null
 
     override suspend fun emit(results: Map<PushRequest, Result<ResolvedPushEvent>>) {
-        resultFlow.emit(results)
+        val collector = ensureStarted()
+        val pending = PendingResults(results)
+        pendingResults.send(pending)
+        // Suspend until the batch has been processed, or give up if the collector was stopped in the meantime.
+        select<Unit> {
+            pending.processed.onAwait {}
+            collector.onJoin { Timber.tag(TAG).w("Processing stopped before the results were processed") }
+        }
     }
 
     override fun start() {
-        if (processJob?.isActive == true) {
-            Timber.tag(TAG).w("Is already processing, not starting again")
-            return
-        }
-        processJob = resultFlow
-            .onEach(::processResults)
-            .launchIn(coroutineScope)
+        ensureStarted()
     }
 
+    @Synchronized
+    private fun ensureStarted(): Job {
+        processJob?.takeIf { it.isActive }?.let { return it }
+        return pendingResults
+            .receiveAsFlow()
+            .onEach { pending ->
+                try {
+                    // Don't let a failing batch cancel the collector, or subsequent batches would never be processed.
+                    runCatchingExceptions { processResults(pending.results) }
+                        .onFailure { Timber.tag(TAG).e(it, "Failed to process notification results") }
+                } finally {
+                    pending.processed.complete(Unit)
+                }
+            }
+            .launchIn(coroutineScope)
+            .also { processJob = it }
+    }
+
+    @Synchronized
     override fun stop() {
         if (processJob?.isActive != true) {
             Timber.tag(TAG).w("Is not processing, not stopping")

--- a/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationResultProcessorTest.kt
+++ b/libraries/push/impl/src/test/kotlin/io/element/android/libraries/push/impl/notifications/DefaultNotificationResultProcessorTest.kt
@@ -303,6 +303,48 @@ class DefaultNotificationResultProcessorTest {
             )
     }
 
+    @Test
+    fun `emit starts the processing if needed and only returns once the results have been processed`() = runTest {
+        val onNotifiableEventsReceived = lambdaRecorder<List<NotifiableEvent>, Unit> {}
+        val processor = createDefaultNotificationResultProcessor(
+            pushHistoryService = FakePushHistoryService(onPushReceivedResult = { _, _, _, _, _, _, _ -> }),
+            onNotifiableEventsReceived = onNotifiableEventsReceived,
+        )
+
+        // No call to start(): the worker may run in a process where no push has been received yet
+        processor.emit(mapOf(aPushRequest() to Result.success(ResolvedPushEvent.Event(aNotifiableMessageEvent()))))
+
+        // No runCurrent(): the results must already have been processed when emit returns
+        onNotifiableEventsReceived.assertions().isCalledOnce()
+
+        processor.stop()
+    }
+
+    @Test
+    fun `a failing batch does not prevent later batches from being processed`() = runTest {
+        var pushHistoryCalls = 0
+        val pushHistoryService = FakePushHistoryService(
+            onPushReceivedResult = { _, _, _, _, _, _, _ ->
+                pushHistoryCalls++
+                if (pushHistoryCalls == 1) error("boom")
+            },
+        )
+        val onNotifiableEventsReceived = lambdaRecorder<List<NotifiableEvent>, Unit> {}
+        val processor = createDefaultNotificationResultProcessor(
+            pushHistoryService = pushHistoryService,
+            onNotifiableEventsReceived = onNotifiableEventsReceived,
+        )
+
+        runningProcessor(processor) {
+            // Processing the first batch throws, but emit must still return and the collector must survive
+            emit(mapOf(aPushRequest() to Result.success(ResolvedPushEvent.Event(aNotifiableMessageEvent()))))
+            emit(mapOf(aPushRequest() to Result.success(ResolvedPushEvent.Event(aNotifiableMessageEvent()))))
+        }
+
+        // Only the second batch made it to the notification drawer
+        onNotifiableEventsReceived.assertions().isCalledOnce()
+    }
+
     private suspend fun TestScope.runningProcessor(processor: NotificationResultProcessor, block: suspend NotificationResultProcessor.() -> Unit) {
         processor.start()
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

This change makes `NotificationResultProcessor` own its lifecycle instead of relying on the push handler having been constructed first. `emit` starts the collector if it is not running, and results go through an unlimited channel, which holds items until a receiver takes them, so nothing is lost while the collector is starting or between it being launched and actually subscribing. `emit` also suspends until its batch has been processed, so the worker only completes once the notification or ringing call has been set up, and the wakelock or foreground service the worker holds covers the whole path rather than ending while the batch is still queued. Finally, a batch that throws while being processed is logged instead of cancelling the collector, which previously stopped all further notifications for the life of the process.

<!-- Describe shortly what has been changed -->

## Motivation and context

`NotificationResultProcessor` currently hands resolved push events from the fetch worker to a collector running on the app scope. That collector is only started from `DefaultPushHandler`, which is only created when a push receiver runs in the current process, and the shared flow in between has no replay, so values emitted while nobody is subscribed are dropped. A `FetchPendingNotificationsWorker` that `WorkManager` runs in a fresh process, for example a retry after the process was killed or an expedited job that was deferred, therefore fetches and decrypts the events and then emits them into nothing. No notification is shown and nothing is logged.

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

None.

## Tests

See unit tests.

## Tested devices

None.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [X] Yes. In this case, please request a review by Copilot.
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] You've made a self review of your PR
