### PR TITLE
Stop clearing the remote config when clearing the cache

### DIFF
--- a/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
+++ b/features/preferences/impl/src/main/kotlin/io/element/android/features/preferences/impl/tasks/ClearCacheUseCase.kt
@@ -13,7 +13,6 @@ import coil3.SingletonImageLoader
 import dev.zacsweers.metro.ContributesBinding
 import io.element.android.features.invite.api.SeenInvitesStore
 import io.element.android.features.preferences.impl.DefaultCacheService
-import io.element.android.libraries.cachestore.api.CacheStore
 import io.element.android.libraries.core.coroutine.CoroutineDispatchers
 import io.element.android.libraries.di.SessionScope
 import io.element.android.libraries.di.annotations.ApplicationContext
@@ -37,11 +36,8 @@ class DefaultClearCacheUseCase(
     private val pushService: PushService,
     private val seenInvitesStore: SeenInvitesStore,
     private val activeRoomsHolder: ActiveRoomsHolder,
-    private val cacheStore: CacheStore,
 ) : ClearCacheUseCase {
     override suspend fun invoke() = withContext(coroutineDispatchers.io) {
-        // Clear cache store
-        cacheStore.deleteAll()
         // Active rooms should be disposed of before clearing the cache
         activeRoomsHolder.clear(matrixClient.sessionId)
         // Clear Matrix cache

--- a/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/tasks/DefaultClearCacheUseCaseTest.kt
+++ b/features/preferences/impl/src/test/kotlin/io/element/android/features/preferences/impl/tasks/DefaultClearCacheUseCaseTest.kt
@@ -19,8 +19,6 @@ import io.element.android.libraries.matrix.test.A_SESSION_ID
 import io.element.android.libraries.matrix.test.FakeMatrixClient
 import io.element.android.libraries.matrix.test.room.FakeJoinedRoom
 import io.element.android.libraries.push.test.FakePushService
-import io.element.android.libraries.sessionstorage.test.InMemoryCacheStore
-import io.element.android.libraries.sessionstorage.test.aCacheData
 import io.element.android.services.appnavstate.impl.DefaultActiveRoomsHolder
 import io.element.android.tests.testutils.lambda.lambdaRecorder
 import io.element.android.tests.testutils.lambda.value
@@ -49,9 +47,6 @@ class DefaultClearCacheUseCaseTest : RobolectricTest() {
         )
         val seenInvitesStore = InMemorySeenInvitesStore(setOf(A_ROOM_ID))
         assertThat(seenInvitesStore.seenRoomIds().first()).isNotEmpty()
-        val cacheStore = InMemoryCacheStore(
-            initialData = mapOf("key1" to aCacheData())
-        )
         val sut = DefaultClearCacheUseCase(
             context = InstrumentationRegistry.getInstrumentation().context,
             matrixClient = matrixClient,
@@ -61,11 +56,9 @@ class DefaultClearCacheUseCaseTest : RobolectricTest() {
             pushService = pushService,
             seenInvitesStore = seenInvitesStore,
             activeRoomsHolder = activeRoomsHolder,
-            cacheStore = cacheStore,
         )
         defaultCacheService.clearedCacheEventFlow.test {
             sut.invoke()
-            assertThat(cacheStore.dataMap).isEmpty()
             clearCacheLambda.assertions().isCalledOnce()
             setIgnoreRegistrationErrorLambda.assertions().isCalledOnce()
                 .with(value(matrixClient.sessionId), value(false))


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

What the title says. The remote config / Element well known data won't be cleared now when clearing the cache.

## Motivation and context

Doing this conflicts with other features in Element Pro, and it's a divergence between the 2 mobile platforms, since iOS doesn't clear this data.

We probably want to add some new API to manually refresh this remote configuration from the developer options instead.

## Tests

Clear the cache, check no calls to `https://server-name.tld/.well-known/matrix/client` happen anymore.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
