### PR TITLE
Maestro (local): queue pending runs in the maestro-test concurrency group instead of cancelling them

### DIFF
--- a/.github/workflows/maestro-local.yml
+++ b/.github/workflows/maestro-local.yml
@@ -75,8 +75,11 @@ jobs:
     needs: [ build-apk ]
     # Allow only one to run at a time, since they use the same environment.
     # Otherwise, tests running in parallel can break each other.
+    # queue: max lets several runs wait their turn instead of the default, where a
+    # newly queued run cancels the one already pending (that run then never gets a verdict).
     concurrency:
       group: maestro-test
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: (github.event_name == 'pull_request' && github.event.pull_request.fork == null) || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Content

Add `queue: max` to the `maestro-test` concurrency group on the `Maestro test suite` job. One-at-a-time execution is unchanged (no `cancel-in-progress`); the only difference is that runs waiting for the slot now queue instead of the newest one cancelling the one already pending.

## Motivation and context

Fixes #7654. With the default (`queue: single`), when run A is executing and run B is pending, run C finishing `Build APK` cancels B within a second; B's PR then has no Maestro verdict for that commit and nothing re-runs it. Two timestamped instances are in the issue. GitHub's docs for the property: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs (up to 100 pending runs, no runner cost while pending; `queue: max` is explicitly incompatible with `cancel-in-progress: true`, which this group does not use).

## Screenshots / GIFs

n/a (CI only)

## Tests

- `actionlint` 1.7.12 reports `unexpected key "queue" for "concurrency" section`: its schema predates the property. GitHub's workflow validator accepts it (see the docs above); the PR's own workflow run is the check.
- No behaviour change unless two runs are pending at once, so the effect is visible only on a busy morning: a run that previously showed `cancelled` with 0 steps will instead wait and then execute.

## Tested devices

- n/a (workflow change only)

## Checklist

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [x] Yes. In this case, please request a review by Copilot. (I cannot request reviewers from a fork.)
    - [ ] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24 (n/a)
- [ ] UI change has been tested on both light and dark themes (n/a)
- [ ] Accessibility has been taken into account (n/a)
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes (n/a)
- [x] You've made a self review of your PR

Independent of #7653's PR; both touch adjacent lines of the same file, so whichever lands second I will rebase. Label: `PR-Misc` (cannot add from a fork).
