### PR TITLE
Make global search use a `Joined` filter for room results

### DIFF
--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/GlobalSearchPresenter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/GlobalSearchPresenter.kt
@@ -31,6 +31,7 @@ import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
 import io.element.android.libraries.matrix.api.room.RoomInfo
 import io.element.android.libraries.matrix.api.roomlist.LatestEventValue
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
 import io.element.android.libraries.matrix.api.search.MessageSearch
 import io.element.android.libraries.matrix.api.search.MessageSearchPaginationState
 import io.element.android.libraries.matrix.api.search.MessageSearchResult
@@ -94,7 +95,14 @@ class GlobalSearchPresenter(
                 AsyncData.Uninitialized
             }
 
-            launch { roomListSearchDataSource.setSearchQuery(queryState.text.toString()) }
+            // Apply the query to the room list search, looking only for joined rooms matching the query
+            launch {
+                roomListSearchDataSource.setSearchQuery(
+                    searchQuery = queryState.text.toString(),
+                    additionalFilters = RoomListFilter.Joined,
+                )
+            }
+            // Apply the query to the message search too
             launch {
                 currentMessageSearch.setQuery(queryState.text.toString())
                     .onFailure { Timber.e(it, "Could not set query for message search") }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchDataSource.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchDataSource.kt
@@ -60,11 +60,15 @@ class RoomListSearchDataSource(
         roomList.updateVisibleRange(visibleRange)
     }
 
-    suspend fun setSearchQuery(searchQuery: String) = coroutineScope {
+    suspend fun setSearchQuery(searchQuery: String, additionalFilters: RoomListFilter?) = coroutineScope {
         val filter = if (searchQuery.isBlank()) {
             RoomListFilter.None
         } else {
-            RoomListFilter.NormalizedMatchRoomName(searchQuery)
+            if (additionalFilters != null) {
+                RoomListFilter.all(additionalFilters, RoomListFilter.NormalizedMatchRoomName(searchQuery))
+            } else {
+                RoomListFilter.NormalizedMatchRoomName(searchQuery)
+            }
         }
         roomList.updateFilter(filter)
     }

--- a/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchPresenter.kt
+++ b/features/home/impl/src/main/kotlin/io/element/android/features/home/impl/search/RoomListSearchPresenter.kt
@@ -39,7 +39,7 @@ class RoomListSearchPresenter(
         val dataSource = remember { dataSourceFactory.create(coroutineScope) }
 
         LaunchedEffect(searchQuery.text) {
-            dataSource.setSearchQuery(searchQuery.text.toString())
+            dataSource.setSearchQuery(searchQuery = searchQuery.text.toString(), additionalFilters = null)
         }
 
         fun handleEvent(event: RoomListSearchEvent) {

--- a/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/search/GlobalSearchPresenterTest.kt
+++ b/features/home/impl/src/test/kotlin/io/element/android/features/home/impl/search/GlobalSearchPresenterTest.kt
@@ -23,6 +23,9 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.featureflag.test.FakeFeatureFlagService
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.permalink.PermalinkParser
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter.Joined
+import io.element.android.libraries.matrix.api.roomlist.RoomListFilter.NormalizedMatchRoomName
 import io.element.android.libraries.matrix.api.roomlist.RoomListService
 import io.element.android.libraries.matrix.api.search.MessageSearchService
 import io.element.android.libraries.matrix.test.FakeMatrixClient
@@ -141,6 +144,9 @@ class GlobalSearchPresenterTest {
             // Let the query be propagated to the data source before emitting results
             testScheduler.advanceUntilIdle()
             roomList.summaries.emit(listOf(aRoomSummary()))
+
+            // The filter is updated to include the search query and only search joined rooms
+            assertThat(roomList.currentFilter.value).isEqualTo(RoomListFilter.all(Joined, NormalizedMatchRoomName("A query")))
 
             // Wait for the presenter to emit a loading state before the success state
             consumeItemsUntilPredicate { it.results is AsyncData.Loading }

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/roomlist/RoomListFilter.kt
@@ -68,6 +68,11 @@ sealed interface RoomListFilter {
     data object Invite : RoomListFilter
 
     /**
+     * A filter that matches rooms with Joined membership.
+     */
+    data object Joined : RoomListFilter
+
+    /**
      * A filter that matches either Group,People rooms or Space.
      */
     sealed interface Category : RoomListFilter {

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterMapper.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/roomlist/RoomListFilterMapper.kt
@@ -16,6 +16,7 @@ import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Deduplicat
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Favourite
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Identifiers
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Invite
+import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.Joined
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.NonLeft
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.NonSpace
 import org.matrix.rustcomponents.sdk.RoomListEntriesDynamicFilterKind.None
@@ -73,6 +74,7 @@ internal object RoomListFilterMapper {
             is RoomListFilter.NormalizedMatchRoomName -> NormalizedMatchRoomName(
                 pattern = filter.pattern
             )
+            RoomListFilter.Joined -> Joined
             RoomListFilter.Invite -> Invite
         }
     }


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

- Add an `additionalFilters` parameter to `RoomListSearchDataSource.setSearchQuery`.
- Provide `RoomListFilter.Joined` for it in the `GlobalSearchPresenter`.

## Motivation and context

We don't want to display invites in the global search room results.

## Tests

Enable the room search developer option and search for a room you are invited to: it should not be displayed in the results.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 17

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [ ] Changes have been tested on an Android device or Android emulator with API 24
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
