### PR TITLE
Add enter animation to new timeline events

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemRow.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/timeline/components/TimelineItemRow.kt
@@ -8,17 +8,29 @@
 
 package io.element.android.features.messages.impl.timeline.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.isTraversalGroup
@@ -45,6 +57,7 @@ import io.element.android.libraries.designsystem.preview.PreviewsDayNight
 import io.element.android.libraries.designsystem.text.toPx
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.timeline.Timeline
+import io.element.android.libraries.matrix.api.timeline.item.event.TimelineItemEventOrigin
 import io.element.android.libraries.matrix.api.user.MatrixUser
 import io.element.android.libraries.ui.strings.CommonStrings
 import io.element.android.libraries.ui.utils.a11y.isTalkbackActive
@@ -102,8 +115,98 @@ internal fun TimelineItemRow(
     } else {
         Modifier
     }
-    Box(modifier = modifier.then(backgroundModifier)) {
-        when (timelineItem) {
+    val content = @Composable {
+        Box(modifier = modifier.then(backgroundModifier)) {
+            RowContent(
+                timelineItem = timelineItem,
+                timelineMode = timelineMode,
+                timelineRoomInfo = timelineRoomInfo,
+                isLastOutgoingMessage = isLastOutgoingMessage,
+                timelineProtectionState = timelineProtectionState,
+                focusedEventId = focusedEventId,
+                displayThreadSummaries = displayThreadSummaries,
+                onUserDataClick = onUserDataClick,
+                onLinkClick = onLinkClick,
+                onLinkLongClick = onLinkLongClick,
+                onContentClick = onContentClick,
+                onGalleryItemClick = onGalleryItemClick,
+                onLongClick = onLongClick,
+                inReplyToClick = inReplyToClick,
+                onReactionClick = onReactionClick,
+                onReactionLongClick = onReactionLongClick,
+                onMoreReactionsClick = onMoreReactionsClick,
+                onReadReceiptClick = onReadReceiptClick,
+                onJoinCallClick = onJoinCallClick,
+                onSwipeToReply = onSwipeToReply,
+                eventSink = eventSink,
+                eventContentView = eventContentView,
+            )
+        }
+    }
+
+    WithEnterAnimation(
+        timelineItem = timelineItem,
+        content = content,
+    )
+}
+
+@Composable
+private fun WithEnterAnimation(
+    timelineItem: TimelineItem,
+    content: @Composable () -> Unit,
+) {
+    val movableContent = remember { movableContentOf(content) }
+    // Only events with SYNC or LOCAL origin should have an enter animation, to avoid animating events that are already in the timeline
+    // when the user opens the room.
+    val needsEnterAnimation = remember {
+        timelineItem is TimelineItem.Event &&
+        (timelineItem.origin == TimelineItemEventOrigin.SYNC || timelineItem.origin == TimelineItemEventOrigin.LOCAL)
+    }
+    if (needsEnterAnimation && !LocalInspectionMode.current) {
+        // Animate the  item in the first time it is displayed, e.g. when a new message arrives.
+        // We also remember the animation state so it doesn't re-animate when the timeline recomposes or we come back to the screen it's in.
+        var isDisplayed by rememberSaveable { mutableStateOf(false) }
+        val visibleState = remember { MutableTransitionState(initialState = isDisplayed).apply { targetState = true } }
+        LaunchedEffect(visibleState.currentState) {
+            isDisplayed = visibleState.currentState
+        }
+        AnimatedVisibility(
+            visibleState = visibleState,
+            enter = fadeIn() + slideInVertically { fullHeight -> fullHeight / 2 },
+        ) {
+            movableContent()
+        }
+    } else {
+        movableContent()
+    }
+}
+
+@Composable
+private fun RowContent(
+    timelineItem: TimelineItem,
+    timelineMode: Timeline.Mode,
+    timelineRoomInfo: TimelineRoomInfo,
+    isLastOutgoingMessage: Boolean,
+    timelineProtectionState: TimelineProtectionState,
+    focusedEventId: EventId?,
+    displayThreadSummaries: Boolean,
+    onUserDataClick: (MatrixUser) -> Unit,
+    onLinkClick: (Link) -> Unit,
+    onLinkLongClick: (Link) -> Unit,
+    onContentClick: (TimelineItem.Event) -> Unit,
+    onGalleryItemClick: (TimelineItem.Event, Int) -> Unit,
+    onLongClick: (TimelineItem.Event) -> Unit,
+    inReplyToClick: (EventId) -> Unit,
+    onReactionClick: (key: String, TimelineItem.Event) -> Unit,
+    onReactionLongClick: (key: String, TimelineItem.Event) -> Unit,
+    onMoreReactionsClick: (TimelineItem.Event) -> Unit,
+    onReadReceiptClick: (TimelineItem.Event) -> Unit,
+    onJoinCallClick: (isAudioCall: Boolean) -> Unit,
+    onSwipeToReply: (TimelineItem.Event) -> Unit,
+    eventSink: (TimelineEvent.TimelineItemEvent) -> Unit,
+    eventContentView: @Composable (TimelineItem.Event, Modifier, (ContentAvoidingLayoutData) -> Unit) -> Unit,
+) {
+    when (timelineItem) {
             is TimelineItem.Virtual -> {
                 TimelineItemVirtualRow(
                     virtual = timelineItem,
@@ -226,7 +329,6 @@ internal fun TimelineItemRow(
                     eventSink = eventSink,
                 )
             }
-        }
     }
 }
 


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Add the `WithEnterAnimation` wrapper to add an slide-up + fade in animation to timeline events with SYNC or LOCAL origin so new items either coming from sync or sent by the current users animate when added to the timeline. Other items will work the same.

## Motivation and context

Implement https://github.com/element-hq/element-x-android/issues/6966.

FWIW, I tried a more thorough implementation with `Modifier.animateItem()` but there were lots of weird animations, as we had before: 

- Grouped events overlapping with any events above them when being expanded.
- When you send several items in a row, the latest event with the 'sent' indicator will collapse with an animation, and the new item being added will be animating from what it looks like the middle of that event, which makes them overlap in an awkward way.
- Probably more I haven't noticed.

So I decided to drop that implementation and do something simpler.

## Screenshots / GIFs


https://github.com/user-attachments/assets/731a1d2e-0b03-4c82-87d4-bcc85140aaf7



## Tests

Test sending and receiving new events in the timeline, as well as redacting them or paginating.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 15

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
