### PR TITLE
Try improving renovate issues with Maven Central rate limiting

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,13 @@
     "gradle",
   ],
   "minimumReleaseAge": "7 days",
+  "hostRules": [
+    {
+      "matchHost": "https://repo1.maven.org/maven2/",
+      "concurrentRequestLimit": 4,
+      "maxRequestsPerSecond": 4,
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,13 @@
   "packageRules": [
     {
       "matchPackageNames": [
+          "/^androidx.\.*/"
+      ],
+      "groupName": "androidx",
+      "registryUrls": [ "https://dl.google.com/android/maven2/" ],
+    },
+    {
+      "matchPackageNames": [
         "org.matrix.rustcomponents:sdk-android",
         "/^io.element.android/",
       ],


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Try not to make too many concurrent requests to Maven Central: the logs display rate limit responses followed by OK responses, which could mean we're hammering the Maven Central repo with too many concurrent requests.
- Also, try not hitting Maven Central for `androidx.` libraries.

## Motivation and context

Fix Renovate being rate-limited, which makes it hard to update dependencies sometimes.

## Tests

I think the only way to test this is to merge it 🫤 .

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
