### PR TITLE
Improve Renovate configuration to fix issues with Maven Central

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,15 @@
       "registryUrls": [ "https://repo1.maven.org/maven2/" ],
     },
     {
+      // Fetch Android dependencies from Google's Maven repo instead of Maven Central.
+      "matchPackageNames": [
+        "/^androidx\\./",
+        "/^android\\./",
+        "/^com\\.android\\.tools/",
+      ],
+      "registryUrls": [ "https://dl.google.com/android/maven2/" ],
+    },
+    {
       "groupName": "kotlin",
       "matchPackageNames": [
         "/^org.jetbrains.kotlin/",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,18 +13,12 @@
   "hostRules": [
     {
       "matchHost": "https://repo1.maven.org/maven2/",
-      "concurrentRequestLimit": 4,
-      "maxRequestsPerSecond": 4,
+      "concurrentRequestLimit": 10,
+      "maxRequestsPerSecond": 10,
+      "timeout": 10000,
     }
   ],
   "packageRules": [
-    {
-      "matchPackageNames": [
-          "/^androidx.\.*/"
-      ],
-      "groupName": "androidx",
-      "registryUrls": [ "https://dl.google.com/android/maven2/" ],
-    },
     {
       "matchPackageNames": [
         "org.matrix.rustcomponents:sdk-android",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,7 @@
       "minimumReleaseAge": null,
       // Max default value is 6, with this we give absolute priority to our own dependencies
       "prPriority": 7,
+      "registryUrls": [ "https://repo1.maven.org/maven2/" ],
     },
     {
       "groupName": "kotlin",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,8 @@
         "/^androidx\\./",
         "/^android\\./",
         "/^com\\.android\\.tools/",
+        "/^com\\.google\\.firebase/",
+        "/^com\\.google\\.android/",
       ],
       "registryUrls": [ "https://dl.google.com/android/maven2/" ],
     },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,19 @@ dependencyResolutionManagement {
                 includeModule("com.github.philburk", "jsyn")
             }
         }
-        google()
+        // Check for official Android-related packages only in Google's maven repo
+        exclusiveContent {
+            forRepository {
+                google()
+            }
+            filter {
+                includeGroupByRegex("android\\..*")
+                includeGroupByRegex("androidx\\..*")
+                includeGroupByRegex("com\\.android\\.tools.*")
+                includeGroupByRegex("com\\.google\\.firebase.*")
+                includeGroupByRegex("com\\.google\\.android.*")
+            }
+        }
         mavenCentral()
         maven {
             url = uri("https://repo1.maven.org/maven2/")


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Don't group `androidx` dependencies.
- Make sure `android.*`, `androidx.*` and `com.android.tools*` dependencies are only fetched from Google's Android repo. It should make both renovate and gradle sync faster.
- Tweak the concurrent requests options to higher values that still don't seem to trigger the Maven Central rate limit.

## Motivation and context

https://github.com/element-hq/element-x-android/pull/7667 didn't really work as expected.

## Tests

I tested this locally with `--dry-run` and it worked fine AFAICT.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
