### PR TITLE
Maestro (local): skip the lane on pull requests from forks

### DIFF
--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -20,6 +20,9 @@ jobs:
   build-apk:
     name: Build APK
     runs-on: ubuntu-latest
+    # Secrets are not available to pull_request runs from forks, so the Maestro job below
+    # cannot run for them; skip the build too, as its only consumer is that job.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: ${{ format('maestro-build-{0}', github.ref) }}
       cancel-in-progress: true
@@ -73,13 +76,13 @@ jobs:
     name: Maestro test suite
     runs-on: ubuntu-latest
     needs: [ build-apk ]
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     # Allow only one to run at a time, since they use the same environment.
     # Otherwise, tests running in parallel can break each other.
     concurrency:
       group: maestro-test
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'
         with:
           # Ensure we are building the branch and not the branch after being merged on develop
           # https://github.com/actions/checkout/issues/881


### PR DESCRIPTION
## Content

Skip the `Maestro (local)` workflow on pull requests from forks, at job level, and drop the step-level guard that was meant to do this.

- `build-apk` and `maestro-cloud` now carry `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository`. `workflow_dispatch` keeps working; PRs from branches in this repo are unaffected.
- The removed condition tested `github.event.pull_request.fork`, which is not a property of the `pull_request` payload (`head.repo.fork` is), so it evaluated to `null == null` and never skipped anything.

The build is skipped too, not only the test job: the APK it produces is consumed only by `maestro-cloud`.

## Motivation and context

Fixes #7653. Secrets are never exposed to `pull_request` runs from forks, so `checkEnv.js` throws on `MAESTRO_PASSWORD` after a 4-12 minute APK build and a ~3.5 minute emulator boot; every fork-PR run last week failed that way (11 of 11), and each held the shared `maestro-test` concurrency slot while doing so.

## Screenshots / GIFs

n/a (CI only)

## Tests

- `actionlint` on the modified workflow: no new findings (the four pre-existing SC2086 notes are untouched).
- This PR itself comes from a fork, so its own `Maestro (local)` run should now show both jobs as skipped instead of a red `Maestro test suite`. A `workflow_dispatch` run on `develop` after merge exercises the other branch of the condition.

## Tested devices

- n/a (workflow change only)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot. (I cannot request reviewers from a fork.)
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24 (n/a)
- [ ] UI change has been tested on both light and dark themes (n/a)
- [ ] Accessibility has been taken into account (n/a)
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes (n/a)
- [x] You've made a self review of your PR

Label: I cannot add labels from a fork; `PR-Misc` seems right for a CI-only change.
